### PR TITLE
V2 Phase 4a: arcade Press-Your-Luck gauntlet (server engine)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,9 +45,14 @@ Living plan for the game's evolution. **Update the Status column as we go.**
 - 📋 **Shareable result card** (spoiler-free), e.g. `WordBank #142 🟩🟩⬛ $740 · 🔥12 · ⭐Gold`. ← top growth lever.
 - 📋 **Streak freeze** so one missed day doesn't nuke a long streak.
 
-### 🕹️ Arcade — high-roller mode
-- ❓ **Direction TBD:** full **roguelike run** (escalating puzzles, power-up drafting between rounds, run ends on bust, best-run leaderboard) **vs** keep **endless** cumulative bankroll + layer power-ups/better risk. *Decide after Phase 0.*
-- 📋 Replace the "free-EV when confident" wager with a real pre-commit risk decision (e.g., double-or-nothing *before* buying letters).
+### 🕹️ Arcade — daily Press-Your-Luck gauntlet (LOCKED)
+- **One shared daily sequence** of puzzles (same order for everyone) → the leaderboard is a real, fair skill comparison. **No difficulty escalation.**
+- **Climb the ladder.** Each puzzle = fresh $1,000 working bank, same core play (buy letters / Reveal / Solve).
+- **Auto-bank:** every solve banks `leftover bankroll × multiplier`. The **multiplier rises with each clean consecutive solve** (×1 → ×1.25 → ×1.5 → ×2 …, capped).
+- **Bust = setback, not game over.** Run out of money on a puzzle → **multiplier resets to ×1**, but you keep your banked total and your place; you retry that puzzle (fresh $1,000) and keep climbing.
+- So a flawless 1→N run banks far more than a stop-start one over the *same* puzzles — pure execution skill.
+- **Server-authoritative** (answers off the client) so the fair board is trustworthy — reuses the Daily engine. **Leaderboard = total banked today** (+ furthest reached).
+- Auto-bank chosen over cash-out: in a skill puzzle you control bust risk, so a "bank or risk" gamble is a fake decision; the multiplier (skill) is the real tension. Cash-out can bolt on later if we want a casino feel.
 
 ---
 
@@ -84,7 +89,7 @@ Status: 📋 Planned (Phase 3)
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Badges ✅ (4 daily, My Account, 🔥 flair). Streak **freeze** ✅ (auto-bridge a missed day, earn 1 per 7-day milestone, cap 3; shown in My Account). | Server + UI | ✅ |
 | **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
-| **4 — Roguelike arcade** | Run structure, escalation, power-up drafting, best-run board (pending arcade decision) | Mostly client + leaderboard | 📋 |
+| **4 — Arcade gauntlet** | Daily Press-Your-Luck ladder: shared sequence, auto-bank + multiplier, continue-on-bust, server-authoritative, banked-today board. 4a server 🚧. | Server + client | 🚧 |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.
@@ -105,7 +110,7 @@ Recommended order de-risks: economy first → cheap-high-impact share → retent
 ---
 
 ## Open decisions (❓)
-1. Arcade direction: full roguelike run vs endless + power-ups (decide after Phase 0).
+1. ✅ Arcade direction: daily Press-Your-Luck gauntlet (shared sequence, auto-bank, server-authoritative). LOCKED.
 2. Power-up source: earned-only vs earned + free daily pick.
 3. Daily scoring formula specifics (par definition, efficiency bonus weight, streak multiplier curve).
 4. Wrong-guess penalty amount / does it scale.

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -1,0 +1,216 @@
+-- ============================================================
+-- WordBank V2 Phase 4a: Arcade Press-Your-Luck gauntlet (server engine)
+-- Run AFTER the daily server-authoritative + powerups files (reuses letter_cost,
+-- _daily_board, _todays_puzzle_id).
+-- ============================================================
+--
+-- Shared daily ladder: a deterministic ordering of the puzzle pool (excluding
+-- today's Daily) that's identical for everyone. Climb it; each solve auto-banks
+-- leftover × multiplier; the multiplier rises on clean streaks and resets on a
+-- bust; busting lets you retry the same puzzle. Server-authoritative.
+
+CREATE TABLE IF NOT EXISTS public.arcade_runs (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  run_date DATE NOT NULL DEFAULT CURRENT_DATE,
+  position INT NOT NULL DEFAULT 0,
+  puzzle_id UUID NOT NULL REFERENCES public.daily_puzzles(id) ON DELETE RESTRICT,
+  bankroll INT NOT NULL DEFAULT 1000,
+  guesses_remaining INT NOT NULL DEFAULT 3,
+  revealed_positions INT[] NOT NULL DEFAULT '{}',
+  incorrect_letters TEXT[] NOT NULL DEFAULT '{}',
+  active_powerups TEXT[] NOT NULL DEFAULT '{}',
+  multiplier_x100 INT NOT NULL DEFAULT 100,
+  banked INT NOT NULL DEFAULT 0,
+  furthest INT NOT NULL DEFAULT 0,
+  last_gain INT NOT NULL DEFAULT 0,
+  state TEXT NOT NULL DEFAULT 'active',   -- active | solved | busted | complete
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, run_date)
+);
+ALTER TABLE public.arcade_runs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "read own arcade run" ON public.arcade_runs;
+CREATE POLICY "read own arcade run" ON public.arcade_runs FOR SELECT USING (auth.uid() = user_id);
+REVOKE INSERT, UPDATE, DELETE ON public.arcade_runs FROM anon, authenticated;
+
+CREATE OR REPLACE FUNCTION public._arcade_ladder_size()
+RETURNS INT LANGUAGE sql STABLE SECURITY DEFINER AS $fn$
+  SELECT count(*)::INT FROM public.daily_puzzles
+  WHERE id NOT IN (SELECT puzzle_id FROM public.daily_puzzle_schedule WHERE scheduled_date = CURRENT_DATE);
+$fn$;
+
+CREATE OR REPLACE FUNCTION public._arcade_puzzle_at(p_position INT)
+RETURNS UUID LANGUAGE sql STABLE SECURITY DEFINER AS $fn$
+  SELECT id FROM (
+    SELECT id, (row_number() OVER (ORDER BY md5(CURRENT_DATE::text || id::text)) - 1) AS pos
+    FROM public.daily_puzzles
+    WHERE id NOT IN (SELECT puzzle_id FROM public.daily_puzzle_schedule WHERE scheduled_date = CURRENT_DATE)
+  ) t WHERE t.pos = p_position;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public._arcade_response(p_uid UUID)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE r public.arcade_runs; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_bstate TEXT;
+BEGIN
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  v_bstate := CASE r.state WHEN 'solved' THEN 'won' WHEN 'complete' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  RETURN jsonb_build_object(
+    'board', public._daily_board(v_phrase, v_bstate, r.bankroll, r.guesses_remaining, r.revealed_positions, r.incorrect_letters, v_cat, v_sub),
+    'run', jsonb_build_object('state', r.state, 'banked', r.banked, 'multiplier', r.multiplier_x100,
+                              'position', r.position, 'total', public._arcade_ladder_size(),
+                              'furthest', r.furthest, 'last_gain', r.last_gain)
+  );
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public._arcade_resolve(p_uid UUID)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE r public.arcade_runs; v_phrase TEXT; v_won BOOLEAN; v_lost BOOLEAN; v_gain INT;
+BEGIN
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  v_won := NOT EXISTS (
+    SELECT 1 FROM generate_series(0, length(v_phrase) - 1) g(i)
+    WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions)));
+  v_lost := (r.bankroll < 30) AND NOT v_won;
+  IF v_won THEN
+    v_gain := ROUND(r.bankroll * r.multiplier_x100 / 100.0)::INT;
+    UPDATE public.arcade_runs SET state = 'solved', banked = banked + v_gain, last_gain = v_gain,
+      multiplier_x100 = LEAST(multiplier_x100 + 25, 500),
+      furthest = GREATEST(furthest, position + 1), updated_at = NOW()
+    WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+  ELSIF v_lost THEN
+    UPDATE public.arcade_runs SET state = 'busted', multiplier_x100 = 100, updated_at = NOW()
+    WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+  END IF;
+  RETURN public._arcade_response(p_uid);
+END;
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.arcade_start()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_start: not authenticated'; END IF;
+  PERFORM public._todays_puzzle_id();  -- ensure today's Daily is assigned so the ladder excludes it
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    v_pid := public._arcade_puzzle_at(0);
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'arcade_start: no puzzles available'; END IF;
+    INSERT INTO public.arcade_runs (user_id, run_date, position, puzzle_id) VALUES (v_uid, CURRENT_DATE, 0, v_pid);
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_start() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_next()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_next UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_next: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_next: no run'; END IF;
+  IF r.state = 'solved' THEN
+    IF r.position + 1 >= public._arcade_ladder_size() THEN
+      UPDATE public.arcade_runs SET state = 'complete', updated_at = NOW() WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+    ELSE
+      v_next := public._arcade_puzzle_at(r.position + 1);
+      UPDATE public.arcade_runs SET position = position + 1, puzzle_id = v_next, bankroll = 1000,
+        guesses_remaining = 3, revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}',
+        last_gain = 0, state = 'active', updated_at = NOW() WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+    END IF;
+  ELSIF r.state = 'busted' THEN
+    UPDATE public.arcade_runs SET bankroll = 1000, guesses_remaining = 3, revealed_positions = '{}',
+      incorrect_letters = '{}', active_powerups = '{}', state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_next() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_buy_letter(p_letter TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'arcade_buy_letter: invalid letter'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_buy_letter: no run'; END IF;
+  IF r.state <> 'active' THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  IF v_letter = ANY(r.incorrect_letters) OR r.bankroll < v_cost THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ r.revealed_positions THEN RETURN public._arcade_response(v_uid); END IF;
+  r.bankroll := r.bankroll - v_cost;
+  IF v_positions IS NULL THEN r.incorrect_letters := array_append(r.incorrect_letters, v_letter);
+  ELSE r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.arcade_runs SET bankroll = r.bankroll, incorrect_letters = r.incorrect_letters,
+    revealed_positions = r.revealed_positions, updated_at = NOW() WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_resolve(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_buy_letter(TEXT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_reveal()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_phrase TEXT; v_letter TEXT; v_positions INT[]; v_cost INT := 150;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_reveal: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_reveal: no run'; END IF;
+  IF r.state <> 'active' THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  SELECT t.ch INTO v_letter FROM (
+    SELECT substr(v_phrase, g.i + 1, 1) AS ch, count(*) AS c
+    FROM generate_series(0, length(v_phrase) - 1) g(i)
+    WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions))
+    GROUP BY substr(v_phrase, g.i + 1, 1) ORDER BY c DESC, ch LIMIT 1) t;
+  IF r.bankroll < v_cost OR v_letter IS NULL THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+  r.bankroll := r.bankroll - v_cost;
+  r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_positions) ORDER BY 1);
+  UPDATE public.arcade_runs SET bankroll = r.bankroll, revealed_positions = r.revealed_positions, updated_at = NOW()
+  WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_resolve(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_reveal() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_submit_guess(p_guess JSONB)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_phrase TEXT;
+  v_editable INT[]; v_correct INT[] := '{}'; v_all_correct BOOLEAN := true; pos INT; v_guess_char TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_submit_guess: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_submit_guess: no run'; END IF;
+  IF r.state <> 'active' OR r.guesses_remaining <= 0 THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase) - 1) g(i)
+  WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable, 1) THEN
+    RETURN public._arcade_response(v_uid);
+  END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_guess_char := upper(p_guess ->> pos::text);
+    IF v_guess_char IS NULL THEN v_all_correct := false;
+    ELSIF v_guess_char = substr(v_phrase, pos + 1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all_correct := false; END IF;
+  END LOOP;
+  IF array_length(v_correct, 1) > 0 THEN
+    r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_correct) ORDER BY 1);
+  END IF;
+  IF NOT v_all_correct THEN r.guesses_remaining := GREATEST(0, r.guesses_remaining - 1); END IF;
+  UPDATE public.arcade_runs SET revealed_positions = r.revealed_positions,
+    guesses_remaining = r.guesses_remaining, updated_at = NOW() WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_resolve(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_submit_guess(JSONB) TO authenticated;


### PR DESCRIPTION
First slice of [Phase 4](./ROADMAP.md) — the server engine for the arcade gauntlet. **Additive**: the existing client-side arcade is untouched until 4b wires it up.

## What it is
A server-authoritative **daily Press-Your-Luck ladder** that reuses the Daily engine (`letter_cost`, `_daily_board`, masked boards).

- **`arcade_runs`** — per-user/per-day run state (position, working bankroll, multiplier, banked total, furthest, per-puzzle session). Read-own; writes only via SECURITY DEFINER.
- **Shared deterministic ladder** — `_arcade_puzzle_at` / `_arcade_ladder_size` order the pool by `md5(date‖id)`, **excluding today's Daily** so arcade can't leak the daily answer.
- **RPCs** — `arcade_start`, `arcade_buy_letter`, `arcade_reveal`, `arcade_submit_guess`, `arcade_next`. Each returns `{ board (masked), run }`.
- **Auto-bank** on solve (`leftover × multiplier`); multiplier **+0.25 per clean solve** (cap ×5); a **bust resets the multiplier to ×1** and lets you **retry the same puzzle**; you keep your banked total + place and climb on.

## Verified
The deterministic ladder: **29 puzzles** today, today's Daily excluded, stable distinct ordering, out-of-range → null. (The full play-flow is exercised in 4b, which needs auth + the client.) `supabase-arcade-gauntlet.sql` synced.

## Next (4b/4c)
4b: wire the client to a new arcade game flow (banked + multiplier + position HUD, solve/bust transitions). 4c: banked-today leaderboard. Then power-ups in arcade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)