### PR TITLE
Harden leaderboard economy: server-authoritative scoring RPCs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,5 +30,18 @@ export default ts.config(
 				parser: ts.parser
 			}
 		}
+	},
+	{
+		rules: {
+			// Allow intentional throwaways (e.g. `{#each Array(20) as _, i}`) prefixed with `_`.
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			]
+		}
 	}
 );

--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -1,13 +1,11 @@
 <script>
   import { gameStore } from '$lib/stores/GameStore.js';
   import { onDestroy, createEventDispatcher } from 'svelte';
-  import { getFormattedPhrase, getGlobalIndex } from '$lib/helpers/gameUtils.js';
+  import { getGlobalIndex } from '$lib/helpers/gameUtils.js';
 
   const dispatch = createEventDispatcher();
 
   // 📤 Reactive State Setup
-  $: phrase = $gameStore.currentPhrase || "";
-  $: formattedPhrase = getFormattedPhrase(phrase);
 
   // 💢 Shake Animation
   let shakeIndexes = new Set();

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,10 +3,9 @@
 import { writable, get } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient.js';
 import confetti from 'canvas-confetti';
-import { saveUserProfile } from '$lib/stores/userStore.js';
 import { user } from '$lib/stores/userStore.js';
 import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
-import { recordDailyResult, recordArcadeResult } from '$lib/stores/statsStore.js';
+import { recordDailyResult, recordArcadeResult, saveArcadeBankroll } from '$lib/stores/statsStore.js';
 
 /* ================================
    Types (JSDoc for checkJs)
@@ -322,7 +321,7 @@ export function confirmPurchase() {
 
       const currentUser = get(user);
       if (currentUser?.id && state.gameMode === 'arcade') {
-        saveUserProfile({ id: currentUser.id, arcade_bankroll: newBankroll });
+        saveArcadeBankroll(newBankroll);
       }
 
       finalState = checkLossCondition(newState);
@@ -356,7 +355,7 @@ export function confirmPurchase() {
       };
       const currentUser = get(user);
       if (currentUser?.id && state.gameMode === 'arcade') {
-        saveUserProfile({ id: currentUser.id, arcade_bankroll: newBankroll });
+        saveArcadeBankroll(newBankroll);
       }
       saveGameToLocalStorage();
       return newState;
@@ -401,7 +400,7 @@ export function confirmPurchase() {
 
       const currentUser = get(user);
       if (currentUser?.id && state.gameMode === 'arcade') {
-        saveUserProfile({ id: currentUser.id, arcade_bankroll: newBankroll });
+        saveArcadeBankroll(newBankroll);
       }
 
       finalState = checkLossCondition(newState);
@@ -468,7 +467,7 @@ export function inputGuessLetter(letter) {
     if (editableIndices.length === 0) return state;
 
     // Find the first empty slot; if all filled, overwrite the last slot.
-    let activeIndex = editableIndices.find(idx => !state.guessedLetters.hasOwnProperty(idx));
+    let activeIndex = editableIndices.find(idx => !Object.hasOwn(state.guessedLetters, idx));
     if (activeIndex === undefined) {
       activeIndex = editableIndices[editableIndices.length - 1];
     }
@@ -592,7 +591,7 @@ export function submitGuess() {
     // 💾 Sync to Supabase (arcade: persist during play; final save via recordArcadeResult on win)
     const currentUser = get(user);
     if (currentUser?.id && state.gameMode === 'arcade') {
-      saveUserProfile({ id: currentUser.id, arcade_bankroll: newBankroll });
+      saveArcadeBankroll(newBankroll);
     }
 
     // 💾 Save to localStorage

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -107,6 +107,21 @@ export async function recordArcadeResult(userId, won, bankrollLeft) {
 }
 
 /**
+ * Persist the caller's arcade bankroll between/within games.
+ * Goes through a SECURITY DEFINER RPC (auth.uid() + clamp) instead of writing the
+ * profiles table directly, so a client can't set an arbitrary bankroll on any row.
+ * @param {number} bankroll
+ */
+export async function saveArcadeBankroll(bankroll) {
+  const { error } = await supabase.rpc('save_arcade_bankroll', {
+    p_bankroll: bankroll
+  });
+  if (error) {
+    console.error('❌ Error saving arcade bankroll:', error);
+  }
+}
+
+/**
  * Record daily game result (call when daily game ends - won or lost)
  * @param {string} userId
  * @param {boolean} won

--- a/src/lib/stores/userStore.js
+++ b/src/lib/stores/userStore.js
@@ -1,4 +1,4 @@
-import { writable, get } from 'svelte/store';
+import { writable } from 'svelte/store';
 import { supabase } from '$lib/supabaseClient';
 
 /**
@@ -60,59 +60,28 @@ export async function fetchUserProfile(userId) {
 }
 
 /**
- * 💾 Save (insert or update) user profile data to Supabase
- * @param {ProfileData & { id: string }} updatedProfile - Updated profile object to insert or update
- * @returns {Promise<null | Error | { message?: string }>} - Returns error if any occurs during saving
+ * 💾 Ensure a profile row exists for the user (creation fallback for the DB trigger).
+ * INSERT-only: a duplicate (row already created by the on-signup trigger) is treated as success.
+ * Bankroll and stats are never written from the client — those go through SECURITY DEFINER RPCs.
+ * @param {string} userId - Supabase user ID
+ * @returns {Promise<null | Error | { message?: string }>} - Returns error if creation truly failed
  */
-export async function saveUserProfile(updatedProfile) {
+export async function ensureProfileExists(userId) {
   try {
-    console.log("🔄 Saving updated profile:", updatedProfile);
-
     const { error } = await supabase
       .from('profiles')
-      .upsert(updatedProfile);
+      .insert({ id: userId, arcade_bankroll: 1000 });
 
-    if (error) {
-      console.error("❌ Failed to save profile:", error.message);
+    // 23505 = unique_violation: the profile already exists (created by the on-signup trigger).
+    // That's the expected happy path, not an error.
+    if (error && error.code !== '23505') {
+      console.error("❌ Failed to create profile:", error.message);
       return error;
     }
 
-    console.log("✅ Profile saved (inserted or updated):", updatedProfile);
     return null;
   } catch (err) {
-    console.error("❌ Error in saving user profile:", err instanceof Error ? err.message : String(err));
+    console.error("❌ Error ensuring user profile:", err instanceof Error ? err.message : String(err));
     return err instanceof Error ? err : new Error(String(err));
-  }
-}
-
-/**
- * 📊 Save daily stats (called after each puzzle or at end of session)
- */
-export async function saveDailyStats({ puzzlesCompleted = 0, highestBankroll = 0, cashSpent = 0 }) {
-  const currentUser = get(user);
-
-  if (!currentUser?.id) {
-    console.warn('⛔ No user found when trying to save daily stats.');
-    return;
-  }
-
-  const today = new Date().toISOString().split('T')[0];
-
-  const { data, error } = await supabase
-    .from('daily_stats')
-    .upsert({
-      user_id: currentUser.id,
-      date: today,
-      puzzles_completed: puzzlesCompleted,
-      highest_bankroll: highestBankroll,
-      cash_spent: cashSpent
-    }, {
-      onConflict: 'user_id,date'
-    });
-
-  if (error) {
-    console.error("❌ Error saving daily stats:", error.message);
-  } else {
-    console.log("✅ Daily stats saved:", data);
   }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,8 @@
   import { get } from 'svelte/store';
 
   import { gameStore, fetchRandomGame, fetchDailyGame } from '$lib/stores/GameStore.js';
-  import { user, userProfile, fetchUserProfile, saveUserProfile } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday } from '$lib/stores/statsStore.js';
+  import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
+  import { hasPlayedDailyToday, saveArcadeBankroll } from '$lib/stores/statsStore.js';
   import {
     saveGameToLocalStorage,
     loadGameFromLocalStorage,
@@ -52,7 +52,7 @@
       if (error || !profile) {
         console.warn("⚠️ Failed to load profile:", error?.message ?? error);
         // Auto-create profile for new users (no profile row yet)
-        const createError = await saveUserProfile({ id: userId, arcade_bankroll: 1000 });
+        const createError = await ensureProfileExists(userId);
         if (createError) {
           console.error("❌ Failed to create profile:", createError);
           return null;
@@ -171,7 +171,6 @@
   $: loggedIn = !!$user?.id;
   $: bankroll = $gameStore.bankroll || 0;
   $: digits = String(bankroll).split('');
-  $: nextPuzzleAvailable = $gameStore.gameState === 'won' || $gameStore.gameState === 'lost';
   $: sliderLocked = $gameStore.gameState === 'guess_mode';
 
   // ✅ Auto-save whenever state is valid
@@ -288,7 +287,7 @@
 
     const store = get(gameStore);
     if (store.gameMode === 'arcade') {
-      await saveUserProfile({ id: currentUser.id, arcade_bankroll: 1000 });
+      await saveArcadeBankroll(1000);
     }
     clearSavedGame();
     gameWasRestored.set(false);
@@ -309,7 +308,7 @@
 
     const store = get(gameStore);
     if (store.gameMode === 'arcade') {
-      await saveUserProfile({ id: currentUser.id, arcade_bankroll: store.bankroll });
+      await saveArcadeBankroll(store.bankroll);
     }
 
     clearSavedGame();

--- a/src/routes/select/arcade/+page.svelte
+++ b/src/routes/select/arcade/+page.svelte
@@ -16,7 +16,6 @@
   ];
 
   let status = $state({ arcade_bankroll: 1000 });
-  let loading = $state(true);
 
   onMount(async () => {
     const { data: { session } } = await supabase.auth.getSession();
@@ -25,7 +24,6 @@
       const s = await getDailyStatus(session.user.id);
       status = { arcade_bankroll: s.arcade_bankroll ?? 1000 };
     }
-    loading = false;
   });
 
   /** @param {string} category */

--- a/supabase-create-profile-trigger.sql
+++ b/supabase-create-profile-trigger.sql
@@ -21,10 +21,25 @@ CREATE TRIGGER on_auth_user_created
   FOR EACH ROW
   EXECUTE FUNCTION public.handle_new_user();
 
--- 4. RLS: Allow users to insert their own profile (fixes "new row violates row-level security policy")
+-- 4. RLS: profiles policies (version-controlled so the schema is reproducible from scratch).
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Allow users to insert their own profile (creation fallback; the trigger above normally
+-- handles this). Fixes "new row violates row-level security policy" for new signups.
 DROP POLICY IF EXISTS "Users can insert own profile" ON public.profiles;
 CREATE POLICY "Users can insert own profile"
   ON public.profiles FOR INSERT
   WITH CHECK (auth.uid() = id);
+
+-- Allow users to read their own profile row (fetchUserProfile). Leaderboards read profiles
+-- via SECURITY DEFINER RPCs, so they do not depend on a public SELECT policy.
+DROP POLICY IF EXISTS "Users can read own profile" ON public.profiles;
+CREATE POLICY "Users can read own profile"
+  ON public.profiles FOR SELECT
+  USING (auth.uid() = id);
+
+-- NOTE: There is intentionally NO client UPDATE policy. Bankroll and stats are written only by
+-- the SECURITY DEFINER RPCs (record_daily_result / record_arcade_result / save_arcade_bankroll).
+-- supabase-security-hardening.sql additionally REVOKEs UPDATE/DELETE from the client roles.
 
 -- Note: If your profiles table has different columns, edit the INSERT above.

--- a/supabase-daily-leaderboard.sql
+++ b/supabase-daily-leaderboard.sql
@@ -124,18 +124,25 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- 4b. RPC: Check if user has already played daily today
+-- 4b. RPC: Check if THE CALLER has already played daily today
+-- p_user_id is ignored (kept for signature compatibility); identity comes from auth.uid()
+-- so a client can never probe another user's play status.
 CREATE OR REPLACE FUNCTION public.has_played_daily_today(p_user_id UUID)
 RETURNS BOOLEAN AS $$
+DECLARE
+  v_uid UUID := auth.uid();
 BEGIN
+  IF v_uid IS NULL THEN RETURN false; END IF;
   RETURN EXISTS (
     SELECT 1 FROM public.profiles
-    WHERE id = p_user_id AND last_daily_play_date = CURRENT_DATE
+    WHERE id = v_uid AND last_daily_play_date = CURRENT_DATE
   );
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- 4c. RPC: Get daily status and bankrolls for select page
+-- 4c. RPC: Get THE CALLER's daily status and bankrolls for the select page.
+-- p_user_id is ignored (kept for signature compatibility); identity comes from auth.uid()
+-- so a client can never read another user's bankroll/status.
 CREATE OR REPLACE FUNCTION public.get_daily_status(p_user_id UUID)
 RETURNS TABLE (
   has_played_today BOOLEAN,
@@ -143,7 +150,10 @@ RETURNS TABLE (
   daily_bankroll INT,
   arcade_bankroll INT
 ) AS $$
+DECLARE
+  v_uid UUID := auth.uid();
 BEGIN
+  IF v_uid IS NULL THEN RETURN; END IF;
   RETURN QUERY
   SELECT
     (p.last_daily_play_date = CURRENT_DATE) AS has_played_today,
@@ -151,7 +161,7 @@ BEGIN
     COALESCE(p.daily_bankroll, 0)::INT AS daily_bankroll,
     COALESCE(p.arcade_bankroll, 1000)::INT AS arcade_bankroll
   FROM public.profiles p
-  WHERE p.id = p_user_id;
+  WHERE p.id = v_uid;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
@@ -178,7 +188,8 @@ BEGIN
       v_start := date_trunc('day', CURRENT_DATE) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '1 day';
     WHEN 'weekly' THEN
-      v_start := (date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMPTZ;
+      -- Tuesday-keyed league week, interpreted in UTC to match game_results.played_at (stored via NOW() in UTC)
+      v_start := ((date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMP) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '7 days';
     WHEN 'monthly' THEN
       v_start := date_trunc('month', CURRENT_DATE) AT TIME ZONE 'UTC';
@@ -272,7 +283,8 @@ BEGIN
         v_start := date_trunc('day', CURRENT_DATE) AT TIME ZONE 'UTC';
         v_end := v_start + INTERVAL '1 day';
       WHEN 'weekly' THEN
-        v_start := (date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMPTZ;
+        -- Tuesday-keyed league week, interpreted in UTC to match game_results.played_at
+        v_start := ((date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMP) AT TIME ZONE 'UTC';
         v_end := v_start + INTERVAL '7 days';
       WHEN 'monthly' THEN
         v_start := date_trunc('month', CURRENT_DATE) AT TIME ZONE 'UTC';
@@ -347,6 +359,10 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 5. RPC: Record daily game result and update weekly stats
+-- SECURITY: p_user_id is IGNORED (kept only for signature/JS compatibility). The caller's
+-- identity comes from auth.uid(), so a client can never record a result for another user.
+-- One result per user per day is enforced here (the client-side button-disable is not trustworthy),
+-- and the bankroll is clamped to the only range a legitimate daily game can produce ([0, 1000]).
 CREATE OR REPLACE FUNCTION public.record_daily_result(
   p_user_id UUID,
   p_won BOOLEAN,
@@ -354,23 +370,38 @@ CREATE OR REPLACE FUNCTION public.record_daily_result(
 )
 RETURNS void AS $$
 DECLARE
+  v_uid UUID := auth.uid();
   v_week_start DATE;
   v_current_streak INT;
   v_highest_streak INT;
   v_last_win DATE;
+  v_last_play DATE;
+  v_bankroll INT;
 BEGIN
-  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1; -- Monday
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'record_daily_result: not authenticated';
+  END IF;
 
-  -- Get current streak from profiles
-  SELECT current_win_streak, highest_win_streak, last_daily_win_date
-  INTO v_current_streak, v_highest_streak, v_last_win
-  FROM public.profiles WHERE id = p_user_id;
+  -- Daily starts at 1000 and can only decrease; reject anything outside that range.
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll_left, 0), 0), 1000);
+
+  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1; -- Tuesday-keyed league week
+
+  SELECT current_win_streak, highest_win_streak, last_daily_win_date, last_daily_play_date
+  INTO v_current_streak, v_highest_streak, v_last_win, v_last_play
+  FROM public.profiles WHERE id = v_uid;
+
+  -- Enforce one daily result per day, server-side.
+  IF v_last_play = CURRENT_DATE THEN
+    RETURN;
+  END IF;
 
   -- Update streak, daily bankroll, and last result
   IF p_won THEN
     IF v_last_win = CURRENT_DATE - 1 THEN
       v_current_streak := COALESCE(v_current_streak, 0) + 1;
-    ELSIF v_last_win != CURRENT_DATE THEN
+    ELSIF v_last_win IS DISTINCT FROM CURRENT_DATE THEN
+      -- First win ever (NULL) or a gap since the last win: start a fresh streak at 1.
       v_current_streak := 1;
     END IF;
     v_highest_streak := GREATEST(COALESCE(v_highest_streak, 0), v_current_streak);
@@ -379,29 +410,30 @@ BEGIN
       highest_win_streak = v_highest_streak,
       last_daily_win_date = CURRENT_DATE,
       last_daily_play_date = CURRENT_DATE,
-      daily_bankroll = p_bankroll_left,
+      daily_bankroll = v_bankroll,
       last_daily_won = true
-    WHERE id = p_user_id;
+    WHERE id = v_uid;
   ELSE
+    v_current_streak := 0;
     UPDATE public.profiles SET
       current_win_streak = 0,
       last_daily_play_date = CURRENT_DATE,
-      daily_bankroll = p_bankroll_left,
+      daily_bankroll = v_bankroll,
       last_daily_won = false
-    WHERE id = p_user_id;
+    WHERE id = v_uid;
   END IF;
 
   -- Insert into game_results for period-based leaderboards
   INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode)
-  VALUES (p_user_id, NOW(), p_won, p_bankroll_left, 'daily');
+  VALUES (v_uid, NOW(), p_won, v_bankroll, 'daily');
 
   -- Upsert weekly stats
   INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
   VALUES (
-    p_user_id, v_week_start,
+    v_uid, v_week_start,
     CASE WHEN p_won THEN 1 ELSE 0 END,
-    CASE WHEN p_won THEN p_bankroll_left ELSE 0 END,
-    p_bankroll_left,
+    CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    v_bankroll,
     CASE WHEN p_won THEN 1 ELSE 0 END,
     1,
     COALESCE(v_current_streak, 0)
@@ -410,13 +442,18 @@ BEGIN
     total_played = user_weekly_stats.total_played + 1,
     total_wins = user_weekly_stats.total_wins + CASE WHEN p_won THEN 1 ELSE 0 END,
     puzzles_completed = user_weekly_stats.puzzles_completed + CASE WHEN p_won THEN 1 ELSE 0 END,
-    bankroll_earned = user_weekly_stats.bankroll_earned + CASE WHEN p_won THEN p_bankroll_left ELSE 0 END,
-    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, p_bankroll_left),
+    bankroll_earned = user_weekly_stats.bankroll_earned + CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, v_bankroll),
     win_streak = GREATEST(user_weekly_stats.win_streak, v_current_streak);
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 5b. RPC: Record arcade game result
+-- SECURITY: p_user_id is IGNORED (kept for signature/JS compatibility); identity comes from
+-- auth.uid(). Bankroll is clamped to a non-negative, sane ceiling. NOTE: arcade bankroll is
+-- still client-derived (the answer lives in the browser), so the arcade leaderboard is only as
+-- trustworthy as the client. The daily leaderboard is the integrity-critical one and is clamped
+-- tightly. Fully trustless scoring would require server-held puzzle state (see review note #2).
 CREATE OR REPLACE FUNCTION public.record_arcade_result(
   p_user_id UUID,
   p_won BOOLEAN,
@@ -424,11 +461,19 @@ CREATE OR REPLACE FUNCTION public.record_arcade_result(
 )
 RETURNS void AS $$
 DECLARE
+  v_uid UUID := auth.uid();
   v_arcade_streak INT;
   v_highest_arcade_streak INT;
+  v_bankroll INT;
 BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'record_arcade_result: not authenticated';
+  END IF;
+
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll_left, 0), 0), 100000000);
+
   SELECT arcade_win_streak, highest_arcade_streak INTO v_arcade_streak, v_highest_arcade_streak
-  FROM public.profiles WHERE id = p_user_id;
+  FROM public.profiles WHERE id = v_uid;
 
   IF p_won THEN
     v_arcade_streak := COALESCE(v_arcade_streak, 0) + 1;
@@ -438,14 +483,34 @@ BEGIN
   END IF;
 
   UPDATE public.profiles SET
-    arcade_bankroll = p_bankroll_left,
-    highest_arcade_bankroll = GREATEST(COALESCE(highest_arcade_bankroll, 1000), p_bankroll_left),
+    arcade_bankroll = v_bankroll,
+    highest_arcade_bankroll = GREATEST(COALESCE(highest_arcade_bankroll, 1000), v_bankroll),
     arcade_win_streak = v_arcade_streak,
     highest_arcade_streak = COALESCE(v_highest_arcade_streak, highest_arcade_streak, 0)
-  WHERE id = p_user_id;
+  WHERE id = v_uid;
 
   INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode)
-  VALUES (p_user_id, NOW(), p_won, p_bankroll_left, 'arcade');
+  VALUES (v_uid, NOW(), p_won, v_bankroll, 'arcade');
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- 5c. RPC: Persist the caller's arcade bankroll between/within games (replaces the old
+-- direct client UPDATE of profiles.arcade_bankroll, which let any client write any value to
+-- any column). Identity comes from auth.uid(); bankroll is clamped.
+CREATE OR REPLACE FUNCTION public.save_arcade_bankroll(p_bankroll INT)
+RETURNS void AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_bankroll INT;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'save_arcade_bankroll: not authenticated';
+  END IF;
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll, 0), 0), 100000000);
+  UPDATE public.profiles SET
+    arcade_bankroll = v_bankroll,
+    highest_arcade_bankroll = GREATEST(COALESCE(highest_arcade_bankroll, 1000), v_bankroll)
+  WHERE id = v_uid;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
@@ -554,7 +619,8 @@ BEGIN
       v_start := date_trunc('day', CURRENT_DATE) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '1 day';
     WHEN 'weekly' THEN
-      v_start := (date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMPTZ;
+      -- Tuesday-keyed league week, interpreted in UTC to match game_results.played_at
+      v_start := ((date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMP) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '7 days';
     WHEN 'monthly' THEN
       v_start := date_trunc('month', CURRENT_DATE) AT TIME ZONE 'UTC';
@@ -563,7 +629,7 @@ BEGIN
       v_start := date_trunc('year', CURRENT_DATE) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '1 year';
     ELSE
-      v_start := (date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMPTZ;
+      v_start := ((date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMP) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '7 days';
   END CASE;
 

--- a/supabase-security-hardening.sql
+++ b/supabase-security-hardening.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- WordBank: Security hardening for the leaderboard economy
+-- Run in Supabase SQL Editor AFTER supabase-daily-leaderboard.sql
+-- ============================================================
+--
+-- Problem this fixes:
+--   The game economy (bankroll, streaks, wins) is computed in the browser and was
+--   written to the database either by direct table writes or by SECURITY DEFINER RPCs
+--   that trusted a client-supplied user id and value. Because the anon key ships in the
+--   client bundle, ANY visitor could:
+--     - call record_daily_result / record_arcade_result with any user id + any bankroll,
+--     - directly INSERT fake rows into game_results (the leaderboard source),
+--     - directly UPDATE their own profiles.arcade_bankroll to any value,
+--     - pre-seed daily_puzzle_schedule.
+--
+-- Fix strategy:
+--   1. All economy writes now go through SECURITY DEFINER RPCs that use auth.uid()
+--      (see supabase-daily-leaderboard.sql) and clamp/validate inputs.
+--   2. Revoke direct write privileges on the underlying tables from the client roles
+--      (anon, authenticated) so the RPCs are the ONLY write path. The RPCs run as the
+--      function owner and are unaffected by these REVOKEs.
+--   3. Drop the now-misleading permissive write policies.
+--
+-- SELECT stays open where leaderboards/UI need it; only writes are locked down.
+
+-- ---- profiles -------------------------------------------------------------
+-- Clients may still INSERT their own row (creation fallback) and SELECT for the UI,
+-- but may NOT UPDATE/DELETE: bankroll & stats are written only by the SECURITY DEFINER RPCs.
+REVOKE UPDATE, DELETE ON public.profiles FROM anon, authenticated;
+-- Existing permissive UPDATE policy (confirmed present in prod) — the direct bankroll-write hole.
+DROP POLICY IF EXISTS "Update own profile" ON public.profiles;
+
+-- ---- game_results (leaderboard source of truth) ---------------------------
+-- No direct client writes at all; only record_daily_result / record_arcade_result insert.
+REVOKE INSERT, UPDATE, DELETE ON public.game_results FROM anon, authenticated;
+DROP POLICY IF EXISTS "Users can insert own game results" ON public.game_results;
+
+-- ---- user_weekly_stats ----------------------------------------------------
+-- Written only by record_daily_result. Reads stay open for the weekly leaderboard.
+REVOKE INSERT, UPDATE, DELETE ON public.user_weekly_stats FROM anon, authenticated;
+DROP POLICY IF EXISTS "Users can insert own weekly stats" ON public.user_weekly_stats;
+DROP POLICY IF EXISTS "Users can update own weekly stats" ON public.user_weekly_stats;
+
+-- ---- daily_puzzle_schedule ------------------------------------------------
+-- Assigned only by get_todays_puzzle (SECURITY DEFINER). No client inserts.
+REVOKE INSERT, UPDATE, DELETE ON public.daily_puzzle_schedule FROM anon, authenticated;
+DROP POLICY IF EXISTS "Service can insert daily puzzle schedule" ON public.daily_puzzle_schedule;
+
+-- ---- Ensure the RPCs are callable by signed-in users ----------------------
+GRANT EXECUTE ON FUNCTION public.record_daily_result(UUID, BOOLEAN, INT)  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.record_arcade_result(UUID, BOOLEAN, INT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.save_arcade_bankroll(INT)               TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_daily_status(UUID)                  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.has_played_daily_today(UUID)            TO authenticated;


### PR DESCRIPTION
## Summary
The game economy (bankroll, streaks, wins) was fully **client-trusted** and written via SECURITY DEFINER RPCs that accepted an arbitrary client-supplied user id and value. Because the anon key ships in the client bundle, any visitor could top the leaderboards, write to other users' rows, or directly insert fake results. This PR makes scoring server-authoritative and fixes several correctness bugs surfaced during review.

## Security
- `record_daily_result` / `record_arcade_result` / `get_daily_status` / `has_played_daily_today` now derive identity from **`auth.uid()`** instead of a client-supplied id → closes impersonation / writing other users' rows.
- Daily bankroll **clamped to [0, 1000]**; arcade clamped non-negative.
- Daily result **enforced one-per-day server-side** (the client button-disable is not trustworthy).
- New **`save_arcade_bankroll`** RPC replaces direct client `UPDATE`s of `profiles.arcade_bankroll`; all client bankroll writes route through it.
- `supabase-security-hardening.sql` (new) **REVOKE**s direct client writes on `profiles` / `game_results` / `user_weekly_stats` / `daily_puzzle_schedule` and drops the permissive write policies.

## Correctness
- Fix first-win daily **streak bug** (NULL `last_daily_win_date`) via `IS DISTINCT FROM`.
- Make weekly leaderboard windows **UTC-consistent** with `game_results.played_at`.

## Client
- `statsStore`: add `saveArcadeBankroll`; `GameStore`/`+page` route bankroll writes through it.
- `userStore`: replace upsert-based `saveUserProfile` with insert-only `ensureProfileExists`; remove dead `saveDailyStats` (wrote to a non-existent table).
- Fix `hasOwnProperty` lint bug (`Object.hasOwn`); remove dead vars; add eslint `^_` ignore pattern.
- Passes `build`, `check`, and `lint`.

## Deploy ordering ⚠️
The **backward-compatible function migrations are already applied to prod** (they don't break the old frontend). The **REVOKE hardening (`supabase-security-hardening.sql`) must be run only after this PR is deployed to production**, because it removes the direct `profiles` UPDATE path the old code relies on.

1. Merge + deploy this PR to production.
2. Run `supabase-security-hardening.sql` against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)