### PR TITLE
V2 Phase 3a: power-up framework + Free Reveal

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Status: 📋 Planned (Phase 3)
 | **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Badges ✅ (4 daily, My Account, 🔥 flair). Streak **freeze** ✅ (auto-bridge a missed day, earn 1 per 7-day milestone, cap 3; shown in My Account). | Server + UI | ✅ |
-| **3 — Power-up system** | Inventory + effects, earned via play/badges (no payments) | Server + UI | 📋 |
+| **3 — Power-up system** | Framework: inventory, earning, display + **Free Reveal** consumable (3a). More effects (extra bank, discount, insurance…) TODO (3b). | Server + UI | 🚧 |
 | **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
 

--- a/scripts/check-freereveal.mjs
+++ b/scripts/check-freereveal.mjs
@@ -1,0 +1,29 @@
+// Verify the Free Reveal power-up: FREE badge on Reveal, and using it reveals a
+// letter without charging bankroll.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+await p.getByRole('button', { name: /daily/i }).first().click().catch(()=>{}); await wait(2600);
+const freeBadge = await p.locator('.free-badge').count();
+const revealedBefore = await p.locator('.letter-box.locked').count();
+console.log('free-badge shown:', freeBadge > 0, ' badge text:', await p.locator('.free-badge').innerText().catch(()=>'—'));
+await p.screenshot({ path: 'screenshots/freereveal-1.png' });
+// Use Reveal (will be free if a power-up is owned)
+await p.locator('.hint-button').click({ force: true }).catch(()=>{}); await wait(400);
+await p.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch(()=>{}); await wait(1600);
+await p.screenshot({ path: 'screenshots/freereveal-2.png' });
+console.log('free-badge after:', await p.locator('.free-badge').innerText().catch(()=>'—'));
+await b.close();

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -29,6 +29,7 @@
   $: canConfirmWager = sliderWagerAmount > 0;
   $: gameOver = $gameStore.gameState === 'won' || $gameStore.gameState === 'lost';
   $: buttonsDisabled = gameOver;
+  $: hasFreeReveal = isDailyMode && ($gameStore.freeReveals ?? 0) > 0;
 
   // ✅ Detect full phrase input
   $: guessComplete = guessModeActive && (() => {
@@ -139,17 +140,16 @@
 <div class="main-button-wrapper">
   <div class="hint-button-container">
     {#if showHintCost}
-      <div class="cost-indicator">
-        $150
-      </div>
+      <div class="cost-indicator">{hasFreeReveal ? '🎟️ FREE' : '$150'}</div>
     {/if}
     <button
-      class="hint-button {fundsLow ? 'disabled-purchase' : ''} {hintPending ? 'glow' : ''}"
+      class="hint-button {(fundsLow && !hasFreeReveal) ? 'disabled-purchase' : ''} {hintPending ? 'glow' : ''}"
       on:click={toggleHintPurchase}
-      disabled={fundsLow || buttonsDisabled}
-      title="Reveal the most useful letter ($150)"
+      disabled={(fundsLow && !hasFreeReveal) || buttonsDisabled}
+      title={hasFreeReveal ? 'Free Reveal (power-up)' : 'Reveal the most useful letter ($150)'}
     >
       Reveal
+      {#if hasFreeReveal}<span class="free-badge">{$gameStore.freeReveals}</span>{/if}
     </button>
   </div>
 
@@ -310,6 +310,7 @@
   position: relative;
 }
 .hint-button {
+  position: relative;
   width: 54px;
   height: 46px;
   border-radius: 13px;
@@ -332,6 +333,23 @@
 .hint-button:hover { transform: translateY(-2px); background: var(--surface-2); border-color: var(--border-strong); }
 .hint-button:active { transform: scale(0.96); }
 .hint-button.glow { border-color: rgba(163, 230, 53, 0.5) !important; box-shadow: var(--glow-brand); }
+.free-badge {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  color: #06210f;
+  background: var(--brand-grad);
+  border-radius: 999px;
+  box-shadow: var(--glow-brand);
+}
 
 /* ---------------------------
    Guesses Button (blue, right of Solve)

--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -1,0 +1,11 @@
+// Power-up catalog. Keys match server user_powerups.powerup values.
+/** @type {Record<string, { emoji: string, name: string, desc: string }>} */
+export const POWERUPS = {
+  free_reveal: { emoji: '🎟️', name: 'Free Reveal', desc: 'One free smart reveal (no $ charge)' },
+  // Phase 3b: extra_bank, discount, insurance, vowel_vision, double_payout…
+};
+
+/** @param {string} id */
+export function powerupInfo(id) {
+  return POWERUPS[id] || { emoji: '⚡', name: id, desc: '' };
+}

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -6,7 +6,7 @@ import confetti from 'canvas-confetti';
 import { user } from '$lib/stores/userStore.js';
 import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
 import { recordDailyResult, recordArcadeResult, saveArcadeBankroll } from '$lib/stores/statsStore.js';
-import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getUserPowerups, dailyUseFreeReveal } from '$lib/stores/statsStore.js';
 
 /* ================================
    Types (JSDoc for checkJs)
@@ -33,7 +33,8 @@ import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess } from '$lib/
  *   shakenLetters: number[],
  *   message: string,
  *   subcategory: string,
- *   gameMode: string
+ *   gameMode: string,
+ *   freeReveals?: number
  * }} GameState
  */
 
@@ -65,7 +66,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   shakenLetters: [],
   message: '',
   subcategory: '',
-  gameMode: 'daily' // 'daily' | 'arcade'
+  gameMode: 'daily', // 'daily' | 'arcade'
+  freeReveals: 0 // owned Free Reveal power-ups (daily)
 }));
 
 /* ================================
@@ -172,11 +174,21 @@ async function confirmPurchaseDaily(state) {
   dailyInFlight = true;
   try {
     let board = null;
-    if (purchase.type === 'letter') board = await dailyBuyLetter(purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await dailyReveal();
+    let usedFree = false;
+    if (purchase.type === 'letter') {
+      board = await dailyBuyLetter(purchase.value ?? '');
+    } else if (purchase.type === 'hint') {
+      // Reveal uses a Free Reveal power-up if you own one; otherwise it costs $150.
+      if ((state.freeReveals || 0) > 0) { board = await dailyUseFreeReveal(); usedFree = true; }
+      else board = await dailyReveal();
+    }
 
-    if (board) reconcileDailyBoard(board);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+    if (board) {
+      reconcileDailyBoard(board);
+      if (usedFree) gameStore.update(s => ({ ...s, freeReveals: Math.max(0, (s.freeReveals || 0) - 1) }));
+    } else {
+      gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+    }
   } finally {
     dailyInFlight = false;
   }
@@ -798,6 +810,12 @@ export async function fetchDailyGame() {
       return false;
     }
     reconcileDailyBoard(board);
+    // Load Free Reveal inventory for the in-game button.
+    try {
+      const pus = await getUserPowerups();
+      const fr = pus.find(p => p.powerup === 'free_reveal')?.count ?? 0;
+      gameStore.update(s => ({ ...s, freeReveals: fr }));
+    } catch { /* non-fatal */ }
     console.log('✅ Daily session started/resumed');
     return true;
   } catch (err) {

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -142,6 +142,23 @@ export async function getUserBadges(userId) {
   return (data ?? []).map((/** @type {{ badge: string }} */ r) => r.badge);
 }
 
+/**
+ * Fetch the caller's power-up inventory.
+ * @returns {Promise<{powerup: string, count: number}[]>}
+ */
+export async function getUserPowerups() {
+  const { data, error } = await supabase.rpc('get_user_powerups');
+  if (error) { console.error('❌ get_user_powerups error:', error); return []; }
+  return data ?? [];
+}
+
+/** Use a Free Reveal power-up (free smart reveal). @returns {Promise<object|null>} board */
+export async function dailyUseFreeReveal() {
+  const { data, error } = await supabase.rpc('daily_use_free_reveal');
+  if (error) { console.error('❌ daily_use_free_reveal error:', error); return null; }
+  return data;
+}
+
 /** Reveal ($150): all instances of the most-useful unrevealed letter. @returns {Promise<object|null>} board */
 export async function dailyReveal() {
   const { data, error } = await supabase.rpc('daily_reveal');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,8 +6,9 @@
 
   import { gameStore, fetchRandomGame, fetchDailyGame } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday, saveArcadeBankroll, getUserBadges, getDailyStatus } from '$lib/stores/statsStore.js';
+  import { hasPlayedDailyToday, saveArcadeBankroll, getUserBadges, getDailyStatus, getUserPowerups } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
+  import { powerupInfo } from '$lib/powerups.js';
   import {
     saveGameToLocalStorage,
     loadGameFromLocalStorage,
@@ -325,15 +326,18 @@
   let badgesLoaded = false;
   let accountStreak = 0;
   let accountFreezes = 0;
+  /** @type {{powerup: string, count: number}[]} */
+  let accountPowerups = [];
   async function handleMenuMyAccount() {
     showMyAccount = true;
     badgesLoaded = false;
     const u = get(user);
     if (u?.id) {
-      const [badges, status] = await Promise.all([getUserBadges(u.id), getDailyStatus(u.id)]);
+      const [badges, status, powerups] = await Promise.all([getUserBadges(u.id), getDailyStatus(u.id), getUserPowerups()]);
       accountBadges = badges;
       accountStreak = status.current_streak ?? 0;
       accountFreezes = status.streak_freezes ?? 0;
+      accountPowerups = powerups;
     }
     badgesLoaded = true;
   }
@@ -544,6 +548,22 @@
             <div class="stat-chip" title="Auto-protects your streak across one missed day. Earn one every 7-day streak.">
               <span class="stat-emoji">🧊</span> {accountFreezes}<span class="stat-cap">freeze{accountFreezes === 1 ? '' : 's'}</span>
             </div>
+          </div>
+
+          <div class="badges-section">
+            <p class="badges-title">Power-ups</p>
+            {#if badgesLoaded && accountPowerups.length === 0}
+              <p class="powerups-empty">Win daily puzzles to earn power-ups 🎟️</p>
+            {:else}
+              <div class="badge-grid">
+                {#each accountPowerups as pu}
+                  <div class="badge earned" title={powerupInfo(pu.powerup).desc}>
+                    <span class="badge-emoji">{powerupInfo(pu.powerup).emoji}</span>
+                    <span class="badge-name">{powerupInfo(pu.powerup).name} ×{pu.count}</span>
+                  </div>
+                {/each}
+              </div>
+            {/if}
           </div>
 
           <div class="badges-section">
@@ -961,8 +981,9 @@
     color: var(--text-faint);
   }
 
-  /* Badges (My Account) */
+  /* Badges + power-ups (My Account) */
   .badges-section { margin: 18px 0 8px; }
+  .powerups-empty { font-size: 0.82rem; color: var(--text-faint); margin: 0; }
   .badges-title {
     font-family: var(--font-display);
     font-weight: 600;

--- a/supabase-powerups.sql
+++ b/supabase-powerups.sql
@@ -1,0 +1,142 @@
+-- ============================================================
+-- WordBank V2 Phase 3a: power-up framework + Free Reveal
+-- Run AFTER supabase-streak-freeze.sql (redefines _finalize_daily to also grant
+-- a Free Reveal on each win).
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.user_powerups (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  powerup TEXT NOT NULL,
+  count INT NOT NULL DEFAULT 0,
+  PRIMARY KEY (user_id, powerup)
+);
+ALTER TABLE public.user_powerups ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "read own powerups" ON public.user_powerups;
+CREATE POLICY "read own powerups" ON public.user_powerups FOR SELECT USING (auth.uid() = user_id);
+REVOKE INSERT, UPDATE, DELETE ON public.user_powerups FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public._grant_powerup(p_uid UUID, p_powerup TEXT, p_cap INT DEFAULT 3)
+RETURNS void LANGUAGE sql SECURITY DEFINER AS $fn$
+  INSERT INTO public.user_powerups (user_id, powerup, count) VALUES (p_uid, p_powerup, 1)
+  ON CONFLICT (user_id, powerup) DO UPDATE SET count = LEAST(public.user_powerups.count + 1, p_cap);
+$fn$;
+REVOKE EXECUTE ON FUNCTION public._grant_powerup(UUID, TEXT, INT) FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_user_powerups()
+RETURNS TABLE (powerup TEXT, count INT) LANGUAGE sql SECURITY DEFINER AS $fn$
+  SELECT up.powerup, up.count FROM public.user_powerups up
+  WHERE up.user_id = auth.uid() AND up.count > 0 ORDER BY up.powerup;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.get_user_powerups() TO authenticated;
+
+-- Free Reveal: a free smart reveal that consumes one 'free_reveal' power-up.
+CREATE OR REPLACE FUNCTION public.daily_use_free_reveal()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  v_letter TEXT; v_positions INT[]; v_owned INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_use_free_reveal: not authenticated'; END IF;
+
+  SELECT count INTO v_owned FROM public.user_powerups WHERE user_id = v_uid AND powerup = 'free_reveal';
+
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_use_free_reveal: no active session'; END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  SELECT t.ch INTO v_letter FROM (
+    SELECT substr(v_phrase, g.i + 1, 1) AS ch, count(*) AS c
+    FROM generate_series(0, length(v_phrase) - 1) g(i)
+    WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
+    GROUP BY substr(v_phrase, g.i + 1, 1) ORDER BY c DESC, ch LIMIT 1
+  ) t;
+
+  IF s.state <> 'active' OR COALESCE(v_owned, 0) <= 0 OR v_letter IS NULL THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  SELECT array_agg(g.i) INTO v_positions
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+
+  s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || v_positions) ORDER BY 1);
+  UPDATE public.daily_sessions SET revealed_positions = s.revealed_positions, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+
+  UPDATE public.user_powerups SET count = count - 1 WHERE user_id = v_uid AND powerup = 'free_reveal';
+
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_use_free_reveal() TO authenticated;
+
+-- _finalize_daily also grants a Free Reveal on each win (capped at 3).
+-- (Full body lives here as the latest definition; supersedes earlier versions.)
+CREATE OR REPLACE FUNCTION public._finalize_daily(p_uid UUID, p_won BOOLEAN, p_bankroll INT, p_incorrect_count INT DEFAULT 0)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_week_start DATE; v_current_streak INT; v_highest_streak INT; v_last_win DATE;
+  v_bankroll INT; v_score INT; v_freezes INT;
+BEGIN
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll, 0), 0), 1000);
+  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1;
+
+  SELECT current_win_streak, highest_win_streak, last_daily_win_date, COALESCE(streak_freezes, 0)
+  INTO v_current_streak, v_highest_streak, v_last_win, v_freezes
+  FROM public.profiles WHERE id = p_uid;
+
+  IF p_won THEN
+    IF v_last_win = CURRENT_DATE - 1 THEN
+      v_current_streak := COALESCE(v_current_streak, 0) + 1;
+    ELSIF v_last_win = CURRENT_DATE - 2 AND v_freezes > 0 AND COALESCE(v_current_streak, 0) > 0 THEN
+      v_freezes := v_freezes - 1; v_current_streak := v_current_streak + 1;
+    ELSIF v_last_win IS DISTINCT FROM CURRENT_DATE THEN
+      v_current_streak := 1;
+    END IF;
+    IF v_current_streak > 0 AND v_current_streak % 7 = 0 THEN v_freezes := LEAST(v_freezes + 1, 3); END IF;
+    v_highest_streak := GREATEST(COALESCE(v_highest_streak, 0), v_current_streak);
+    UPDATE public.profiles SET
+      current_win_streak = v_current_streak, highest_win_streak = v_highest_streak,
+      last_daily_win_date = CURRENT_DATE, last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll, last_daily_won = true, streak_freezes = v_freezes
+    WHERE id = p_uid;
+  ELSE
+    v_current_streak := 0;
+    UPDATE public.profiles SET
+      current_win_streak = 0, last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll, last_daily_won = false
+    WHERE id = p_uid;
+  END IF;
+
+  v_score := ROUND(v_bankroll * (1 + LEAST(GREATEST(COALESCE(v_current_streak, 0) - 1, 0), 10) * 0.1))::INT;
+
+  INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode, score)
+  VALUES (p_uid, NOW(), p_won, v_bankroll, 'daily', v_score);
+
+  INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
+  VALUES (p_uid, v_week_start,
+    CASE WHEN p_won THEN 1 ELSE 0 END, CASE WHEN p_won THEN v_bankroll ELSE 0 END, v_bankroll,
+    CASE WHEN p_won THEN 1 ELSE 0 END, 1, COALESCE(v_current_streak, 0))
+  ON CONFLICT (user_id, week_start) DO UPDATE SET
+    total_played = user_weekly_stats.total_played + 1,
+    total_wins = user_weekly_stats.total_wins + CASE WHEN p_won THEN 1 ELSE 0 END,
+    puzzles_completed = user_weekly_stats.puzzles_completed + CASE WHEN p_won THEN 1 ELSE 0 END,
+    bankroll_earned = user_weekly_stats.bankroll_earned + CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, v_bankroll),
+    win_streak = GREATEST(user_weekly_stats.win_streak, v_current_streak);
+
+  IF p_won THEN
+    IF COALESCE(p_incorrect_count, 0) = 0 THEN PERFORM public._award_badge(p_uid, 'flawless'); END IF;
+    IF v_bankroll >= 700 THEN PERFORM public._award_badge(p_uid, 'gold_bank'); END IF;
+    IF v_current_streak >= 7 THEN PERFORM public._award_badge(p_uid, 'streak_7'); END IF;
+    IF v_current_streak >= 30 THEN PERFORM public._award_badge(p_uid, 'streak_30'); END IF;
+    PERFORM public._grant_powerup(p_uid, 'free_reveal', 3);
+  END IF;
+END;
+$fn$;


### PR DESCRIPTION
First slice of [Phase 3](./ROADMAP.md) — the power-up system foundation, proven end-to-end with one real power-up.

## Framework
- `user_powerups` inventory (read-own; writes only via SECURITY DEFINER).
- `_grant_powerup` helper + `get_user_powerups` RPC.
- Catalog in `src/lib/powerups.js`.

## Free Reveal (the proof)
- `daily_use_free_reveal` — a free smart reveal that consumes a `free_reveal` power-up.
- Earned: `_finalize_daily` grants one on each daily win (cap 3).
- UI: the **Reveal button auto-uses a Free Reveal when you own one** — shows a `🎟️ FREE` cost label + a count badge, and stays usable even when you're too broke to pay \$150.
- **My Account** shows your power-up inventory.

## Verified
Playwright: granted ×2 → badge showed **2** → using Reveal revealed a letter for **free** (bankroll unchanged) → badge dropped to **1**. Server consumed the power-up. Build + lint + type-check clean. `supabase-powerups.sql` synced.

## Still TODO in Phase 3 (3b)
The pre-game power-ups that need a selection UI: **+$250 Start, Discount (−25%), Insurance (free wrong guess), Vowel Vision, Double Payout.** Roadmap row 🚧.

🤖 Generated with [Claude Code](https://claude.com/claude-code)