### PR TITLE
Design overhaul: premium dark neon-arcade aesthetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright / design screenshots
+screenshots/
+test-results/
+playwright-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
 				"@eslint/js": "^9.18.0",
+				"@playwright/test": "^1.61.0",
 				"@sveltejs/adapter-auto": "^4.0.0",
 				"@sveltejs/adapter-vercel": "^5.6.2",
 				"@sveltejs/kit": "^2.16.0",
@@ -868,6 +869,22 @@
 			"optional": true,
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+			"integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -3231,6 +3248,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+			"integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.61.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+			"integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	"devDependencies": {
 		"@eslint/compat": "^1.2.5",
 		"@eslint/js": "^9.18.0",
+		"@playwright/test": "^1.61.0",
 		"@sveltejs/adapter-auto": "^4.0.0",
 		"@sveltejs/adapter-vercel": "^5.6.2",
 		"@sveltejs/kit": "^2.16.0",

--- a/scripts/measure.mjs
+++ b/scripts/measure.mjs
@@ -1,0 +1,73 @@
+// Measure the fixed bottom UI (keyboard / action buttons / wager bar) and screenshot
+// the game on mobile + desktop, in both daily and arcade(+wager) states.
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = process.env.PW_EMAIL || 'pwtest+wb@example.com';
+const PASS = process.env.PW_PASS || 'TestPass123!';
+mkdirSync('screenshots', { recursive: true });
+
+const viewports = [
+  { tag: 'mobile', width: 390, height: 844 },
+  { tag: 'desktop', width: 1440, height: 900 },
+];
+
+async function login(page) {
+  await page.goto(BASE, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(900);
+  if (await page.locator('input[type=password]').count()) {
+    await page.fill('input[type=email]', EMAIL).catch(() => {});
+    await page.fill('input[type=password]', PASS).catch(() => {});
+    await page.getByRole('button', { name: /log in/i }).first().click().catch(() => {});
+    await page.waitForTimeout(2600);
+    if (await page.locator('input[type=password]').count()) {
+      await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
+      await page.waitForTimeout(300);
+      await page.fill('input[type=email]', EMAIL).catch(() => {});
+      await page.fill('input[type=password]', PASS).catch(() => {});
+      await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
+      await page.waitForTimeout(2600);
+    }
+  }
+}
+
+async function boxes(page, vh) {
+  const sel = { keyboard: '.keyboard-container', buttons: '.main-button-wrapper', wager: '.wager-ui', solve: '.guess-phrase-button' };
+  const out = {};
+  for (const [k, s] of Object.entries(sel)) {
+    const el = page.locator(s).first();
+    if (await el.count()) {
+      const b = await el.boundingBox();
+      if (b) out[k] = { top: Math.round(b.y), bottom: Math.round(b.y + b.height), h: Math.round(b.height), gapBelow: Math.round(vh - (b.y + b.height)) };
+    }
+  }
+  return out;
+}
+
+for (const vp of viewports) {
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext({ viewport: { width: vp.width, height: vp.height }, deviceScaleFactor: 1 });
+  const page = await ctx.newPage();
+  await login(page);
+
+  // Daily
+  await page.getByRole('button', { name: /daily/i }).first().click().catch(() => {});
+  await page.waitForTimeout(2600);
+  await page.screenshot({ path: `screenshots/fix-${vp.tag}-daily.png` });
+  console.log(`\n[${vp.tag} ${vp.width}x${vp.height}] daily:`, JSON.stringify(await boxes(page, vp.height)));
+
+  // Arcade with wager bar — go through category select so the arcade game loads
+  await page.goto(`${BASE}/select/arcade`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1200);
+  await page.locator('.category-grid button').first().click().catch(() => {});
+  await page.waitForTimeout(3000);
+  // In arcade, clicking Solve reveals the wager UI
+  await page.locator('.guess-phrase-button').first().click({ force: true }).catch(() => {});
+  await page.waitForTimeout(1000);
+  await page.screenshot({ path: `screenshots/fix-${vp.tag}-arcade-wager.png` });
+  console.log(`[${vp.tag}] arcade+wager:`, JSON.stringify(await boxes(page, vp.height)));
+
+  await browser.close();
+}
+console.log('\ndone');

--- a/scripts/shoot-public.mjs
+++ b/scripts/shoot-public.mjs
@@ -1,0 +1,18 @@
+// Screenshot public-ish routes (no auth needed) for the redesign loop.
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+const BASE = process.env.BASE || 'http://localhost:5174';
+const TAG = process.env.TAG || 'pub';
+mkdirSync('screenshots', { recursive: true });
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const page = await ctx.newPage();
+const routes = [['select', '/select'], ['arcade', '/select/arcade'], ['reset', '/reset-password'], ['leaderboard', '/leaderboard']];
+for (const [name, path] of routes) {
+  await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle' });
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: `screenshots/${TAG}-${name}.png` });
+  console.log('shot', `${TAG}-${name}`);
+}
+await browser.close();
+console.log('done');

--- a/scripts/shoot.mjs
+++ b/scripts/shoot.mjs
@@ -1,0 +1,68 @@
+// Screenshot harness for the WordBank UI baseline/redesign loop.
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5174';
+const EMAIL = process.env.PW_EMAIL || 'pwtest+wb@example.com';
+const PASS = process.env.PW_PASS || 'TestPass123!';
+const TAG = process.env.TAG || 'base';
+mkdirSync('screenshots', { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const page = await ctx.newPage();
+page.on('console', (m) => { if (m.type() === 'error') console.log('  [console.error]', m.text().slice(0, 160)); });
+const shot = async (name) => { await page.screenshot({ path: `screenshots/${TAG}-${name}.png` }); console.log('shot', `${TAG}-${name}`); };
+const wait = (ms) => page.waitForTimeout(ms);
+
+await page.goto(BASE, { waitUntil: 'networkidle' });
+await wait(1000);
+if (await page.locator('input[type=password]').count()) {
+  await shot('01-login');
+  await page.fill('input[type=email]', EMAIL).catch(() => {});
+  await page.fill('input[type=password]', PASS).catch(() => {});
+  await page.getByRole('button', { name: /log in/i }).first().click().catch(() => {});
+  await wait(2800);
+  // If login failed (e.g. fresh DB / deleted test user), sign up instead.
+  if (await page.locator('input[type=password]').count()) {
+    await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); // toggle link
+    await wait(300);
+    await page.fill('input[type=email]', EMAIL).catch(() => {});
+    await page.fill('input[type=password]', PASS).catch(() => {});
+    await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); // submit
+    await wait(2800);
+  }
+}
+await wait(800);
+await shot('02-menu');
+
+// Daily board
+await page.getByRole('button', { name: /daily puzzle/i }).click().catch((e) => console.log('daily click', e.message));
+await wait(2500);
+await shot('03-daily-board');
+
+// Buy a letter: tap E, then confirm
+await page.locator('.key:has(.letter:text-is("E"))').first().click({ force: true }).catch((e) => console.log('key E', e.message));
+await wait(600);
+await shot('04-letter-pending');
+await page.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch((e) => console.log('confirm', e.message));
+await wait(1800);
+await shot('05-after-letter');
+
+// Enter guess mode (Solve), screenshot
+await page.getByRole('button', { name: /^solve$/i }).click({ force: true }).catch(() => {});
+await wait(800);
+await shot('06-guess-mode');
+
+// Leaderboard
+await page.goto(`${BASE}/leaderboard`, { waitUntil: 'networkidle' });
+await wait(2000);
+await shot('07-leaderboard');
+
+// Mode select
+await page.goto(`${BASE}/select`, { waitUntil: 'networkidle' });
+await wait(1500);
+await shot('08-select');
+
+await browser.close();
+console.log('done');

--- a/src/app.css
+++ b/src/app.css
@@ -1,0 +1,161 @@
+/* ============================================================
+   WordBank design system — premium dark neon-arcade aesthetic
+   Global tokens + base styles. Imported once in +layout.svelte.
+============================================================ */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  /* Brand */
+  --brand-1: #34d399;          /* emerald */
+  --brand-2: #a3e635;          /* lime */
+  --brand-grad: linear-gradient(135deg, #34d399 0%, #a3e635 100%);
+  --gold: #fbbf24;             /* money accent */
+  --gold-2: #f59e0b;
+  --danger: #fb5a5a;
+  --info: #38bdf8;
+
+  /* Surfaces (dark) */
+  --bg-0: #070b12;             /* page base */
+  --bg-1: #0c121d;
+  --surface: rgba(255, 255, 255, 0.045);
+  --surface-2: rgba(255, 255, 255, 0.08);
+  --surface-strong: rgba(20, 28, 42, 0.72);
+  --border: rgba(255, 255, 255, 0.09);
+  --border-strong: rgba(255, 255, 255, 0.16);
+
+  /* Text */
+  --text: #eaf0f7;
+  --text-muted: #93a0b4;
+  --text-faint: #5d6b80;
+
+  /* Radii */
+  --r-sm: 10px;
+  --r-md: 14px;
+  --r-lg: 20px;
+  --r-xl: 28px;
+  --r-pill: 999px;
+
+  /* Shadows / glow */
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.55);
+  --glow-brand: 0 0 0 1px rgba(163, 230, 53, 0.25), 0 8px 30px rgba(52, 211, 153, 0.28);
+  --glow-gold: 0 0 24px rgba(251, 191, 36, 0.35);
+
+  /* Type */
+  --font-display: 'Space Grotesk', system-ui, sans-serif;
+  --font-ui: 'Inter', system-ui, sans-serif;
+
+  /* Motion */
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: var(--font-ui);
+  color: var(--text);
+  background-color: var(--bg-0);
+  /* Layered radial glows for atmosphere */
+  background-image:
+    radial-gradient(900px 600px at 15% -10%, rgba(52, 211, 153, 0.10), transparent 60%),
+    radial-gradient(800px 600px at 110% 10%, rgba(56, 189, 248, 0.08), transparent 55%),
+    radial-gradient(1000px 800px at 50% 120%, rgba(163, 230, 53, 0.07), transparent 60%);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+button { font-family: inherit; }
+
+/* Numbers that should feel like a readout (money, counters) */
+.tabular { font-variant-numeric: tabular-nums; font-feature-settings: 'tnum' 1; }
+
+/* Brand gradient text helper */
+.brand-text {
+  background: var(--brand-grad);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Reusable glass surface */
+.glass {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+}
+
+/* Primary brand button */
+.btn-brand {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: #06210f;
+  background: var(--brand-grad);
+  border: none;
+  border-radius: var(--r-md);
+  padding: 14px 20px;
+  cursor: pointer;
+  box-shadow: var(--glow-brand);
+  transition: transform 0.15s var(--ease-spring), box-shadow 0.2s var(--ease-out), filter 0.2s;
+}
+.btn-brand:hover { transform: translateY(-2px); filter: brightness(1.05); }
+.btn-brand:active { transform: translateY(0) scale(0.98); }
+.btn-brand:disabled { opacity: 0.5; cursor: not-allowed; filter: grayscale(0.4); box-shadow: none; }
+
+/* Ghost / secondary button */
+.btn-ghost {
+  font-family: var(--font-ui);
+  font-weight: 600;
+  color: var(--text);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 13px 18px;
+  cursor: pointer;
+  transition: transform 0.15s var(--ease-spring), background 0.2s, border-color 0.2s;
+}
+.btn-ghost:hover { background: var(--surface-2); border-color: var(--border-strong); transform: translateY(-1px); }
+.btn-ghost:active { transform: scale(0.98); }
+
+/* Inputs */
+.field {
+  width: 100%;
+  font-family: var(--font-ui);
+  font-size: 1rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: 14px 16px;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+}
+.field::placeholder { color: var(--text-faint); }
+.field:focus {
+  outline: none;
+  border-color: rgba(163, 230, 53, 0.55);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.12);
+}
+
+@keyframes wb-fade-up {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.fade-up { animation: wb-fade-up 0.5s var(--ease-out) both; }

--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -106,24 +106,27 @@
   }
 </script>
 
-<div class="auth-container">
-  <div class="auth-box">
-    <!-- 🟢 WordBank Logo -->
-    <img src="/1.png" alt="WordBank Logo" class="wordbank-logo" />
+<div class="auth-screen">
+  <div class="auth-card glass fade-up">
+    <div class="brand">
+      <div class="mark">WB</div>
+      <h1 class="wordmark"><span class="brand-text">Word</span>Bank</h1>
+      <p class="tagline">Crack the phrase. Bank the win.</p>
+    </div>
 
-    <h2>
+    <h2 class="auth-title">
       {#if showReset}
-        Reset Password
+        Reset password
       {:else}
-        {isLogin ? 'Login' : 'Sign Up'} to Play
+        {isLogin ? 'Welcome back' : 'Create your account'}
       {/if}
     </h2>
 
     {#if showReset}
-      <input type="email" bind:value={resetEmail} placeholder="Your email" />
+      <input class="field" type="email" bind:value={resetEmail} placeholder="Your email" />
 
-      <button on:click={handlePasswordReset} disabled={isLoading}>
-        {isLoading ? 'Sending...' : 'Send Reset Link'}
+      <button class="btn-brand full" on:click={handlePasswordReset} disabled={isLoading}>
+        {isLoading ? 'Sending…' : 'Send reset link'}
       </button>
 
       {#if resetMsg}
@@ -131,23 +134,22 @@
       {/if}
 
       <p class="toggle-mode">
-        <button type="button" on:click={() => showReset = false}>
-          ← Back to Login
+        <button type="button" class="link" on:click={() => showReset = false}>
+          ← Back to login
         </button>
       </p>
 
     {:else}
-      <input type="email" bind:value={email} placeholder="Email" />
-      <input type="password" bind:value={password} placeholder="Password" />
+      <input class="field" type="email" bind:value={email} placeholder="Email" />
+      <input class="field" type="password" bind:value={password} placeholder="Password" />
 
-      <button on:click={handleAuth} disabled={isLoading}>
-        {isLoading ? 'Loading...' : (isLogin ? 'Login' : 'Sign Up')}
+      <button class="btn-brand full" on:click={handleAuth} disabled={isLoading}>
+        {isLoading ? 'Loading…' : (isLogin ? 'Log in' : 'Sign up')}
       </button>
 
-      <div class="divider">or</div>
+      <div class="divider"><span>or</span></div>
 
-      <!-- 🟥 Google Sign-In Button -->
-      <button class="google-btn" on:click={signInWithGoogle}>
+      <button class="btn-ghost full google" on:click={signInWithGoogle}>
         <img src="/googlelogo.png" alt="Google icon" class="google-icon" />
         Continue with Google
       </button>
@@ -157,15 +159,15 @@
       {/if}
 
       <p class="toggle-mode">
-        <button type="button" on:click={() => showReset = true}>
-          Forgot Password?
+        <button type="button" class="link subtle" on:click={() => showReset = true}>
+          Forgot password?
         </button>
       </p>
 
       <p class="toggle-mode">
         {isLogin ? "Don't have an account?" : 'Already have an account?'}
-        <button type="button" on:click={() => isLogin = !isLogin}>
-          {isLogin ? 'Sign up here' : 'Log in here'}
+        <button type="button" class="link" on:click={() => isLogin = !isLogin}>
+          {isLogin ? 'Sign up' : 'Log in'}
         </button>
       </p>
     {/if}
@@ -173,140 +175,114 @@
 </div>
 
 <style>
-  .auth-container {
+  .auth-screen {
     display: flex;
     justify-content: center;
     align-items: center;
-    height: 100vh;
-    padding: 16px;
+    min-height: 100vh;
+    padding: 20px;
   }
 
-  .auth-box {
-    background-color: white;
-    padding: 24px 32px;
-    border-radius: 12px;
-    box-shadow: 0 0 16px rgba(0, 0, 0, 0.15);
+  .auth-card {
     width: 100%;
     max-width: 400px;
+    padding: 32px 28px 28px;
     text-align: center;
+    box-shadow: var(--shadow-lg);
   }
 
-  input {
-    display: block;
+  .brand { margin-bottom: 22px; }
+
+  .mark {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 14px;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.25rem;
+    color: #06210f;
+    background: var(--brand-grad);
+    border-radius: 16px;
+    box-shadow: var(--glow-brand);
+  }
+
+  .wordmark {
+    font-size: 2.1rem;
+    letter-spacing: -0.03em;
+    margin: 0;
+  }
+
+  .tagline {
+    margin: 8px 0 0;
+    color: var(--text-muted);
+    font-size: 0.92rem;
+  }
+
+  .auth-title {
+    font-family: var(--font-display);
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: var(--text);
+    margin: 0 0 18px;
+  }
+
+  .field { margin: 10px 0; text-align: left; }
+
+  .full { width: 100%; }
+  .btn-brand.full { margin-top: 6px; padding: 15px; font-size: 1.02rem; }
+
+  .divider {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 20px 2px;
+    color: var(--text-faint);
+    font-size: 0.82rem;
+  }
+  .divider::before, .divider::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: var(--border);
+  }
+
+  .google {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
     width: 100%;
-    padding: 10px;
-    margin: 12px 0;
-    font-size: 1rem;
-    border: 2px solid #ccc;
-    border-radius: 8px;
-    background-color: white;
-    color: black;
   }
-
-  button {
-    padding: 10px;
-    font-size: 1rem;
-    background-color: limegreen;
-    color: white;
-    border: none;
-    font-weight: bold;
-    border-radius: 8px;
-    cursor: pointer;
-    transition: background 0.2s ease;
-  }
-
-  button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+  .google-icon { width: 18px; height: 18px; }
 
   .toggle-mode {
-    margin-top: 15px;
+    margin-top: 16px;
     font-size: 0.9rem;
-    color: black;
+    color: var(--text-muted);
   }
 
-  .toggle-mode button {
-    color: #007bff;
-    text-decoration: underline;
-    cursor: pointer;
+  .link {
     background: none;
     border: none;
+    padding: 0;
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--brand-2);
   }
+  .link:hover { text-decoration: underline; }
+  .link.subtle { color: var(--text-muted); font-weight: 500; }
 
   .error-text {
-    color: red;
+    margin-top: 12px;
+    color: var(--danger);
+    font-size: 0.9rem;
+  }
+
+  .reset-msg {
     margin-top: 10px;
+    font-size: 0.9rem;
+    color: var(--text-muted);
   }
-
-  :global(body.dark-mode) .auth-box {
-    background-color: #222;
-  }
-
-  :global(body.dark-mode) .auth-box h2,
-  :global(body.dark-mode) .toggle-mode,
-  :global(body.dark-mode) .error-text {
-    color: white;
-  }
-
-  :global(body.dark-mode) input {
-    background-color: #333;
-    color: white;
-    border: 2px solid #666;
-  }
-
-  :global(body.dark-mode) .toggle-mode button {
-    color: #4da3ff;
-  }
-  .wordbank-logo {
-  width: 280px;
-  max-width: 80%;
-  margin-bottom: 20px;
-  height: auto;
-}
-
-@media (max-width: 600px) {
-  .wordbank-logo {
-    width: 200px;
-  }
-}
-
-.google-btn {
-  background-color: #fff;
-  color: #444;
-  border: 2px solid #ccc;
-  padding: 10px;
-  width: 100%;
-  font-weight: bold;
-  border-radius: 8px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  transition: background 0.2s ease;
-}
-
-.google-btn:hover {
-  background-color: #f1f1f1;
-}
-
-.google-icon {
-  width: 20px;
-  height: 20px;
-}
-
-.divider {
-  margin: 20px 0;
-  font-size: 0.9rem;
-  color: #888;
-}
-
-.reset-msg {
-  font-size: 0.9rem;
-  color: #444;
-  margin-top: 6px;
-}
-
-
 </style>

--- a/src/lib/components/FlipDigit.svelte
+++ b/src/lib/components/FlipDigit.svelte
@@ -34,11 +34,9 @@
 </div>
 
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
-
   .slot-container {
     overflow: hidden;
-    width: 15px;
+    width: 22px;
     height: 40px;
   }
 
@@ -51,8 +49,11 @@
     height: 40px;
     line-height: 40px;
     text-align: center;
-    font-size: 1.8rem;
-    font-family: 'VT323', monospace;
-    color: white;
+    font-size: 1.9rem;
+    font-family: 'Space Grotesk', system-ui, sans-serif;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: #fcd34d;
+    text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
   }
 </style>

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -270,11 +270,37 @@
 }
 .cost-indicator {
   position: absolute;
-  top: -25px;
-  font-size: 20px;
-  font-family: 'VT323', sans-serif;
-  color: red;
-  animation: blinkColor 1s infinite;
+  top: -30px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 13px;
+  color: #fcd34d;
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  padding: 3px 9px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.message-box {
+  position: fixed;
+  bottom: 190px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1001;
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text);
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  padding: 9px 16px;
+  border-radius: 999px;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(12px);
+  white-space: nowrap;
 }
 
 /* ---------------------------
@@ -298,25 +324,28 @@
   position: relative;
 }
 .hint-button {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #4488ff, #0055bb 80%);
-  color: #fff;
-  font-family: 'VT323', sans-serif;
+  width: 54px;
+  height: 46px;
+  border-radius: 13px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-family: var(--font-ui);
   font-size: 9px;
-  font-weight: bold;
+  font-weight: 700;
   text-transform: uppercase;
-  border: none;
+  letter-spacing: 0.02em;
+  line-height: 1.15;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 0.2s ease;
+  backdrop-filter: blur(10px);
+  transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
   cursor: pointer;
 }
-.hint-button:hover { transform: translateY(-2px); }
-.hint-button:active { transform: translateY(2px); }
-.hint-button.glow { animation: softGlow 0.3s infinite alternate ease-in-out; border: 3px outset #0d3e01 !important; }
+.hint-button:hover { transform: translateY(-2px); background: var(--surface-2); border-color: var(--border-strong); }
+.hint-button:active { transform: scale(0.96); }
+.hint-button.glow { border-color: rgba(163, 230, 53, 0.5) !important; box-shadow: var(--glow-brand); }
 
 /* ---------------------------
    Guesses Button (blue, right of Solve)
@@ -325,32 +354,38 @@
   position: relative;
 }
 .guesses-button {
-  width: 52px;
-  height: 40px;
-  border-radius: 8px;
-  background: radial-gradient(circle at 30% 30%, #4488ff, #0055bb 80%);
-  color: #fff;
-  font-family: 'VT323', sans-serif;
-  font-size: 14px;
-  font-weight: bold;
-  border: 2px solid #2266cc;
+  width: 54px;
+  height: 46px;
+  border-radius: 13px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--border);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   line-height: 1.1;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  backdrop-filter: blur(10px);
+  transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
   cursor: pointer;
 }
 .guesses-button .guesses-count {
+  font-family: var(--font-display);
   font-size: 18px;
+  font-weight: 700;
+  color: var(--brand-2);
   display: block;
 }
-.guesses-button:hover { transform: translateY(-2px); }
-.guesses-button:active { transform: translateY(2px); }
+.guesses-button:hover { transform: translateY(-2px); background: var(--surface-2); border-color: var(--border-strong); }
+.guesses-button:active { transform: scale(0.96); }
 .guesses-button.glow {
-  box-shadow: 0 0 12px rgba(68, 136, 255, 0.8);
-  border-color: #66aaff;
+  box-shadow: var(--glow-brand);
+  border-color: rgba(163, 230, 53, 0.5);
 }
 
 /* ---------------------------
@@ -358,8 +393,8 @@
 --------------------------- */
 .solve-button-container,
 .dual-button-container {
-  width: 190px;
-  height: 34px;
+  width: 200px;
+  height: 46px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -369,44 +404,46 @@
 .guess-phrase-button {
   width: 100%;
   height: 100%;
-  font-family: 'VT323', sans-serif;
-  font-size: 21px;
-  font-weight: bold;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   text-transform: uppercase;
-  background: linear-gradient(180deg, #46a230, #318020); /* Always green */
-  color: white;
-  border-radius: 6px;
-  border: 2px solid #2e9417; /* Green border */
-  box-shadow: inset 1px 1px 4px rgba(255,255,255,0.3), 2px 2px 6px rgba(0,0,0,0.6);
-  transition: background-color 0.3s, transform 0.2s;
+  background: var(--brand-grad);
+  color: #06210f;
+  border-radius: 14px;
+  border: none;
+  box-shadow: var(--glow-brand);
+  transition: transform 0.16s var(--ease-spring), filter 0.2s, box-shadow 0.2s;
 }
 
 .guess-phrase-button:hover {
   transform: translateY(-2px);
-  background: linear-gradient(180deg, #46a230, #318020); /* Keep it green on hover */
+  filter: brightness(1.05);
 }
 
 .guess-phrase-button:active {
-  transform: translateY(2px);
-  background: linear-gradient(180deg, #46a230, #318020); /* Keep it green when active */
+  transform: scale(0.97);
 }
 
-.guess-phrase-button.pending {
-  animation: blinkDarkGreen 1s infinite;
-}
-
+.guess-phrase-button.pending,
 .guess-phrase-button.guess-complete {
-  animation: blinkGreen 1s infinite;
+  animation: solvePulse 1.1s infinite;
+}
+@keyframes solvePulse {
+  0%, 100% { box-shadow: var(--glow-brand); }
+  50% { box-shadow: 0 0 0 1px rgba(163, 230, 53, 0.4), 0 8px 36px rgba(52, 211, 153, 0.5); }
 }
 
 .guess-phrase-button.exit-mode {
-  background: linear-gradient(180deg, #ff2222, #aa0000); /* Red for exit mode */
-  border: 2px solid darkred;
+  background: linear-gradient(135deg, #fb5a5a, #c81e1e);
+  color: #fff;
+  border: none;
+  box-shadow: 0 8px 24px rgba(200, 30, 30, 0.35);
 }
 
 .guess-phrase-button.exit-mode:active {
-  background: linear-gradient(180deg, #cc0000, #990000);
-  transform: scale(0.95);
+  transform: scale(0.96);
 }
 
 /* Dark mode adjustments */
@@ -422,55 +459,38 @@
 }
 .confirm-button,
 .cancel-button {
-  font-family: 'VT323', monospace;
-  font-size: 18px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 16px;
   flex: 1;
-  height: 34px;
-  border-radius: 6px;
-  transition: transform 0.2s ease;
+  height: 46px;
+  border-radius: 14px;
   cursor: pointer;
+  transition: transform 0.16s var(--ease-spring), filter 0.2s;
 }
 
 /* Confirm */
 .confirm-button {
-  background: linear-gradient(180deg, #28a745, #218838);
-  color: white;
-  border: 3px solid #1e7e34;
-  animation: pulseGlow 1s infinite;
+  background: var(--brand-grad);
+  color: #06210f;
+  border: none;
+  box-shadow: var(--glow-brand);
+  animation: solvePulse 1.1s infinite;
 }
 .confirm-button:hover {
-  background: linear-gradient(180deg, #45c362, #2f9f4a);
+  filter: brightness(1.05);
   transform: translateY(-2px);
 }
+.confirm-button:active { transform: scale(0.97); }
 
 /* Cancel */
 .cancel-button {
-  background: linear-gradient(180deg, #aa0000, #660000);
-  color: white;
-  border: 2px solid darkred;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
 }
-.cancel-button:hover {
-  transform: scale(1.08);
-}
-
-/* ---------------------------
-   Dark Mode
---------------------------- */
-:global(body.dark-mode) .guess-phrase-button {
-  background: linear-gradient(180deg, #46a230, #318020);
-}
-:global(body.dark-mode) .hint-button {
-  background: radial-gradient(circle at 30% 30%, #66aaff, #3388ff 80%) !important;
-  border: 3px solid #66aaff !important;
-}
-:global(body.dark-mode) .guess-phrase-button.exit-mode {
-  background: linear-gradient(180deg, #ff2222, #aa0000) !important;
-  border: 3px solid #880000 !important;
-}
-:global(body.dark-mode) .guess-phrase-button.guess-complete {
-  background: linear-gradient(180deg, #28a745, #218838) !important;
-  border: 3px solid #1e7e34 !important;
-}
+.cancel-button:hover { transform: translateY(-1px); background: rgba(251, 90, 90, 0.16); border-color: rgba(251, 90, 90, 0.4); }
+.cancel-button:active { transform: scale(0.97); }
 .guess-phrase-button:disabled,
 .confirm-button:disabled,
 .cancel-button:disabled {

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -286,10 +286,10 @@
 
 .message-box {
   position: fixed;
-  bottom: 190px;
+  bottom: 232px;
   left: 50%;
   transform: translateX(-50%);
-  z-index: 1001;
+  z-index: 1002;
   font-family: var(--font-ui);
   font-weight: 600;
   font-size: 0.85rem;
@@ -308,7 +308,7 @@
 --------------------------- */
 .main-button-wrapper {
   position: fixed;
-  bottom: 132px;
+  bottom: 174px; /* clears the 156px-tall keyboard + gap */
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -247,32 +247,35 @@
   --------------------------- */
   .key {
     width: 56px;
-    height: 40px;
-    font-size: 12px;
-    font-weight: bold;
-    border: 2px solid black;
-    background-color: white;
+    height: 46px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 10px;
     cursor: pointer;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    gap: 1px;
     padding: 2px;
     box-sizing: border-box;
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    transition: transform 0.12s var(--ease-spring), background 0.15s, border-color 0.15s;
   }
-/* 🔹 Delete Button (Match Exit Guess Mode Style) */
-.key.delete {
-    background: linear-gradient(180deg, #ff4444, #cc0000); /* Red gradient */
-    color: white !important;
-    border: 1px solid darkred !important;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-}
+  .key:hover:not(.purchased):not(.incorrect):not(.disabled) {
+    background: var(--surface-2);
+    border-color: var(--border-strong);
+    transform: translateY(-1px);
+  }
+  .key:active { transform: scale(0.94); }
 
-/* 🔹 Dark Mode: Ensure Delete Button Stays Red */
-:global(body.dark-mode) .key.delete {
-    background: linear-gradient(180deg, #ff2222, #aa0000) !important;
-    border: 1px solid #880000 !important;
-}
+  .key.delete {
+    background: rgba(251, 90, 90, 0.15);
+    color: #ffb4b4 !important;
+    border-color: rgba(251, 90, 90, 0.4) !important;
+  }
   @keyframes blink {
   0% { opacity: 1; }
   50% { opacity: 0; }
@@ -284,38 +287,44 @@
   --------------------------- */
   .letter {
     line-height: 1;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 15px;
   }
   .price {
     line-height: 1;
     font-size: 9px;
+    color: var(--text-faint);
+    font-variant-numeric: tabular-nums;
   }
 
   /* ---------------------------
      Key State Styles
   --------------------------- */
   .purchased {
-    background-color: green;
-    color: white;
+    background: linear-gradient(135deg, rgba(52, 211, 153, 0.30), rgba(163, 230, 53, 0.18)) !important;
+    color: var(--brand-2) !important;
+    border-color: rgba(163, 230, 53, 0.4) !important;
     cursor: default;
-    filter: blur(.8px); /* Apply a subtle blur */
-    opacity: 0.7; /* Make slightly faded */
-    pointer-events: none; /* Prevent clicking */
-    transition: filter 0.3s ease, opacity 0.3s ease;
+    pointer-events: none;
   }
+  .purchased .price { color: rgba(163, 230, 53, 0.65); }
   .pending {
-    background-color: blue !important;
-    color: white !important;
-    animation: blink 1s infinite;
-  
+    background: var(--brand-grad) !important;
+    color: #06210f !important;
+    border-color: transparent !important;
+    box-shadow: var(--glow-brand);
+    animation: keyPulse 1s infinite;
   }
+  .pending .price { color: rgba(6, 33, 15, 0.7); }
+  @keyframes keyPulse { 0%, 100% { filter: brightness(1); } 50% { filter: brightness(1.12); } }
   .incorrect {
-    background-color: red;
-    color: white;
+    background: rgba(255, 255, 255, 0.02) !important;
+    color: var(--text-faint) !important;
+    border-color: var(--border) !important;
     cursor: default;
-    filter: blur(.8px); /* Apply a subtle blur */
-    opacity: 0.7; /* Make slightly faded */
-    pointer-events: none; /* Prevent clicking */
-    transition: filter 0.3s ease, opacity 0.3s ease;
+    opacity: 0.5;
+    pointer-events: none;
   }
 
   /* Blinking animation for pending keys */
@@ -325,57 +334,17 @@
     100% { opacity: 1; }
   }
 
-  /* ---------------------------
-     Dark Mode Overrides
-  --------------------------- */
-  :global(body.dark-mode) .keyboard-container {
-    background-color: #333;
-  }
-  :global(body.dark-mode) .key {
-    background-color: #444;
-    color: white;
-    border-color: #777;
-  }
-  :global(body.dark-mode) .purchased {
-    background-color: green !important;
-    color: white !important;
-  }
-  :global(body.dark-mode) .incorrect {
-    background-color: red !important;
-    color: white !important;
-  }
-  :global(body.dark-mode) .pending {
-    background-color: blue !important;
-    color: white !important;
-    animation: blink 1s infinite;
-  }
-
-  /* 🔹 Apply blur effect to unaffordable letters */
+  /* Unaffordable letters: dim, not blurred */
   .key.disabled {
-    filter: blur(.8px);  /* 🔹 Blur effect */
-    opacity: 0.5;       /* 🔹 Make slightly faded */
-    pointer-events: none; /* 🔹 Prevent clicking */
-    transition: filter 0.3s ease, opacity 0.3s ease;
-}
+    opacity: 0.4;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+  }
 
-/* 🔹 Remove blur when in guess mode */
-:global(body.guess-mode) .key.incorrect,
-:global(body.guess-mode) .key.disabled {
-    filter: none !important;
+  /* In guess mode, all letters are tappable */
+  :global(body.guess-mode) .key.incorrect,
+  :global(body.guess-mode) .key.disabled {
     opacity: 1 !important;
     pointer-events: all;
-}
-/* 🔹 Light up keys that are NOT purchased, incorrect, or disabled */
-.key:not(.purchased):not(.incorrect):not(.disabled) {
-    box-shadow: 0px 0px 8px rgba(0, 255, 180, 0.6); /* Initial blue-green glow */
-    animation: subtleGlow 2s infinite alternate ease-in-out;
-}
-
-/* 🔹 Smooth Blue-Green Glow Animation */
-@keyframes subtleGlow {
-    0% { box-shadow: 0px 0px 6px rgba(0, 150, 255, 0.5); } /* Soft blue */
-    50% { box-shadow: 0px 0px 10px rgba(0, 255, 180, 0.6); } /* Mix between blue & green */
-    100% { box-shadow: 0px 0px 8px rgba(0, 255, 120, 0.5); } /* Soft green */
-}
-
+  }
 </style>

--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -164,36 +164,40 @@
     text-align: center;
   }
   .letter-box {
-    width: 40px;
-    min-width: 40px;
-    height: 44px;
-    min-height: 44px;
+    width: 42px;
+    min-width: 42px;
+    height: 48px;
+    min-height: 48px;
     padding: 0;
     flex-shrink: 0; /* Prevent collapse when empty */
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
-    border: 2px solid #453d3d;
-    background: linear-gradient(145deg, #dfe6e9, #ffffff);
-    font-size: 20px;
-    font-weight: bold;
-    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    font-family: var(--font-display);
+    font-size: 22px;
+    font-weight: 700;
+    border-radius: 11px;
     box-shadow:
-      inset 1px 1px 3px rgba(255, 255, 255, 0.8),
-      1px 1px 3px rgba(0, 0, 0, 0.2),
-      0 0 0 1px rgba(0, 0, 0, 0.05);
-    color: black;
+      inset 0 1px 0 rgba(255, 255, 255, 0.05),
+      0 2px 8px rgba(0, 0, 0, 0.3);
+    color: var(--text);
+    backdrop-filter: blur(8px);
     box-sizing: border-box;
+    transition: transform 0.2s var(--ease-spring), border-color 0.2s, background 0.2s, box-shadow 0.2s;
   }
   .letter-box.locked {
-    color: black !important;
-    font-weight: bold;
+    color: #06210f;
+    background: var(--brand-grad);
+    border-color: transparent;
+    box-shadow: 0 4px 16px rgba(52, 211, 153, 0.35);
   }
   .letter-box.active {
-    border: 3px solid #41ae29 !important;  /* Same green as main guess button */
-    color: black !important;
-}
+    border: 2px solid var(--brand-2);
+    box-shadow: 0 0 0 4px rgba(163, 230, 53, 0.16), 0 0 18px rgba(163, 230, 53, 0.25);
+  }
 
   /* ---------------------------
      Guess Mode Styling
@@ -211,11 +215,12 @@
   --------------------------- */
   @media (max-width: 480px) {
     .letter-box {
-      width: 32px;
-      min-width: 32px;
-      height: 36px;
-      min-height: 36px;
-      font-size: 16px;
+      width: 36px;
+      min-width: 36px;
+      height: 42px;
+      min-height: 42px;
+      font-size: 19px;
+      border-radius: 9px;
     }
     .phrase-container {
       margin: 16px 0 10px 0;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,6 @@
+<script>
+  import '../app.css';
+  let { children } = $props();
+</script>
+
+{@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -613,7 +613,7 @@
     margin: 0 auto;
     text-align: center;
     font-family: var(--font-ui);
-    padding: 16px 12px 200px; /* space so content stays above fixed Solve + keyboard */
+    padding: 16px 12px 248px; /* space so content stays above fixed Solve + keyboard */
     min-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -992,8 +992,10 @@
   .top-buttons {
     position: fixed;
     top: 12px;
-    left: 12px;
-    right: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: calc(100% - 24px);
+    max-width: 600px;
     display: flex;
     justify-content: space-between;
     z-index: 1000;
@@ -1113,21 +1115,21 @@
   justify-content: center;
   align-items: center;
   position: fixed;
-  bottom: 245px;
+  bottom: 230px; /* sits above the action buttons (which clear the keyboard) */
   left: 50%;
   transform: translateX(-50%);
-  width: 100%;
+  width: calc(100% - 24px);
   max-width: 360px;
   padding: 10px 14px;
   border-radius: var(--r-lg);
 
   background: var(--surface-strong);
   border: 1px solid var(--border-strong);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-lg);
   backdrop-filter: blur(14px);
 
   gap: 8px;
-  z-index: 999;
+  z-index: 1003; /* always in front */
 }
 
 .wager-row {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -932,19 +932,22 @@
   }
 
   .banner.win {
-    font-size: 2rem;
-    font-weight: 600;
-    color: limegreen;
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: #06210f;
     text-transform: uppercase;
-    background: linear-gradient(45deg, green, limegreen);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    background: var(--brand-grad);
     text-align: center;
-    padding: 20px;
-    border: 5px solid limegreen;
-    border-radius: 10px;
-    animation: winPulse 1.5s infinite, winFlash 0.5s infinite;
+    padding: 14px 28px;
+    border-radius: var(--r-pill);
+    box-shadow: var(--glow-brand);
+    animation: bannerPop 0.5s var(--ease-spring) both;
+  }
+  @keyframes bannerPop {
+    from { transform: scale(0.8); opacity: 0; }
+    to { transform: scale(1); opacity: 1; }
   }
 
   @keyframes gameOverPulse {
@@ -961,24 +964,18 @@
   }
 
   .banner.lose {
-    font-size: 2rem;
-    font-weight: 600;
-    color: red;
+    font-family: var(--font-display);
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: #fff;
     text-transform: uppercase;
-    background: linear-gradient(45deg, red, black);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    background: linear-gradient(135deg, #fb5a5a, #c81e1e);
     text-align: center;
-    padding: 20px;
-    border: 5px solid red;
-    border-radius: 10px;
-    animation: gameOverPulse 1.5s infinite, gameOverFlash 0.5s infinite;
-  }
-
-  :global(body.dark-mode) {
-    background: #222;
-    color: white;
+    padding: 14px 28px;
+    border-radius: var(--r-pill);
+    box-shadow: 0 8px 28px rgba(200, 30, 30, 0.4);
+    animation: bannerPop 0.5s var(--ease-spring) both;
   }
 
   button:focus,
@@ -1029,17 +1026,16 @@
   .subtle-button { opacity: 0.95; }
 
   .modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: rgba(0, 0, 0, 0.3); /* 🌘 Semi-transparent black */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 9999;
-  /* Removed blur so puzzle stays sharp */
+    position: fixed;
+    inset: 0;
+    background: rgba(4, 7, 12, 0.66);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+    animation: fadeIn 0.25s ease-out;
   }
   .modal-backdrop {
     position: absolute;
@@ -1050,30 +1046,39 @@
   }
 
   .modal-content {
-    background: white;
-    padding: 20px;
-    border-radius: 10px;
+    background: var(--surface-strong);
+    padding: 28px 24px;
+    border-radius: var(--r-xl);
     width: 90%;
     max-width: 400px;
     text-align: center;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
-    animation: slideIn 0.3s ease-out;
-    border: 3px solid #007bff;
-    color: black;
+    box-shadow: var(--shadow-lg);
+    animation: slideIn 0.35s var(--ease-out);
+    border: 1px solid var(--border-strong);
+    color: var(--text);
+    backdrop-filter: blur(20px) saturate(140%);
+    -webkit-backdrop-filter: blur(20px) saturate(140%);
     position: relative;
     z-index: 1;
   }
+  .modal-content :global(h2) { font-family: var(--font-display); }
 
-  :global(body.dark-mode) .modal-content {
-    background: linear-gradient(135deg, #222, #333);
-    border: 3px solid limegreen;
-    color: white;
-    box-shadow: 0 4px 10px rgba(0, 255, 0, 0.3);
+  .close-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    font-size: 13px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-pill);
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s;
   }
-
-  .close-btn:hover {
-    background: darkred;
-  }
+  .close-btn:hover { background: rgba(251, 90, 90, 0.16); border-color: rgba(251, 90, 90, 0.4); }
 
   @keyframes fadeIn {
     from { opacity: 0; }
@@ -1087,25 +1092,20 @@
 
   .next-puzzle-button {
     margin-top: 12px;
-    background-color: limegreen;
-    color: white;
-    font-weight: bold;
+    background: var(--brand-grad);
+    color: #06210f;
+    font-family: var(--font-display);
+    font-weight: 700;
     border: none;
-    padding: 12px 24px;
-    border-radius: 8px;
+    padding: 13px 28px;
+    border-radius: var(--r-md);
     font-size: 1rem;
     cursor: pointer;
-    animation: pulse 1s infinite alternate;
+    box-shadow: var(--glow-brand);
+    transition: transform 0.16s var(--ease-spring), filter 0.2s;
   }
-
-  @keyframes pulse {
-    0% { transform: scale(1); }
-    100% { transform: scale(1.08); }
-  }
-
-  .next-puzzle-button:hover {
-    background-color: green;
-  }
+  .next-puzzle-button:hover { transform: translateY(-2px); filter: brightness(1.05); }
+  .next-puzzle-button:active { transform: scale(0.97); }
 
   .wager-ui {
   display: flex;
@@ -1118,13 +1118,13 @@
   transform: translateX(-50%);
   width: 100%;
   max-width: 360px;
-  padding: 6px 10px;
-  border-radius: 10px;
+  padding: 10px 14px;
+  border-radius: var(--r-lg);
 
-  /* 🔧 NEW: Light mode border and shadow */
-  background: rgba(255, 255, 255, 0.9);
-  border: 2px solid #ccc;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(14px);
 
   gap: 8px;
   z-index: 999;
@@ -1139,12 +1139,16 @@
 }
 
 .wager-label {
-  font-family: 'Orbitron', sans-serif;
-  font-size: 0.8rem;
-  color: #222;
+  font-family: var(--font-ui);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-faint);
   text-align: center;
   width: 70px;
 }
+.wager-amount { color: #fcd34d; }
 
 .wager-amount {
   font-size: 1rem;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -402,35 +402,48 @@
     <div class="init-loading">Loading…</div>
   {:else if showMainMenu}
     <!-- 🏠 Main Menu (after sign-in) -->
-    <div class="main-menu">
-      <div class="logo-container">
-        <img src="/1.png" alt="WordBank Logo" class="wordbank-logo" />
+    <div class="main-menu fade-up">
+      <div class="menu-hero">
+        <div class="menu-mark">WB</div>
+        <h1 class="menu-wordmark"><span class="brand-text">Word</span>Bank</h1>
+        <p class="menu-tagline">Crack the phrase. Bank the win.</p>
       </div>
-      <h1 class="main-menu-title">Main Menu</h1>
       <div class="main-menu-buttons">
         <button
-          class="main-menu-btn"
+          class="menu-card primary"
           class:disabled={menuDailyPlayed && !(savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost')}
           on:click={handleMenuDaily}
         >
-          {#if savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}
-            Resume Daily Puzzle
-          {:else}
-            Daily Puzzle
-          {/if}
+          <span class="mc-icon">🎯</span>
+          <span class="mc-body">
+            <span class="mc-title">{#if savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}Resume Daily{:else}Daily Puzzle{/if}</span>
+            <span class="mc-sub">One puzzle a day · ranked</span>
+          </span>
+          <span class="mc-arrow">→</span>
         </button>
-        <button class="main-menu-btn" on:click={handleMenuArcade}>
-          {#if savedGameInfo?.gameMode === 'arcade' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}
-            Resume Arcade Mode
-          {:else}
-            Arcade Mode
-          {/if}
+        <button class="menu-card" on:click={handleMenuArcade}>
+          <span class="mc-icon">🕹️</span>
+          <span class="mc-body">
+            <span class="mc-title">{#if savedGameInfo?.gameMode === 'arcade' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}Resume Arcade{:else}Arcade Mode{/if}</span>
+            <span class="mc-sub">Unlimited · build your bankroll</span>
+          </span>
+          <span class="mc-arrow">→</span>
         </button>
-        <button class="main-menu-btn" on:click={handleMenuLeaderboard}>
-          Leaderboard
+        <button class="menu-card" on:click={handleMenuLeaderboard}>
+          <span class="mc-icon">🏆</span>
+          <span class="mc-body">
+            <span class="mc-title">Leaderboard</span>
+            <span class="mc-sub">See who's on top</span>
+          </span>
+          <span class="mc-arrow">→</span>
         </button>
-        <button class="main-menu-btn" on:click={handleMenuMyAccount}>
-          My Account
+        <button class="menu-card" on:click={handleMenuMyAccount}>
+          <span class="mc-icon">👤</span>
+          <span class="mc-body">
+            <span class="mc-title">My Account</span>
+            <span class="mc-sub">Profile &amp; sign out</span>
+          </span>
+          <span class="mc-arrow">→</span>
         </button>
       </div>
     </div>
@@ -464,9 +477,7 @@
     <!-- ✅ GAME UI (Visible only when logged in) -->
 
     <!-- 🧠 Game Logo -->
-    <div class="logo-container">
-      <img src="/1.png" alt="WordBank Logo" class="wordbank-logo" />
-    </div>
+    <div class="game-logo"><span class="brand-text">Word</span>Bank</div>
 
     <!-- 🔍 Diagnostic banner (shows when init failed) -->
     {#if initError}
@@ -485,10 +496,10 @@
     {/if}
 
     <!-- 🌍 Category Display -->
-    <p class="category">{$gameStore.category} 🌍</p>
-    {#if $gameStore.subcategory}
-  <p class="subcategory-hint"> {$gameStore.subcategory}</p>
-{/if}
+    <div class="puzzle-meta">
+      {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
+      {#if $gameStore.subcategory}<span class="subcat-chip">{$gameStore.subcategory}</span>{/if}
+    </div>
 
 
     <!-- 🔤 Phrase Display -->
@@ -500,10 +511,13 @@
     <section class="stats-section">
       <div class="bankroll-container">
         <div class="bankroll-box">
-          <span class="currency">$</span>
-          {#each digits as d}
-            <FlipDigit digit={+d} />
-          {/each}
+          <span class="bankroll-label">Balance</span>
+          <span class="bankroll-amount">
+            <span class="currency">$</span>
+            {#each digits as d}
+              <FlipDigit digit={+d} />
+            {/each}
+          </span>
         </div>
       </div>
     </section>
@@ -598,19 +612,39 @@
     max-width: 600px;
     margin: 0 auto;
     text-align: center;
-    font-family: 'Orbitron', sans-serif;
-    padding: 6px;
-    padding-bottom: 185px; /* space so bankroll stays above fixed Solve + keyboard */
+    font-family: var(--font-ui);
+    padding: 16px 12px 200px; /* space so content stays above fixed Solve + keyboard */
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
   }
 
-  .category {
-    font-size: .7rem;
-    margin-top: -95px;
-    margin-bottom: 0.15rem;
-    font-weight: bold;
+  .puzzle-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin: 0 0 22px;
+  }
+  .category-chip {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.8rem;
+    color: var(--brand-2);
+    background: rgba(163, 230, 53, 0.10);
+    border: 1px solid rgba(163, 230, 53, 0.28);
+    padding: 6px 13px;
+    border-radius: var(--r-pill);
+  }
+  .subcat-chip {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    padding: 6px 13px;
+    border-radius: var(--r-pill);
   }
 
   .phrase-section {
@@ -683,87 +717,127 @@
     color: #666;
   }
 
-  /* Main menu (after sign-in) – same blue/green as game (hint + Solve) */
+  /* Main menu (after sign-in) — premium dark */
   .main-menu {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 2rem 1rem;
-    gap: 1.5rem;
+    padding: 3.5rem 1.1rem 2rem;
+    gap: 2rem;
   }
-  .main-menu .logo-container {
-    margin-top: 0;
+  .menu-hero {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
   }
-  .main-menu-title {
-    font-family: 'Orbitron', sans-serif;
-    font-size: 1.75rem;
+  .menu-mark {
+    width: 60px;
+    height: 60px;
+    display: grid;
+    place-items: center;
+    font-family: var(--font-display);
     font-weight: 700;
-    margin: 0 0 0.5rem 0;
-    color: #0055bb;
-    text-shadow: 0 0 8px rgba(68, 136, 255, 0.4);
+    font-size: 1.35rem;
+    color: #06210f;
+    background: var(--brand-grad);
+    border-radius: 18px;
+    box-shadow: var(--glow-brand);
+    margin-bottom: 16px;
+  }
+  .menu-wordmark {
+    font-family: var(--font-display);
+    font-size: 2.4rem;
+    letter-spacing: -0.03em;
+    margin: 0;
+  }
+  .menu-tagline {
+    margin: 8px 0 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
   }
   .main-menu-buttons {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.85rem;
     width: 100%;
-    max-width: 320px;
+    max-width: 360px;
   }
-  .main-menu-btn {
-    font-family: 'Orbitron', sans-serif;
-    font-size: 1rem;
-    padding: 0.9rem 1.25rem;
-    border-radius: 10px;
-    border: 2px solid #2e9417;
-    background: linear-gradient(180deg, #46a230, #318020);
-    color: #fff;
+  .menu-card {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    text-align: left;
+    padding: 16px 18px;
+    border-radius: var(--r-lg);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text);
     cursor: pointer;
-    box-shadow: inset 1px 1px 4px rgba(255, 255, 255, 0.3), 2px 2px 6px rgba(0, 0, 0, 0.6);
-    transition: transform 0.15s, box-shadow 0.15s;
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
-  .main-menu-btn:hover:not(:disabled):not(.disabled) {
+  .menu-card:hover:not(.disabled) {
     transform: translateY(-2px);
-    background: linear-gradient(180deg, #4cb038, #368828);
-    box-shadow: inset 1px 1px 4px rgba(255, 255, 255, 0.35), 2px 2px 8px rgba(0, 0, 0, 0.5);
+    background: var(--surface-2);
+    border-color: var(--border-strong);
+    box-shadow: var(--shadow-md);
   }
-  .main-menu-btn:disabled,
-  .main-menu-btn.disabled {
-    opacity: 0.7;
-    cursor: not-allowed;
-    background: linear-gradient(180deg, #6b6b6b, #4a4a4a);
-    border-color: #555;
+  .menu-card:active:not(.disabled) { transform: scale(0.99); }
+  .menu-card.primary {
+    border-color: rgba(163, 230, 53, 0.4);
+    background: linear-gradient(135deg, rgba(52, 211, 153, 0.16), rgba(163, 230, 53, 0.06));
+    box-shadow: var(--glow-brand);
   }
-  .main-menu-modal {
-    text-align: center;
+  .menu-card.disabled { opacity: 0.45; cursor: not-allowed; }
+  .mc-icon {
+    width: 46px;
+    height: 46px;
+    flex-shrink: 0;
+    display: grid;
+    place-items: center;
+    font-size: 1.4rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border);
+    border-radius: 13px;
   }
-  .main-menu-modal .main-menu-btn {
-    margin-top: 1rem;
+  .menu-card.primary .mc-icon {
+    background: var(--brand-grad);
+    border: none;
   }
+  .mc-body { display: flex; flex-direction: column; gap: 2px; flex: 1; }
+  .mc-title { font-family: var(--font-display); font-weight: 600; font-size: 1.06rem; }
+  .mc-sub { font-size: 0.8rem; color: var(--text-muted); }
+  .mc-arrow { color: var(--text-faint); font-size: 1.1rem; transition: transform 0.2s, color 0.2s; }
+  .menu-card:hover:not(.disabled) .mc-arrow { transform: translateX(3px); color: var(--brand-2); }
+
+  /* Modal action button (reused brand button) */
+  .main-menu-btn {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1rem;
+    padding: 13px 20px;
+    border-radius: var(--r-md);
+    border: none;
+    background: var(--brand-grad);
+    color: #06210f;
+    cursor: pointer;
+    box-shadow: var(--glow-brand);
+    transition: transform 0.15s var(--ease-spring), filter 0.2s;
+  }
+  .main-menu-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
+  .main-menu-modal { text-align: center; }
+  .main-menu-modal .main-menu-btn { margin-top: 1rem; }
   .streak-message {
     margin: 1rem 0 0 0;
     font-size: 1.05rem;
-    color: #333;
+    color: var(--text-muted);
   }
   .account-email {
     font-size: 0.95rem;
-    color: #888;
+    color: var(--text-muted);
     margin: 0.5rem 0 0 0;
-  }
-  :global(body.dark-mode) .main-menu-title {
-    color: #66aaff;
-    text-shadow: 0 0 10px rgba(102, 170, 255, 0.5);
-  }
-  :global(body.dark-mode) .main-menu-btn {
-    background: linear-gradient(180deg, #46a230, #318020);
-    border-color: #2e9417;
-  }
-  :global(body.dark-mode) .main-menu-btn:hover:not(:disabled):not(.disabled) {
-    background: linear-gradient(180deg, #4cb038, #368828);
-  }
-  :global(body.dark-mode) .main-menu-btn:disabled,
-  :global(body.dark-mode) .main-menu-btn.disabled {
-    background: linear-gradient(180deg, #5a5a5a, #3d3d3d);
-    border-color: #555;
   }
 
   :global(body.dark-mode) .diagnostic-banner {
@@ -778,65 +852,57 @@
   }
 
   .bankroll-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  margin: 0 auto;
-}
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    margin: 0 auto;
+  }
 
+  .bankroll-box {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 12px 30px;
+    background: var(--surface-strong);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
 
-.bankroll-box {
-  padding: 2px 28px;
-  font-size: 0.4rem;
-  font-family: 'Orbitron', sans-serif;
-  color: #fff;
-  background: linear-gradient(180deg, #d1cdcd, #858484);
-  border: 2px solid rgba(255, 255, 255, 0.4);
-  border-radius: 8px;
-  text-align: center;
-  box-shadow:
-    inset 1px 1px 4px rgba(255, 255, 255, 0.2),
-    2px 2px 6px rgba(0, 0, 0, 0.742),
-    3px 3px 8px rgba(0, 0, 0, 0.5),
-    0 0 6px rgba(245, 246, 245, 0.5);
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  letter-spacing: 1px;
-  backdrop-filter: blur(5px);
-  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
-  animation: bankrollGlow 2.5s infinite alternate ease-in-out;
-}
+  .bankroll-label {
+    font-family: var(--font-ui);
+    font-size: 0.62rem;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+  }
 
-.bankroll-box:hover {
-  transform: scale(1.05);
-  box-shadow:
-    0 0 25px rgba(251, 251, 251, 0.8),
-    0 0 10px rgba(158, 158, 158, 0.7) inset;
-}
+  .bankroll-amount {
+    display: inline-flex;
+    align-items: center;
+  }
 
-.currency {
-  font-size: 0.85rem;
-  margin-right: 4px;
-  font-weight: bold;
-  color: rgba(255, 255, 255, 0.8);
-  text-shadow: 0 0 5px rgba(255, 255, 255, 0.5);
-}
+  .currency {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.55rem;
+    margin-right: 3px;
+    color: #fcd34d;
+    text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
+  }
 
-@keyframes bankrollGlow {
-  0%   { box-shadow: 0 0 8px rgba(245, 246, 245, 0.5); }
-  50%  { box-shadow: 0 0 12px rgba(242, 243, 242, 0.7); }
-  100% { box-shadow: 0 0 8px rgba(239, 241, 239, 0.5); }
-}
-
-  .wordbank-logo {
-    width: 280px;
-    height: auto;
-    display: block;
-    margin: -35px auto -42px;
-    padding-bottom: 0;
-    align-self: center;
+  .game-logo {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.5rem;
+    letter-spacing: -0.02em;
+    text-align: center;
+    margin: 4px 0 14px;
   }
 
   .logo-container {
@@ -937,28 +1003,30 @@
   }
 
   .icon-button, a.icon-button {
-    background: transparent;
-    border: none;
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-pill);
     text-decoration: none;
-    font-size: 20px;
+    font-size: 18px;
+    line-height: 1;
     cursor: pointer;
-    color: rgba(0, 0, 0, 0.85);
-    transition: color 0.3s ease, transform 0.2s ease, opacity 0.3s ease;
+    color: var(--text);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    transition: transform 0.18s var(--ease-spring), background 0.2s, border-color 0.2s;
   }
 
-  :global(body.dark-mode) .icon-button,
-  :global(body.dark-mode) a.icon-button {
-    color: rgba(255, 255, 255, 0.95);
+  .icon-button:hover, a.icon-button:hover {
+    background: var(--surface-2);
+    border-color: var(--border-strong);
+    transform: translateY(-1px) scale(1.05);
   }
 
-  .subtle-button {
-    opacity: 0.9;
-  }
-
-  .subtle-button:hover {
-    opacity: 1;
-    transform: scale(1.15);
-  }
+  .subtle-button { opacity: 0.95; }
 
   .modal-overlay {
   position: fixed;

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -240,211 +240,152 @@
 <style>
   .leaderboard-page {
     max-width: 700px;
-    margin: 2rem auto;
-    padding: 1rem;
+    margin: 0 auto;
+    padding: 2.5rem 1rem 3rem;
     text-align: center;
   }
 
   h1 {
-    color: limegreen;
+    font-family: var(--font-display);
     font-size: 2rem;
-    margin-bottom: 0.25rem;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.1rem;
   }
 
   .mode-tabs {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: center;
-    margin-bottom: 1rem;
+    display: inline-flex;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: 1.4rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-pill);
   }
 
   .tab-btn {
-    padding: 0.6rem 1.5rem;
-    border: 2px solid #ccc;
-    background: #fff;
-    color: #333;
-    border-radius: 8px;
+    padding: 0.55rem 1.6rem;
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    border-radius: var(--r-pill);
     cursor: pointer;
-    font-size: 1rem;
-    font-weight: bold;
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    font-weight: 600;
+    transition: color 0.2s, background 0.2s;
   }
-
-  .tab-btn:hover {
-    background: #f5f5f5;
-  }
-
+  .tab-btn:hover { color: var(--text); }
   .tab-btn.active {
-    background: limegreen;
-    color: white;
-    border-color: limegreen;
+    background: var(--brand-grad);
+    color: #06210f;
+    box-shadow: var(--glow-brand);
   }
 
   .period-label {
-    color: #888;
-    font-size: 0.95rem;
-    margin-bottom: 1rem;
+    color: var(--text-faint);
+    font-size: 0.9rem;
+    margin-bottom: 0.9rem;
   }
 
-  .period-filters {
+  .period-filters, .sort-filters {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.45rem;
     justify-content: center;
     flex-wrap: wrap;
     margin-bottom: 1rem;
   }
 
-  .period-btn {
+  .period-btn, .sort-btn {
     padding: 0.4rem 0.9rem;
-    border: 1px solid #ccc;
-    background: #fff;
-    color: #333;
-    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-muted);
+    border-radius: var(--r-pill);
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    transition: background 0.2s, border-color 0.2s, color 0.2s;
   }
-
-  .period-btn:hover {
-    background: #f5f5f5;
-  }
-
-  .period-btn.active {
-    background: limegreen;
-    color: white;
-    border-color: limegreen;
+  .period-btn:hover, .sort-btn:hover { background: var(--surface-2); color: var(--text); }
+  .period-btn.active, .sort-btn.active {
+    background: rgba(163, 230, 53, 0.12);
+    color: var(--brand-2);
+    border-color: rgba(163, 230, 53, 0.4);
   }
 
   .sort-label {
-    color: #888;
-    font-size: 0.85rem;
-    margin: 0.5rem 0 0.25rem;
-  }
-
-  .sort-filters {
-    display: flex;
-    gap: 0.4rem;
-    justify-content: center;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
-  }
-
-  .sort-btn {
-    padding: 0.35rem 0.75rem;
-    border: 1px solid #ccc;
-    background: #fff;
-    color: #333;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.85rem;
-  }
-
-  .sort-btn:hover {
-    background: #f5f5f5;
-  }
-
-  .sort-btn.active {
-    background: limegreen;
-    color: white;
-    border-color: limegreen;
+    color: var(--text-faint);
+    font-size: 0.8rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin: 0.5rem 0 0.5rem;
   }
 
   .back-btn {
     display: inline-block;
     margin-bottom: 2rem;
-    padding: 0.5rem 1rem;
-    background: #333;
-    color: white;
-    border: none;
-    border-radius: 8px;
+    padding: 0.6rem 1.2rem;
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
     cursor: pointer;
-    font-size: 0.95rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+    transition: background 0.2s, border-color 0.2s, transform 0.15s;
   }
-
-  .back-btn:hover {
-    background: #555;
-  }
+  .back-btn:hover { background: var(--surface-2); border-color: var(--border-strong); transform: translateY(-1px); }
 
   .loading, .error, .empty {
-    padding: 2rem;
-    color: #666;
+    padding: 2.5rem 1rem;
+    color: var(--text-muted);
   }
-
-  .error {
-    color: #c62828;
-  }
+  .error { color: var(--danger); }
 
   .table-wrap {
     overflow-x: auto;
-    border-radius: 12px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
-    margin: 0 -1rem;
+    border-radius: var(--r-lg);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    backdrop-filter: blur(14px);
   }
 
   table {
     width: 100%;
     min-width: 550px;
     border-collapse: collapse;
-    background: white;
   }
 
   th, td {
-    padding: 0.5rem 0.75rem;
+    padding: 0.7rem 0.85rem;
     text-align: left;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--border);
+    font-variant-numeric: tabular-nums;
   }
 
   th {
-    background: #f5f5f5;
-    font-weight: 700;
-    color: #333;
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: var(--text-faint);
+    background: rgba(255, 255, 255, 0.02);
   }
+  tbody tr { transition: background 0.15s; }
+  tbody tr:hover { background: rgba(255, 255, 255, 0.03); }
+  td { color: var(--text); }
 
   tr.top-three {
-    background: linear-gradient(90deg, rgba(76, 175, 80, 0.08), transparent);
+    background: linear-gradient(90deg, rgba(52, 211, 153, 0.10), transparent);
   }
 
-  td.rank {
-    font-weight: bold;
-    width: 50px;
-  }
-
-  td.name {
-    font-weight: 600;
-  }
+  td.rank { font-weight: 700; width: 50px; font-family: var(--font-display); }
+  td.name { font-weight: 600; }
 
   .hint {
-    margin-top: 2rem;
-    font-size: 0.85rem;
-    color: #999;
-  }
-
-  :global(body.dark-mode) .leaderboard-page table {
-    background: #333;
-  }
-
-  :global(body.dark-mode) th, :global(body.dark-mode) td {
-    border-color: #555;
-    color: #eee;
-  }
-
-  :global(body.dark-mode) th {
-    background: #444;
-  }
-
-  :global(body.dark-mode) .tab-btn, :global(body.dark-mode) .period-btn {
-    background: #333;
-    color: #eee;
-    border-color: #555;
-  }
-
-  :global(body.dark-mode) .tab-btn.active, :global(body.dark-mode) .period-btn.active, :global(body.dark-mode) .sort-btn.active {
-    background: limegreen;
-    color: white;
-    border-color: limegreen;
-  }
-
-  :global(body.dark-mode) .sort-btn {
-    background: #333;
-    color: #eee;
-    border-color: #555;
+    margin-top: 1.6rem;
+    font-size: 0.82rem;
+    color: var(--text-faint);
   }
 </style>

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -72,55 +72,49 @@
 </script>
 
 <main class="reset-wrapper">
-  <h2>🔑 Reset Your Password</h2>
+  <div class="reset-card glass fade-up">
+    <h2>Reset your password</h2>
 
-  {#if message}
-    <p class="message {success ? 'success' : 'error'}">{message}</p>
-  {/if}
+    {#if message}
+      <p class="message {success ? 'success' : 'error'}">{message}</p>
+    {/if}
 
-  {#if isTokenReady}
-    <input type="password" placeholder="New Password" bind:value={password} />
-    <input type="password" placeholder="Confirm Password" bind:value={confirmPassword} />
-    <button on:click={updatePassword}>Update Password</button>
-  {/if}
+    {#if isTokenReady}
+      <input class="field" type="password" placeholder="New password" bind:value={password} />
+      <input class="field" type="password" placeholder="Confirm password" bind:value={confirmPassword} />
+      <button class="btn-brand full" on:click={updatePassword}>Update password</button>
+    {/if}
+  </div>
 </main>
 
 <style>
   .reset-wrapper {
-    max-width: 400px;
-    margin: 60px auto;
-    padding: 1rem;
-    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 20px;
   }
-
-  input {
-    display: block;
+  .reset-card {
     width: 100%;
-    margin: 0.5rem 0;
-    padding: 0.75rem;
-    font-size: 1rem;
+    max-width: 400px;
+    padding: 30px 26px;
+    text-align: center;
+    box-shadow: var(--shadow-lg);
   }
-
-  button {
-    background: limegreen;
-    color: white;
-    font-weight: bold;
-    padding: 10px 16px;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
+  h2 {
+    font-family: var(--font-display);
+    font-size: 1.4rem;
+    margin: 0 0 1.2rem;
   }
+  .field { margin: 10px 0; text-align: left; }
+  .full { width: 100%; margin-top: 8px; }
 
   .message {
-    margin: 1rem 0;
-    font-weight: bold;
+    margin: 0 0 1rem;
+    font-weight: 600;
+    font-size: 0.9rem;
   }
-
-  .message.success {
-    color: green;
-  }
-
-  .message.error {
-    color: red;
-  }
+  .message.success { color: var(--brand-2); }
+  .message.error { color: var(--danger); }
 </style>

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -78,15 +78,15 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 1rem;
-    margin-top: 2rem;
+    gap: 0.75rem;
+    margin-top: 2.5rem;
   }
-
   h2 {
     text-align: center;
     margin: 0;
-    font-size: 2rem;
-    color: limegreen;
+    font-family: var(--font-display);
+    font-size: 1.9rem;
+    letter-spacing: -0.02em;
   }
 
   .leaderboard-link {
@@ -95,106 +95,83 @@
     justify-content: center;
     width: 44px;
     height: 44px;
-    font-size: 1.5rem;
-    background: #333;
-    color: white;
-    border-radius: 10px;
+    font-size: 1.3rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
     text-decoration: none;
-    transition: background 0.2s;
+    transition: background 0.2s, border-color 0.2s, transform 0.15s;
   }
-
-  .leaderboard-link:hover {
-    background: limegreen;
-  }
+  .leaderboard-link:hover { background: var(--surface-2); border-color: var(--border-strong); transform: translateY(-1px); }
 
   .mode-section {
-    margin: 2rem 0;
-    padding: 1.5rem;
-    border-radius: 12px;
-    background: rgba(0, 0, 0, 0.05);
+    width: 100%;
+    max-width: 460px;
+    margin: 1.5rem auto;
+    padding: 1.6rem 1.4rem;
+    border-radius: var(--r-xl);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    backdrop-filter: blur(14px);
   }
+  .mode-section.arcade { border-color: rgba(163, 230, 53, 0.18); }
 
   .mode-section h3 {
     margin-top: 0;
-    color: #333;
+    font-family: var(--font-display);
+    font-size: 1.25rem;
+    color: var(--text);
   }
-
   .mode-section p {
-    color: #666;
+    color: var(--text-muted);
     margin-bottom: 1rem;
+    font-size: 0.92rem;
   }
 
-  .status-loading {
-    margin: 1rem 0;
-    color: #888;
-  }
-
-  .daily-status {
-    margin: 1rem 0;
-  }
-
-  .played-badge {
-    font-weight: bold;
-    color: #333;
-    margin-bottom: 0.25rem;
-  }
-
-  .bankroll-badge {
-    font-weight: bold;
-    color: limegreen;
-    margin-bottom: 1rem;
-  }
-
-  .arcade-bankroll {
-    font-weight: 600;
-  }
-
-  .arcade-bankroll strong {
-    color: limegreen;
-  }
+  .status-loading { margin: 1rem 0; color: var(--text-faint); }
+  .daily-status { margin: 1rem 0; }
+  .played-badge { font-weight: 600; color: var(--text); margin-bottom: 0.25rem; }
+  .bankroll-badge { font-weight: 700; color: #fcd34d; margin-bottom: 1rem; }
+  .arcade-bankroll { font-weight: 600; color: var(--text-muted); }
+  .arcade-bankroll strong { color: #fcd34d; }
 
   .daily-btn {
-    padding: 1rem 2rem;
-    font-size: 1.2rem;
-    font-weight: bold;
-    background: linear-gradient(135deg, #ff6b35, #f7931e);
+    padding: 0.95rem 2rem;
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    font-weight: 700;
+    background: var(--brand-grad);
     border: none;
-    border-radius: 12px;
-    color: white;
+    border-radius: var(--r-md);
+    color: #06210f;
     cursor: pointer;
-    transition: transform 0.2s, box-shadow 0.2s;
+    box-shadow: var(--glow-brand);
+    transition: transform 0.16s var(--ease-spring), filter 0.2s;
   }
-
-  .daily-btn:hover:not(.disabled) {
-    transform: scale(1.05);
-    box-shadow: 0 4px 12px rgba(255, 107, 53, 0.4);
-  }
-
-  .daily-btn.disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
+  .daily-btn:hover:not(.disabled) { transform: translateY(-2px); filter: brightness(1.05); }
+  .daily-btn.disabled { opacity: 0.45; cursor: not-allowed; background: var(--surface-2); color: var(--text-muted); box-shadow: none; }
 
   .category-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.65rem;
     margin-top: 1rem;
   }
-
   .category-grid button {
-    padding: 1rem;
-    font-size: 1rem;
-    font-weight: bold;
-    background-color: limegreen;
-    border: none;
-    border-radius: 10px;
-    color: white;
+    padding: 1rem 0.75rem;
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    font-weight: 600;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    color: var(--text);
     cursor: pointer;
-    transition: background 0.2s ease;
+    transition: background 0.2s, border-color 0.2s, transform 0.15s var(--ease-spring);
   }
-
   .category-grid button:hover {
-    background-color: green;
+    transform: translateY(-2px);
+    background: linear-gradient(135deg, rgba(52, 211, 153, 0.14), rgba(163, 230, 53, 0.05));
+    border-color: rgba(163, 230, 53, 0.4);
   }
 </style>

--- a/src/routes/select/arcade/+page.svelte
+++ b/src/routes/select/arcade/+page.svelte
@@ -72,142 +72,114 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 1rem;
-    margin-top: 2rem;
+    margin-top: 2.5rem;
   }
-
   h2 {
     text-align: center;
     margin: 0;
-    font-size: 2rem;
-    color: #0055bb;
+    font-family: var(--font-display);
+    font-size: 1.9rem;
+    letter-spacing: -0.02em;
   }
 
   .main-menu-link-wrap {
     text-align: center;
     margin: 1rem 0 1.5rem 0;
   }
-
   .main-menu-btn {
-    font-family: 'Orbitron', sans-serif;
-    font-size: 1rem;
-    padding: 0.6rem 1rem;
-    border-radius: 10px;
-    border: 2px solid #2e9417;
-    background: linear-gradient(180deg, #46a230, #318020);
-    color: #fff;
+    font-family: var(--font-ui);
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 0.6rem 1.1rem;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
     cursor: pointer;
-    box-shadow: inset 1px 1px 4px rgba(255, 255, 255, 0.3), 2px 2px 6px rgba(0, 0, 0, 0.6);
+    transition: background 0.2s, border-color 0.2s, transform 0.15s;
   }
-
   .main-menu-btn:hover {
-    transform: translateY(-2px);
-    background: linear-gradient(180deg, #4cb038, #368828);
+    transform: translateY(-1px);
+    background: var(--surface-2);
+    border-color: var(--border-strong);
   }
 
   .mode-section {
-    margin: 2rem 0;
-    padding: 1.5rem;
-    border-radius: 12px;
-    background: rgba(0, 85, 187, 0.08);
-    border: 2px solid rgba(0, 85, 187, 0.35);
+    width: 100%;
+    max-width: 440px;
+    margin: 0 auto 2rem;
+    padding: 1.6rem 1.4rem;
+    border-radius: var(--r-xl);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    backdrop-filter: blur(14px);
   }
 
   .select-category-heading {
-    margin: 0 0 0.5rem 0;
-    font-size: 2rem;
+    margin: 0 0 0.25rem 0;
+    font-family: var(--font-display);
+    font-size: 1.5rem;
     font-weight: 700;
-    color: #0055bb;
     text-align: center;
-    text-shadow: 0 0 8px rgba(68, 136, 255, 0.4);
   }
 
   .current-bankroll-label {
     margin: 1rem 0 0.5rem 0;
-    font-size: 1rem;
-    color: #0055bb;
+    font-size: 0.65rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-faint);
     text-align: center;
     font-weight: 600;
   }
 
-  .mode-section p {
-    color: #0055bb;
-    margin-bottom: 1rem;
-  }
-
-  /* Same bankroll graphic as in-game */
   .bankroll-container {
     display: flex;
     justify-content: center;
     align-items: center;
     width: 100%;
-    margin: 1rem auto;
+    margin: 0.5rem auto 1.5rem;
   }
-
   .bankroll-box {
-    padding: 2px 28px;
-    font-size: 0.4rem;
-    font-family: 'Orbitron', sans-serif;
-    color: #fff;
-    background: linear-gradient(180deg, #d1cdcd, #858484);
-    border: 2px solid rgba(255, 255, 255, 0.4);
-    border-radius: 8px;
-    text-align: center;
-    box-shadow:
-      inset 1px 1px 4px rgba(255, 255, 255, 0.2),
-      2px 2px 6px rgba(0, 0, 0, 0.742),
-      3px 3px 8px rgba(0, 0, 0, 0.5),
-      0 0 6px rgba(245, 246, 245, 0.5);
     display: inline-flex;
-    justify-content: center;
     align-items: center;
-    letter-spacing: 1px;
-    backdrop-filter: blur(5px);
-    transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
-    animation: bankrollGlow 2.5s infinite alternate ease-in-out;
+    padding: 12px 26px;
+    background: var(--surface-strong);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    box-shadow: var(--shadow-md);
+    backdrop-filter: blur(14px);
   }
-
-  .bankroll-box:hover {
-    transform: scale(1.05);
-    box-shadow:
-      0 0 25px rgba(251, 251, 251, 0.8),
-      0 0 10px rgba(158, 158, 158, 0.7) inset;
-  }
-
   .currency {
-    font-size: 0.85rem;
-    margin-right: 4px;
-    font-weight: bold;
-    color: rgba(255, 255, 255, 0.8);
-    text-shadow: 0 0 5px rgba(255, 255, 255, 0.5);
-  }
-
-  @keyframes bankrollGlow {
-    0%   { box-shadow: 0 0 8px rgba(245, 246, 245, 0.5); }
-    50%  { box-shadow: 0 0 12px rgba(242, 243, 242, 0.7); }
-    100% { box-shadow: 0 0 8px rgba(239, 241, 239, 0.5); }
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.45rem;
+    margin-right: 3px;
+    color: #fcd34d;
+    text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
   }
 
   .category-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 0.65rem;
     margin-top: 1rem;
   }
-
   .category-grid button {
-    padding: 1rem;
-    font-size: 1rem;
-    font-weight: bold;
-    background-color: limegreen;
-    border: none;
-    border-radius: 10px;
-    color: white;
+    padding: 1rem 0.75rem;
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    font-weight: 600;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    color: var(--text);
     cursor: pointer;
-    transition: background 0.2s ease;
+    transition: background 0.2s, border-color 0.2s, transform 0.15s var(--ease-spring);
   }
-
   .category-grid button:hover {
-    background-color: green;
+    transform: translateY(-2px);
+    background: linear-gradient(135deg, rgba(52, 211, 153, 0.14), rgba(163, 230, 53, 0.05));
+    border-color: rgba(163, 230, 53, 0.4);
   }
 </style>


### PR DESCRIPTION
## Summary
Replaces the unstyled white prototype with a cohesive, modern, dark **neon-arcade / fintech** game UI, driven by a real design system. Validated with a Playwright screenshot harness.

**Foundation**
- `app.css` — design tokens (color/space/radius/shadow/motion), `Space Grotesk` + `Inter`, glass/button/field helpers, atmospheric radial-glow background.
- `+layout.svelte` — loads the system globally.

**Screens restyled**
- **Login** — glass card, gradient wordmark, modern fields, brand-gradient button.
- **Main menu** — glass cards with icon tiles, brand-highlighted Daily, glass top-bar pills.
- **Game board** — gradient wordmark, category chips, dark glass phrase tiles (brand-glow active slot, gradient locked letters), gold **Balance** readout, centered layout that kills the dead gap.
- **Keyboard** — dark glass keys, brand pending/locked states, dimmed incorrect.
- **Action buttons** — brand-gradient Solve/Confirm, glass Bank Letter/Guesses, gold cost chips.
- **Leaderboard** — segmented pill control, brand-tinted filters, dark glass table.

**Tooling** — `scripts/shoot.mjs` (Playwright) drives the app and screenshots every screen for the redesign loop; `screenshots/` gitignored.

## Status: WIP — not all screens done
Still to restyle: select/arcade pages, modals (how-to-play, account, streak), the win/loss result banner, reset-password page, and motion polish (count-up bankroll, tile-reveal springs). Opening for review of the **direction** before finishing the long tail.

Build + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)