### PR TITLE
V2 Phase 1a: shareable result card + medals

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ Status: 📋 Planned (Phase 3)
 | Phase | Scope | Touches | Status |
 |---|---|---|---|
 | **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
-| **1 — Daily scoring + share** | Par/efficiency/streak scoring, medals, **share card** | Server scoring + UI | 📋 |
+| **1 — Daily scoring + share** | Share card ✅ + medals ✅ (client). Par/efficiency/streak **leaderboard scoring** still TODO (server). | Server scoring + UI | 🚧 |
 | **2 — Streaks & badges** | Streak freeze, badge engine, leaderboard flair | Server + UI | 📋 |
 | **3 — Power-up system** | Inventory + effects, earned via play/badges (no payments) | Server + UI | 📋 |
 | **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |

--- a/scripts/check-result.mjs
+++ b/scripts/check-result.mjs
@@ -1,0 +1,32 @@
+// Force a daily result modal by buying Reveals until win-by-reveal (or bust), then shoot it.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+await p.getByRole('button', { name: /daily/i }).first().click().catch(()=>{}); await wait(2600);
+
+// Buy letters down the alphabet until the puzzle resolves (solved → win, or broke → loss)
+const letters = 'EARSTONILCDUMPHGBYFVKWZXJQ'.split('');
+for (const L of letters) {
+  if (await p.locator('.result-modal').count()) break;
+  const key = p.locator(`.key:has(.letter:text-is("${L}"))`).first();
+  await key.click({ force: true }).catch(()=>{}); await wait(300);
+  await p.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch(()=>{}); await wait(1300);
+}
+await wait(900);
+await p.screenshot({ path: 'screenshots/result-modal.png' });
+console.log('result-modal present:', await p.locator('.result-modal').count() > 0);
+await b.close();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -191,6 +191,43 @@
     if (typeof b === 'number') _prevBankroll = b;
   }
 
+  // ---- Daily result: medal + shareable card ----
+  const PUZZLE_EPOCH = Date.UTC(2026, 5, 1); // 2026-06-01
+  $: puzzleNumber = Math.max(1, Math.floor((Date.now() - PUZZLE_EPOCH) / 86400000) + 1);
+
+  /** @param {number} br @param {boolean} won */
+  function medalFor(br, won) {
+    if (!won) return { emoji: '💀', name: 'Busted', tier: 'none' };
+    if (br >= 700) return { emoji: '🥇', name: 'Gold', tier: 'gold' };
+    if (br >= 400) return { emoji: '🥈', name: 'Silver', tier: 'silver' };
+    return { emoji: '🥉', name: 'Bronze', tier: 'bronze' };
+  }
+  $: resultWon = $gameStore.gameState === 'won';
+  $: isDailyResult = $gameStore.gameMode === 'daily';
+  $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
+  $: resultMedal = medalFor(resultBankroll, resultWon);
+
+  let shareCopied = false;
+  function buildShareText() {
+    const br = '$' + resultBankroll.toLocaleString();
+    const link = 'https://wordbanksvelte1.vercel.app';
+    if (isDailyResult) {
+      return `🏦 WordBank Daily #${puzzleNumber}\n${resultMedal.emoji} ${resultWon ? resultMedal.name + ' — ' : ''}${br} banked\n${link}`;
+    }
+    return `🏦 WordBank Arcade\n${resultMedal.emoji} ${br} banked\n${link}`;
+  }
+  async function handleShare() {
+    const text = buildShareText();
+    try {
+      if (typeof navigator !== 'undefined' && navigator.share) { await navigator.share({ text }); return; }
+    } catch { /* user cancelled native share */ }
+    try {
+      await navigator.clipboard.writeText(text);
+      shareCopied = true;
+      setTimeout(() => { shareCopied = false; }, 1800);
+    } catch { /* clipboard unavailable */ }
+  }
+
   // ✅ Auto-save whenever state is valid
   $: if (
     loggedIn &&
@@ -599,23 +636,30 @@
     <!-- 🎯 Result Modal -->
     {#if showResultModal && ['won', 'lost'].includes($gameStore.gameState)}
       <div class="modal-overlay">
-        <div class="modal-content">
-          <h2>{$gameStore.gameState === 'won' ? '🎉 You Win!' : '💀 Game Over'}</h2>
-          <p>
-            {$gameStore.gameState === 'won'
-              ? 'Great job! Want to try the next one?'
-              : 'You ran out of cash. Want to try again?'}
-          </p>
+        <div class="modal-content result-modal">
+          <div class="result-medal {resultMedal.tier}">{resultMedal.emoji}</div>
+          <h2>{resultWon ? 'Solved!' : 'Busted'}</h2>
+          {#if isDailyResult}
+            <p class="result-sub">Daily #{puzzleNumber}{#if resultWon} · {resultMedal.name}{/if}</p>
+          {:else}
+            <p class="result-sub">Arcade</p>
+          {/if}
 
-          <div style="margin-top: 16px;">
-<!-- ✅ Fixed version -->
-<button
-  class="next-puzzle-button"
-  on:click={$gameStore.gameState === 'won' ? handleNextPuzzle : handlePlayAgain}
-  disabled={!['won', 'lost'].includes($gameStore.gameState)}
->
-  {$gameStore.gameState === 'won' ? 'Next Puzzle' : 'Play Again'}
-</button>
+          <div class="result-bankroll">
+            <span class="rb-label">Banked</span>
+            <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
+          </div>
+
+          <div class="result-actions">
+            <button class="share-btn" on:click={handleShare}>
+              {shareCopied ? '✓ Copied!' : 'Share'}
+            </button>
+            <button
+              class="next-puzzle-button"
+              on:click={resultWon ? handleNextPuzzle : handlePlayAgain}
+            >
+              {isDailyResult ? 'Leaderboard' : (resultWon ? 'Next Puzzle' : 'Play Again')}
+            </button>
           </div>
         </div>
       </div>
@@ -1177,6 +1221,70 @@
   }
   .next-puzzle-button:hover { transform: translateY(-2px); filter: brightness(1.05); }
   .next-puzzle-button:active { transform: scale(0.97); }
+
+  /* Result modal (daily/arcade) */
+  .result-modal h2 { font-size: 1.7rem; margin: 4px 0 2px; }
+  .result-medal {
+    font-size: 3.4rem;
+    line-height: 1;
+    margin-bottom: 6px;
+    animation: wb-pop-in 0.6s var(--ease-spring) both;
+    filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.5));
+  }
+  .result-medal.gold { filter: drop-shadow(0 0 22px rgba(251, 191, 36, 0.6)); }
+  .result-medal.silver { filter: drop-shadow(0 0 18px rgba(203, 213, 225, 0.5)); }
+  .result-medal.bronze { filter: drop-shadow(0 0 18px rgba(217, 119, 60, 0.5)); }
+  .result-sub {
+    color: var(--text-muted);
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.92rem;
+    margin: 0 0 16px;
+  }
+  .result-bankroll {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 14px;
+    margin: 0 0 18px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+  }
+  .rb-label {
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    font-weight: 600;
+  }
+  .rb-amount {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 2rem;
+    color: #fcd34d;
+    text-shadow: 0 0 18px rgba(251, 191, 36, 0.4);
+  }
+  .result-actions {
+    display: flex;
+    gap: 10px;
+  }
+  .result-actions > * { flex: 1; margin-top: 0; }
+  .share-btn {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1rem;
+    padding: 13px 18px;
+    border-radius: var(--r-md);
+    background: var(--surface-2);
+    color: var(--text);
+    border: 1px solid var(--border-strong);
+    cursor: pointer;
+    transition: transform 0.15s var(--ease-spring), background 0.2s, border-color 0.2s;
+  }
+  .share-btn:hover { transform: translateY(-2px); background: rgba(56, 189, 248, 0.14); border-color: rgba(56, 189, 248, 0.4); }
+  .share-btn:active { transform: scale(0.97); }
 
   .wager-ui {
   display: flex;


### PR DESCRIPTION
The first slice of [Phase 1](./ROADMAP.md) — the growth lever. Client-only.

## What changed
Redesigned the win/loss result modal:
- **Medal tier** from ending bankroll: 🥇 Gold (\$700+), 🥈 Silver (\$400+), 🥉 Bronze (solved), 💀 Busted — with a pop-in + glow.
- **"Banked \$X"** readout, **Daily #N**, Solved!/Busted title.
- **Share button** → spoiler-free card (`🏦 WordBank Daily #19\n🥇 Gold — \$740 banked\n<link>`) via the Web Share API with a clipboard fallback ("✓ Copied!"). Works for arcade too.
- Primary action adapts: **Leaderboard** (daily) / **Next Puzzle** / **Play Again** (arcade).

## Verified
Playwright drove a daily to a terminal state and confirmed the modal renders (screenshot: 💀 Busted, Daily #19, $10 banked, Share + Leaderboard). Build + lint + type-check clean.

## Still TODO in Phase 1 (separate PR)
Server-side **par / efficiency / streak leaderboard scoring** so rank rewards playing well, not just knowing the answer. Roadmap row marked 🚧.

🤖 Generated with [Claude Code](https://claude.com/claude-code)