### PR TITLE
V2 Phase 0: economy refactor (one currency, free tries, smart Reveal)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,10 +30,13 @@ Living plan for the game's evolution. **Update the Status column as we go.**
 
 ## V2 design decisions (agreed)
 
-### Shared core
-- 📋 **One currency: bankroll.** Remove guess-buying and the "0 guesses + <$150 = instant loss" dead-end.
-- 📋 **Wrong guess costs money** (fixed penalty) instead of consuming a separate "guess" currency. You lose only when you can't afford to act.
-- 📋 **"Bank Letter" → "Reveal"**: smart (reveals most-useful letter / a vowel), dynamically priced. Specific letters = cheap-but-risky; Reveal = pricey-but-safe.
+### Shared core (Phase 0 — LOCKED)
+- **Bankroll is only for information.** No more buying guesses; no "<$150" dead-end.
+- **Guessing is free but limited to 3 attempts** (not purchasable). A wrong guess burns an attempt — **no money lost** (avoids the harsh cliff where a wrong guess at $70 zeroes you out).
+- **Out of attempts ≠ stuck:** you can still win by buying letters until the phrase is fully revealed (expensive → low score). The economy still matters without an instant-loss gotcha.
+- **"Bank Letter" → "Reveal":** reveals **all instances of the most-frequent unrevealed letter** (guaranteed useful, not random), flat **$150** (tunable). Strictly better than the old random single-tile hint.
+- **Lose only when broke + unsolved** (bankroll < $30, the cheapest letter). One clean failure state.
+- **Attempts start at 3.** Daily has no wager; arcade keeps its wager for now (revisit Phase 4).
 
 ### 🗓️ Daily — ranked & fair (prestige mode)
 - 📋 Same puzzle for everyone, once a day. (already true)
@@ -77,7 +80,7 @@ Status: 📋 Planned (Phase 3)
 
 | Phase | Scope | Touches | Status |
 |---|---|---|---|
-| **0 — Economy refactor** | One currency, wrong-guess-costs-money, Reveal rework/retune | Daily RPCs (server) + arcade client | 📋 |
+| **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
 | **1 — Daily scoring + share** | Par/efficiency/streak scoring, medals, **share card** | Server scoring + UI | 📋 |
 | **2 — Streaks & badges** | Streak freeze, badge engine, leaderboard flair | Server + UI | 📋 |
 | **3 — Power-up system** | Inventory + effects, earned via play/badges (no payments) | Server + UI | 📋 |

--- a/scripts/check-reveal.mjs
+++ b/scripts/check-reveal.mjs
@@ -1,0 +1,33 @@
+// Verify the new daily Reveal: reveals a full letter and charges $150.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+await p.getByRole('button', { name: /daily/i }).first().click().catch(()=>{}); await wait(2600);
+
+const revealed = async () => p.locator('.letter-box.locked').count();
+const tries = async () => (await p.locator('.guesses-count').innerText().catch(()=>'?')).trim();
+
+await p.screenshot({ path: 'screenshots/rev-1-fresh.png' });
+console.log('fresh:   revealedTiles=', await revealed(), ' tries=', await tries());
+
+await p.locator('.hint-button').click({ force: true }).catch(e=>console.log('reveal click', e.message)); await wait(500);
+await p.screenshot({ path: 'screenshots/rev-2-pending.png' });
+
+await p.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch(e=>console.log('confirm', e.message)); await wait(1800);
+await p.screenshot({ path: 'screenshots/rev-3-after.png' });
+console.log('after:   revealedTiles=', await revealed(), ' tries=', await tries());
+await b.close();

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -1,6 +1,6 @@
 <script>
   import { createEventDispatcher, onMount } from 'svelte';
-  import { gameStore, confirmPurchase, submitGuess, selectExtraGuess } from '$lib/stores/GameStore.js';
+  import { gameStore, confirmPurchase, submitGuess } from '$lib/stores/GameStore.js';
 
   /** @type {boolean} */
   export let wagerUIVisible = false;
@@ -23,9 +23,7 @@
   $: purchasePending = !!$gameStore.selectedPurchase;
   $: hintPending = $gameStore.selectedPurchase?.type === 'hint' && $gameStore.gameState === 'purchase_pending';
   $: showHintCost = hintPending;
-  $: extraGuessPending = $gameStore.selectedPurchase?.type === 'extra_guess' && $gameStore.gameState === 'purchase_pending';
-  $: showExtraGuessCost = extraGuessPending;
-  $: guessesRemaining = $gameStore.guessesRemaining ?? 2;
+  $: guessesRemaining = $gameStore.guessesRemaining ?? 3;
   $: fundsLow = bankroll < 150;
   $: noGuessesLeft = guessesRemaining <= 0;
   $: canConfirmWager = sliderWagerAmount > 0;
@@ -81,7 +79,7 @@
 
     if (isDailyMode) {
       if (noGuessesLeft) {
-        gameStore.update(s => ({ ...s, message: 'Buy another guess ($150)' }));
+        gameStore.update(s => ({ ...s, message: 'Out of guesses — buy letters to finish the phrase' }));
         return;
       }
       gameStore.update(state => ({
@@ -107,7 +105,7 @@
     }
 
     if (noGuessesLeft) {
-      gameStore.update(s => ({ ...s, message: 'Buy another guess ($150)' }));
+      gameStore.update(s => ({ ...s, message: 'Out of guesses — buy letters to finish the phrase' }));
       return;
     }
 
@@ -132,11 +130,6 @@
     });
   }
 
-  function toggleExtraGuessPurchase() {
-    dispatch('setWagerUIVisible', false);
-    dispatch('setSliderWagerAmount', 0);
-    selectExtraGuess();
-  }
 </script>
 
 {#if $gameStore.message}
@@ -154,8 +147,9 @@
       class="hint-button {fundsLow ? 'disabled-purchase' : ''} {hintPending ? 'glow' : ''}"
       on:click={toggleHintPurchase}
       disabled={fundsLow || buttonsDisabled}
+      title="Reveal the most useful letter ($150)"
     >
-      Bank Letter
+      Reveal
     </button>
   </div>
 
@@ -219,17 +213,9 @@
   {/if}
 
   <div class="guesses-button-container">
-    {#if showExtraGuessCost}
-      <div class="cost-indicator">$150</div>
-    {/if}
-    <button
-      class="guesses-button {fundsLow ? 'disabled-purchase' : ''} {extraGuessPending ? 'glow' : ''}"
-      on:click={toggleExtraGuessPurchase}
-      disabled={fundsLow || buttonsDisabled}
-      title="Guesses: {guessesRemaining}. $150 for another."
-    >
-      Guesses<br /><span class="guesses-count">{guessesRemaining}</span>
-    </button>
+    <div class="guesses-display" title="Solve attempts remaining">
+      Tries<br /><span class="guesses-count">{guessesRemaining}</span>
+    </div>
   </div>
 </div>
 <style>
@@ -374,7 +360,26 @@
   transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
   cursor: pointer;
 }
-.guesses-button .guesses-count {
+.guesses-display {
+  width: 54px;
+  height: 46px;
+  border-radius: 13px;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 8px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  line-height: 1.1;
+  backdrop-filter: blur(10px);
+}
+.guesses-count {
   font-family: var(--font-display);
   font-size: 18px;
   font-weight: 700;

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -6,7 +6,7 @@ import confetti from 'canvas-confetti';
 import { user } from '$lib/stores/userStore.js';
 import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
 import { recordDailyResult, recordArcadeResult, saveArcadeBankroll } from '$lib/stores/statsStore.js';
-import { dailyStart, dailyBuyLetter, dailyBuyHint, dailyBuyGuess, dailySubmitGuess } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess } from '$lib/stores/statsStore.js';
 
 /* ================================
    Types (JSDoc for checkJs)
@@ -53,7 +53,7 @@ export const LETTER_COSTS = {
 export const gameStore = writable(/** @type {GameState} */ ({
   bankroll: 1000,
   wagerAmount: 1,
-  guessesRemaining: 2,
+  guessesRemaining: 3,
   category: '',
   currentPhrase: '',
   gameState: 'default', // States: "default", "purchase_pending", "guess_mode", "won", "lost"
@@ -173,8 +173,7 @@ async function confirmPurchaseDaily(state) {
   try {
     let board = null;
     if (purchase.type === 'letter') board = await dailyBuyLetter(purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await dailyBuyHint();
-    else if (purchase.type === 'extra_guess') board = await dailyBuyGuess();
+    else if (purchase.type === 'hint') board = await dailyReveal();
 
     if (board) reconcileDailyBoard(board);
     else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
@@ -227,54 +226,40 @@ function animateBankrollReduction(startingAmount) {
 }
 
 
+// Cheapest letter you can buy — below this you can't act, so the game is lost.
+const MIN_LETTER_COST = 30;
+
 /**
- * checkLossCondition
- * Ends the game if bankroll hits zero, or if zero guesses remaining and bankroll < $150.
- * Reveals the phrase, records result, and syncs state.
+ * checkLossCondition (arcade only — daily resolves on the server)
+ * The only failure state: broke and unsolved (can't afford the cheapest letter).
+ * Guesses are free and unlimited isn't a loss; you can always buy toward a full reveal.
  *
  * @param {GameState} state - The current game state
  * @returns {GameState} Updated state if loss occurred, otherwise original state
  */
 function checkLossCondition(state) {
-  const guessesLeft = state.guessesRemaining ?? 2;
-  const noGuessesAndCantBuy = guessesLeft <= 0 && state.bankroll < 150;
-  const bankrollZero = state.bankroll < 1;
-
-  if (!noGuessesAndCantBuy && !bankrollZero) return state;
+  if (state.gameState === 'won' || state.bankroll >= MIN_LETTER_COST) return state;
 
   // Reveal the full phrase
   const fullReveal = Object.fromEntries(
     state.currentPhrase.split('').map((/** @type {string} */ ch, /** @type {number} */ i) => [i, ch])
   );
 
-  if (bankrollZero) {
-    console.log("💀 Game Over: Bankroll is zero.");
-    animateBankrollReduction(state.bankroll);
-  } else {
-    console.log("💀 Game Over: No guesses remaining and can't afford another ($150).");
-  }
+  console.log("💀 Game Over: out of money.");
+  animateBankrollReduction(state.bankroll);
 
   const newState = {
     ...state,
     gameState: "lost",
-    guessedLetters: fullReveal,
-    bankroll: bankrollZero ? 1000 : state.bankroll
+    guessedLetters: fullReveal
   };
 
-  // 💾 Save to Supabase
   const currentUser = get(user);
-  if (currentUser?.id) {
-    if (state.gameMode === 'daily') {
-      recordDailyResult(currentUser.id, false, bankrollZero ? 0 : state.bankroll);
-    } else {
-      recordArcadeResult(currentUser.id, false, bankrollZero ? 0 : state.bankroll);
-    }
+  if (currentUser?.id && state.gameMode === 'arcade') {
+    recordArcadeResult(currentUser.id, false, state.bankroll);
   }
 
-  // 💾 Save to localStorage
   saveGameToLocalStorage();
-  console.log("💾 Saved game state after loss:", newState);
-
   return newState;
 }
 /* ================================
@@ -333,23 +318,6 @@ export function selectHint() {
       ...state,
       gameState: "purchase_pending",
       selectedPurchase: { type: 'hint' }
-    };
-  });
-}
-
-/**
- * selectExtraGuess
- * Toggles extra guess purchase ($150).
- */
-export function selectExtraGuess() {
-  gameStore.update(state => {
-    if (state.selectedPurchase && state.selectedPurchase.type === 'extra_guess') {
-      return { ...state, selectedPurchase: null, gameState: "default" };
-    }
-    return {
-      ...state,
-      gameState: "purchase_pending",
-      selectedPurchase: { type: 'extra_guess' }
     };
   });
 }
@@ -467,68 +435,61 @@ export function confirmPurchase() {
       return finalState;
     }
 
-    // === Handle Extra Guess Purchase ($150) ===
-    if (purchase.type === 'extra_guess') {
-      const cost = 150;
-      if (newBankroll < cost) return { ...state, selectedPurchase: null, gameState: "default" };
-      newBankroll -= cost;
-      const currentGuesses = state.guessesRemaining ?? 2;
-      const newState = {
-        ...state,
-        bankroll: newBankroll,
-        guessesRemaining: currentGuesses + 1,
-        selectedPurchase: null,
-        gameState: "default"
-      };
-      const currentUser = get(user);
-      if (currentUser?.id && state.gameMode === 'arcade') {
-        saveArcadeBankroll(newBankroll);
-      }
-      saveGameToLocalStorage();
-      return newState;
-    }
-
-    // === Handle Hint Purchase ===
+    // === Handle Reveal Purchase ($150): all instances of the most-frequent unrevealed letter ===
     if (purchase.type === 'hint') {
       const cost = 150;
       if (newBankroll < cost) return { ...state, selectedPurchase: null, gameState: "default" };
 
-      /** @type {number[]} */
-      const unrevealedIndices = phrase.split('').reduce((/** @type {number[]} */ acc, ch, i) => {
-        if (ch !== ' ' && !state.purchasedLetters[i]) acc.push(i);
-        return acc;
-      }, []);
-      if (unrevealedIndices.length === 0) return { ...state, selectedPurchase: null, gameState: "default" };
+      // Tally unrevealed non-space letters, pick the most frequent (ties: alphabetical).
+      /** @type {Record<string, number>} */
+      const unrevealedCounts = {};
+      for (let i = 0; i < phrase.length; i++) {
+        const ch = phrase[i];
+        if (ch !== ' ' && state.purchasedLetters[i] !== ch) {
+          unrevealedCounts[ch] = (unrevealedCounts[ch] || 0) + 1;
+        }
+      }
+      const candidates = Object.keys(unrevealedCounts);
+      if (candidates.length === 0) return { ...state, selectedPurchase: null, gameState: "default" };
+      candidates.sort((a, b) => unrevealedCounts[b] - unrevealedCounts[a] || a.localeCompare(b));
+      const letter = candidates[0];
 
-      const randomIndex = unrevealedIndices[Math.floor(Math.random() * unrevealedIndices.length)];
-      const letter = phrase[randomIndex];
+      // Reveal every instance of that letter.
       /** @type {string[]} */
       const newPurchased = [...state.purchasedLetters];
-      newPurchased[randomIndex] = letter;
-
       /** @type {number[]} */
-      const indices = phrase.split('').reduce((/** @type {number[]} */ acc, ch, i) => {
-        if (ch === letter) acc.push(i);
-        return acc;
-      }, []);
+      const indices = [];
+      for (let i = 0; i < phrase.length; i++) {
+        if (phrase[i] === letter) { newPurchased[i] = letter; indices.push(i); }
+      }
       const newLockedLetters = { ...state.lockedLetters };
-      newLockedLetters[letter] = indices.every(idx => newPurchased[idx] === letter);
+      newLockedLetters[letter] = true;
 
       newBankroll -= cost;
+
+      const newShaken = new Set(state.shakenLetters || []);
+      indices.forEach(idx => newShaken.add(idx));
+
+      // Revealing the final letters can complete the puzzle.
+      const win = phrase.length > 0 &&
+        phrase.split('').every((ch, i) => ch === ' ' || newPurchased[i] === ch);
 
       const newState = {
         ...state,
         bankroll: newBankroll,
         purchasedLetters: newPurchased,
         lockedLetters: newLockedLetters,
+        shakenLetters: Array.from(newShaken),
         selectedPurchase: null,
-        gameState: "default"
+        gameState: win ? "won" : "default"
       };
 
       const currentUser = get(user);
       if (currentUser?.id && state.gameMode === 'arcade') {
-        saveArcadeBankroll(newBankroll);
+        if (win) recordArcadeResult(currentUser.id, true, newBankroll);
+        else saveArcadeBankroll(newBankroll);
       }
+      if (win) setTimeout(() => launchConfetti(), 300);
 
       finalState = checkLossCondition(newState);
       return finalState;
@@ -645,7 +606,7 @@ export function submitGuess() {
 
   gameStore.update(/** @param {GameState} state */ (state) => {
     if (state.gameState !== "guess_mode") return state;
-    const guessesLeft = state.guessesRemaining ?? 2;
+    const guessesLeft = state.guessesRemaining ?? 3;
     if (guessesLeft <= 0) {
       console.log("⛔ No guesses remaining. Buy another for $150.");
       return state;
@@ -709,7 +670,7 @@ export function submitGuess() {
     const newBankroll = state.bankroll + bankrollChange;
 
     const usedGuess = !(allCorrect || win);
-    const newGuessesRemaining = usedGuess ? Math.max(0, (state.guessesRemaining ?? 2) - 1) : (state.guessesRemaining ?? 2);
+    const newGuessesRemaining = usedGuess ? Math.max(0, (state.guessesRemaining ?? 3) - 1) : (state.guessesRemaining ?? 3);
 
     const newState = {
       ...state,
@@ -792,13 +753,13 @@ export async function fetchRandomGame(category) {
 
     const { data: profile } = await supabase.from('profiles').select('arcade_bankroll').eq('id', get(user)?.id).maybeSingle();
     const arcadeBankroll = profile?.arcade_bankroll ?? 1000;
-    const startingBankroll = arcadeBankroll > 0 ? arcadeBankroll : 1000;
+    const startingBankroll = arcadeBankroll >= 30 ? arcadeBankroll : 1000;
 
     const newState = /** @type {GameState} */ ({
       ...get(gameStore),
       bankroll: startingBankroll,
       wagerAmount: 1,
-      guessesRemaining: 2,
+      guessesRemaining: 3,
       category: puzzle.category ?? '',
       currentPhrase: (puzzle.phrase ?? '').toUpperCase(),
       gameState: 'default',

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -129,17 +129,10 @@ export async function dailyBuyLetter(letter) {
   return data;
 }
 
-/** Buy a hint ($150). @returns {Promise<object|null>} board */
-export async function dailyBuyHint() {
-  const { data, error } = await supabase.rpc('daily_buy_hint');
-  if (error) { console.error('❌ daily_buy_hint error:', error); return null; }
-  return data;
-}
-
-/** Buy an extra guess ($150). @returns {Promise<object|null>} board */
-export async function dailyBuyGuess() {
-  const { data, error } = await supabase.rpc('daily_buy_guess');
-  if (error) { console.error('❌ daily_buy_guess error:', error); return null; }
+/** Reveal ($150): all instances of the most-useful unrevealed letter. @returns {Promise<object|null>} board */
+export async function dailyReveal() {
+  const { data, error } = await supabase.rpc('daily_reveal');
+  if (error) { console.error('❌ daily_reveal error:', error); return null; }
   return data;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -384,25 +384,25 @@
       <button class="close-btn" on:click={() => showHowToPlay = false}>❌</button>
 
       <h2>📜 How to Play</h2>
-      <p>💰 Start with $1000. Use it wisely to buy letters, get hints, and guess the phrase!</p>
+      <p>💰 Start with $1000. Spend it on information, then solve the phrase. Whatever's left is your score.</p>
 
       <h3>📅 Daily vs Arcade</h3>
       <p><b>Daily:</b> One puzzle per day. Counts for the daily leaderboard!<br />
       <b>Arcade:</b> Unlimited play. Build your cumulative bankroll!</p>
 
       <h3>🎯 Goal</h3>
-      <p>Solve the phrase before running out of money!</p>
+      <p>Solve the phrase before you run out of money.</p>
 
       <h3>🕹️ Gameplay</h3>
       <ul>
-        <li>🔤 <b>Buy Letters:</b> Click or tap letters to purchase.</li>
-        <li>⏎ <b>Confirm:</b> Press Enter to submit purchases or guesses.</li>
-        <li>🔄 <b>Guess Mode:</b> Press Spacebar to toggle Guess Mode.</li>
-        <li>💡 <b>Hint ($150):</b> Reveals one random letter in the phrase.</li>
-        <li>🎟️ <b>Extra Guess ($150):</b> Buy another guess attempt.</li>
+        <li>🔤 <b>Buy Letters:</b> Tap a letter to buy it. In the phrase → all copies revealed. Not in it → you lose the money.</li>
+        <li>🔍 <b>Reveal ($150):</b> Reveals every copy of the most useful unrevealed letter — guaranteed, never random.</li>
+        <li>✏️ <b>Solve:</b> Fill the blanks and submit. You get <b>3 free tries</b> — a wrong guess just costs a try, no money.</li>
+        <li>🏁 <b>Out of tries?</b> You can still win by buying letters until the whole phrase is revealed.</li>
+        <li>💀 <b>You only lose</b> if you go broke before solving.</li>
       </ul>
 
-      <p><strong>Think smart, spend wisely, and guess like a pro! 🚀</strong></p>
+      <p><strong>Spend smart, solve cheap, bank the rest. 🚀</strong></p>
     </div>
   </div>
 {/if}

--- a/supabase-daily-server-authoritative.sql
+++ b/supabase-daily-server-authoritative.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS public.daily_sessions (
   puzzle_date DATE NOT NULL DEFAULT CURRENT_DATE,
   puzzle_id UUID NOT NULL REFERENCES public.daily_puzzles(id) ON DELETE RESTRICT,
   bankroll INT NOT NULL DEFAULT 1000,
-  guesses_remaining INT NOT NULL DEFAULT 2,
+  guesses_remaining INT NOT NULL DEFAULT 3,   -- "attempts"; free, not purchasable
   revealed_positions INT[] NOT NULL DEFAULT '{}',   -- 0-indexed positions revealed so far
   incorrect_letters TEXT[] NOT NULL DEFAULT '{}',   -- letters bought that aren't in the phrase
   state TEXT NOT NULL DEFAULT 'active',              -- 'active' | 'won' | 'lost'
@@ -215,7 +215,7 @@ BEGIN
     WHERE substr(p_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
   );
   -- Loss = broke, or out of guesses and can't afford another ($150). Mirrors original game.
-  v_lost := (s.bankroll < 1) OR (s.guesses_remaining <= 0 AND s.bankroll < 150);
+  v_lost := (s.bankroll < 30);  -- broke: can't afford the cheapest letter
 
   IF v_won THEN
     s.state := 'won';
@@ -261,7 +261,7 @@ BEGIN
   IF NOT FOUND THEN
     IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
     INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining)
-    VALUES (v_uid, CURRENT_DATE, v_pid, 1000, 2)
+    VALUES (v_uid, CURRENT_DATE, v_pid, 1000, 3)
     RETURNING * INTO s;
   END IF;
 
@@ -328,72 +328,48 @@ BEGIN
 END;
 $$;
 
--- Buy a hint ($150): reveal one random unrevealed position.
-CREATE OR REPLACE FUNCTION public.daily_buy_hint()
+-- Reveal ($150): reveal ALL instances of the most-frequent unrevealed letter.
+-- Smart (not random) and a strict upgrade over the old single-tile hint.
+CREATE OR REPLACE FUNCTION public.daily_reveal()
 RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
 DECLARE
   v_uid UUID := auth.uid();
   s public.daily_sessions;
   v_phrase TEXT; v_cat TEXT; v_sub TEXT;
-  v_pos INT;
+  v_letter TEXT; v_positions INT[]; v_cost INT := 150;
 BEGIN
-  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_buy_hint: not authenticated'; END IF;
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_reveal: not authenticated'; END IF;
 
   SELECT * INTO s FROM public.daily_sessions
   WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
-  IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_hint: no active session'; END IF;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_reveal: no active session'; END IF;
 
   SELECT upper(phrase), category, COALESCE(subcategory, '')
   INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
 
-  SELECT g.i INTO v_pos
-  FROM generate_series(0, length(v_phrase) - 1) g(i)
-  WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
-  ORDER BY md5(random()::text) LIMIT 1;
+  SELECT t.ch INTO v_letter FROM (
+    SELECT substr(v_phrase, g.i + 1, 1) AS ch, count(*) AS c
+    FROM generate_series(0, length(v_phrase) - 1) g(i)
+    WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
+    GROUP BY substr(v_phrase, g.i + 1, 1)
+    ORDER BY c DESC, ch
+    LIMIT 1
+  ) t;
 
-  IF s.state <> 'active' OR s.bankroll < 150 OR v_pos IS NULL THEN
+  IF s.state <> 'active' OR s.bankroll < v_cost OR v_letter IS NULL THEN
     RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
                                s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
   END IF;
 
-  s.bankroll := s.bankroll - 150;
-  s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || ARRAY[v_pos]) ORDER BY 1);
+  SELECT array_agg(g.i) INTO v_positions
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+
+  s.bankroll := s.bankroll - v_cost;
+  s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || v_positions) ORDER BY 1);
 
   UPDATE public.daily_sessions SET
     bankroll = s.bankroll, revealed_positions = s.revealed_positions, updated_at = NOW()
-  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
-
-  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
-END;
-$$;
-
--- Buy an extra guess ($150): +1 guess.
-CREATE OR REPLACE FUNCTION public.daily_buy_guess()
-RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
-DECLARE
-  v_uid UUID := auth.uid();
-  s public.daily_sessions;
-  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
-BEGIN
-  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_buy_guess: not authenticated'; END IF;
-
-  SELECT * INTO s FROM public.daily_sessions
-  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
-  IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_guess: no active session'; END IF;
-
-  SELECT upper(phrase), category, COALESCE(subcategory, '')
-  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
-
-  IF s.state <> 'active' OR s.bankroll < 150 THEN
-    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
-                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
-  END IF;
-
-  s.bankroll := s.bankroll - 150;
-  s.guesses_remaining := s.guesses_remaining + 1;
-
-  UPDATE public.daily_sessions SET
-    bankroll = s.bankroll, guesses_remaining = s.guesses_remaining, updated_at = NOW()
   WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
 
   RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
@@ -471,8 +447,7 @@ $$;
 -- ---- Grants: signed-in users may call the public RPCs only -----------------
 GRANT EXECUTE ON FUNCTION public.daily_start()                 TO authenticated;
 GRANT EXECUTE ON FUNCTION public.daily_buy_letter(TEXT)        TO authenticated;
-GRANT EXECUTE ON FUNCTION public.daily_buy_hint()              TO authenticated;
-GRANT EXECUTE ON FUNCTION public.daily_buy_guess()             TO authenticated;
+GRANT EXECUTE ON FUNCTION public.daily_reveal()                TO authenticated;
 GRANT EXECUTE ON FUNCTION public.daily_submit_guess(JSONB)     TO authenticated;
 -- Internal helpers are not granted to clients (called only via SECURITY DEFINER RPCs).
 REVOKE EXECUTE ON FUNCTION public._todays_puzzle_id()                         FROM anon, authenticated;


### PR DESCRIPTION
First step of the [ROADMAP](./ROADMAP.md) V2 plan — the shared-economy cleanup everything else builds on.

## What changed (the new rules)
- **Bankroll is the only resource.** Removed buying guesses and the harsh "under \$150 + out of guesses = instant loss" dead-end.
- **3 free solve attempts ("Tries")**, not purchasable. A wrong guess just **burns a try — no money lost** (fixes the cliff where a wrong guess at \$70 zeroed you out).
- **Out of tries ≠ stuck:** you can still win by buying letters until the phrase is fully revealed (expensive → low score).
- **"Bank Letter" → "Reveal":** reveals **all instances of the most-frequent unrevealed letter** (smart, not random) for \$150 — a strict upgrade over the old single-tile hint.
- **Lose only when broke + unsolved** (bankroll < \$30).
- Arcade busts restart at \$1000 next game.

## Server / client
- Daily is server-authoritative: `daily_reveal` replaces `daily_buy_hint`, `daily_buy_guess` dropped, loss condition + 3-try default updated. **Applied to prod**; the `.sql` file is synced.
- Client `GameStore` reveal/loss rework; `GameButtons` shows **Reveal** + a passive **Tries** counter; how-to-play rewritten to match.

## Verified
Playwright drove a fresh daily: Reveal charged exactly \$150, revealed both `H` tiles, Tries stayed at 3. Build + lint + type-check clean.

Roadmap Phase 0 flipped to ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)