### PR TITLE
V2 Phase 3c: Insurance + Vowel Vision (Phase 3 complete)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Status: 📋 Planned (Phase 3)
 | **0 — Economy refactor** | 3 free attempts, free guessing, win-by-reveal, Reveal rework, broke-only loss | Daily RPCs (server) + arcade client | ✅ |
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Badges ✅ (4 daily, My Account, 🔥 flair). Streak **freeze** ✅ (auto-bridge a missed day, earn 1 per 7-day milestone, cap 3; shown in My Account). | Server + UI | ✅ |
-| **3 — Power-up system** | Inventory + earning + display ✅; Free Reveal (in-game) ✅; pre-game picker + **+$250 Start** | **3 — Power-up system** | Framework: inventory, earning, display + **Free Reveal** consumable (3a). More effects (extra bank, discount, insurance…) TODO (3b). | Server + UI | 🚧 | **Discount** ✅. Insurance / Vowel Vision / Double Payout TODO (3c). | Server + UI | 🚧 |
+| **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
 | **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
 

--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -2,10 +2,12 @@
 // pregame: chosen before a daily starts (selection modal). Otherwise used in-game.
 /** @type {Record<string, { emoji: string, name: string, desc: string, pregame?: boolean }>} */
 export const POWERUPS = {
-  free_reveal: { emoji: '🎟️', name: 'Free Reveal', desc: 'One free smart reveal (no $ charge)' },
-  extra_bank:  { emoji: '💰', name: '+$250 Start', desc: 'Begin the puzzle with $1,250', pregame: true },
-  discount:    { emoji: '🏷️', name: 'Discount',    desc: 'All letters −25% this puzzle', pregame: true },
-  // Phase 3c: insurance, vowel_vision, double_payout…
+  free_reveal:  { emoji: '🎟️', name: 'Free Reveal',  desc: 'One free smart reveal (no $ charge)' },
+  extra_bank:   { emoji: '💰', name: '+$250 Start',  desc: 'Begin the puzzle with $1,250', pregame: true },
+  discount:     { emoji: '🏷️', name: 'Discount',     desc: 'All letters −25% this puzzle', pregame: true },
+  insurance:    { emoji: '🛡️', name: 'Insurance',    desc: 'Your first wrong guess is free', pregame: true },
+  vowel_vision: { emoji: '👁️', name: 'Vowel Vision', desc: 'Vowels cost half this puzzle', pregame: true },
+  // Phase 4: double_payout (arcade)
 };
 
 /** @param {string} id */

--- a/supabase-pregame-powerups.sql
+++ b/supabase-pregame-powerups.sql
@@ -15,7 +15,7 @@ GRANT EXECUTE ON FUNCTION public.daily_session_exists() TO authenticated;
 -- Random power-up grant from the pool (used by _finalize_daily on a win).
 CREATE OR REPLACE FUNCTION public._grant_random_powerup(p_uid UUID)
 RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $fn$
-DECLARE pool TEXT[] := ARRAY['free_reveal', 'extra_bank', 'discount'];
+DECLARE pool TEXT[] := ARRAY['free_reveal', 'extra_bank', 'discount', 'insurance', 'vowel_vision'];
 BEGIN
   PERFORM public._grant_powerup(p_uid, pool[1 + floor(random() * array_length(pool, 1))::int], 3);
 END;
@@ -40,7 +40,7 @@ BEGIN
     IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
     IF p_powerups IS NOT NULL THEN
       FOREACH v_pu IN ARRAY p_powerups LOOP
-        IF v_pu IN ('extra_bank', 'discount') AND NOT (v_pu = ANY(v_active)) THEN
+        IF v_pu IN ('extra_bank', 'discount', 'insurance', 'vowel_vision') AND NOT (v_pu = ANY(v_active)) THEN
           SELECT count INTO v_owned FROM public.user_powerups WHERE user_id = v_uid AND powerup = v_pu;
           IF COALESCE(v_owned, 0) > 0 THEN
             UPDATE public.user_powerups SET count = count - 1 WHERE user_id = v_uid AND powerup = v_pu;
@@ -81,6 +81,7 @@ BEGIN
   IF NOT FOUND THEN RAISE EXCEPTION 'daily_buy_letter: no active session (call daily_start)'; END IF;
 
   IF 'discount' = ANY(s.active_powerups) THEN v_cost := CEIL(v_cost * 0.75)::INT; END IF;
+  IF 'vowel_vision' = ANY(s.active_powerups) AND v_letter IN ('A','E','I','O','U') THEN v_cost := CEIL(v_cost * 0.5)::INT; END IF;
 
   SELECT upper(phrase), category, COALESCE(subcategory, '')
   INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
@@ -116,8 +117,57 @@ END;
 $fn$;
 GRANT EXECUTE ON FUNCTION public.daily_buy_letter(TEXT) TO authenticated;
 
--- NOTE: _finalize_daily's final line is changed to grant a RANDOM power-up on win:
---   PERFORM public._grant_random_powerup(p_uid);
--- (replacing the Phase 3a `_grant_powerup(p_uid, 'free_reveal', 3)`). The full body
--- lives in supabase-powerups.sql; re-run that with this one line swapped, or apply
--- the v2_phase3b migration which redefines it.
+-- daily_submit_guess applies Insurance (first wrong guess free; consumes the power-up).
+CREATE OR REPLACE FUNCTION public.daily_submit_guess(p_guess JSONB)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_uid UUID := auth.uid();
+  s public.daily_sessions;
+  v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  v_editable INT[]; v_correct INT[] := '{}'; v_all_correct BOOLEAN := true;
+  pos INT; v_guess_char TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_submit_guess: not authenticated'; END IF;
+  SELECT * INTO s FROM public.daily_sessions
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'daily_submit_guess: no active session'; END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+  IF s.state <> 'active' OR s.guesses_remaining <= 0 THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable
+  FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable, 1) THEN
+    RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                               s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+  END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_guess_char := upper(p_guess ->> pos::text);
+    IF v_guess_char IS NULL THEN v_all_correct := false;
+    ELSIF v_guess_char = substr(v_phrase, pos + 1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all_correct := false; END IF;
+  END LOOP;
+  IF array_length(v_correct, 1) > 0 THEN
+    s.revealed_positions := ARRAY(SELECT DISTINCT unnest(s.revealed_positions || v_correct) ORDER BY 1);
+  END IF;
+  IF NOT v_all_correct THEN
+    IF 'insurance' = ANY(s.active_powerups) THEN
+      s.active_powerups := array_remove(s.active_powerups, 'insurance');
+    ELSE
+      s.guesses_remaining := GREATEST(0, s.guesses_remaining - 1);
+    END IF;
+  END IF;
+  UPDATE public.daily_sessions SET
+    revealed_positions = s.revealed_positions, guesses_remaining = s.guesses_remaining,
+    active_powerups = s.active_powerups, updated_at = NOW()
+  WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  RETURN public._daily_resolve_and_return(v_uid, v_phrase, v_cat, v_sub);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_submit_guess(JSONB) TO authenticated;
+
+-- NOTE: _finalize_daily grants a RANDOM power-up on win (PERFORM _grant_random_powerup);
+-- full body in supabase-powerups.sql.


### PR DESCRIPTION
Completes [Phase 3](./ROADMAP.md) — the full daily power-up set.

## New effects
- 🛡️ **Insurance** — your first wrong guess is free (absorbed, then the power-up is consumed). Applied in `daily_submit_guess`.
- 👁️ **Vowel Vision** — vowels cost half this puzzle (stacks under Discount). Applied in `daily_buy_letter`.
- `daily_start` activates both; `_grant_random_powerup` pool now covers all 5.

## Client
Catalog gains the two entries (both `pregame`) — the existing pre-game picker surfaces them automatically. No other client change.

## Verified
SQL effect math: E \$140 → **\$105** (discount) / **\$70** (vowel) / **\$53** (both); Q \$30 → \$23. Insurance `array_remove`s the power-up, leaving tries untouched. Build + lint + type-check clean. `supabase-pregame-powerups.sql` synced.

## Power-up set (Phase 3 done)
🎟️ Free Reveal · 💰 +\$250 Start · 🏷️ Discount · 🛡️ Insurance · 👁️ Vowel Vision. (Double Payout is arcade — Phase 4.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)