### PR TITLE
Phase 5b: guided tutorial

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,7 @@ Status: 📋 Planned (Phase 3)
 | **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
 | **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again); leaderboard ✅ (4c: best banked run + furthest reached, day/week/month/all). | Server + client | ✅ |
 | **4d — Legacy cleanup** | Removed the dead pre-gauntlet arcade: wager UI + slider, `/select` & `/select/arcade` routes, client-side win/loss/bankroll paths (`fetchRandomGame`, `resetGame`, `reduceBankrollToZero`, `setWager`, `checkLossCondition`, `loadGameFromLocalStorage`, `save/recordArcade/DailyResult`). Both modes are now purely server-authoritative. | Client + stores | ✅ |
-| **5 — Polish** | Sound + haptics ✅ (5a: WebAudio cue engine — tap/select/correct/wrong/reveal/win/bust/multiplier + `navigator.vibrate`, persisted 🔊/🔇 header toggle). Guided tutorial (5b) + "ghost of yesterday" compare (5c) TODO. | Client | 🚧 |
+| **5 — Polish** | Sound + haptics ✅ (5a: WebAudio cue engine + `navigator.vibrate`, persisted 🔊/🔇 toggle). Guided tutorial ✅ (5b: 5-step carousel, first-run + replay via ❓, `wb_tutorial_seen`). "Ghost of yesterday" compare (5c) TODO. | Client | 🚧 |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.
 

--- a/scripts/check-tutorial.mjs
+++ b/scripts/check-tutorial.mjs
@@ -1,0 +1,32 @@
+// Verify the guided tutorial: shows on first run, steps through, dismisses,
+// stays dismissed, and replays from the ❓ button.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const ctx = await b.newContext({ viewport: { width: 430, height: 900 } });
+const p = await ctx.newPage();
+const wait = (ms) => p.waitForTimeout(ms);
+await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(700);
+// Ensure a clean first-run state
+await p.evaluate(() => localStorage.removeItem('wb_tutorial_seen'));
+if (await p.locator('input[type=password]').count()) {
+  await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+  await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+}
+await p.evaluate(() => localStorage.removeItem('wb_tutorial_seen'));
+await p.reload({ waitUntil: 'networkidle' });
+await wait(2200);
+console.log('tutorial on first run:', await p.locator('.tut-card').count() > 0);
+console.log('step 1 title:', await p.locator('.tut-title').innerText().catch(()=>'—'));
+// Step through to the end
+for (let s = 0; s < 5; s++) {
+  await p.locator('.tut-btn.primary').click().catch(()=>{}); await wait(350);
+}
+console.log('dismissed after Play:', await p.locator('.tut-card').count() === 0);
+console.log('seen flag set:', await p.evaluate(() => localStorage.getItem('wb_tutorial_seen')));
+// Replay from the ❓ button (accessible name is the emoji; select by title attr)
+await p.locator('button[title="How to play"]').first().click().catch(()=>{}); await wait(500);
+console.log('reopened from help:', await p.locator('.tut-card').count() > 0);
+await p.screenshot({ path: 'screenshots/tutorial.png' });
+await b.close();

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -1,0 +1,204 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import { fx } from '$lib/sound.js';
+
+  const dispatch = createEventDispatcher();
+
+  const steps = [
+    {
+      icon: '🧠',
+      title: 'Welcome to WordBank',
+      body: 'Uncover the hidden phrase for the lowest cost. Whatever you don’t spend becomes your score.'
+    },
+    {
+      icon: '🔤',
+      title: 'Buy letters',
+      body: 'Tap a letter to buy it. If it’s in the phrase, every copy lights up. If not, you lose that money — so spend on likely letters first.'
+    },
+    {
+      icon: '🔍',
+      title: 'Reveal',
+      body: 'Stuck? Reveal ($150) uncovers every copy of the single most useful letter — guaranteed, never random.'
+    },
+    {
+      icon: '✏️',
+      title: 'Solve the phrase',
+      body: 'Think you’ve got it? Hit Solve, fill the blanks, and Submit. You get 3 free tries — a wrong guess just costs a try, never money.'
+    },
+    {
+      icon: '🏆',
+      title: 'Daily & Arcade',
+      body: 'Daily: one ranked puzzle a day — score = bankroll × your win streak. Arcade: a press-your-luck gauntlet — bank each solve and grow your multiplier before you bust.'
+    }
+  ];
+
+  let i = 0;
+  $: step = steps[i];
+  $: last = i === steps.length - 1;
+
+  function next() {
+    fx('tap');
+    if (last) dispatch('close');
+    else i += 1;
+  }
+  function back() {
+    fx('tap');
+    if (i > 0) i -= 1;
+  }
+  function skip() {
+    dispatch('close');
+  }
+</script>
+
+<div class="tut-overlay" role="dialog" aria-modal="true" aria-label="How to play WordBank">
+  <div class="tut-card">
+    <button class="tut-skip" on:click={skip}>Skip</button>
+
+    {#key i}
+      <div class="tut-icon">{step.icon}</div>
+      <h2 class="tut-title">{step.title}</h2>
+      <p class="tut-body">{step.body}</p>
+    {/key}
+
+    <div class="tut-dots">
+      {#each steps as _, d}
+        <span class="tut-dot" class:active={d === i}></span>
+      {/each}
+    </div>
+
+    <div class="tut-actions">
+      {#if i > 0}
+        <button class="tut-btn ghost" on:click={back}>Back</button>
+      {/if}
+      <button class="tut-btn primary" on:click={next}>{last ? 'Play →' : 'Next'}</button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .tut-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 3000;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    background: rgba(4, 8, 14, 0.72);
+    backdrop-filter: blur(8px);
+    animation: tutFade 0.25s ease;
+  }
+  @keyframes tutFade {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .tut-card {
+    position: relative;
+    width: 100%;
+    max-width: 380px;
+    padding: 30px 24px 22px;
+    border-radius: var(--r-lg, 20px);
+    background: var(--surface-strong, rgba(20, 26, 38, 0.9));
+    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+    box-shadow: var(--shadow-lg, 0 24px 60px rgba(0, 0, 0, 0.5)), var(--glow-brand, 0 0 30px rgba(52, 211, 153, 0.25));
+    text-align: center;
+    animation: tutPop 0.3s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+  }
+  @keyframes tutPop {
+    from { transform: translateY(14px) scale(0.96); opacity: 0; }
+    to { transform: translateY(0) scale(1); opacity: 1; }
+  }
+
+  .tut-skip {
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    background: none;
+    border: none;
+    color: var(--text-muted, #9aa6b8);
+    font-family: var(--font-ui, sans-serif);
+    font-size: 0.78rem;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 4px 6px;
+  }
+  .tut-skip:hover { color: var(--text, #fff); }
+
+  .tut-icon {
+    font-size: 3rem;
+    line-height: 1;
+    margin: 4px 0 14px;
+    animation: tutIcon 0.4s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+  }
+  @keyframes tutIcon {
+    from { transform: scale(0.4) rotate(-12deg); opacity: 0; }
+    to { transform: scale(1) rotate(0); opacity: 1; }
+  }
+
+  .tut-title {
+    font-family: var(--font-display, sans-serif);
+    font-size: 1.4rem;
+    font-weight: 700;
+    margin: 0 0 10px;
+    color: var(--text, #fff);
+  }
+  .tut-body {
+    font-family: var(--font-ui, sans-serif);
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: var(--text-muted, #c2cbd8);
+    margin: 0 auto 20px;
+    max-width: 320px;
+    min-height: 4.5em;
+  }
+
+  .tut-dots {
+    display: flex;
+    justify-content: center;
+    gap: 7px;
+    margin-bottom: 20px;
+  }
+  .tut-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 999px;
+    background: var(--border-strong, rgba(255, 255, 255, 0.2));
+    transition: all 0.2s ease;
+  }
+  .tut-dot.active {
+    width: 22px;
+    background: var(--brand-grad, linear-gradient(135deg, #34d399, #a3e635));
+  }
+
+  .tut-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+  }
+  .tut-btn {
+    flex: 1;
+    max-width: 160px;
+    height: 46px;
+    border-radius: 14px;
+    font-family: var(--font-display, sans-serif);
+    font-size: 1rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.16s var(--ease-spring, ease), filter 0.2s;
+  }
+  .tut-btn.primary {
+    background: var(--brand-grad, linear-gradient(135deg, #34d399, #a3e635));
+    color: #06210f;
+    border: none;
+    box-shadow: var(--glow-brand, 0 8px 24px rgba(52, 211, 153, 0.35));
+  }
+  .tut-btn.primary:hover { transform: translateY(-2px); filter: brightness(1.05); }
+  .tut-btn.primary:active { transform: scale(0.97); }
+  .tut-btn.ghost {
+    background: var(--surface-2, rgba(255, 255, 255, 0.06));
+    color: var(--text, #fff);
+    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+  }
+  .tut-btn.ghost:hover { transform: translateY(-1px); }
+  .tut-btn.ghost:active { transform: scale(0.97); }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,11 +23,12 @@
   import GameButtons from '$lib/components/GameButtons.svelte';
   import FlipDigit from '$lib/components/FlipDigit.svelte';
   import Auth from '$lib/components/Auth.svelte';
+  import Tutorial from '$lib/components/Tutorial.svelte';
 
   export let data;
 
   // UI state
-  let showHowToPlay = false;
+  let showTutorial = false;
   let darkMode = false;
   let showResultModal = false;
   let hasTriggeredModal = false;
@@ -227,6 +228,16 @@
     );
   });
 
+  const TUTORIAL_KEY = 'wb_tutorial_seen';
+  // First-run guided tutorial: show once a signed-in user reaches the menu.
+  $: if (browser && loggedIn && hasInitialized && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
+    showTutorial = true;
+  }
+  function dismissTutorial() {
+    showTutorial = false;
+    if (browser) localStorage.setItem(TUTORIAL_KEY, 'true');
+  }
+
   /** @param {Event} e */
   const removeButtonFocus = (e) => {
     if (e.target && /** @type {HTMLElement} */ (e.target).tagName === 'BUTTON') /** @type {HTMLButtonElement} */ (e.target).blur();
@@ -375,8 +386,8 @@
 <svelte:window on:keydown={handleEscape} />
 <!-- 🔹 Top Control Buttons -->
 <div class="top-buttons">
-  <!-- ❓ How to Play -->
-  <button class="icon-button subtle-button" on:click={() => showHowToPlay = true}>
+  <!-- ❓ How to Play (replays the guided tutorial) -->
+  <button class="icon-button subtle-button" title="How to play" on:click={() => showTutorial = true}>
     ❓
   </button>
 
@@ -415,34 +426,9 @@
   {/if}
 </div>
 
-<!-- 📜 How to Play Modal -->
-{#if showHowToPlay}
-  <div class="modal-overlay">
-    <div class="modal-content">
-      <button class="close-btn" on:click={() => showHowToPlay = false}>❌</button>
-
-      <h2>📜 How to Play</h2>
-      <p>💰 Start with $1000. Spend it on information, then solve the phrase. Whatever's left is your score.</p>
-
-      <h3>📅 Daily vs Arcade</h3>
-      <p><b>Daily:</b> One puzzle per day. Counts for the daily leaderboard!<br />
-      <b>Arcade:</b> Unlimited play. Build your cumulative bankroll!</p>
-
-      <h3>🎯 Goal</h3>
-      <p>Solve the phrase before you run out of money.</p>
-
-      <h3>🕹️ Gameplay</h3>
-      <ul>
-        <li>🔤 <b>Buy Letters:</b> Tap a letter to buy it. In the phrase → all copies revealed. Not in it → you lose the money.</li>
-        <li>🔍 <b>Reveal ($150):</b> Reveals every copy of the most useful unrevealed letter — guaranteed, never random.</li>
-        <li>✏️ <b>Solve:</b> Fill the blanks and submit. You get <b>3 free tries</b> — a wrong guess just costs a try, no money.</li>
-        <li>🏁 <b>Out of tries?</b> You can still win by buying letters until the whole phrase is revealed.</li>
-        <li>💀 <b>You only lose</b> if you go broke before solving.</li>
-      </ul>
-
-      <p><strong>Spend smart, solve cheap, bank the rest. 🚀</strong></p>
-    </div>
-  </div>
+<!-- 📜 Guided tutorial (first run + replayable from ❓) -->
+{#if showTutorial}
+  <Tutorial on:close={dismissTutorial} />
 {/if}
 
 <main>


### PR DESCRIPTION
Second slice of **Phase 5 — Polish**: onboarding.

## What
- **`Tutorial.svelte`** — a 5-step carousel styled to the dark neon-arcade design system: Welcome → Buy letters → Reveal → Solve → Daily vs Arcade. Animated icon, elongating progress dots, Back/Next/Skip, and a tap cue per step (uses the 5a sound engine).
- **First-run** — shows once after a signed-in user reaches the menu (reactive guard on the `wb_tutorial_seen` localStorage flag); dismissing (Play or Skip) persists the flag.
- **Replayable** any time from the ❓ header button.
- **Replaces** the old static "How to Play" modal (its markup is removed).

## Verify
- `svelte-check`: 0 / 0. `npm run build`: ✅.
- Playwright (`scripts/check-tutorial.mjs`): first-run shows → steps through to Play → dismisses → flag persists → reopens from ❓. Screenshot confirms the styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)