### PR TITLE
Phase 4c: arcade gauntlet leaderboard (best banked run + furthest)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,7 +89,7 @@ Status: 📋 Planned (Phase 3)
 | **1 — Daily scoring + share** | Share card ✅ + medals ✅. Daily **score = bankroll × streak multiplier** (server), leaderboard ranks by score ✅ | Server scoring + UI | ✅ |
 | **2 — Streaks & badges** | Badges ✅ (4 daily, My Account, 🔥 flair). Streak **freeze** ✅ (auto-bridge a missed day, earn 1 per 7-day milestone, cap 3; shown in My Account). | Server + UI | ✅ |
 | **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
-| **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again). Banked-today leaderboard TODO (4c). | Server + client | 🚧 |
+| **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again); leaderboard ✅ (4c: best banked run + furthest reached, day/week/month/all). | Server + client | ✅ |
 | **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.

--- a/scripts/check-arcade-board.mjs
+++ b/scripts/check-arcade-board.mjs
@@ -1,0 +1,25 @@
+// Verify the arcade leaderboard tab renders banked/furthest columns.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(300);
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+}
+await p.goto(BASE + '/leaderboard?mode=arcade', { waitUntil: 'networkidle' }); await wait(1500);
+await p.getByRole('button', { name: /^arcade$/i }).first().click().catch(()=>{}); await wait(1500);
+console.log('headers:', await p.locator('table thead th').allInnerTexts().catch(()=>[]));
+console.log('period btns:', await p.locator('.period-filters .period-btn').allInnerTexts().catch(()=>[]));
+console.log('sort filters present:', await p.locator('.sort-filters').count());
+console.log('first row:', await p.locator('table tbody tr').first().allInnerTexts().catch(()=>['—']));
+await p.screenshot({ path: 'screenshots/arcade-board.png', fullPage: true });
+await b.close();

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -75,15 +75,11 @@ export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score')
 }
 
 /**
- * Fetch arcade leaderboard
- * @param {string} period - 'all' | 'daily' | 'weekly' | 'monthly' | 'yearly'
- * @param {string} orderBy - 'bankroll' | 'highest_bankroll' | 'streak' | 'highest_streak' | 'puzzles' | 'win_pct'
+ * Fetch the arcade gauntlet leaderboard (best banked run + furthest reached).
+ * @param {string} period - 'daily' | 'weekly' | 'monthly' | 'yearly' | 'all'
  */
-export async function fetchArcadeLeaderboard(period = 'all', orderBy = 'bankroll') {
-  const { data, error } = await supabase.rpc('get_arcade_leaderboard', {
-    p_period: period,
-    p_order_by: orderBy
-  });
+export async function fetchArcadeLeaderboard(period = 'daily') {
+  const { data, error } = await supabase.rpc('get_arcade_gauntlet_leaderboard', { p_period: period });
   if (error) {
     console.error('❌ Error fetching arcade leaderboard:', error);
     return [];

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -8,7 +8,7 @@
   } from '$lib/stores/statsStore.js';
 
   /** @typedef {{ rank?: number, display_name?: string, score?: number, bankroll_left?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} DailyRow */
-  /** @typedef {{ rank?: number, display_name?: string, current_bankroll?: number, highest_bankroll?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} ArcadeRow */
+  /** @typedef {{ rank?: number, display_name?: string, banked?: number, furthest?: number, total?: number }} ArcadeRow */
 
   /** @type {'daily' | 'arcade'} */
   let mode = $state('daily');
@@ -26,9 +26,7 @@
   }
   /** @type {DailyRow[]} */
   let dailyData = $state([]);
-  let arcadePeriod = $state('all');
-  /** @type {'bankroll' | 'highest_bankroll' | 'streak' | 'highest_streak' | 'puzzles' | 'win_pct'} */
-  let arcadeOrderBy = $state('bankroll');
+  let arcadePeriod = $state('daily');
   /** @type {ArcadeRow[]} */
   let arcadeData = $state([]);
   let loading = $state(true);
@@ -52,7 +50,7 @@
 
   async function loadArcade() {
     try {
-      arcadeData = await fetchArcadeLeaderboard(arcadePeriod, arcadeOrderBy);
+      arcadeData = await fetchArcadeLeaderboard(arcadePeriod);
     } catch (e) {
       error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
     }
@@ -72,7 +70,7 @@
     if (mode === 'daily' && (dailyPeriod || dailyOrderBy)) {
       loadDaily();
     }
-    if (mode === 'arcade' && (arcadePeriod || arcadeOrderBy)) {
+    if (mode === 'arcade' && arcadePeriod) {
       loadArcade();
     }
   });
@@ -133,22 +131,13 @@
       <button class="sort-btn" class:active={dailyOrderBy === 'win_pct'} onclick={() => { dailyOrderBy = 'win_pct'; }}>Win %</button>
     </div>
   {:else}
-    <p class="period-label">{periodLabels[arcadePeriod] ?? 'All Time'}</p>
+    <p class="period-label">{periodLabels[arcadePeriod] ?? 'Today'} · best run</p>
     <div class="period-filters">
-      {#each ['all', 'daily', 'weekly', 'monthly', 'yearly'] as p}
+      {#each ['daily', 'weekly', 'monthly', 'all'] as p}
         <button class="period-btn" class:active={arcadePeriod === p} onclick={() => { arcadePeriod = p; }}>
           {periodLabels[p] ?? p}
         </button>
       {/each}
-    </div>
-    <p class="sort-label">Sort by:</p>
-    <div class="sort-filters">
-      <button class="sort-btn" class:active={arcadeOrderBy === 'bankroll'} onclick={() => { arcadeOrderBy = 'bankroll'; }}>Bankroll</button>
-      <button class="sort-btn" class:active={arcadeOrderBy === 'highest_bankroll'} onclick={() => { arcadeOrderBy = 'highest_bankroll'; }}>Highest Bankroll</button>
-      <button class="sort-btn" class:active={arcadeOrderBy === 'streak'} onclick={() => { arcadeOrderBy = 'streak'; }}>Current Streak</button>
-      <button class="sort-btn" class:active={arcadeOrderBy === 'highest_streak'} onclick={() => { arcadeOrderBy = 'highest_streak'; }}>Highest Streak</button>
-      <button class="sort-btn" class:active={arcadeOrderBy === 'puzzles'} onclick={() => { arcadeOrderBy = 'puzzles'; }}>Puzzles</button>
-      <button class="sort-btn" class:active={arcadeOrderBy === 'win_pct'} onclick={() => { arcadeOrderBy = 'win_pct'; }}>Win %</button>
     </div>
   {/if}
 
@@ -200,7 +189,7 @@
     {/if}
   {:else}
     {#if arcadeData.length === 0}
-      <p class="empty">No arcade results yet. Play arcade mode to build your bankroll!</p>
+      <p class="empty">No arcade runs yet. Climb today's gauntlet to appear!</p>
     {:else}
       <div class="table-wrap">
         <table>
@@ -208,12 +197,8 @@
             <tr>
               <th>#</th>
               <th>Player</th>
-              <th>Bankroll</th>
-              <th>Highest Bankroll</th>
-              <th>Current Streak</th>
-              <th>Highest Streak</th>
-              <th>Puzzles</th>
-              <th>Win %</th>
+              <th>Banked</th>
+              <th>Furthest</th>
             </tr>
           </thead>
           <tbody>
@@ -226,12 +211,8 @@
                   {:else}{row.rank}{/if}
                 </td>
                 <td class="name">{row.display_name || 'Player'}</td>
-                <td>${fmt(row.current_bankroll)}</td>
-                <td>${fmt(row.highest_bankroll)}</td>
-                <td>{fmt(row.current_streak)}</td>
-                <td>{fmt(row.highest_streak)}</td>
-                <td>{fmt(row.total_played)}</td>
-                <td>{fmt(row.win_rate)}%</td>
+                <td class="score-cell">${fmt(row.banked)}</td>
+                <td>{fmt(row.furthest)}/{fmt(row.total)}</td>
               </tr>
             {/each}
           </tbody>
@@ -242,9 +223,9 @@
 
   <p class="hint">
     {#if mode === 'daily'}
-      Daily: Bankroll left, current streak (consecutive days won), highest streak, puzzles, win %.
+      Daily: Score = bankroll × streak multiplier. Medals 🥇$700 / 🥈$400 / 🥉$100. 🔥 = 7+ day streak.
     {:else}
-      Arcade: Current bankroll, highest bankroll, streaks, puzzles played, win %.
+      Arcade: your best banked run in the period (Press-Your-Luck gauntlet), and how far you climbed.
     {/if}
   </p>
 </main>

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -214,3 +214,47 @@ BEGIN
 END;
 $fn$;
 GRANT EXECUTE ON FUNCTION public.arcade_submit_guess(JSONB) TO authenticated;
+
+-- ============================================================
+-- Phase 4c: Arcade gauntlet leaderboard (best banked run + furthest reached)
+-- Ranks each user by their best banked run over the period window, tie-break
+-- on how far they climbed. 'daily' = today; weekly/monthly/yearly/all windows.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_arcade_gauntlet_leaderboard(p_period text DEFAULT 'daily')
+  RETURNS TABLE(rank bigint, user_id uuid, display_name text, banked integer, furthest integer, total integer)
+  LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_start DATE; v_end DATE;
+BEGIN
+  CASE p_period
+    WHEN 'weekly' THEN
+      v_start := date_trunc('week', CURRENT_DATE)::DATE + 1; v_end := v_start + 7;
+    WHEN 'monthly' THEN
+      v_start := date_trunc('month', CURRENT_DATE)::DATE; v_end := (date_trunc('month', CURRENT_DATE) + INTERVAL '1 month')::DATE;
+    WHEN 'yearly' THEN
+      v_start := date_trunc('year', CURRENT_DATE)::DATE; v_end := (date_trunc('year', CURRENT_DATE) + INTERVAL '1 year')::DATE;
+    WHEN 'all' THEN
+      v_start := DATE '1970-01-01'; v_end := DATE '9999-12-31';
+    ELSE  -- daily / today
+      v_start := CURRENT_DATE; v_end := CURRENT_DATE + 1;
+  END CASE;
+
+  RETURN QUERY
+  WITH agg AS (
+    SELECT ar.user_id, MAX(ar.banked)::INT AS banked, MAX(ar.furthest)::INT AS furthest
+    FROM public.arcade_runs ar
+    WHERE ar.run_date >= v_start AND ar.run_date < v_end
+    GROUP BY ar.user_id
+  ),
+  base AS (
+    SELECT a.user_id,
+      COALESCE(au.raw_user_meta_data->>'full_name', split_part(au.raw_user_meta_data->>'email', '@', 1), 'Player')::TEXT AS display_name,
+      a.banked, a.furthest
+    FROM agg a LEFT JOIN auth.users au ON au.id = a.user_id
+  )
+  SELECT ROW_NUMBER() OVER (ORDER BY base.banked DESC, base.furthest DESC)::BIGINT AS rank,
+    base.user_id, base.display_name, base.banked, base.furthest, public._arcade_ladder_size()
+  FROM base
+  ORDER BY base.banked DESC, base.furthest DESC;
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.get_arcade_gauntlet_leaderboard(text) TO authenticated;


### PR DESCRIPTION
Completes **Phase 4 — Arcade gauntlet**: the banked-today leaderboard.

## What
- **New RPC** `get_arcade_gauntlet_leaderboard(period)` (SECURITY DEFINER): ranks each user by their **best banked run** in the period window, tie-breaking on **furthest reached**. Windows: `daily` (today) / `weekly` / `monthly` / `all`. Synced to `supabase-arcade-gauntlet.sql` and applied to prod.
- **statsStore** `fetchArcadeLeaderboard(period)` now calls the gauntlet RPC — sort options dropped since banked is the single objective.
- **Leaderboard arcade tab**: removed the sort buttons, reordered period filters to Today/Week/Month/All, rewrote the table to `# / Player / Banked / Furthest` (furthest shown as `reached/total`).

## Verify
- `svelte-check`: 0 errors / 0 warnings. `npm run build`: ✅.
- Playwright (`scripts/check-arcade-board.mjs`): headers `# PLAYER BANKED FURTHEST`, period chips `Today/This Week/This Month/All Time`, no sort filters, a seeded run rendered `🥇 pwtest+wb  $1,250  4/29` (seed row cleaned up afterward — no fake data left on the live board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)