### PR TITLE
V2 Phase 1b: daily score (bankroll × streak) + leaderboard ranking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,7 +81,7 @@ Status: 📋 Planned (Phase 3)
 | Phase | Scope | Touches | Status |
 |---|---|---|---|
 | **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
-| **1 — Daily scoring + share** | Share card ✅ + medals ✅ (client). Par/efficiency/streak **leaderboard scoring** still TODO (server). | Server scoring + UI | 🚧 |
+| **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Streak freeze, badge engine, leaderboard flair | Server + UI | 📋 |
 | **3 — Power-up system** | Inventory + effects, earned via play/badges (no payments) | Server + UI | 📋 |
 | **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -60,7 +60,7 @@ export async function getDailyStatus(userId) {
  * @param {string} period - 'daily' | 'weekly' | 'monthly' | 'yearly'
  * @param {string} orderBy - 'bankroll' | 'streak' | 'puzzles' | 'win_pct'
  */
-export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'bankroll') {
+export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score') {
   const { data, error } = await supabase.rpc('get_daily_leaderboard', {
     p_period: period,
     p_order_by: orderBy

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -7,14 +7,23 @@
     fetchArcadeLeaderboard
   } from '$lib/stores/statsStore.js';
 
-  /** @typedef {{ rank?: number, display_name?: string, bankroll_left?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} DailyRow */
+  /** @typedef {{ rank?: number, display_name?: string, score?: number, bankroll_left?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} DailyRow */
   /** @typedef {{ rank?: number, display_name?: string, current_bankroll?: number, highest_bankroll?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} ArcadeRow */
 
   /** @type {'daily' | 'arcade'} */
   let mode = $state('daily');
   let dailyPeriod = $state('daily');
-  /** @type {'bankroll' | 'streak' | 'highest_streak' | 'puzzles' | 'win_pct'} */
-  let dailyOrderBy = $state('bankroll');
+  /** @type {'score' | 'bankroll' | 'streak' | 'highest_streak' | 'puzzles' | 'win_pct'} */
+  let dailyOrderBy = $state('score');
+
+  /** Medal from ending bankroll. @param {number} br @param {number} played */
+  function medal(br, played) {
+    if (!played) return '';
+    if (br >= 700) return '🥇';
+    if (br >= 400) return '🥈';
+    if (br >= 100) return '🥉';
+    return ''; // busted / negligible bankroll
+  }
   /** @type {DailyRow[]} */
   let dailyData = $state([]);
   let arcadePeriod = $state('all');
@@ -116,6 +125,7 @@
     </div>
     <p class="sort-label">Sort by:</p>
     <div class="sort-filters">
+      <button class="sort-btn" class:active={dailyOrderBy === 'score'} onclick={() => { dailyOrderBy = 'score'; }}>Score</button>
       <button class="sort-btn" class:active={dailyOrderBy === 'bankroll'} onclick={() => { dailyOrderBy = 'bankroll'; }}>Bankroll</button>
       <button class="sort-btn" class:active={dailyOrderBy === 'streak'} onclick={() => { dailyOrderBy = 'streak'; }}>Current Streak</button>
       <button class="sort-btn" class:active={dailyOrderBy === 'highest_streak'} onclick={() => { dailyOrderBy = 'highest_streak'; }}>Highest Streak</button>
@@ -158,10 +168,11 @@
             <tr>
               <th>#</th>
               <th>Player</th>
-              <th>Bankroll Left</th>
-              <th>Current Streak</th>
-              <th>Highest Streak</th>
-              <th>Puzzles</th>
+              <th>Score</th>
+              <th>Bankroll</th>
+              <th>Streak</th>
+              <th>Best</th>
+              <th>Plays</th>
               <th>Win %</th>
             </tr>
           </thead>
@@ -175,7 +186,8 @@
                   {:else}{row.rank}{/if}
                 </td>
                 <td class="name">{row.display_name || 'Player'}</td>
-                <td>${fmt(row.bankroll_left)}</td>
+                <td class="score-cell">{fmt(row.score)}</td>
+                <td>${fmt(row.bankroll_left)} {medal(row.bankroll_left ?? 0, row.total_played ?? 0)}</td>
                 <td>{fmt(row.current_streak)}</td>
                 <td>{fmt(row.highest_streak)}</td>
                 <td>{fmt(row.total_played)}</td>
@@ -388,6 +400,11 @@
   }
   tr.top-three td.name { color: #fde68a; }
 
+  td.score-cell {
+    font-family: var(--font-display);
+    font-weight: 700;
+    color: var(--brand-2);
+  }
   td.rank { font-weight: 700; width: 50px; font-family: var(--font-display); }
   tr.top-three td.rank { font-size: 1.1rem; animation: wb-pop-in 0.5s var(--ease-spring) both; display: inline-block; }
   td.name { font-weight: 600; }

--- a/supabase-daily-leaderboard.sql
+++ b/supabase-daily-leaderboard.sql
@@ -63,6 +63,8 @@ CREATE TABLE IF NOT EXISTS public.game_results (
   game_mode TEXT NOT NULL DEFAULT 'daily'
 );
 ALTER TABLE public.game_results ADD COLUMN IF NOT EXISTS game_mode TEXT NOT NULL DEFAULT 'daily';
+-- Daily score = bankroll × streak multiplier (see _finalize_daily). Ranks the daily leaderboard.
+ALTER TABLE public.game_results ADD COLUMN IF NOT EXISTS score INT NOT NULL DEFAULT 0;
 
 CREATE INDEX IF NOT EXISTS idx_game_results_user_played ON public.game_results(user_id, played_at);
 ALTER TABLE public.game_results ENABLE ROW LEVEL SECURITY;
@@ -167,11 +169,12 @@ $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 4d. RPC: Daily leaderboard (bankroll, current/highest streak, puzzles, win %; sortable)
 DROP FUNCTION IF EXISTS public.get_daily_leaderboard(TEXT, TEXT);
-CREATE OR REPLACE FUNCTION public.get_daily_leaderboard(p_period TEXT DEFAULT 'daily', p_order_by TEXT DEFAULT 'bankroll')
+CREATE OR REPLACE FUNCTION public.get_daily_leaderboard(p_period TEXT DEFAULT 'daily', p_order_by TEXT DEFAULT 'score')
 RETURNS TABLE (
   rank BIGINT,
   user_id UUID,
   display_name TEXT,
+  score INT,
   bankroll_left INT,
   current_streak INT,
   highest_streak INT,
@@ -184,11 +187,8 @@ DECLARE
   v_end TIMESTAMPTZ;
 BEGIN
   CASE p_period
-    WHEN 'daily' THEN
-      v_start := date_trunc('day', CURRENT_DATE) AT TIME ZONE 'UTC';
-      v_end := v_start + INTERVAL '1 day';
     WHEN 'weekly' THEN
-      -- Tuesday-keyed league week, interpreted in UTC to match game_results.played_at (stored via NOW() in UTC)
+      -- Tuesday-keyed league week, interpreted in UTC to match game_results.played_at
       v_start := ((date_trunc('week', CURRENT_DATE)::DATE + 1)::TIMESTAMP) AT TIME ZONE 'UTC';
       v_end := v_start + INTERVAL '7 days';
     WHEN 'monthly' THEN
@@ -206,6 +206,7 @@ BEGIN
   WITH agg AS (
     SELECT
       gr.user_id,
+      MAX(gr.score)::INT AS score,
       MAX(gr.bankroll_left)::INT AS bankroll_left,
       COUNT(*)::INT AS total_played,
       COUNT(*) FILTER (WHERE gr.won)::INT AS total_wins
@@ -218,6 +219,7 @@ BEGIN
     SELECT
       prof.id AS user_id,
       COALESCE(au.raw_user_meta_data->>'full_name', split_part(au.raw_user_meta_data->>'email', '@', 1), 'Player')::TEXT AS display_name,
+      agg.score,
       agg.bankroll_left,
       COALESCE(prof.current_win_streak, 0)::INT AS current_streak,
       COALESCE(prof.highest_win_streak, 0)::INT AS highest_streak,
@@ -236,16 +238,11 @@ BEGIN
         CASE WHEN p_order_by = 'highest_streak' THEN base.highest_streak END DESC NULLS LAST,
         CASE WHEN p_order_by = 'puzzles' THEN base.total_played END DESC NULLS LAST,
         CASE WHEN p_order_by = 'win_pct' THEN base.win_rate END DESC NULLS LAST,
-        base.bankroll_left DESC NULLS LAST
+        CASE WHEN p_order_by = 'score' THEN base.score END DESC NULLS LAST,
+        base.score DESC NULLS LAST
     )::BIGINT AS rank,
-    base.user_id,
-    base.display_name,
-    base.bankroll_left,
-    base.current_streak,
-    base.highest_streak,
-    base.total_played,
-    base.total_wins,
-    base.win_rate
+    base.user_id, base.display_name, base.score, base.bankroll_left,
+    base.current_streak, base.highest_streak, base.total_played, base.total_wins, base.win_rate
   FROM base
   ORDER BY
     CASE WHEN p_order_by = 'bankroll' THEN base.bankroll_left END DESC NULLS LAST,
@@ -253,7 +250,8 @@ BEGIN
     CASE WHEN p_order_by = 'highest_streak' THEN base.highest_streak END DESC NULLS LAST,
     CASE WHEN p_order_by = 'puzzles' THEN base.total_played END DESC NULLS LAST,
     CASE WHEN p_order_by = 'win_pct' THEN base.win_rate END DESC NULLS LAST,
-    base.bankroll_left DESC NULLS LAST;
+    CASE WHEN p_order_by = 'score' THEN base.score END DESC NULLS LAST,
+    base.score DESC NULLS LAST;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 

--- a/supabase-daily-server-authoritative.sql
+++ b/supabase-daily-server-authoritative.sql
@@ -143,6 +143,7 @@ DECLARE
   v_highest_streak INT;
   v_last_win DATE;
   v_bankroll INT;
+  v_score INT;
 BEGIN
   v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll, 0), 0), 1000);
   v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1;
@@ -176,8 +177,11 @@ BEGIN
     WHERE id = p_uid;
   END IF;
 
-  INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode)
-  VALUES (p_uid, NOW(), p_won, v_bankroll, 'daily');
+  -- Streak multiplier: 0% at streak 1, +10%/day, capped at +100% (streak 11+).
+  v_score := ROUND(v_bankroll * (1 + LEAST(GREATEST(COALESCE(v_current_streak, 0) - 1, 0), 10) * 0.1))::INT;
+
+  INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode, score)
+  VALUES (p_uid, NOW(), p_won, v_bankroll, 'daily', v_score);
 
   INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
   VALUES (


### PR DESCRIPTION
Completes [Phase 1](./ROADMAP.md). Fixes the "foreknowledge wins" flaw — daily rank now rewards **consistency**, not just spending the least.

## Scoring
`score = bankroll × (1 + min(streak − 1, 10) × 0.1)` — 0% bonus at streak 1, +10% per consecutive day, capped at +100% (streak 11+). A one-off \$1000 (streak 1) = 1000; a consistent \$700 on a 10-day streak = 1330. Consistency beats a lucky/known answer.

- `game_results.score` column; `_finalize_daily` computes & stores it.
- `get_daily_leaderboard` returns `score` and ranks by it by default (score sort option added).

## UI
- Leaderboard: **Score** column (brand-highlighted) + **Score** sort (default), plus a performance **medal** (🥇 \$700 / 🥈 \$400 / 🥉 \$100) next to each bankroll.

## Verified
Applied to prod, `.sql` files synced. Playwright: played a daily → leaderboard renders the Score column, sorted by score (screenshot confirmed `# · Player · Score · Bankroll · Streak`). Build + lint + type-check clean.

Roadmap **Phase 1 → ✅**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)