### PR TITLE
Epic motion polish + atmospheric detail

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -62,14 +62,39 @@ body {
   font-family: var(--font-ui);
   color: var(--text);
   background-color: var(--bg-0);
-  /* Layered radial glows for atmosphere */
-  background-image:
-    radial-gradient(900px 600px at 15% -10%, rgba(52, 211, 153, 0.10), transparent 60%),
-    radial-gradient(800px 600px at 110% 10%, rgba(56, 189, 248, 0.08), transparent 55%),
-    radial-gradient(1000px 800px at 50% 120%, rgba(163, 230, 53, 0.07), transparent 60%);
-  background-attachment: fixed;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+}
+
+/* Animated aurora glow layer (drifts slowly behind everything) */
+body::before {
+  content: '';
+  position: fixed;
+  inset: -25%;
+  z-index: -2;
+  pointer-events: none;
+  background:
+    radial-gradient(38% 46% at 16% 10%, rgba(52, 211, 153, 0.16), transparent 60%),
+    radial-gradient(36% 44% at 86% 16%, rgba(56, 189, 248, 0.13), transparent 60%),
+    radial-gradient(52% 56% at 50% 112%, rgba(163, 230, 53, 0.13), transparent 60%);
+  filter: blur(24px);
+  animation: auroraDrift 26s ease-in-out infinite alternate;
+}
+@keyframes auroraDrift {
+  0%   { transform: translate3d(0, 0, 0) scale(1); }
+  50%  { transform: translate3d(2.5%, -2%, 0) scale(1.1); }
+  100% { transform: translate3d(-2%, 1.5%, 0) scale(1.05); }
+}
+
+/* Fine film grain for a premium, less-flat surface */
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
 h1, h2, h3, h4 {
@@ -159,3 +184,51 @@ button { font-family: inherit; }
   to   { opacity: 1; transform: translateY(0); }
 }
 .fade-up { animation: wb-fade-up 0.5s var(--ease-out) both; }
+
+/* Staggered children: set style="--i: n" on each child for a cascade */
+.stagger > * { animation: wb-fade-up 0.55s var(--ease-out) both; animation-delay: calc(var(--i, 0) * 70ms); }
+
+/* Pop / glow / shimmer / float — reusable epic accents */
+@keyframes wb-pop-in {
+  0%   { opacity: 0; transform: scale(0.8); }
+  60%  { transform: scale(1.06); }
+  100% { opacity: 1; transform: scale(1); }
+}
+.pop-in { animation: wb-pop-in 0.5s var(--ease-spring) both; }
+
+@keyframes wb-glow-pulse {
+  0%, 100% { box-shadow: var(--glow-brand); }
+  50%      { box-shadow: 0 0 0 1px rgba(163,230,53,0.45), 0 10px 42px rgba(52,211,153,0.55); }
+}
+@keyframes wb-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-5px); }
+}
+.float { animation: wb-float 4.5s ease-in-out infinite; }
+
+/* Sweeping sheen for brand buttons / cards */
+@keyframes wb-sheen {
+  0%   { transform: translateX(-130%) skewX(-18deg); }
+  100% { transform: translateX(230%) skewX(-18deg); }
+}
+.btn-brand, .sheen { position: relative; overflow: hidden; isolation: isolate; }
+.btn-brand::after, .sheen::after {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0; left: 0;
+  width: 40%;
+  background: linear-gradient(100deg, transparent, rgba(255,255,255,0.5), transparent);
+  transform: translateX(-130%) skewX(-18deg);
+  pointer-events: none;
+}
+.btn-brand:hover::after, .sheen:hover::after { animation: wb-sheen 0.85s var(--ease-out); }
+
+/* Respect users who prefer less motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+  body::before { animation: none !important; }
+}

--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -153,6 +153,14 @@
     box-sizing: border-box;
     overflow-x: hidden;
     text-align: center;
+    perspective: 800px;
+  }
+  .letter-box.active {
+    animation: activePulse 1.4s ease-in-out infinite;
+  }
+  @keyframes activePulse {
+    0%, 100% { box-shadow: 0 0 0 4px rgba(163,230,53,0.14), 0 0 14px rgba(163,230,53,0.2); }
+    50%      { box-shadow: 0 0 0 5px rgba(163,230,53,0.26), 0 0 22px rgba(163,230,53,0.4); }
   }
   .word {
     display: flex;
@@ -193,6 +201,12 @@
     background: var(--brand-grad);
     border-color: transparent;
     box-shadow: 0 4px 16px rgba(52, 211, 153, 0.35);
+    animation: tileReveal 0.55s var(--ease-spring) both;
+  }
+  @keyframes tileReveal {
+    0%   { transform: perspective(600px) rotateX(-90deg); box-shadow: 0 0 0 rgba(52,211,153,0); }
+    55%  { transform: perspective(600px) rotateX(0deg) scale(1.14); box-shadow: 0 0 26px rgba(163,230,53,0.7); }
+    100% { transform: perspective(600px) rotateX(0deg) scale(1); }
   }
   .letter-box.active {
     border: 2px solid var(--brand-2);

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -77,13 +77,13 @@ export const gameStore = writable(/** @type {GameState} */ ({
  * Triggers a celebratory confetti animation.
  */
 function launchConfetti() {
-  confetti({
-    particleCount: 120,
-    spread: 100,
-    startVelocity: 40,
-    scalar: 1.2,
-    origin: { y: 0.6 }
-  });
+  const colors = ['#34d399', '#a3e635', '#fcd34d', '#ffffff'];
+  /** @param {number} particleCount @param {object} opts */
+  const fire = (particleCount, opts) => confetti({ particleCount, colors, disableForReducedMotion: true, ...opts });
+  fire(90, { spread: 75, startVelocity: 55, origin: { y: 0.62 } });
+  fire(55, { spread: 110, decay: 0.92, scalar: 1.25, origin: { y: 0.6 } });
+  setTimeout(() => fire(65, { spread: 120, startVelocity: 48, angle: 60, origin: { x: 0.15, y: 0.65 } }), 160);
+  setTimeout(() => fire(65, { spread: 120, startVelocity: 48, angle: 120, origin: { x: 0.85, y: 0.65 } }), 300);
 }
 
 /* ================================

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -175,6 +175,22 @@
   $: digits = String(bankroll).split('');
   $: sliderLocked = $gameStore.gameState === 'guess_mode';
 
+  // ✨ Bankroll change reaction (pulse + floating delta)
+  let bankrollPulse = '';
+  let bankrollDelta = 0;
+  /** @type {number | null} */
+  let _prevBankroll = null;
+  $: {
+    const b = $gameStore.bankroll;
+    if (_prevBankroll !== null && typeof b === 'number' && b !== _prevBankroll) {
+      bankrollDelta = b - _prevBankroll;
+      bankrollPulse = bankrollDelta > 0 ? 'up' : 'down';
+      const token = bankrollDelta;
+      setTimeout(() => { if (bankrollDelta === token) bankrollPulse = ''; }, 950);
+    }
+    if (typeof b === 'number') _prevBankroll = b;
+  }
+
   // ✅ Auto-save whenever state is valid
   $: if (
     loggedIn &&
@@ -404,13 +420,14 @@
     <!-- 🏠 Main Menu (after sign-in) -->
     <div class="main-menu fade-up">
       <div class="menu-hero">
-        <div class="menu-mark">WB</div>
+        <div class="menu-mark float">WB</div>
         <h1 class="menu-wordmark"><span class="brand-text">Word</span>Bank</h1>
         <p class="menu-tagline">Crack the phrase. Bank the win.</p>
       </div>
-      <div class="main-menu-buttons">
+      <div class="main-menu-buttons stagger">
         <button
-          class="menu-card primary"
+          class="menu-card primary sheen"
+          style="--i: 0"
           class:disabled={menuDailyPlayed && !(savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost')}
           on:click={handleMenuDaily}
         >
@@ -421,7 +438,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" on:click={handleMenuArcade}>
+        <button class="menu-card" style="--i: 1" on:click={handleMenuArcade}>
           <span class="mc-icon">🕹️</span>
           <span class="mc-body">
             <span class="mc-title">{#if savedGameInfo?.gameMode === 'arcade' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}Resume Arcade{:else}Arcade Mode{/if}</span>
@@ -429,7 +446,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" on:click={handleMenuLeaderboard}>
+        <button class="menu-card" style="--i: 2" on:click={handleMenuLeaderboard}>
           <span class="mc-icon">🏆</span>
           <span class="mc-body">
             <span class="mc-title">Leaderboard</span>
@@ -437,7 +454,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" on:click={handleMenuMyAccount}>
+        <button class="menu-card" style="--i: 3" on:click={handleMenuMyAccount}>
           <span class="mc-icon">👤</span>
           <span class="mc-body">
             <span class="mc-title">My Account</span>
@@ -510,7 +527,10 @@
     <!-- 💰 Bankroll Display -->
     <section class="stats-section">
       <div class="bankroll-container">
-        <div class="bankroll-box">
+        <div class="bankroll-box" class:pulse-up={bankrollPulse === 'up'} class:pulse-down={bankrollPulse === 'down'}>
+          {#if bankrollPulse}
+            <span class="bankroll-delta {bankrollPulse}">{bankrollDelta > 0 ? '+' : '−'}${Math.abs(bankrollDelta)}</span>
+          {/if}
           <span class="bankroll-label">Balance</span>
           <span class="bankroll-amount">
             <span class="currency">$</span>
@@ -570,6 +590,7 @@
 
     <!-- 🏆 Game Outcome Banner -->
     {#if $gameStore.gameState === "won"}
+      <div class="win-burst" aria-hidden="true"></div>
       <div class="banner win">Winner!</div>
     {:else if $gameStore.gameState === "lost"}
       <div class="banner lose">Bankrupt!</div>
@@ -860,6 +881,7 @@
   }
 
   .bankroll-box {
+    position: relative;
     display: inline-flex;
     flex-direction: column;
     align-items: center;
@@ -871,6 +893,39 @@
     box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.06);
     backdrop-filter: blur(14px);
     -webkit-backdrop-filter: blur(14px);
+  }
+  .bankroll-box.pulse-up { animation: bankPulseUp 0.7s var(--ease-spring); }
+  .bankroll-box.pulse-down { animation: bankPulseDown 0.6s var(--ease-spring); }
+  @keyframes bankPulseUp {
+    0%, 100% { transform: scale(1); box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255,255,255,0.06); }
+    40% { transform: scale(1.07); box-shadow: var(--shadow-md), 0 0 30px rgba(163,230,53,0.55); }
+  }
+  @keyframes bankPulseDown {
+    0%, 100% { transform: scale(1); }
+    35% { transform: scale(0.96); }
+  }
+  .bankroll-delta {
+    position: absolute;
+    top: 2px;
+    right: 12px;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.95rem;
+    font-variant-numeric: tabular-nums;
+    pointer-events: none;
+    text-shadow: 0 0 12px currentColor;
+  }
+  .bankroll-delta.up { color: var(--brand-2); animation: deltaFloatUp 0.95s var(--ease-out) forwards; }
+  .bankroll-delta.down { color: #fb7185; animation: deltaFloatDown 0.95s var(--ease-out) forwards; }
+  @keyframes deltaFloatUp {
+    0% { opacity: 0; transform: translateY(8px); }
+    25% { opacity: 1; }
+    100% { opacity: 0; transform: translateY(-28px); }
+  }
+  @keyframes deltaFloatDown {
+    0% { opacity: 0; transform: translateY(-8px); }
+    25% { opacity: 1; }
+    100% { opacity: 0; transform: translateY(24px); }
   }
 
   .bankroll-label {
@@ -929,6 +984,20 @@
     0% { opacity: 1; }
     50% { opacity: 0.2; }
     100% { opacity: 1; }
+  }
+
+  .win-burst {
+    position: fixed;
+    inset: 0;
+    z-index: 998;
+    pointer-events: none;
+    background: radial-gradient(circle at 50% 45%, rgba(163, 230, 53, 0.35), rgba(52, 211, 153, 0.18) 35%, transparent 60%);
+    animation: winBurst 1s var(--ease-out) forwards;
+  }
+  @keyframes winBurst {
+    0% { opacity: 0; transform: scale(0.4); }
+    30% { opacity: 1; }
+    100% { opacity: 0; transform: scale(1.6); }
   }
 
   .banner.win {

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -372,15 +372,24 @@
     color: var(--text-faint);
     background: rgba(255, 255, 255, 0.02);
   }
-  tbody tr { transition: background 0.15s; }
+  tbody tr { transition: background 0.15s; animation: wb-fade-up 0.45s var(--ease-out) both; }
+  tbody tr:nth-child(1) { animation-delay: 0.03s; }
+  tbody tr:nth-child(2) { animation-delay: 0.08s; }
+  tbody tr:nth-child(3) { animation-delay: 0.13s; }
+  tbody tr:nth-child(4) { animation-delay: 0.18s; }
+  tbody tr:nth-child(5) { animation-delay: 0.23s; }
+  tbody tr:nth-child(n+6) { animation-delay: 0.28s; }
   tbody tr:hover { background: rgba(255, 255, 255, 0.03); }
   td { color: var(--text); }
 
   tr.top-three {
-    background: linear-gradient(90deg, rgba(52, 211, 153, 0.10), transparent);
+    background: linear-gradient(90deg, rgba(251, 191, 36, 0.13), transparent);
+    box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.12);
   }
+  tr.top-three td.name { color: #fde68a; }
 
   td.rank { font-weight: 700; width: 50px; font-family: var(--font-display); }
+  tr.top-three td.rank { font-size: 1.1rem; animation: wb-pop-in 0.5s var(--ease-spring) both; display: inline-block; }
   td.name { font-weight: 600; }
 
   .hint {

--- a/src/routes/select/+page.svelte
+++ b/src/routes/select/+page.svelte
@@ -66,9 +66,9 @@
   <h3>🎮 Arcade Mode</h3>
   <p>Unlimited play. Build your cumulative bankroll!</p>
   <p class="arcade-bankroll">Your arcade bankroll: <strong>${status.arcade_bankroll?.toLocaleString() ?? 1000}</strong></p>
-  <div class="category-grid">
-    {#each categories as cat}
-      <button onclick={() => selectArcade(cat)}>{cat}</button>
+  <div class="category-grid stagger">
+    {#each categories as cat, i}
+      <button style="--i: {i}" onclick={() => selectArcade(cat)}>{cat}</button>
     {/each}
   </div>
 </div>

--- a/src/routes/select/arcade/+page.svelte
+++ b/src/routes/select/arcade/+page.svelte
@@ -60,9 +60,9 @@
       {/each}
     </div>
   </div>
-  <div class="category-grid">
-    {#each categories as cat}
-      <button onclick={() => selectArcade(cat)}>{cat}</button>
+  <div class="category-grid stagger">
+    {#each categories as cat, i}
+      <button style="--i: {i}" onclick={() => selectArcade(cat)}>{cat}</button>
     {/each}
   </div>
 </div>


### PR DESCRIPTION
## Summary
Brings the UI to life with performant (transform/opacity, GPU-friendly) motion across every surface. Respects \`prefers-reduced-motion\`.

**Global**
- Drifting **aurora glow** layer + fine **film-grain** behind everything.
- Reusable motion utilities: \`.stagger\` cascade, \`.pop-in\`, \`.float\`, glow-pulse, and a sweeping **sheen** on brand buttons/cards.

**Game board**
- Letter tiles now **3D flip-reveal** with a glow pop; the active guess slot **breathes**.
- Bankroll **reacts** — scale/glow pulse + a floating **"+$ / −$" delta** on every change.
- **Win**: multi-burst brand-colored confetti + a radial **glow-burst** overlay.

**Menu / Leaderboard / Select**
- Menu: staggered card entrance, floating WB mark, sheen on the Daily card.
- Leaderboard: rows cascade in, **gold top-3 glow** + medal pop.
- Select: category cards stagger in.

## Verification
Build + type-check pass (0 warnings). Captured static end-states on mobile + desktop via Playwright to confirm no layout breakage (motion itself is best felt on the preview). Honoring reduced-motion preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)