### PR TITLE
Phase 5a: sound + haptics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,7 @@ Status: 📋 Planned (Phase 3)
 | **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
 | **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again); leaderboard ✅ (4c: best banked run + furthest reached, day/week/month/all). | Server + client | ✅ |
 | **4d — Legacy cleanup** | Removed the dead pre-gauntlet arcade: wager UI + slider, `/select` & `/select/arcade` routes, client-side win/loss/bankroll paths (`fetchRandomGame`, `resetGame`, `reduceBankrollToZero`, `setWager`, `checkLossCondition`, `loadGameFromLocalStorage`, `save/recordArcade/DailyResult`). Both modes are now purely server-authoritative. | Client + stores | ✅ |
-| **5 — Polish** | Guided tutorial, sound + haptics, "ghost of yesterday" compare | Client | 📋 |
+| **5 — Polish** | Sound + haptics ✅ (5a: WebAudio cue engine — tap/select/correct/wrong/reveal/win/bust/multiplier + `navigator.vibrate`, persisted 🔊/🔇 header toggle). Guided tutorial (5b) + "ghost of yesterday" compare (5c) TODO. | Client | 🚧 |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.
 

--- a/scripts/check-sound.mjs
+++ b/scripts/check-sound.mjs
@@ -1,0 +1,32 @@
+// Verify the sound/haptics toggle renders + toggles, and that the game still
+// plays without throwing (WebAudio is best-effort under headless chromium).
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+const errors = [];
+p.on('pageerror', (e) => errors.push(String(e)));
+p.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(900);
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+}
+const toggle = p.getByRole('button', { name: /toggle sound and haptics/i }).first();
+console.log('toggle present:', await toggle.count() > 0, ' label before:', await toggle.innerText().catch(()=>'—'));
+await toggle.click().catch(()=>{}); await wait(300);
+console.log('label after toggle:', await toggle.innerText().catch(()=>'—'));
+await toggle.click().catch(()=>{}); await wait(300); // back to on
+console.log('label restored:', await toggle.innerText().catch(()=>'—'));
+// Play a couple arcade letters to exercise fx() paths
+await p.getByRole('button', { name: /arcade/i }).first().click().catch(()=>{}); await wait(2600);
+for (const L of ['E','A','R']) {
+  if (await p.locator('.result-modal').count()) break;
+  await p.locator(`.key:has(.letter:text-is("${L}"))`).first().click({ force: true }).catch(()=>{}); await wait(250);
+  await p.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch(()=>{}); await wait(900);
+}
+console.log('arcade HUD present:', await p.locator('.arcade-hud').count() > 0);
+console.log('page/console errors:', errors.length, errors.slice(0, 4));
+await b.close();

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -1,5 +1,6 @@
 <script>
   import { gameStore, confirmPurchase, submitGuess } from '$lib/stores/GameStore.js';
+  import { fx } from '$lib/sound.js';
 
   // 🧠 Reactive state (daily & arcade are both server-authoritative — no wager)
   $: bankroll = $gameStore.bankroll;
@@ -46,6 +47,7 @@
 
   // 🎯 Main button logic
   function handleMainButtonClick() {
+    fx('tap');
     if (purchasePending) {
       confirmPurchase();
       return;
@@ -69,6 +71,7 @@
   }
 
   function toggleHintPurchase() {
+    fx('tap');
     gameStore.update(state => {
       if (state.selectedPurchase?.type === 'hint') {
         return { ...state, selectedPurchase: null, gameState: 'default' };

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount, createEventDispatcher } from 'svelte';
+  import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import {
     gameStore,
@@ -10,8 +10,7 @@
     deleteGuessLetter,
     enterGuessMode
   } from '$lib/stores/GameStore.js';
-
-  const dispatch = createEventDispatcher();
+  import { fx } from '$lib/sound.js';
 
   type LetterCosts = Record<string, number>;
   const letterCosts: LetterCosts = {
@@ -41,10 +40,9 @@
 
   /**
    * 🔹 Letter click logic for both guess mode and purchase mode.
-   * 🔸 Also emits a custom event to parent to cancel wager UI.
    */
   function handleLetterClick(letter: string): void {
-    dispatch('letterSelected'); // ✅ Notify parent to hide slider
+    fx('select');
     if ($gameStore.gameState === 'guess_mode') {
       inputGuessLetter(letter);
     } else {
@@ -65,11 +63,8 @@
       event.preventDefault();
       if (state.gameState === 'guess_mode') {
         enterGuessMode();
-        window.dispatchEvent(new CustomEvent('hideWagerSlider'));
       } else if (state.selectedPurchase) {
         gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-      } else {
-        window.dispatchEvent(new CustomEvent('hideWagerSlider'));
       }
       const active = document.activeElement;
       if (active && active instanceof HTMLElement) active.blur();
@@ -114,7 +109,7 @@
     // A–Z – Select letter (purchase or guess)
     if (/^[A-Z]$/.test(key)) {
       event.preventDefault();
-      dispatch('letterSelected');
+      fx('select');
       if (state.gameState === 'guess_mode') {
         inputGuessLetter(key);
       } else {

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -1,0 +1,139 @@
+// Lightweight WebAudio sound + haptics engine. No asset files — every cue is
+// synthesised from oscillators, so there's nothing to download or bundle.
+// One toggle (persisted) controls both audio and vibration ("feedback").
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'wb_sound_on';
+const initial = browser ? localStorage.getItem(STORAGE_KEY) !== 'false' : true;
+
+/** Whether sound + haptics are enabled (persisted to localStorage). */
+export const soundEnabled = writable(initial);
+let enabled = initial;
+soundEnabled.subscribe((v) => {
+  enabled = v;
+  if (browser) localStorage.setItem(STORAGE_KEY, String(v));
+});
+
+export function toggleSound() {
+  soundEnabled.update((v) => !v);
+}
+
+/** @type {AudioContext | null} */
+let ctx = null;
+function ac() {
+  if (!browser) return null;
+  if (!ctx) {
+    const AC = window.AudioContext || /** @type {any} */ (window).webkitAudioContext;
+    if (!AC) return null;
+    ctx = new AC();
+  }
+  // Browsers start the context suspended until a user gesture; resume on demand.
+  if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+  return ctx;
+}
+
+/**
+ * A short tone with a fast attack and exponential decay.
+ * @param {number} freq @param {number} dur @param {OscillatorType} [type]
+ * @param {number} [gain] @param {number} [when] seconds from now
+ */
+function tone(freq, dur, type = 'sine', gain = 0.16, when = 0) {
+  const c = ac();
+  if (!c) return;
+  const t0 = c.currentTime + when;
+  const osc = c.createOscillator();
+  const g = c.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, t0);
+  g.gain.setValueAtTime(0.0001, t0);
+  g.gain.exponentialRampToValueAtTime(gain, t0 + 0.012);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(g).connect(c.destination);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.03);
+}
+
+/**
+ * A pitch glide (whoosh-ish).
+ * @param {number} f1 @param {number} f2 @param {number} dur
+ * @param {OscillatorType} [type] @param {number} [gain] @param {number} [when]
+ */
+function sweep(f1, f2, dur, type = 'triangle', gain = 0.15, when = 0) {
+  const c = ac();
+  if (!c) return;
+  const t0 = c.currentTime + when;
+  const osc = c.createOscillator();
+  const g = c.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(f1, t0);
+  osc.frequency.exponentialRampToValueAtTime(Math.max(1, f2), t0 + dur);
+  g.gain.setValueAtTime(0.0001, t0);
+  g.gain.exponentialRampToValueAtTime(gain, t0 + 0.02);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(g).connect(c.destination);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.03);
+}
+
+/** @type {Record<string, () => void>} */
+const SOUNDS = {
+  tap: () => tone(420, 0.05, 'square', 0.05),
+  select: () => tone(660, 0.07, 'sine', 0.09),
+  correct: () => {
+    tone(720, 0.1, 'sine', 0.15);
+    tone(960, 0.12, 'sine', 0.11, 0.06);
+  },
+  wrong: () => tone(150, 0.2, 'sawtooth', 0.11),
+  reveal: () => sweep(420, 1150, 0.24, 'triangle', 0.13),
+  win: () => [523, 659, 784, 1047].forEach((f, i) => tone(f, 0.2, 'sine', 0.16, i * 0.09)),
+  bust: () => sweep(440, 80, 0.55, 'sawtooth', 0.16),
+  multiplier: () => {
+    tone(880, 0.09, 'sine', 0.13);
+    tone(1320, 0.13, 'sine', 0.12, 0.08);
+  }
+};
+
+/** @type {Record<string, number[]>} */
+const HAPTICS = {
+  tap: [8],
+  select: [8],
+  correct: [14],
+  wrong: [22, 36, 22],
+  reveal: [12],
+  win: [18, 40, 18, 40, 36],
+  bust: [60, 30, 60],
+  multiplier: [10, 24, 10]
+};
+
+/** Play an audio cue by name (no-op when disabled). @param {string} name */
+export function playSound(name) {
+  if (!enabled) return;
+  const fn = SOUNDS[name];
+  if (fn) {
+    try {
+      fn();
+    } catch {
+      /* audio is best-effort */
+    }
+  }
+}
+
+/** Fire a haptic pattern by name (no-op when disabled / unsupported). @param {string} name */
+export function vibrate(name) {
+  if (!enabled || !browser || !navigator.vibrate) return;
+  const p = HAPTICS[name];
+  if (p) {
+    try {
+      navigator.vibrate(p);
+    } catch {
+      /* haptics are best-effort */
+    }
+  }
+}
+
+/** Combined sound + haptic feedback for a named event. @param {string} name */
+export function fx(name) {
+  playSound(name);
+  vibrate(name);
+}

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -2,6 +2,7 @@
 
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
+import { fx } from '$lib/sound.js';
 import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getUserPowerups, dailyUseFreeReveal } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext } from '$lib/stores/statsStore.js';
 
@@ -149,6 +150,23 @@ function boardToState(board, prev) {
   };
 }
 
+/**
+ * In-play audio/haptic cue from comparing the previous board to the new one.
+ * (Win/bust cues are fired by the callers.)
+ * @param {GameState} prev @param {any} board
+ */
+function playMoveCue(prev, board) {
+  const revealed = board.revealed || {};
+  let newReveals = 0;
+  for (const [k, v] of Object.entries(revealed)) {
+    if (prev.purchasedLetters?.[Number(k)] !== v) newReveals++;
+  }
+  const incGrew = (board.incorrect_letters || []).length > (prev.incorrectLetters || []).length;
+  if (newReveals >= 2) fx('reveal');
+  else if (newReveals > 0) fx('correct');
+  else if (incGrew) fx('wrong');
+}
+
 /** @param {any} board */
 function reconcileDailyBoard(board) {
   if (!board) return;
@@ -159,7 +177,9 @@ function reconcileDailyBoard(board) {
     gameMode: 'daily',
     gameState: finished ? board.state : 'default'
   }));
-  if (board.state === 'won') setTimeout(() => launchConfetti(), 300);
+  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
+  else if (finished) fx('bust');
+  else playMoveCue(prev, board);
 }
 
 /**
@@ -182,7 +202,15 @@ function reconcileArcadeBoard(resp) {
     arcadeRun: run,
     freeReveals: 0
   }));
-  if (run.state === 'solved' || run.state === 'complete') setTimeout(() => launchConfetti(), 300);
+  if (run.state === 'solved' || run.state === 'complete') {
+    setTimeout(() => launchConfetti(), 300);
+    fx('win');
+    if ((run.last_gain || 0) > 0) setTimeout(() => fx('multiplier'), 240);
+  } else if (run.state === 'busted') {
+    fx('bust');
+  } else {
+    playMoveCue(prev, board);
+  }
 }
 
 /** confirmPurchaseArcade — commit a letter/reveal on the current gauntlet puzzle. @param {GameState} state */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,6 +15,7 @@
     getSavedGameInfo
   } from '$lib/stores/localGameUtils.js';
   import { gameWasRestored } from '$lib/stores/GameStateFlags.js';
+  import { soundEnabled, toggleSound, fx } from '$lib/sound.js';
   import { goto } from '$app/navigation';
 
   import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
@@ -390,6 +391,16 @@
   {#if loggedIn}
     <a href="/leaderboard" class="icon-button subtle-button" title="Weekly Leaderboard">🏆</a>
   {/if}
+
+  <!-- 🔊 Sound + Haptics Toggle -->
+  <button
+    class="icon-button subtle-button"
+    on:click={() => { toggleSound(); if ($soundEnabled) fx('select'); }}
+    title={$soundEnabled ? 'Sound & haptics on' : 'Sound & haptics off'}
+    aria-label="Toggle sound and haptics"
+  >
+    {$soundEnabled ? '🔊' : '🔇'}
+  </button>
 
   <!-- 🌙 Dark Mode Toggle -->
   <button class="icon-button subtle-button" on:click={toggleDarkMode}>


### PR DESCRIPTION
First slice of **Phase 5 — Polish**: tactile feedback.

## What
- **`src/lib/sound.js`** — a small WebAudio engine. Every cue is synthesised from oscillators (tones + pitch sweeps), so there are **no audio assets** to download or bundle. One persisted toggle gates both sound and `navigator.vibrate`.
- **Cues**: `tap`, `select`, `correct`, `wrong`, `reveal`, `win`, `bust`, `multiplier`.
- **Wiring at the reconcile layer** — `reconcileDailyBoard`/`reconcileArcadeBoard` diff the previous board against the new one to fire `correct`/`wrong`/`reveal` during play, `win`/`bust` on resolution, and `multiplier` on a banked solve. Button + key taps play `tap`/`select`, which also unlocks the `AudioContext` on the first user gesture (browsers start it suspended).
- **🔊/🔇 header toggle** next to dark mode, persisted to `localStorage` (`wb_sound_on`). Respects best-effort failure (no `AudioContext`, no `navigator.vibrate`) silently.

While wiring I also removed now-dead wager event plumbing from `Keyboard.svelte` (the `letterSelected` dispatch and `hideWagerSlider` CustomEvents — their listeners were deleted in 4d).

## Verify
- `svelte-check`: 0 / 0. `npm run build`: ✅.
- Playwright (`scripts/check-sound.mjs`): toggle cycles 🔊→🔇→🔊, arcade plays through with cues wired, **0 console/page errors**.

Note: audio is best-effort under headless chromium, so the harness checks wiring + no-throw rather than actual waveform output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)