### PR TITLE
V2 Phase 4b: arcade gauntlet client

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ Status: 📋 Planned (Phase 3)
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Badges ✅ (4 daily, My Account, 🔥 flair). Streak **freeze** ✅ (auto-bridge a missed day, earn 1 per 7-day milestone, cap 3; shown in My Account). | Server + UI | ✅ |
 | **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
-| **4 — Arcade gauntlet** | Daily Press-Your-Luck ladder: shared sequence, auto-bank + multiplier, continue-on-bust, server-authoritative, banked-today board. 4a server 🚧. | Server + client | 🚧 |
+| **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again). Banked-today leaderboard TODO (4c). | Server + client | 🚧 |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.

--- a/scripts/check-arcade.mjs
+++ b/scripts/check-arcade.mjs
@@ -1,0 +1,33 @@
+// Verify the arcade gauntlet: HUD + play to a solve/bust transition + continue.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+await p.getByRole('button', { name: /arcade/i }).first().click().catch(e=>console.log('arcade', e.message));
+await wait(2600);
+console.log('arcade HUD present:', await p.locator('.arcade-hud').count() > 0,
+            ' cells:', await p.locator('.ah-cell .ah-val').allInnerTexts().catch(()=>[]));
+await p.screenshot({ path: 'screenshots/arcade-1-board.png' });
+// Buy letters down the alphabet until the puzzle resolves
+const letters = 'EARSTONILCDUMPHGBYFVKWZXJQ'.split('');
+for (const L of letters) {
+  if (await p.locator('.result-modal').count()) break;
+  await p.locator(`.key:has(.letter:text-is("${L}"))`).first().click({ force: true }).catch(()=>{}); await wait(300);
+  await p.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch(()=>{}); await wait(1200);
+}
+await wait(700);
+await p.screenshot({ path: 'screenshots/arcade-2-transition.png' });
+console.log('transition modal:', await p.locator('.result-modal h2').innerText().catch(()=>'—'));
+await b.close();

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -20,6 +20,8 @@
   $: bankroll = $gameStore.bankroll;
   $: guessModeActive = $gameStore.gameState === 'guess_mode';
   $: isDailyMode = $gameStore.gameMode === 'daily';
+  // Both daily and arcade are server-authoritative now (no wager) — same button flow.
+  $: serverMode = $gameStore.gameMode === 'daily' || $gameStore.gameMode === 'arcade';
   $: purchasePending = !!$gameStore.selectedPurchase;
   $: hintPending = $gameStore.selectedPurchase?.type === 'hint' && $gameStore.gameState === 'purchase_pending';
   $: showHintCost = hintPending;
@@ -44,7 +46,7 @@
 
   // 🔁 Button display modes (daily: no wager, go straight to guess)
   $: dualButtonMode = purchasePending
-    || (!isDailyMode && wagerUIVisible && sliderWagerAmount > 0 && !guessModeActive)
+    || (!serverMode && wagerUIVisible && sliderWagerAmount > 0 && !guessModeActive)
     || (guessModeActive && guessComplete);
 
   $: guessCancelOnlyMode = guessModeActive && !guessComplete;
@@ -54,7 +56,7 @@
     ? 'Confirm'
     : guessModeActive
       ? (guessComplete ? 'Submit' : 'Cancel')
-      : (isDailyMode ? 'Solve' : (!canConfirmWager && wagerUIVisible ? 'Cancel' : 'Solve'));
+      : (serverMode ? 'Solve' : (!canConfirmWager && wagerUIVisible ? 'Cancel' : 'Solve'));
 
   // 🎨 Button classes
   $: buttonClass = [
@@ -78,7 +80,7 @@
       return;
     }
 
-    if (isDailyMode) {
+    if (serverMode) {
       if (noGuessesLeft) {
         gameStore.update(s => ({ ...s, message: 'Out of guesses — buy letters to finish the phrase' }));
         return;

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -7,6 +7,7 @@ import { user } from '$lib/stores/userStore.js';
 import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
 import { recordDailyResult, recordArcadeResult, saveArcadeBankroll } from '$lib/stores/statsStore.js';
 import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getUserPowerups, dailyUseFreeReveal } from '$lib/stores/statsStore.js';
+import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext } from '$lib/stores/statsStore.js';
 
 /* ================================
    Types (JSDoc for checkJs)
@@ -34,7 +35,8 @@ import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getUserPower
  *   message: string,
  *   subcategory: string,
  *   gameMode: string,
- *   freeReveals?: number
+ *   freeReveals?: number,
+ *   arcadeRun?: any
  * }} GameState
  */
 
@@ -67,7 +69,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   message: '',
   subcategory: '',
   gameMode: 'daily', // 'daily' | 'arcade'
-  freeReveals: 0 // owned Free Reveal power-ups (daily)
+  freeReveals: 0, // owned Free Reveal power-ups (daily)
+  arcadeRun: null // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
 }));
 
 /* ================================
@@ -108,15 +111,14 @@ let dailyInFlight = false;
  *
  * @param {any} board - board JSON returned by a daily_* RPC
  */
-function reconcileDailyBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-
+/**
+ * boardToState — shared masked-board → gameStore partial (used by daily + arcade).
+ * @param {any} board @param {GameState} prev
+ */
+function boardToState(board, prev) {
   /** @type {number[]} */
   const wordLengths = board.word_lengths || [];
-  // Masked phrase: '#' per letter slot, single space between words.
   const chars = wordLengths.map((/** @type {number} */ len) => '#'.repeat(len)).join(' ').split('');
-
   /** @type {Record<string, string>} */
   const revealed = board.revealed || {};
   /** @type {string[]} */
@@ -129,25 +131,17 @@ function reconcileDailyBoard(board) {
     purchased[i] = /** @type {string} */ (v);
     if (prev.purchasedLetters?.[i] !== v) newlyRevealed.push(i);
   }
-
   const finished = board.state !== 'active';
-  const currentPhrase = finished && board.phrase
-    ? String(board.phrase).toUpperCase()
-    : chars.join('');
-
+  const currentPhrase = finished && board.phrase ? String(board.phrase).toUpperCase() : chars.join('');
   /** @type {Record<string, boolean>} */
   const lockedLetters = {};
   (board.locked_letters || []).forEach((/** @type {string} */ l) => { lockedLetters[l] = true; });
-
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev,
+  return {
     bankroll: board.bankroll,
     guessesRemaining: board.guesses_remaining,
     category: board.category ?? prev.category,
     subcategory: board.subcategory ?? '',
     currentPhrase,
-    gameMode: 'daily',
-    gameState: finished ? board.state : 'default',
     purchasedLetters: purchased,
     guessedLetters: {},
     lockedLetters,
@@ -156,10 +150,99 @@ function reconcileDailyBoard(board) {
     shakenLetters: newlyRevealed,
     wagerAmount: 0,
     message: ''
-  }));
+  };
+}
 
-  if (board.state === 'won') {
-    setTimeout(() => launchConfetti(), 300);
+/** @param {any} board */
+function reconcileDailyBoard(board) {
+  if (!board) return;
+  const prev = get(gameStore);
+  const finished = board.state !== 'active';
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(board, prev),
+    gameMode: 'daily',
+    gameState: finished ? board.state : 'default'
+  }));
+  if (board.state === 'won') setTimeout(() => launchConfetti(), 300);
+}
+
+/**
+ * reconcileArcadeBoard — arcade gauntlet { board, run } → gameStore.
+ * @param {any} resp
+ */
+function reconcileArcadeBoard(resp) {
+  if (!resp || !resp.board) return;
+  const prev = get(gameStore);
+  const board = resp.board;
+  const run = resp.run || {};
+  // Per-puzzle outcome drives gameState: solved/complete -> won, busted -> lost.
+  let gs = 'default';
+  if (run.state === 'solved' || run.state === 'complete') gs = 'won';
+  else if (run.state === 'busted') gs = 'lost';
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(board, prev),
+    gameMode: 'arcade',
+    gameState: gs,
+    arcadeRun: run,
+    freeReveals: 0
+  }));
+  if (run.state === 'solved' || run.state === 'complete') setTimeout(() => launchConfetti(), 300);
+}
+
+/** confirmPurchaseArcade — commit a letter/reveal on the current gauntlet puzzle. @param {GameState} state */
+async function confirmPurchaseArcade(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    let resp = null;
+    if (purchase.type === 'letter') resp = await arcadeBuyLetter(purchase.value ?? '');
+    else if (purchase.type === 'hint') resp = await arcadeReveal();
+    if (resp) reconcileArcadeBoard(resp);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** submitGuessArcade — submit a guess on the current gauntlet puzzle. @param {GameState} state */
+async function submitGuessArcade(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+  dailyInFlight = true;
+  try {
+    const resp = await arcadeSubmitGuess(guess);
+    if (resp) reconcileArcadeBoard(resp);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** Start or resume today's arcade gauntlet. */
+export async function fetchArcadeGame() {
+  try {
+    const resp = await arcadeStart();
+    if (!resp) { console.error('❌ arcade_start returned nothing'); return false; }
+    reconcileArcadeBoard(resp);
+    return true;
+  } catch (err) {
+    console.error('❌ Error starting arcade:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/** Advance to the next puzzle after a solve, or retry after a bust. */
+export async function arcadeContinue() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const resp = await arcadeNext();
+    if (resp) reconcileArcadeBoard(resp);
+  } finally {
+    dailyInFlight = false;
   }
 }
 
@@ -354,10 +437,14 @@ export function setWager(amount) {
  * Handles purchase of a letter or hint and updates game state.
  */
 export function confirmPurchase() {
-  // Daily is server-authoritative: commit the purchase via RPC and reconcile.
+  // Daily & arcade are both server-authoritative now: commit via RPC and reconcile.
   const current = get(gameStore);
   if (current.gameMode === 'daily') {
     confirmPurchaseDaily(current);
+    return;
+  }
+  if (current.gameMode === 'arcade') {
+    confirmPurchaseArcade(current);
     return;
   }
 
@@ -609,10 +696,14 @@ export function deleteGuessLetter() {
  * syncs to Supabase, and hides wager slider.
  */
 export function submitGuess() {
-  // Daily is server-authoritative: the server validates the guess and scores it.
+  // Daily & arcade are both server-authoritative: the server validates + scores.
   const current = get(gameStore);
   if (current.gameMode === 'daily') {
     submitGuessDaily(current);
+    return;
+  }
+  if (current.gameMode === 'arcade') {
+    submitGuessArcade(current);
     return;
   }
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -128,6 +128,40 @@ export async function dailyStart(powerups = []) {
   return data;
 }
 
+/* ===== Arcade Press-Your-Luck gauntlet (server-authoritative) =====
+   Each returns { board, run } where run = { state, banked, multiplier, position,
+   total, furthest, last_gain }. */
+/** @returns {Promise<any>} */
+export async function arcadeStart() {
+  const { data, error } = await supabase.rpc('arcade_start');
+  if (error) { console.error('❌ arcade_start error:', error); return null; }
+  return data;
+}
+/** @param {string} letter @returns {Promise<any>} */
+export async function arcadeBuyLetter(letter) {
+  const { data, error } = await supabase.rpc('arcade_buy_letter', { p_letter: letter });
+  if (error) { console.error('❌ arcade_buy_letter error:', error); return null; }
+  return data;
+}
+/** @returns {Promise<any>} */
+export async function arcadeReveal() {
+  const { data, error } = await supabase.rpc('arcade_reveal');
+  if (error) { console.error('❌ arcade_reveal error:', error); return null; }
+  return data;
+}
+/** @param {Record<string,string>} guess @returns {Promise<any>} */
+export async function arcadeSubmitGuess(guess) {
+  const { data, error } = await supabase.rpc('arcade_submit_guess', { p_guess: guess });
+  if (error) { console.error('❌ arcade_submit_guess error:', error); return null; }
+  return data;
+}
+/** Advance after a solve / retry after a bust. @returns {Promise<any>} */
+export async function arcadeNext() {
+  const { data, error } = await supabase.rpc('arcade_next');
+  if (error) { console.error('❌ arcade_next error:', error); return null; }
+  return data;
+}
+
 /** Whether the caller already has a session for today (drives the pre-game picker). */
 export async function dailySessionExists() {
   const { data, error } = await supabase.rpc('daily_session_exists');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,14 +4,13 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchRandomGame, fetchDailyGame } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
   import { hasPlayedDailyToday, saveArcadeBankroll, getUserBadges, getDailyStatus, getUserPowerups, dailySessionExists } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
   import { powerupInfo } from '$lib/powerups.js';
   import {
     saveGameToLocalStorage,
-    loadGameFromLocalStorage,
     clearSavedGame,
     getSavedGameInfo
   } from '$lib/stores/localGameUtils.js';
@@ -100,37 +99,10 @@
         return;
       }
 
-      const peek = getSavedGameInfo(session.user.id);
-      // Daily is now server-resumed (daily_start); only arcade resumes from localStorage.
-      const arcadeSave = peek && peek.gameMode === 'arcade' ? peek : null;
-      const inProgress = arcadeSave && arcadeSave.gameState !== 'won' && arcadeSave.gameState !== 'lost';
-
-      if (inProgress) {
-        const restored = loadGameFromLocalStorage();
-        if (restored) {
-          gameWasRestored.set(true);
-          showMainMenu = false;
-          console.log("🔁 Game restored from localStorage");
-        } else {
-          showMainMenu = true;
-          savedGameInfo = arcadeSave;
-          menuDailyPlayed = await hasPlayedDailyToday(session.user.id);
-        }
-      } else {
-        showMainMenu = true;
-        savedGameInfo = arcadeSave;
-        menuDailyPlayed = await hasPlayedDailyToday(session.user.id);
-        // If they just came from /select with a category, start arcade instead of showing menu
-        const mode = localStorage.getItem('gameMode');
-        const category = localStorage.getItem('selectedCategory');
-        if (mode === 'arcade' && category) {
-          const ok = await fetchRandomGame(category);
-          if (ok) {
-            showMainMenu = false;
-            hasInitialized = true;
-          }
-        }
-      }
+      // Daily and arcade are both server-authoritative now — start from the menu.
+      showMainMenu = true;
+      savedGameInfo = null;
+      menuDailyPlayed = await hasPlayedDailyToday(session.user.id);
 
       await tick();
       hasInitialized = true;
@@ -150,19 +122,14 @@
     !$gameWasRestored
   ) {
     const gameMode = localStorage.getItem('gameMode') || 'daily';
-    if (gameMode === 'daily') {
+    if (gameMode === 'arcade') {
+      fetchArcadeGame().then((ok) => {
+        if (!ok) initError = "Arcade failed to load.";
+      });
+    } else {
       fetchDailyGame().then((ok) => {
         if (!ok) initError = "Daily puzzle failed to load.";
       });
-    } else {
-      const category = localStorage.getItem('selectedCategory');
-      if (category) {
-        fetchRandomGame(category).then((ok) => {
-          if (!ok) initError = "Arcade puzzle failed to load.";
-        });
-      } else {
-        window.location.href = '/select/arcade';
-      }
     }
   }
 
@@ -208,6 +175,10 @@
   $: isDailyResult = $gameStore.gameMode === 'daily';
   $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
   $: resultMedal = medalFor(resultBankroll, resultWon);
+  // Arcade gauntlet run state
+  $: arun = $gameStore.arcadeRun;
+  $: arcadeComplete = !isDailyResult && arun?.state === 'complete';
+  $: arcadeMult = ((arun?.multiplier ?? 100) / 100).toFixed(2);
 
   let shareCopied = false;
   function buildShareText() {
@@ -323,14 +294,25 @@
   }
 
   /** Start or resume arcade: resume from save or go to arcade category select */
-  function handleMenuArcade() {
-    if (savedGameInfo?.gameMode === 'arcade' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost') {
-      loadGameFromLocalStorage();
-      gameWasRestored.set(true);
+  async function handleMenuArcade() {
+    const currentUser = get(user);
+    if (!currentUser?.id) return;
+    // Arcade is now the server-authoritative Press-Your-Luck gauntlet (start/resume today's run).
+    localStorage.setItem('gameMode', 'arcade');
+    const ok = await fetchArcadeGame();
+    if (ok) {
+      hasInitialized = true;
       showMainMenu = false;
-      return;
+    } else {
+      initError = 'Arcade failed to load.';
     }
-    goto('/select/arcade');
+  }
+
+  // After solving / busting a gauntlet puzzle, advance or retry.
+  async function handleArcadeContinue() {
+    showResultModal = false;
+    hasTriggeredModal = false;
+    await arcadeContinue();
   }
 
   function handleMenuLeaderboard() {
@@ -663,6 +645,15 @@
       </div>
     {/if}
 
+    <!-- 🕹️ Arcade gauntlet HUD -->
+    {#if $gameStore.gameMode === 'arcade' && arun}
+      <div class="arcade-hud">
+        <div class="ah-cell"><span class="ah-val">{(arun.position ?? 0) + 1}<span class="ah-sub">/{arun.total}</span></span><span class="ah-label">Puzzle</span></div>
+        <div class="ah-cell ah-mult"><span class="ah-val">×{arcadeMult}</span><span class="ah-label">Multiplier</span></div>
+        <div class="ah-cell"><span class="ah-val ah-gold">${(arun.banked ?? 0).toLocaleString()}</span><span class="ah-label">Banked</span></div>
+      </div>
+    {/if}
+
     <!-- 🌍 Category Display -->
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
@@ -751,30 +742,49 @@
     {#if showResultModal && ['won', 'lost'].includes($gameStore.gameState)}
       <div class="modal-overlay">
         <div class="modal-content result-modal">
-          <div class="result-medal {resultMedal.tier}">{resultMedal.emoji}</div>
-          <h2>{resultWon ? 'Solved!' : 'Busted'}</h2>
           {#if isDailyResult}
+            <div class="result-medal {resultMedal.tier}">{resultMedal.emoji}</div>
+            <h2>{resultWon ? 'Solved!' : 'Busted'}</h2>
             <p class="result-sub">Daily #{puzzleNumber}{#if resultWon} · {resultMedal.name}{/if}</p>
+            <div class="result-bankroll">
+              <span class="rb-label">Banked</span>
+              <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
+            </div>
+            <div class="result-actions">
+              <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
+              <button class="next-puzzle-button" on:click={resultWon ? handleNextPuzzle : handlePlayAgain}>Leaderboard</button>
+            </div>
           {:else}
-            <p class="result-sub">Arcade</p>
+            <!-- Arcade Press-Your-Luck transition -->
+            {#if arcadeComplete}
+              <div class="result-medal gold">🏆</div>
+              <h2>Gauntlet Cleared!</h2>
+              <p class="result-sub">All {arun?.total} puzzles solved</p>
+            {:else if resultWon}
+              <div class="result-medal">✅</div>
+              <h2>Solved!</h2>
+              <p class="result-sub">Puzzle {(arun?.position ?? 0) + 1}/{arun?.total} · next ×{arcadeMult}</p>
+            {:else}
+              <div class="result-medal">💥</div>
+              <h2>Busted</h2>
+              <p class="result-sub">Multiplier reset to ×1 — retry this puzzle</p>
+            {/if}
+            <div class="result-bankroll">
+              <span class="rb-label">Total Banked</span>
+              <span class="rb-amount">${(arun?.banked ?? 0).toLocaleString()}</span>
+            </div>
+            {#if resultWon && !arcadeComplete && (arun?.last_gain ?? 0) > 0}
+              <p class="arcade-gain">+${(arun?.last_gain ?? 0).toLocaleString()} this puzzle</p>
+            {/if}
+            <div class="result-actions">
+              <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
+              {#if arcadeComplete}
+                <button class="next-puzzle-button" on:click={() => { showResultModal = false; goToMainMenu(); }}>Done</button>
+              {:else}
+                <button class="next-puzzle-button" on:click={handleArcadeContinue}>{resultWon ? 'Continue' : 'Try Again'}</button>
+              {/if}
+            </div>
           {/if}
-
-          <div class="result-bankroll">
-            <span class="rb-label">Banked</span>
-            <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
-          </div>
-
-          <div class="result-actions">
-            <button class="share-btn" on:click={handleShare}>
-              {shareCopied ? '✓ Copied!' : 'Share'}
-            </button>
-            <button
-              class="next-puzzle-button"
-              on:click={resultWon ? handleNextPuzzle : handlePlayAgain}
-            >
-              {isDailyResult ? 'Leaderboard' : (resultWon ? 'Next Puzzle' : 'Play Again')}
-            </button>
-          </div>
         </div>
       </div>
     {/if}
@@ -799,6 +809,32 @@
     align-items: center;
     justify-content: center;
   }
+
+  .arcade-hud {
+    display: flex;
+    gap: 8px;
+    width: 100%;
+    max-width: 360px;
+    margin: 0 auto 14px;
+  }
+  .ah-cell {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 10px 6px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+  }
+  .ah-mult { border-color: rgba(163, 230, 53, 0.35); background: linear-gradient(135deg, rgba(52,211,153,0.12), rgba(163,230,53,0.04)); }
+  .ah-val { font-family: var(--font-display); font-weight: 700; font-size: 1.15rem; color: var(--text); font-variant-numeric: tabular-nums; }
+  .ah-mult .ah-val { color: var(--brand-2); }
+  .ah-gold { color: #fcd34d; }
+  .ah-sub { font-size: 0.7rem; color: var(--text-faint); font-weight: 600; }
+  .ah-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
 
   .puzzle-meta {
     display: flex;


### PR DESCRIPTION
Wires the client to the [Phase 4](./ROADMAP.md) arcade Press-Your-Luck gauntlet. Arcade is now the server-authoritative ladder (replaces the old client-side category arcade + wager).

## Client
- **GameStore:** extracted a shared `boardToState` helper (daily + arcade); added `reconcileArcadeBoard`, `confirmPurchaseArcade`, `submitGuessArcade`, `fetchArcadeGame`, `arcadeContinue`. `confirmPurchase`/`submitGuess` route arcade to the server RPCs.
- **statsStore:** `arcadeStart` / `arcadeBuyLetter` / `arcadeReveal` / `arcadeSubmitGuess` / `arcadeNext` wrappers.
- **GameButtons:** arcade uses the no-wager (daily-style) flow.
- **+page:** Arcade Mode starts the gauntlet; an in-game **HUD** (Puzzle N/total · ×multiplier · Banked $); the result modal is arcade-aware — **Solved! → Continue** (shows +gain & next multiplier), **Busted → Try Again** (multiplier-reset note), **Gauntlet Cleared → Done**. Removed obsolete localStorage-restore / category auto-start.

## Verified
Playwright: tapping Arcade starts the **29-puzzle gauntlet** (HUD `1/29 · ×1.00 · $0`), the play loop works, and busting shows the **Busted / Try Again** transition with the multiplier reset. Build + lint + type-check clean.

(The solve→Continue path shares the same engine/modal; it's exercised in live play.)

## Still TODO (4c)
**Banked-today arcade leaderboard** (rank by best run today + furthest). Then optional power-ups in arcade. Roadmap row 🚧.

🤖 Generated with [Claude Code](https://claude.com/claude-code)