### PR TITLE
V2 Phase 3b: pre-game power-ups (+$250 Start, Discount) + picker

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Status: 📋 Planned (Phase 3)
 | **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Badges ✅ (4 daily, My Account, 🔥 flair). Streak **freeze** ✅ (auto-bridge a missed day, earn 1 per 7-day milestone, cap 3; shown in My Account). | Server + UI | ✅ |
-| **3 — Power-up system** | Framework: inventory, earning, display + **Free Reveal** consumable (3a). More effects (extra bank, discount, insurance…) TODO (3b). | Server + UI | 🚧 |
+| **3 — Power-up system** | Inventory + earning + display ✅; Free Reveal (in-game) ✅; pre-game picker + **+$250 Start** | **3 — Power-up system** | Framework: inventory, earning, display + **Free Reveal** consumable (3a). More effects (extra bank, discount, insurance…) TODO (3b). | Server + UI | 🚧 | **Discount** ✅. Insurance / Vowel Vision / Double Payout TODO (3c). | Server + UI | 🚧 |
 | **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
 

--- a/scripts/check-picker.mjs
+++ b/scripts/check-picker.mjs
@@ -1,0 +1,27 @@
+// Verify the pre-game power-up picker + extra_bank ($250 start).
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+// Tap Daily Puzzle -> picker
+await p.getByRole('button', { name: /daily/i }).first().click().catch(()=>{}); await wait(1800);
+const pickerShown = await p.locator('.picker-list').count() > 0;
+console.log('picker shown:', pickerShown, ' items:', await p.locator('.picker-item').count());
+await p.screenshot({ path: 'screenshots/picker-1.png' });
+// Select +$250 Start then Start
+await p.locator('.picker-item', { hasText: '250' }).first().click({ force: true }).catch(e=>console.log('select', e.message)); await wait(400);
+await p.getByRole('button', { name: /^start/i }).first().click({ force: true }).catch(e=>console.log('start', e.message)); await wait(2600);
+await p.screenshot({ path: 'screenshots/picker-2-board.png' });
+await b.close();

--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -1,8 +1,11 @@
 // Power-up catalog. Keys match server user_powerups.powerup values.
-/** @type {Record<string, { emoji: string, name: string, desc: string }>} */
+// pregame: chosen before a daily starts (selection modal). Otherwise used in-game.
+/** @type {Record<string, { emoji: string, name: string, desc: string, pregame?: boolean }>} */
 export const POWERUPS = {
   free_reveal: { emoji: '🎟️', name: 'Free Reveal', desc: 'One free smart reveal (no $ charge)' },
-  // Phase 3b: extra_bank, discount, insurance, vowel_vision, double_payout…
+  extra_bank:  { emoji: '💰', name: '+$250 Start', desc: 'Begin the puzzle with $1,250', pregame: true },
+  discount:    { emoji: '🏷️', name: 'Discount',    desc: 'All letters −25% this puzzle', pregame: true },
+  // Phase 3c: insurance, vowel_vision, double_payout…
 };
 
 /** @param {string} id */

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -802,9 +802,12 @@ export async function fetchRandomGame(category) {
  * The phrase is held server-side; the client only ever receives a masked board.
  * No localStorage: the server is the source of truth (and prevents replays).
  */
-export async function fetchDailyGame() {
+/**
+ * @param {string[]} [powerups] - pre-game power-ups to activate (applied only on a fresh session)
+ */
+export async function fetchDailyGame(powerups = []) {
   try {
-    const board = await dailyStart();
+    const board = await dailyStart(powerups);
     if (!board) {
       console.error('❌ daily_start returned no board');
       return false;

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -117,11 +117,22 @@ export async function recordArcadeResult(userId, won, bankrollLeft) {
    phrase is null until the game is over.
 ============================================================ */
 
-/** Start or resume today's daily session. @returns {Promise<object|null>} board */
-export async function dailyStart() {
-  const { data, error } = await supabase.rpc('daily_start');
+/**
+ * Start or resume today's daily session, activating any pre-game power-ups.
+ * @param {string[]} [powerups] - pre-game power-ups to activate (only applied on a fresh session)
+ * @returns {Promise<object|null>} board
+ */
+export async function dailyStart(powerups = []) {
+  const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups });
   if (error) { console.error('❌ daily_start error:', error); return null; }
   return data;
+}
+
+/** Whether the caller already has a session for today (drives the pre-game picker). */
+export async function dailySessionExists() {
+  const { data, error } = await supabase.rpc('daily_session_exists');
+  if (error) { console.error('❌ daily_session_exists error:', error); return false; }
+  return !!data;
 }
 
 /** Buy a letter. @param {string} letter @returns {Promise<object|null>} board */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
   import { gameStore, fetchRandomGame, fetchDailyGame } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday, saveArcadeBankroll, getUserBadges, getDailyStatus, getUserPowerups } from '$lib/stores/statsStore.js';
+  import { hasPlayedDailyToday, saveArcadeBankroll, getUserBadges, getDailyStatus, getUserPowerups, dailySessionExists } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
   import { powerupInfo } from '$lib/powerups.js';
   import {
@@ -276,6 +276,12 @@
   };
 
   /** Start daily: resume if in progress, else show "already played" or fetch new daily */
+  let showPowerupPicker = false;
+  /** @type {{powerup: string, count: number}[]} */
+  let pickerPowerups = [];
+  /** @type {Set<string>} */
+  let selectedPowerups = new Set();
+
   async function handleMenuDaily() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
@@ -284,15 +290,36 @@
       showStreakMessage = true;
       return;
     }
-    // daily_start resumes an in-progress session or begins a fresh one, server-side.
+    // Fresh daily + owns pre-game power-ups -> let the player choose which to use.
+    const [exists, powerups] = await Promise.all([dailySessionExists(), getUserPowerups()]);
+    const pregame = powerups.filter(p => powerupInfo(p.powerup).pregame);
+    if (!exists && pregame.length > 0) {
+      pickerPowerups = pregame;
+      selectedPowerups = new Set();
+      showPowerupPicker = true;
+      return;
+    }
+    await startDaily([]);
+  }
+
+  /** @param {string[]} powerups */
+  async function startDaily(powerups) {
+    showPowerupPicker = false;
     localStorage.setItem('gameMode', 'daily');
-    const ok = await fetchDailyGame();
+    const ok = await fetchDailyGame(powerups);
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
     } else {
       initError = "Daily puzzle failed to load.";
     }
+  }
+
+  /** @param {string} id */
+  function togglePowerup(id) {
+    if (selectedPowerups.has(id)) selectedPowerups.delete(id);
+    else selectedPowerups.add(id);
+    selectedPowerups = selectedPowerups; // trigger reactivity
   }
 
   /** Start or resume arcade: resume from save or go to arcade category select */
@@ -520,6 +547,37 @@
         </button>
       </div>
     </div>
+    <!-- Pre-game power-up picker (fresh daily + owned pre-game power-ups) -->
+    {#if showPowerupPicker}
+      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Use power-ups">
+        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showPowerupPicker = false}></button>
+        <div class="modal-content main-menu-modal">
+          <button class="close-btn" on:click={() => showPowerupPicker = false}>❌</button>
+          <h2>Use a power-up?</h2>
+          <p class="picker-sub">Tap to apply before today's daily. They're consumed when you start.</p>
+          <div class="picker-list">
+            {#each pickerPowerups as pu}
+              <button
+                class="picker-item {selectedPowerups.has(pu.powerup) ? 'on' : ''}"
+                on:click={() => togglePowerup(pu.powerup)}
+              >
+                <span class="pi-emoji">{powerupInfo(pu.powerup).emoji}</span>
+                <span class="pi-body">
+                  <span class="pi-name">{powerupInfo(pu.powerup).name} <span class="pi-count">×{pu.count}</span></span>
+                  <span class="pi-desc">{powerupInfo(pu.powerup).desc}</span>
+                </span>
+                <span class="pi-check">{selectedPowerups.has(pu.powerup) ? '✓' : ''}</span>
+              </button>
+            {/each}
+          </div>
+          <div class="picker-actions">
+            <button class="btn-ghost" on:click={() => startDaily([])}>Skip</button>
+            <button class="main-menu-btn" on:click={() => startDaily([...selectedPowerups])}>Start{#if selectedPowerups.size > 0} ({selectedPowerups.size}){/if}</button>
+          </div>
+        </div>
+      </div>
+    {/if}
+
     <!-- Streak message (when Daily is disabled and user taps it) -->
     {#if showStreakMessage}
       <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Come back tomorrow">
@@ -980,6 +1038,37 @@
     text-transform: uppercase;
     color: var(--text-faint);
   }
+
+  /* Pre-game power-up picker */
+  .picker-sub { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 14px; }
+  .picker-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
+  .picker-item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    text-align: left;
+    padding: 12px 14px;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    transition: background 0.18s, border-color 0.18s, transform 0.15s var(--ease-spring);
+  }
+  .picker-item:hover { transform: translateY(-1px); border-color: var(--border-strong); }
+  .picker-item.on {
+    border-color: rgba(163, 230, 53, 0.5);
+    background: linear-gradient(135deg, rgba(52, 211, 153, 0.14), rgba(163, 230, 53, 0.05));
+    box-shadow: var(--glow-brand);
+  }
+  .pi-emoji { font-size: 1.5rem; line-height: 1; }
+  .pi-body { display: flex; flex-direction: column; gap: 2px; flex: 1; }
+  .pi-name { font-family: var(--font-display); font-weight: 600; font-size: 0.98rem; }
+  .pi-count { color: var(--brand-2); }
+  .pi-desc { font-size: 0.76rem; color: var(--text-muted); }
+  .pi-check { color: var(--brand-2); font-weight: 700; font-size: 1.1rem; width: 16px; }
+  .picker-actions { display: flex; gap: 10px; }
+  .picker-actions > * { flex: 1; margin-top: 0; }
 
   /* Badges + power-ups (My Account) */
   .badges-section { margin: 18px 0 8px; }

--- a/supabase-powerups.sql
+++ b/supabase-powerups.sql
@@ -136,7 +136,7 @@ BEGIN
     IF v_bankroll >= 700 THEN PERFORM public._award_badge(p_uid, 'gold_bank'); END IF;
     IF v_current_streak >= 7 THEN PERFORM public._award_badge(p_uid, 'streak_7'); END IF;
     IF v_current_streak >= 30 THEN PERFORM public._award_badge(p_uid, 'streak_30'); END IF;
-    PERFORM public._grant_powerup(p_uid, 'free_reveal', 3);
+    PERFORM public._grant_random_powerup(p_uid);  -- Phase 3b: random from pool (defined in supabase-pregame-powerups.sql)
   END IF;
 END;
 $fn$;

--- a/supabase-pregame-powerups.sql
+++ b/supabase-pregame-powerups.sql
@@ -1,0 +1,123 @@
+-- ============================================================
+-- WordBank V2 Phase 3b: pre-game power-ups (+$250 Start, Discount)
+-- Run AFTER supabase-powerups.sql. Adds session-scoped active power-ups, a
+-- pre-game selection entry point, the discount effect, and a random grant on win.
+-- ============================================================
+
+ALTER TABLE public.daily_sessions ADD COLUMN IF NOT EXISTS active_powerups TEXT[] NOT NULL DEFAULT '{}';
+
+CREATE OR REPLACE FUNCTION public.daily_session_exists()
+RETURNS BOOLEAN LANGUAGE sql SECURITY DEFINER AS $fn$
+  SELECT EXISTS (SELECT 1 FROM public.daily_sessions WHERE user_id = auth.uid() AND puzzle_date = CURRENT_DATE);
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_session_exists() TO authenticated;
+
+-- Random power-up grant from the pool (used by _finalize_daily on a win).
+CREATE OR REPLACE FUNCTION public._grant_random_powerup(p_uid UUID)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE pool TEXT[] := ARRAY['free_reveal', 'extra_bank', 'discount'];
+BEGIN
+  PERFORM public._grant_powerup(p_uid, pool[1 + floor(random() * array_length(pool, 1))::int], 3);
+END;
+$fn$;
+REVOKE EXECUTE ON FUNCTION public._grant_random_powerup(UUID) FROM anon, authenticated;
+
+-- daily_start activates selected pre-game power-ups on a fresh session.
+DROP FUNCTION IF EXISTS public.daily_start();
+DROP FUNCTION IF EXISTS public.daily_start(TEXT[]);
+CREATE OR REPLACE FUNCTION public.daily_start(p_powerups TEXT[] DEFAULT '{}')
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  s public.daily_sessions;
+  v_bonus INT := 0; v_active TEXT[] := '{}'; v_pu TEXT; v_owned INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_start: not authenticated'; END IF;
+  v_pid := public._todays_puzzle_id();
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
+    IF p_powerups IS NOT NULL THEN
+      FOREACH v_pu IN ARRAY p_powerups LOOP
+        IF v_pu IN ('extra_bank', 'discount') AND NOT (v_pu = ANY(v_active)) THEN
+          SELECT count INTO v_owned FROM public.user_powerups WHERE user_id = v_uid AND powerup = v_pu;
+          IF COALESCE(v_owned, 0) > 0 THEN
+            UPDATE public.user_powerups SET count = count - 1 WHERE user_id = v_uid AND powerup = v_pu;
+            v_active := v_active || v_pu;
+            IF v_pu = 'extra_bank' THEN v_bonus := v_bonus + 250; END IF;
+          END IF;
+        END IF;
+      END LOOP;
+    END IF;
+    INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining, active_powerups)
+    VALUES (v_uid, CURRENT_DATE, v_pid, 1000 + v_bonus, 3, v_active)
+    RETURNING * INTO s;
+  END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+  RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                             s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_start(TEXT[]) TO authenticated;
+
+-- daily_buy_letter applies the Discount power-up (-25%, rounded up).
+CREATE OR REPLACE FUNCTION public.daily_buy_letter(p_letter TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  v_letter TEXT; v_cost INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter);
+  v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'daily_buy_letter: invalid letter'; END IF;
+
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_letter: no active session (call daily_start)'; END IF;
+
+  IF 'discount' = ANY(s.active_powerups) THEN v_cost := CEIL(v_cost * 0.75)::INT; END IF;
+
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+
+  IF s.state <> 'active' OR v_letter = ANY(s.incorrect_letters) OR s.bankroll < v_cost THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  SELECT array_agg(g.i) INTO v_positions
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+
+  IF v_positions IS NOT NULL AND v_positions <@ s.revealed_positions THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+
+  s.bankroll := s.bankroll - v_cost;
+  IF v_positions IS NULL THEN
+    s.incorrect_letters := array_append(s.incorrect_letters, v_letter);
+  ELSE
+    s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || v_positions) ORDER BY 1);
+  END IF;
+
+  UPDATE public.daily_sessions SET
+    bankroll = s.bankroll, incorrect_letters = s.incorrect_letters,
+    revealed_positions = s.revealed_positions, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_buy_letter(TEXT) TO authenticated;
+
+-- NOTE: _finalize_daily's final line is changed to grant a RANDOM power-up on win:
+--   PERFORM public._grant_random_powerup(p_uid);
+-- (replacing the Phase 3a `_grant_powerup(p_uid, 'free_reveal', 3)`). The full body
+-- lives in supabase-powerups.sql; re-run that with this one line swapped, or apply
+-- the v2_phase3b migration which redefines it.


### PR DESCRIPTION
Extends [Phase 3](./ROADMAP.md) with **pre-game** power-ups chosen before a daily starts, and the selection UI for them.

## What changed
- `daily_sessions.active_powerups`; `daily_start(p_powerups[])` consumes the selected pre-game power-ups on a fresh session and applies **+$250 Start**; `daily_buy_letter` applies **Discount** (−25%, rounded up).
- `daily_session_exists()` so the client only shows the picker for a genuinely fresh daily.
- `_finalize_daily` now grants a **random** power-up on win (free_reveal / extra_bank / discount), so players actually earn the pre-game ones.

## UI
- A **pre-game power-up picker** modal: when you tap Daily with a fresh session and own pre-game power-ups, you get a tappable list (with counts + descriptions), **Skip** / **Start**. Selected ones are consumed on Start.
- Catalog gains a `pregame` flag + the two entries.

## Verified
Playwright: granted Discount + $250 Start → tapping Daily showed the picker (2 items) → selecting **+$250 Start** → the daily began at **$1,250** (consumed server-side). Build + lint + type-check clean. `supabase-pregame-powerups.sql` synced.

## Still TODO (3c)
**Insurance** (free wrong guess), **Vowel Vision** (cheap vowels), **Double Payout** (arcade). Roadmap row 🚧.

🤖 Generated with [Claude Code](https://claude.com/claude-code)