### PR TITLE
V2 Phase 2a: achievement badges

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ Status: 📋 Planned (Phase 3)
 |---|---|---|---|
 | **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
-| **2 — Streaks & badges** | Streak freeze, badge engine, leaderboard flair | Server + UI | 📋 |
+| **2 — Streaks & badges** | Badge engine ✅ (4 daily badges, My Account display, leaderboard 🔥 flair). Streak **freeze** still TODO. | Server + UI | 🚧 |
 | **3 — Power-up system** | Inventory + effects, earned via play/badges (no payments) | Server + UI | 📋 |
 | **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |

--- a/scripts/check-badges.mjs
+++ b/scripts/check-badges.mjs
@@ -1,0 +1,22 @@
+// Open My Account and screenshot the badges grid.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+await p.getByRole('button', { name: /my account/i }).first().click().catch(e=>console.log('acct', e.message));
+await wait(1500);
+await p.screenshot({ path: 'screenshots/badges.png' });
+console.log('badges grid present:', await p.locator('.badge-grid').count() > 0, ' badges:', await p.locator('.badge.earned').count());
+await b.close();

--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -1,0 +1,13 @@
+// Achievement badge catalog. Keys match the server's user_badges.badge values.
+/** @type {Record<string, { emoji: string, name: string, desc: string }>} */
+export const BADGES = {
+  flawless:  { emoji: '🎯', name: 'Flawless',     desc: 'Solved a daily with zero wrong letters' },
+  gold_bank: { emoji: '💎', name: 'Gold Bank',    desc: 'Finished a daily with $700+' },
+  streak_7:  { emoji: '🔥', name: 'Week Warrior',  desc: '7-day daily streak' },
+  streak_30: { emoji: '👑', name: 'Iron Will',     desc: '30-day daily streak' },
+};
+
+/** @param {string} id */
+export function badgeInfo(id) {
+  return BADGES[id] || { emoji: '🏅', name: id, desc: '' };
+}

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -129,6 +129,17 @@ export async function dailyBuyLetter(letter) {
   return data;
 }
 
+/**
+ * Fetch a user's earned badge ids (defaults to the caller).
+ * @param {string} [userId]
+ * @returns {Promise<string[]>}
+ */
+export async function getUserBadges(userId) {
+  const { data, error } = await supabase.rpc('get_user_badges', userId ? { p_user_id: userId } : {});
+  if (error) { console.error('❌ get_user_badges error:', error); return []; }
+  return (data ?? []).map((/** @type {{ badge: string }} */ r) => r.badge);
+}
+
 /** Reveal ($150): all instances of the most-useful unrevealed letter. @returns {Promise<object|null>} board */
 export async function dailyReveal() {
   const { data, error } = await supabase.rpc('daily_reveal');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,8 @@
 
   import { gameStore, fetchRandomGame, fetchDailyGame } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday, saveArcadeBankroll } from '$lib/stores/statsStore.js';
+  import { hasPlayedDailyToday, saveArcadeBankroll, getUserBadges } from '$lib/stores/statsStore.js';
+  import { BADGES, badgeInfo } from '$lib/badges.js';
   import {
     saveGameToLocalStorage,
     loadGameFromLocalStorage,
@@ -319,8 +320,17 @@
 
   let showMyAccount = false;
   let showStreakMessage = false;
-  function handleMenuMyAccount() {
+  /** @type {string[]} */
+  let accountBadges = [];
+  let badgesLoaded = false;
+  async function handleMenuMyAccount() {
     showMyAccount = true;
+    badgesLoaded = false;
+    const u = get(user);
+    if (u?.id) {
+      accountBadges = await getUserBadges(u.id);
+    }
+    badgesLoaded = true;
   }
   /** @param {KeyboardEvent} e */
   function handleEscape(e) {
@@ -523,6 +533,20 @@
           {#if $user?.email}
             <p class="account-email">{$user.email}</p>
           {/if}
+
+          <div class="badges-section">
+            <p class="badges-title">Badges {#if badgesLoaded}<span class="badges-count">{accountBadges.length}/{Object.keys(BADGES).length}</span>{/if}</p>
+            <div class="badge-grid">
+              {#each Object.keys(BADGES) as id}
+                {@const earned = accountBadges.includes(id)}
+                <div class="badge {earned ? 'earned' : 'locked'}" title={badgeInfo(id).desc}>
+                  <span class="badge-emoji">{badgeInfo(id).emoji}</span>
+                  <span class="badge-name">{badgeInfo(id).name}</span>
+                </div>
+              {/each}
+            </div>
+          </div>
+
           <button class="main-menu-btn" on:click={() => { showMyAccount = false; handleLogout(); }}>Log Out</button>
         </div>
       </div>
@@ -894,6 +918,41 @@
   .main-menu-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
   .main-menu-modal { text-align: center; }
   .main-menu-modal .main-menu-btn { margin-top: 1rem; }
+
+  /* Badges (My Account) */
+  .badges-section { margin: 18px 0 8px; }
+  .badges-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.85rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin: 0 0 10px;
+  }
+  .badges-count { color: var(--brand-2); margin-left: 4px; }
+  .badge-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+  .badge {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    text-align: left;
+  }
+  .badge.earned {
+    border-color: rgba(163, 230, 53, 0.4);
+    background: linear-gradient(135deg, rgba(52, 211, 153, 0.12), rgba(163, 230, 53, 0.04));
+  }
+  .badge.locked { opacity: 0.4; filter: grayscale(0.8); }
+  .badge-emoji { font-size: 1.4rem; line-height: 1; }
+  .badge-name { font-size: 0.78rem; font-weight: 600; color: var(--text); }
   .streak-message {
     margin: 1rem 0 0 0;
     font-size: 1.05rem;

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -185,7 +185,7 @@
                   {:else if row.rank === 3}🥉
                   {:else}{row.rank}{/if}
                 </td>
-                <td class="name">{row.display_name || 'Player'}</td>
+                <td class="name">{row.display_name || 'Player'}{#if (row.current_streak ?? 0) >= 7} 🔥{/if}</td>
                 <td class="score-cell">{fmt(row.score)}</td>
                 <td>${fmt(row.bankroll_left)} {medal(row.bankroll_left ?? 0, row.total_played ?? 0)}</td>
                 <td>{fmt(row.current_streak)}</td>

--- a/supabase-badges.sql
+++ b/supabase-badges.sql
@@ -1,0 +1,119 @@
+-- ============================================================
+-- WordBank V2 Phase 2: achievement badges
+-- Run AFTER supabase-daily-server-authoritative.sql (it redefines _finalize_daily
+-- with a 4th arg and updates _daily_resolve_and_return to pass it).
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.user_badges (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  badge TEXT NOT NULL,
+  earned_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, badge)
+);
+ALTER TABLE public.user_badges ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "Anyone can read badges" ON public.user_badges;
+CREATE POLICY "Anyone can read badges" ON public.user_badges FOR SELECT USING (true);
+REVOKE INSERT, UPDATE, DELETE ON public.user_badges FROM anon, authenticated;
+
+-- Idempotent award helper (only callable via SECURITY DEFINER functions).
+CREATE OR REPLACE FUNCTION public._award_badge(p_uid UUID, p_badge TEXT)
+RETURNS void LANGUAGE sql SECURITY DEFINER AS $fn$
+  INSERT INTO public.user_badges (user_id, badge) VALUES (p_uid, p_badge)
+  ON CONFLICT (user_id, badge) DO NOTHING;
+$fn$;
+REVOKE EXECUTE ON FUNCTION public._award_badge(UUID, TEXT) FROM anon, authenticated;
+
+-- Read a user's badges (defaults to the caller).
+CREATE OR REPLACE FUNCTION public.get_user_badges(p_user_id UUID DEFAULT NULL)
+RETURNS TABLE (badge TEXT, earned_at TIMESTAMPTZ)
+LANGUAGE sql SECURITY DEFINER AS $fn$
+  SELECT ub.badge, ub.earned_at FROM public.user_badges ub
+  WHERE ub.user_id = COALESCE(p_user_id, auth.uid())
+  ORDER BY ub.earned_at;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.get_user_badges(UUID) TO anon, authenticated;
+
+-- _finalize_daily gains p_incorrect_count and awards daily badges. Drops the old 3-arg form.
+DROP FUNCTION IF EXISTS public._finalize_daily(UUID, BOOLEAN, INT);
+CREATE OR REPLACE FUNCTION public._finalize_daily(p_uid UUID, p_won BOOLEAN, p_bankroll INT, p_incorrect_count INT DEFAULT 0)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_week_start DATE; v_current_streak INT; v_highest_streak INT; v_last_win DATE; v_bankroll INT; v_score INT;
+BEGIN
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll, 0), 0), 1000);
+  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1;
+
+  SELECT current_win_streak, highest_win_streak, last_daily_win_date
+  INTO v_current_streak, v_highest_streak, v_last_win
+  FROM public.profiles WHERE id = p_uid;
+
+  IF p_won THEN
+    IF v_last_win = CURRENT_DATE - 1 THEN
+      v_current_streak := COALESCE(v_current_streak, 0) + 1;
+    ELSIF v_last_win IS DISTINCT FROM CURRENT_DATE THEN
+      v_current_streak := 1;
+    END IF;
+    v_highest_streak := GREATEST(COALESCE(v_highest_streak, 0), v_current_streak);
+    UPDATE public.profiles SET
+      current_win_streak = v_current_streak, highest_win_streak = v_highest_streak,
+      last_daily_win_date = CURRENT_DATE, last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll, last_daily_won = true
+    WHERE id = p_uid;
+  ELSE
+    v_current_streak := 0;
+    UPDATE public.profiles SET
+      current_win_streak = 0, last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll, last_daily_won = false
+    WHERE id = p_uid;
+  END IF;
+
+  -- Streak multiplier: 0% at streak 1, +10%/day, capped at +100% (streak 11+).
+  v_score := ROUND(v_bankroll * (1 + LEAST(GREATEST(COALESCE(v_current_streak, 0) - 1, 0), 10) * 0.1))::INT;
+
+  INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode, score)
+  VALUES (p_uid, NOW(), p_won, v_bankroll, 'daily', v_score);
+
+  INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
+  VALUES (p_uid, v_week_start,
+    CASE WHEN p_won THEN 1 ELSE 0 END, CASE WHEN p_won THEN v_bankroll ELSE 0 END, v_bankroll,
+    CASE WHEN p_won THEN 1 ELSE 0 END, 1, COALESCE(v_current_streak, 0))
+  ON CONFLICT (user_id, week_start) DO UPDATE SET
+    total_played = user_weekly_stats.total_played + 1,
+    total_wins = user_weekly_stats.total_wins + CASE WHEN p_won THEN 1 ELSE 0 END,
+    puzzles_completed = user_weekly_stats.puzzles_completed + CASE WHEN p_won THEN 1 ELSE 0 END,
+    bankroll_earned = user_weekly_stats.bankroll_earned + CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, v_bankroll),
+    win_streak = GREATEST(user_weekly_stats.win_streak, v_current_streak);
+
+  IF p_won THEN
+    IF COALESCE(p_incorrect_count, 0) = 0 THEN PERFORM public._award_badge(p_uid, 'flawless'); END IF;
+    IF v_bankroll >= 700 THEN PERFORM public._award_badge(p_uid, 'gold_bank'); END IF;
+    IF v_current_streak >= 7 THEN PERFORM public._award_badge(p_uid, 'streak_7'); END IF;
+    IF v_current_streak >= 30 THEN PERFORM public._award_badge(p_uid, 'streak_30'); END IF;
+  END IF;
+END;
+$fn$;
+
+-- Pass the wrong-letter count through from the session to the finalizer.
+CREATE OR REPLACE FUNCTION public._daily_resolve_and_return(p_uid UUID, p_phrase TEXT, p_cat TEXT, p_sub TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE s public.daily_sessions; v_won BOOLEAN; v_lost BOOLEAN;
+BEGIN
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+  v_won := NOT EXISTS (
+    SELECT 1 FROM generate_series(0, length(p_phrase) - 1) g(i)
+    WHERE substr(p_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions)));
+  v_lost := (s.bankroll < 30);
+  IF v_won THEN s.state := 'won'; ELSIF v_lost THEN s.state := 'lost'; END IF;
+  UPDATE public.daily_sessions SET
+    bankroll = s.bankroll, guesses_remaining = s.guesses_remaining, revealed_positions = s.revealed_positions,
+    incorrect_letters = s.incorrect_letters, state = s.state, updated_at = NOW(),
+    finished_at = CASE WHEN s.state <> 'active' AND finished_at IS NULL THEN NOW() ELSE finished_at END
+  WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+  IF s.state <> 'active' THEN
+    PERFORM public._finalize_daily(p_uid, s.state = 'won', s.bankroll, COALESCE(array_length(s.incorrect_letters, 1), 0));
+  END IF;
+  RETURN public._daily_board(p_phrase, s.state, s.bankroll, s.guesses_remaining,
+                             s.revealed_positions, s.incorrect_letters, p_cat, p_sub);
+END;
+$fn$;


### PR DESCRIPTION
First slice of [Phase 2](./ROADMAP.md) — earned badges + leaderboard flair.

## Badges
4 daily badges, awarded server-side at finalize (idempotent):
- 🎯 **Flawless** — solved with zero wrong letters
- 💎 **Gold Bank** — finished with \$700+
- 🔥 **Week Warrior** — 7-day streak
- 👑 **Iron Will** — 30-day streak

## Server
- `user_badges` table (world-readable for flair; no client writes).
- `_award_badge` helper + `get_user_badges` RPC.
- `_finalize_daily` awards badges on win (wrong-letter count threaded through `_daily_resolve_and_return`).

## Client
- Badge catalog (`src/lib/badges.js`).
- **My Account** modal shows a 4-badge grid — earned = brand-green, locked = grayed, with an "n/4" count.
- Leaderboard: 🔥 flair next to streak-7+ players.

## Verified
Applied to prod (`supabase-badges.sql` synced). Playwright confirmed the My Account grid renders (BADGES 0/4, all four locked for a fresh user). Build + lint + type-check clean.

## Still TODO in Phase 2
**Streak freeze** (protect a streak across one missed day). Roadmap row 🚧.

🤖 Generated with [Claude Code](https://claude.com/claude-code)