### PR TITLE
Server-authoritative daily mode (trustless competitive leaderboard)

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -6,6 +6,7 @@ import confetti from 'canvas-confetti';
 import { user } from '$lib/stores/userStore.js';
 import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
 import { recordDailyResult, recordArcadeResult, saveArcadeBankroll } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyBuyLetter, dailyBuyHint, dailyBuyGuess, dailySubmitGuess } from '$lib/stores/statsStore.js';
 
 /* ================================
    Types (JSDoc for checkJs)
@@ -83,6 +84,125 @@ function launchConfetti() {
     scalar: 1.2,
     origin: { y: 0.6 }
   });
+}
+
+/* ================================
+   Server-authoritative DAILY adapter
+
+   For daily mode the puzzle answer never reaches the client. These helpers call
+   the server RPCs and reconcile the existing gameStore shape from the masked
+   board they return, so the UI (PhraseDisplay/Keyboard/GameButtons) is unchanged.
+   The local currentPhrase is a MASK: real letters at revealed positions, '#' at
+   unrevealed letter positions, real spaces between words.
+=================================== */
+
+// Guards against double-submits while a daily RPC is in flight.
+let dailyInFlight = false;
+
+/**
+ * reconcileDailyBoard
+ * Rebuild gameStore from a server board view. The answer is only present once
+ * the game is finished (board.phrase), so during play currentPhrase stays masked.
+ *
+ * @param {any} board - board JSON returned by a daily_* RPC
+ */
+function reconcileDailyBoard(board) {
+  if (!board) return;
+  const prev = get(gameStore);
+
+  /** @type {number[]} */
+  const wordLengths = board.word_lengths || [];
+  // Masked phrase: '#' per letter slot, single space between words.
+  const chars = wordLengths.map((/** @type {number} */ len) => '#'.repeat(len)).join(' ').split('');
+
+  /** @type {Record<string, string>} */
+  const revealed = board.revealed || {};
+  /** @type {string[]} */
+  const purchased = [];
+  /** @type {number[]} */
+  const newlyRevealed = [];
+  for (const [k, v] of Object.entries(revealed)) {
+    const i = Number(k);
+    chars[i] = /** @type {string} */ (v);
+    purchased[i] = /** @type {string} */ (v);
+    if (prev.purchasedLetters?.[i] !== v) newlyRevealed.push(i);
+  }
+
+  const finished = board.state !== 'active';
+  const currentPhrase = finished && board.phrase
+    ? String(board.phrase).toUpperCase()
+    : chars.join('');
+
+  /** @type {Record<string, boolean>} */
+  const lockedLetters = {};
+  (board.locked_letters || []).forEach((/** @type {string} */ l) => { lockedLetters[l] = true; });
+
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev,
+    bankroll: board.bankroll,
+    guessesRemaining: board.guesses_remaining,
+    category: board.category ?? prev.category,
+    subcategory: board.subcategory ?? '',
+    currentPhrase,
+    gameMode: 'daily',
+    gameState: finished ? board.state : 'default',
+    purchasedLetters: purchased,
+    guessedLetters: {},
+    lockedLetters,
+    incorrectLetters: board.incorrect_letters || [],
+    selectedPurchase: null,
+    shakenLetters: newlyRevealed,
+    wagerAmount: 0,
+    message: ''
+  }));
+
+  if (board.state === 'won') {
+    setTimeout(() => launchConfetti(), 300);
+  }
+}
+
+/**
+ * confirmPurchaseDaily
+ * Commit a pending letter/hint/extra-guess purchase via the server.
+ * @param {GameState} state
+ */
+async function confirmPurchaseDaily(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    let board = null;
+    if (purchase.type === 'letter') board = await dailyBuyLetter(purchase.value ?? '');
+    else if (purchase.type === 'hint') board = await dailyBuyHint();
+    else if (purchase.type === 'extra_guess') board = await dailyBuyGuess();
+
+    if (board) reconcileDailyBoard(board);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/**
+ * submitGuessDaily
+ * Send the filled blanks to the server, which reveals correct letters and
+ * decides win/loss. Daily wager is 0, so bankroll is unaffected by a guess.
+ * @param {GameState} state
+ */
+async function submitGuessDaily(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+
+  dailyInFlight = true;
+  try {
+    const board = await dailySubmitGuess(guess);
+    if (board) reconcileDailyBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
 }
 
 /**
@@ -254,6 +374,13 @@ export function setWager(amount) {
  * Handles purchase of a letter or hint and updates game state.
  */
 export function confirmPurchase() {
+  // Daily is server-authoritative: commit the purchase via RPC and reconcile.
+  const current = get(gameStore);
+  if (current.gameMode === 'daily') {
+    confirmPurchaseDaily(current);
+    return;
+  }
+
   let finalState;
 
   gameStore.update(/** @param {GameState} state */ (state) => {
@@ -509,6 +636,13 @@ export function deleteGuessLetter() {
  * syncs to Supabase, and hides wager slider.
  */
 export function submitGuess() {
+  // Daily is server-authoritative: the server validates the guess and scores it.
+  const current = get(gameStore);
+  if (current.gameMode === 'daily') {
+    submitGuessDaily(current);
+    return;
+  }
+
   gameStore.update(/** @param {GameState} state */ (state) => {
     if (state.gameState !== "guess_mode") return state;
     const guessesLeft = state.guessesRemaining ?? 2;
@@ -691,44 +825,22 @@ export async function fetchRandomGame(category) {
 }
 
 /**
- * fetchDailyGame - Fetches today's daily puzzle (same for everyone). Always starts with $1000.
+ * fetchDailyGame - Starts or resumes today's server-authoritative daily session.
+ * The phrase is held server-side; the client only ever receives a masked board.
+ * No localStorage: the server is the source of truth (and prevents replays).
  */
 export async function fetchDailyGame() {
   try {
-    const { data, error } = await supabase.rpc('get_todays_puzzle').maybeSingle();
-    if (error || !data) {
-      console.error('❌ Error fetching daily puzzle:', error);
+    const board = await dailyStart();
+    if (!board) {
+      console.error('❌ daily_start returned no board');
       return false;
     }
-
-    /** @type {{ category?: string, phrase?: string, subcategory?: string }} */
-    const puzzle = data;
-
-    const newState = /** @type {GameState} */ ({
-      ...get(gameStore),
-      bankroll: 1000,
-      wagerAmount: 1,
-      guessesRemaining: 2,
-      category: puzzle.category ?? '',
-      currentPhrase: (puzzle.phrase ?? '').toUpperCase(),
-      gameState: 'default',
-      gameMode: 'daily',
-      subcategory: puzzle.subcategory ?? '',
-      purchasedLetters: [],
-      guessedLetters: {},
-      lockedLetters: {},
-      incorrectLetters: [],
-      selectedPurchase: null,
-      shakenLetters: [],
-      message: ''
-    });
-
-    gameStore.set(newState);
-    saveGameToLocalStorage();
-    console.log(`✅ Daily puzzle loaded: "${puzzle.phrase}"`);
+    reconcileDailyBoard(board);
+    console.log('✅ Daily session started/resumed');
     return true;
   } catch (err) {
-    console.error('❌ Error fetching daily puzzle:', err instanceof Error ? err.message : String(err));
+    console.error('❌ Error starting daily game:', err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -106,6 +106,54 @@ export async function recordArcadeResult(userId, won, bankrollLeft) {
   }
 }
 
+/* ============================================================
+   Server-authoritative DAILY mode (the answer never reaches the client).
+   Each call returns a masked board:
+   { state, bankroll, guesses_remaining, category, subcategory,
+     word_lengths[], revealed{pos:letter}, incorrect_letters[],
+     locked_letters[], phrase|null }
+   phrase is null until the game is over.
+============================================================ */
+
+/** Start or resume today's daily session. @returns {Promise<object|null>} board */
+export async function dailyStart() {
+  const { data, error } = await supabase.rpc('daily_start');
+  if (error) { console.error('❌ daily_start error:', error); return null; }
+  return data;
+}
+
+/** Buy a letter. @param {string} letter @returns {Promise<object|null>} board */
+export async function dailyBuyLetter(letter) {
+  const { data, error } = await supabase.rpc('daily_buy_letter', { p_letter: letter });
+  if (error) { console.error('❌ daily_buy_letter error:', error); return null; }
+  return data;
+}
+
+/** Buy a hint ($150). @returns {Promise<object|null>} board */
+export async function dailyBuyHint() {
+  const { data, error } = await supabase.rpc('daily_buy_hint');
+  if (error) { console.error('❌ daily_buy_hint error:', error); return null; }
+  return data;
+}
+
+/** Buy an extra guess ($150). @returns {Promise<object|null>} board */
+export async function dailyBuyGuess() {
+  const { data, error } = await supabase.rpc('daily_buy_guess');
+  if (error) { console.error('❌ daily_buy_guess error:', error); return null; }
+  return data;
+}
+
+/**
+ * Submit a full guess.
+ * @param {Record<string, string>} guess - map of absolute position -> guessed letter
+ * @returns {Promise<object|null>} board
+ */
+export async function dailySubmitGuess(guess) {
+  const { data, error } = await supabase.rpc('daily_submit_guess', { p_guess: guess });
+  if (error) { console.error('❌ daily_submit_guess error:', error); return null; }
+  return data;
+}
+
 /**
  * Persist the caller's arcade bankroll between/within games.
  * Goes through a SECURITY DEFINER RPC (auth.uid() + clamp) instead of writing the

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -99,7 +99,9 @@
       }
 
       const peek = getSavedGameInfo(session.user.id);
-      const inProgress = peek && peek.gameState !== 'won' && peek.gameState !== 'lost';
+      // Daily is now server-resumed (daily_start); only arcade resumes from localStorage.
+      const arcadeSave = peek && peek.gameMode === 'arcade' ? peek : null;
+      const inProgress = arcadeSave && arcadeSave.gameState !== 'won' && arcadeSave.gameState !== 'lost';
 
       if (inProgress) {
         const restored = loadGameFromLocalStorage();
@@ -109,12 +111,12 @@
           console.log("🔁 Game restored from localStorage");
         } else {
           showMainMenu = true;
-          savedGameInfo = peek;
+          savedGameInfo = arcadeSave;
           menuDailyPlayed = await hasPlayedDailyToday(session.user.id);
         }
       } else {
         showMainMenu = true;
-        savedGameInfo = peek;
+        savedGameInfo = arcadeSave;
         menuDailyPlayed = await hasPlayedDailyToday(session.user.id);
         // If they just came from /select with a category, start arcade instead of showing menu
         const mode = localStorage.getItem('gameMode');
@@ -222,16 +224,12 @@
   async function handleMenuDaily() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
-    if (savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost') {
-      loadGameFromLocalStorage();
-      gameWasRestored.set(true);
-      showMainMenu = false;
-      return;
-    }
+    // Finished today's daily already -> show streak message (server enforces one/day).
     if (menuDailyPlayed) {
       showStreakMessage = true;
       return;
     }
+    // daily_start resumes an in-progress session or begins a fresh one, server-side.
     localStorage.setItem('gameMode', 'daily');
     const ok = await fetchDailyGame();
     if (ok) {

--- a/supabase-daily-server-authoritative.sql
+++ b/supabase-daily-server-authoritative.sql
@@ -1,0 +1,465 @@
+-- ============================================================
+-- WordBank: Server-authoritative DAILY mode
+-- Run in Supabase SQL Editor AFTER the other migrations.
+-- ============================================================
+--
+-- Goal: the daily puzzle answer NEVER reaches the client. All scoring
+-- (buying letters/hints/guesses, submitting a guess, win/loss, final bankroll)
+-- is computed server-side from a per-user, per-day session row. The client is a
+-- thin renderer that only ever sees revealed positions + board shape.
+--
+-- This makes the marketed competitive DAILY leaderboard trustless: a client can
+-- no longer fabricate a bankroll or a win, because it never holds the phrase and
+-- never writes the score.
+--
+-- Arcade mode is intentionally left client-side/casual and is unaffected.
+
+-- ---- Per-day session state (server source of truth) -----------------------
+CREATE TABLE IF NOT EXISTS public.daily_sessions (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  puzzle_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  puzzle_id UUID NOT NULL REFERENCES public.daily_puzzles(id) ON DELETE RESTRICT,
+  bankroll INT NOT NULL DEFAULT 1000,
+  guesses_remaining INT NOT NULL DEFAULT 2,
+  revealed_positions INT[] NOT NULL DEFAULT '{}',   -- 0-indexed positions revealed so far
+  incorrect_letters TEXT[] NOT NULL DEFAULT '{}',   -- letters bought that aren't in the phrase
+  state TEXT NOT NULL DEFAULT 'active',              -- 'active' | 'won' | 'lost'
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  finished_at TIMESTAMPTZ,                           -- audit hook for future abuse analysis
+  PRIMARY KEY (user_id, puzzle_date)
+);
+
+ALTER TABLE public.daily_sessions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "read own daily session" ON public.daily_sessions;
+CREATE POLICY "read own daily session" ON public.daily_sessions
+  FOR SELECT USING (auth.uid() = user_id);
+-- No client write policies: only the SECURITY DEFINER RPCs below mutate sessions.
+REVOKE INSERT, UPDATE, DELETE ON public.daily_sessions FROM anon, authenticated;
+
+-- ---- Letter costs live on the server (client can't be the pricing source) --
+CREATE OR REPLACE FUNCTION public.letter_cost(p_letter TEXT)
+RETURNS INT LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE upper(p_letter)
+    WHEN 'Q' THEN 30  WHEN 'W' THEN 50  WHEN 'E' THEN 140 WHEN 'R' THEN 120
+    WHEN 'T' THEN 120 WHEN 'Y' THEN 60  WHEN 'U' THEN 80  WHEN 'I' THEN 110
+    WHEN 'O' THEN 90  WHEN 'P' THEN 80  WHEN 'A' THEN 130 WHEN 'S' THEN 120
+    WHEN 'D' THEN 80  WHEN 'F' THEN 60  WHEN 'G' THEN 70  WHEN 'H' THEN 70
+    WHEN 'J' THEN 30  WHEN 'K' THEN 50  WHEN 'L' THEN 80  WHEN 'Z' THEN 40
+    WHEN 'X' THEN 40  WHEN 'C' THEN 80  WHEN 'V' THEN 50  WHEN 'B' THEN 60
+    WHEN 'N' THEN 100 WHEN 'M' THEN 70  ELSE NULL END;
+$$;
+
+-- ---- Ensure today's puzzle is assigned and return its id ------------------
+CREATE OR REPLACE FUNCTION public._todays_puzzle_id()
+RETURNS UUID LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_pid UUID;
+BEGIN
+  -- First caller of the day assigns a not-yet-used puzzle deterministically; others no-op.
+  INSERT INTO public.daily_puzzle_schedule (scheduled_date, puzzle_id)
+  SELECT CURRENT_DATE, sub.pid FROM (
+    SELECT (
+      SELECT p2.id FROM public.daily_puzzles p2
+      WHERE p2.id NOT IN (SELECT puzzle_id FROM public.daily_puzzle_schedule)
+      ORDER BY md5(CURRENT_DATE::text || p2.id::text)
+      LIMIT 1
+    ) AS pid
+  ) sub
+  WHERE sub.pid IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM public.daily_puzzle_schedule WHERE scheduled_date = CURRENT_DATE)
+  ON CONFLICT (scheduled_date) DO NOTHING;
+
+  SELECT puzzle_id INTO v_pid
+  FROM public.daily_puzzle_schedule WHERE scheduled_date = CURRENT_DATE;
+  RETURN v_pid;
+END;
+$$;
+
+-- ---- Build the masked board view returned to the client -------------------
+-- Reveals letters ONLY for positions the player has earned; reveals the full
+-- phrase once the game is over (so the client can show the answer on win/loss).
+CREATE OR REPLACE FUNCTION public._daily_board(
+  p_phrase TEXT, p_state TEXT, p_bankroll INT, p_guesses INT,
+  p_revealed INT[], p_incorrect TEXT[], p_category TEXT, p_subcategory TEXT
+)
+RETURNS JSONB LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+  v_word_lengths INT[];
+  v_revealed JSONB := '{}'::jsonb;
+  v_finished BOOLEAN := (p_state <> 'active');
+  i INT;
+BEGIN
+  SELECT array_agg(length(x)) INTO v_word_lengths
+  FROM unnest(string_to_array(p_phrase, ' ')) AS x;
+
+  IF v_finished THEN
+    FOR i IN 0 .. length(p_phrase) - 1 LOOP
+      IF substr(p_phrase, i + 1, 1) <> ' ' THEN
+        v_revealed := v_revealed || jsonb_build_object(i::text, substr(p_phrase, i + 1, 1));
+      END IF;
+    END LOOP;
+  ELSIF p_revealed IS NOT NULL THEN
+    FOREACH i IN ARRAY p_revealed LOOP
+      v_revealed := v_revealed || jsonb_build_object(i::text, substr(p_phrase, i + 1, 1));
+    END LOOP;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'state', p_state,
+    'bankroll', p_bankroll,
+    'guesses_remaining', p_guesses,
+    'category', p_category,
+    'subcategory', COALESCE(p_subcategory, ''),
+    'word_lengths', to_jsonb(COALESCE(v_word_lengths, '{}'::int[])),
+    'revealed', v_revealed,
+    'incorrect_letters', to_jsonb(COALESCE(p_incorrect, '{}'::text[])),
+    'phrase', CASE WHEN v_finished THEN p_phrase ELSE NULL END
+  );
+END;
+$$;
+
+-- ---- Finalize: write streak / profile / game_results / weekly stats --------
+-- Server-computed bankroll only; clamped to the legitimate daily range [0,1000].
+CREATE OR REPLACE FUNCTION public._finalize_daily(p_uid UUID, p_won BOOLEAN, p_bankroll INT)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_week_start DATE;
+  v_current_streak INT;
+  v_highest_streak INT;
+  v_last_win DATE;
+  v_bankroll INT;
+BEGIN
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll, 0), 0), 1000);
+  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1;
+
+  SELECT current_win_streak, highest_win_streak, last_daily_win_date
+  INTO v_current_streak, v_highest_streak, v_last_win
+  FROM public.profiles WHERE id = p_uid;
+
+  IF p_won THEN
+    IF v_last_win = CURRENT_DATE - 1 THEN
+      v_current_streak := COALESCE(v_current_streak, 0) + 1;
+    ELSIF v_last_win IS DISTINCT FROM CURRENT_DATE THEN
+      v_current_streak := 1;
+    END IF;
+    v_highest_streak := GREATEST(COALESCE(v_highest_streak, 0), v_current_streak);
+    UPDATE public.profiles SET
+      current_win_streak = v_current_streak,
+      highest_win_streak = v_highest_streak,
+      last_daily_win_date = CURRENT_DATE,
+      last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll,
+      last_daily_won = true
+    WHERE id = p_uid;
+  ELSE
+    v_current_streak := 0;
+    UPDATE public.profiles SET
+      current_win_streak = 0,
+      last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll,
+      last_daily_won = false
+    WHERE id = p_uid;
+  END IF;
+
+  INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode)
+  VALUES (p_uid, NOW(), p_won, v_bankroll, 'daily');
+
+  INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
+  VALUES (
+    p_uid, v_week_start,
+    CASE WHEN p_won THEN 1 ELSE 0 END,
+    CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    v_bankroll,
+    CASE WHEN p_won THEN 1 ELSE 0 END,
+    1,
+    COALESCE(v_current_streak, 0)
+  )
+  ON CONFLICT (user_id, week_start) DO UPDATE SET
+    total_played = user_weekly_stats.total_played + 1,
+    total_wins = user_weekly_stats.total_wins + CASE WHEN p_won THEN 1 ELSE 0 END,
+    puzzles_completed = user_weekly_stats.puzzles_completed + CASE WHEN p_won THEN 1 ELSE 0 END,
+    bankroll_earned = user_weekly_stats.bankroll_earned + CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, v_bankroll),
+    win_streak = GREATEST(user_weekly_stats.win_streak, v_current_streak);
+END;
+$$;
+
+-- ---- Internal: recompute win/loss + persist + finalize, return board ------
+CREATE OR REPLACE FUNCTION public._daily_resolve_and_return(p_uid UUID, p_phrase TEXT, p_cat TEXT, p_sub TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  s public.daily_sessions;
+  v_won BOOLEAN;
+  v_lost BOOLEAN;
+BEGIN
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+
+  -- Win = every non-space position revealed.
+  v_won := NOT EXISTS (
+    SELECT 1 FROM generate_series(0, length(p_phrase) - 1) g(i)
+    WHERE substr(p_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
+  );
+  -- Loss = broke, or out of guesses and can't afford another ($150). Mirrors original game.
+  v_lost := (s.bankroll < 1) OR (s.guesses_remaining <= 0 AND s.bankroll < 150);
+
+  IF v_won THEN
+    s.state := 'won';
+  ELSIF v_lost THEN
+    s.state := 'lost';
+  END IF;
+
+  UPDATE public.daily_sessions SET
+    bankroll = s.bankroll,
+    guesses_remaining = s.guesses_remaining,
+    revealed_positions = s.revealed_positions,
+    incorrect_letters = s.incorrect_letters,
+    state = s.state,
+    updated_at = NOW(),
+    finished_at = CASE WHEN s.state <> 'active' AND finished_at IS NULL THEN NOW() ELSE finished_at END
+  WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+
+  IF s.state <> 'active' THEN
+    PERFORM public._finalize_daily(p_uid, s.state = 'won', s.bankroll);
+  END IF;
+
+  RETURN public._daily_board(p_phrase, s.state, s.bankroll, s.guesses_remaining,
+                             s.revealed_positions, s.incorrect_letters, p_cat, p_sub);
+END;
+$$;
+
+-- ===================== Public RPCs (client entry points) ====================
+
+-- Start or resume today's session; returns the masked board.
+CREATE OR REPLACE FUNCTION public.daily_start()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_pid UUID;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  s public.daily_sessions;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_start: not authenticated'; END IF;
+
+  v_pid := public._todays_puzzle_id();
+
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
+    INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining)
+    VALUES (v_uid, CURRENT_DATE, v_pid, 1000, 2)
+    RETURNING * INTO s;
+  END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                             s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+END;
+$$;
+
+-- Buy a letter: reveal all matching positions, or mark incorrect. Server debits.
+CREATE OR REPLACE FUNCTION public.daily_buy_letter(p_letter TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  v_letter TEXT; v_cost INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter);
+  v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'daily_buy_letter: invalid letter'; END IF;
+
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_letter: no active session (call daily_start)'; END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  -- No-ops (return current board unchanged): finished, already incorrect, or can't afford.
+  IF s.state <> 'active'
+     OR v_letter = ANY(s.incorrect_letters)
+     OR s.bankroll < v_cost THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  SELECT array_agg(g.i) INTO v_positions
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+
+  -- Letter already fully revealed -> treat as no-op (don't double-charge).
+  IF v_positions IS NOT NULL AND v_positions <@ s.revealed_positions THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  s.bankroll := s.bankroll - v_cost;
+  IF v_positions IS NULL THEN
+    s.incorrect_letters := array_append(s.incorrect_letters, v_letter);
+  ELSE
+    s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || v_positions) ORDER BY 1);
+  END IF;
+
+  UPDATE public.daily_sessions SET
+    bankroll = s.bankroll, incorrect_letters = s.incorrect_letters,
+    revealed_positions = s.revealed_positions, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$$;
+
+-- Buy a hint ($150): reveal one random unrevealed position.
+CREATE OR REPLACE FUNCTION public.daily_buy_hint()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  v_pos INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_buy_hint: not authenticated'; END IF;
+
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_hint: no active session'; END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  SELECT g.i INTO v_pos
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
+  ORDER BY md5(random()::text) LIMIT 1;
+
+  IF s.state <> 'active' OR s.bankroll < 150 OR v_pos IS NULL THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  s.bankroll := s.bankroll - 150;
+  s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || ARRAY[v_pos]) ORDER BY 1);
+
+  UPDATE public.daily_sessions SET
+    bankroll = s.bankroll, revealed_positions = s.revealed_positions, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$$;
+
+-- Buy an extra guess ($150): +1 guess.
+CREATE OR REPLACE FUNCTION public.daily_buy_guess()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_buy_guess: not authenticated'; END IF;
+
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_guess: no active session'; END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  IF s.state <> 'active' OR s.bankroll < 150 THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  s.bankroll := s.bankroll - 150;
+  s.guesses_remaining := s.guesses_remaining + 1;
+
+  UPDATE public.daily_sessions SET
+    bankroll = s.bankroll, guesses_remaining = s.guesses_remaining, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$$;
+
+-- Submit a full guess. p_guess maps position (text key) -> guessed letter, for
+-- every currently-unrevealed non-space position. Server reveals only correct ones.
+-- Daily wager is 0, so bankroll is unchanged; a wrong/partial guess costs one guess.
+CREATE OR REPLACE FUNCTION public.daily_submit_guess(p_guess JSONB)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  v_editable INT[];
+  v_correct INT[] := '{}';
+  v_all_correct BOOLEAN := true;
+  pos INT;
+  v_guess_char TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_submit_guess: not authenticated'; END IF;
+
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_submit_guess: no active session'; END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  IF s.state <> 'active' OR s.guesses_remaining <= 0 THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  -- The set of positions the player must fill.
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions));
+
+  -- Require a complete guess (a value for every editable position); else no-op.
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable, 1) THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_guess_char := upper(p_guess ->> pos::text);
+    IF v_guess_char IS NULL THEN
+      v_all_correct := false;            -- missing slot
+    ELSIF v_guess_char = substr(v_phrase, pos + 1, 1) THEN
+      v_correct := v_correct || pos;     -- correct: reveal it
+    ELSE
+      v_all_correct := false;            -- wrong
+    END IF;
+  END LOOP;
+
+  IF array_length(v_correct, 1) > 0 THEN
+    s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || v_correct) ORDER BY 1);
+  END IF;
+
+  -- A non-winning guess consumes one guess.
+  IF NOT v_all_correct THEN
+    s.guesses_remaining := GREATEST(0, s.guesses_remaining - 1);
+  END IF;
+
+  UPDATE public.daily_sessions SET
+    revealed_positions = s.revealed_positions, guesses_remaining = s.guesses_remaining, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$$;
+
+-- ---- Grants: signed-in users may call the public RPCs only -----------------
+GRANT EXECUTE ON FUNCTION public.daily_start()                 TO authenticated;
+GRANT EXECUTE ON FUNCTION public.daily_buy_letter(TEXT)        TO authenticated;
+GRANT EXECUTE ON FUNCTION public.daily_buy_hint()              TO authenticated;
+GRANT EXECUTE ON FUNCTION public.daily_buy_guess()             TO authenticated;
+GRANT EXECUTE ON FUNCTION public.daily_submit_guess(JSONB)     TO authenticated;
+-- Internal helpers are not granted to clients (called only via SECURITY DEFINER RPCs).
+REVOKE EXECUTE ON FUNCTION public._todays_puzzle_id()                         FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public._finalize_daily(UUID, BOOLEAN, INT)         FROM anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public._daily_resolve_and_return(UUID, TEXT, TEXT, TEXT) FROM anon, authenticated;

--- a/supabase-daily-server-authoritative.sql
+++ b/supabase-daily-server-authoritative.sql
@@ -87,6 +87,7 @@ DECLARE
   v_word_lengths INT[];
   v_revealed JSONB := '{}'::jsonb;
   v_finished BOOLEAN := (p_state <> 'active');
+  v_locked TEXT[];
   i INT;
 BEGIN
   SELECT array_agg(length(x)) INTO v_word_lengths
@@ -104,6 +105,19 @@ BEGIN
     END LOOP;
   END IF;
 
+  -- Letters whose EVERY occurrence is revealed (safe to surface: reveals nothing hidden).
+  -- Lets the keyboard green-out fully-solved letters without the client knowing the answer.
+  SELECT array_agg(t.ch ORDER BY t.ch) INTO v_locked FROM (
+    SELECT chpos.ch
+    FROM (
+      SELECT substr(p_phrase, g.i + 1, 1) AS ch, g.i AS pos
+      FROM generate_series(0, length(p_phrase) - 1) g(i)
+      WHERE substr(p_phrase, g.i + 1, 1) <> ' '
+    ) chpos
+    GROUP BY chpos.ch
+    HAVING bool_and(v_finished OR (chpos.pos = ANY(p_revealed)))
+  ) t;
+
   RETURN jsonb_build_object(
     'state', p_state,
     'bankroll', p_bankroll,
@@ -113,6 +127,7 @@ BEGIN
     'word_lengths', to_jsonb(COALESCE(v_word_lengths, '{}'::int[])),
     'revealed', v_revealed,
     'incorrect_letters', to_jsonb(COALESCE(p_incorrect, '{}'::text[])),
+    'locked_letters', to_jsonb(COALESCE(v_locked, '{}'::text[])),
     'phrase', CASE WHEN v_finished THEN p_phrase ELSE NULL END
   );
 END;

--- a/supabase-schema-base.sql
+++ b/supabase-schema-base.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- WordBank: Base schema (run FIRST on a fresh database)
+-- ============================================================
+--
+-- The `profiles` base table was originally created in the Supabase dashboard and
+-- was never version-controlled, so the other migration files (which only ALTER /
+-- reference profiles) fail on a fresh database with:
+--   ERROR: relation "public.profiles" does not exist (SQLSTATE 42P01)
+--
+-- This file defines profiles exactly as it exists in production so the full set of
+-- migrations is reproducible from scratch.
+--
+-- RUN ORDER on a fresh project:
+--   1. supabase-schema-base.sql            (this file)
+--   2. supabase-create-profile-trigger.sql
+--   3. supabase-daily-leaderboard.sql
+--   4. supabase-daily-server-authoritative.sql
+--   5. supabase-security-hardening.sql     (REVOKEs — must be last)
+--
+-- On an EXISTING database that already has profiles, this file is a safe no-op
+-- (every statement is IF NOT EXISTS / ADD COLUMN IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS public.profiles (
+  id UUID NOT NULL DEFAULT auth.uid()
+    REFERENCES auth.users(id) ON DELETE CASCADE,
+  current_bankroll INT NOT NULL DEFAULT 1000,
+  total_games_played INT DEFAULT 0,
+  total_games_won INT DEFAULT 0,
+  total_games_lost INT DEFAULT 0,
+  highest_daily_bankroll INT DEFAULT 0,
+  total_puzzles_correct INT DEFAULT 0,
+  total_puzzles_incorrect INT DEFAULT 0,
+  total_cash_accrued INT DEFAULT 0,
+  total_cash_spent INT DEFAULT 0,
+  most_puzzles_in_one_day INT DEFAULT 0,
+  current_win_streak INT DEFAULT 0,
+  highest_win_streak INT DEFAULT 0,
+  last_daily_win_date DATE,
+  last_daily_play_date DATE,
+  daily_bankroll INT DEFAULT 0,
+  last_daily_won BOOLEAN,
+  arcade_bankroll INT DEFAULT 1000,
+  highest_arcade_bankroll INT DEFAULT 1000,
+  arcade_win_streak INT DEFAULT 0,
+  highest_arcade_streak INT DEFAULT 0,
+  CONSTRAINT profiles_pkey PRIMARY KEY (id)
+);
+
+-- RLS is enabled and policies are defined in supabase-create-profile-trigger.sql.


### PR DESCRIPTION
## Summary
Makes the **daily** puzzle server-authoritative so the marketed competitive leaderboard is trustless: the puzzle answer never reaches the browser, and the client cannot fabricate a bankroll or a win. Builds on the hardening from #62. **Arcade mode is untouched** (intentionally casual/client-side).

## How it works
- New `daily_sessions` table holds per-user/per-day state (bankroll, guesses, revealed positions). RLS: read-own; **no client writes** — only `SECURITY DEFINER` RPCs mutate it.
- Letter costs and all scoring live server-side. RPCs (identity from `auth.uid()`): `daily_start`, `daily_buy_letter`, `daily_buy_hint`, `daily_buy_guess`, `daily_submit_guess`.
- Each RPC returns a **masked board** — word shape + earned letters only; the full phrase is returned **only after the game is over**. Verified: an active board returns `phrase: null`.
- The server computes the final bankroll and finalizes streak / `game_results` / weekly stats — no client value is trusted.

## Client
- `GameStore` branches daily through the RPCs and reconciles the existing store shape from the masked board (real letters at revealed positions, `#` elsewhere), so `PhraseDisplay` / `Keyboard` / `GameButtons` are unchanged.
- Daily no longer uses `localStorage`; it resumes via `daily_start` (the server is the source of truth and enforces one-result-per-day). Arcade localStorage resume unchanged.
- `_daily_board` returns `locked_letters` so the keyboard can green-out solved letters without the client knowing the answer.
- Passes `check`, `lint`, `build`.

## Deploy / DB
The SQL (`supabase-daily-server-authoritative.sql`) is **already applied to prod** (additive: new table + new functions, nothing referenced them until this frontend ships). Merging + deploying this PR switches the daily client over to it.

## Verify after deploy
Play a daily on the live site: buy letters/hints, solve it, confirm bankroll/streak/leaderboard update — and confirm via dev tools that the network responses for an in-progress daily never contain the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)