### PR TITLE
Phase 5c: ghost of yesterday

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,7 +91,7 @@ Status: 📋 Planned (Phase 3)
 | **3 — Power-up system** | Inventory, earning (random on win), display ✅; Free Reveal (in-game) ✅; pre-game picker ✅; effects: +$250 Start, Discount, Insurance, Vowel Vision ✅. (Double Payout = arcade, Phase 4.) | Server + UI | ✅ |
 | **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again); leaderboard ✅ (4c: best banked run + furthest reached, day/week/month/all). | Server + client | ✅ |
 | **4d — Legacy cleanup** | Removed the dead pre-gauntlet arcade: wager UI + slider, `/select` & `/select/arcade` routes, client-side win/loss/bankroll paths (`fetchRandomGame`, `resetGame`, `reduceBankrollToZero`, `setWager`, `checkLossCondition`, `loadGameFromLocalStorage`, `save/recordArcade/DailyResult`). Both modes are now purely server-authoritative. | Client + stores | ✅ |
-| **5 — Polish** | Sound + haptics ✅ (5a: WebAudio cue engine + `navigator.vibrate`, persisted 🔊/🔇 toggle). Guided tutorial ✅ (5b: 5-step carousel, first-run + replay via ❓, `wb_tutorial_seen`). "Ghost of yesterday" compare (5c) TODO. | Client | 🚧 |
+| **5 — Polish** | Sound + haptics ✅ (5a). Guided tutorial ✅ (5b). "Ghost of yesterday" ✅ (5c: daily result modal compares today's bank to your own yesterday — delta ahead/behind — plus share of today's field beaten when ≥5 players, via `get_daily_ghost`). | Client + server | ✅ |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.
 

--- a/scripts/check-ghost.mjs
+++ b/scripts/check-ghost.mjs
@@ -1,0 +1,46 @@
+// Verify the "ghost of yesterday" block in the daily result modal.
+// Requires DB prep: test user's today daily cleared + a seeded yesterday result.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+p.setDefaultTimeout(5000); // fail fast instead of the 30s default
+const wait = (ms) => p.waitForTimeout(ms);
+const log = (...a) => console.log(...a);
+try {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+  log('logged in:', !(await p.locator('input[type=password]').count()));
+  await p.getByRole('button', { name: /daily/i }).first().click().catch((e)=>log('daily click err', e.message));
+  await wait(1200);
+  // A fresh daily with owned pre-game power-ups shows a picker — skip it.
+  const skip = p.getByRole('button', { name: /^skip$/i });
+  if (await skip.count()) { log('powerup picker shown — skipping'); await skip.click().catch(()=>{}); }
+  await wait(2200);
+  const keyCount = await p.locator('.key').count();
+  log('daily board keys:', keyCount, ' bankroll text:', await p.locator('.bankroll-amount').innerText().catch(()=>'—'));
+  const letters = 'EARSTONILCDUMPHGBYFVKWZXJQ'.split('');
+  for (let i = 0; i < letters.length; i++) {
+    if (await p.locator('.result-modal').count()) { log(`resolved after ${i} buys`); break; }
+    const L = letters[i];
+    await p.locator(`.key:has(.letter:text-is("${L}"))`).first().click({ force: true }).catch(()=>{}); await wait(200);
+    const confirm = p.getByRole('button', { name: /^confirm$/i });
+    if (await confirm.count()) { await confirm.click({ force: true }).catch(()=>{}); await wait(900); }
+  }
+  await wait(1400);
+  log('result modal:', await p.locator('.result-modal h2').innerText().catch(()=>'—'));
+  log('ghost block present:', await p.locator('.ghost-compare').count() > 0);
+  log('ghost line:', await p.locator('.ghost-line').innerText().catch(()=>'—'));
+  log('ghost delta:', await p.locator('.ghost-delta').innerText().catch(()=>'(none)'));
+  await p.screenshot({ path: 'screenshots/ghost.png' });
+} catch (e) {
+  log('FATAL', e.message);
+} finally {
+  await b.close();
+  log('done');
+}

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -75,6 +75,17 @@ export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score')
 }
 
 /**
+ * "Ghost of yesterday" — today's daily result vs the caller's own result
+ * yesterday, plus the share of today's field they beat.
+ * @returns {Promise<null | { yesterday_played: boolean, yesterday_banked: number|null, yesterday_won: boolean, yesterday_score: number|null, today_banked: number|null, today_score: number|null, today_players: number, today_percentile: number|null }>}
+ */
+export async function getDailyGhost() {
+  const { data, error } = await supabase.rpc('get_daily_ghost');
+  if (error) { console.error('❌ get_daily_ghost error:', error); return null; }
+  return data;
+}
+
+/**
  * Fetch the arcade gauntlet leaderboard (best banked run + furthest reached).
  * @param {string} period - 'daily' | 'weekly' | 'monthly' | 'yearly' | 'all'
  */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
   import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getUserPowerups, dailySessionExists } from '$lib/stores/statsStore.js';
+  import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getUserPowerups, dailySessionExists, getDailyGhost } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
   import { powerupInfo } from '$lib/powerups.js';
   import {
@@ -374,9 +374,17 @@
     goto('/leaderboard?mode=daily');
   };
 
+  /** @type {null | { yesterday_played: boolean, yesterday_banked: number|null, yesterday_won: boolean, today_banked: number|null, today_players: number, today_percentile: number|null }} */
+  let ghost = null;
+
   const onPhraseRevealComplete = () => {
     if (!hasTriggeredModal && ['won', 'lost'].includes($gameStore.gameState)) {
       hasTriggeredModal = true;
+      // Daily only: fetch the "ghost of yesterday" comparison for the result modal.
+      if ($gameStore.gameMode === 'daily') {
+        ghost = null;
+        getDailyGhost().then((g) => { ghost = g; }).catch(() => {});
+      }
       setTimeout(() => {
         showResultModal = true;
       }, 1000);
@@ -673,6 +681,24 @@
               <span class="rb-label">Banked</span>
               <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
             </div>
+            {#if ghost}
+              <div class="ghost-compare">
+                {#if ghost.yesterday_played}
+                  {@const delta = resultBankroll - (ghost.yesterday_banked ?? 0)}
+                  <p class="ghost-line">👻 Yesterday you banked <b>${(ghost.yesterday_banked ?? 0).toLocaleString()}</b></p>
+                  <p class="ghost-delta {delta > 0 ? 'up' : delta < 0 ? 'down' : 'even'}">
+                    {#if delta > 0}▲ ${delta.toLocaleString()} ahead of your ghost
+                    {:else if delta < 0}▼ ${Math.abs(delta).toLocaleString()} behind your ghost
+                    {:else}= dead even with your ghost{/if}
+                  </p>
+                {:else}
+                  <p class="ghost-line">👻 Your first daily — you just set the ghost for tomorrow.</p>
+                {/if}
+                {#if ghost.today_percentile != null && (ghost.today_players ?? 0) >= 5}
+                  <p class="ghost-field">Ahead of {ghost.today_percentile}% of today’s players</p>
+                {/if}
+              </div>
+            {/if}
             <div class="result-actions">
               <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
               <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
@@ -1435,6 +1461,38 @@
     font-size: 2rem;
     color: #fcd34d;
     text-shadow: 0 0 18px rgba(251, 191, 36, 0.4);
+  }
+  .ghost-compare {
+    margin: 2px auto 16px;
+    padding: 10px 14px;
+    max-width: 300px;
+    border-radius: 14px;
+    background: var(--surface-2, rgba(255, 255, 255, 0.05));
+    border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  }
+  .ghost-line {
+    font-family: var(--font-ui);
+    font-size: 0.86rem;
+    color: var(--text-muted, #c2cbd8);
+    margin: 0 0 4px;
+  }
+  .ghost-line b { color: var(--text, #fff); }
+  .ghost-delta {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.95rem;
+    margin: 0;
+  }
+  .ghost-delta.up { color: #34d399; }
+  .ghost-delta.down { color: #fb7185; }
+  .ghost-delta.even { color: var(--text-muted, #c2cbd8); }
+  .ghost-field {
+    font-family: var(--font-ui);
+    font-size: 0.76rem;
+    color: var(--text-faint, #8a94a6);
+    margin: 8px 0 0;
+    padding-top: 8px;
+    border-top: 1px solid var(--border, rgba(255, 255, 255, 0.08));
   }
   .result-actions {
     display: flex;

--- a/supabase-daily-leaderboard.sql
+++ b/supabase-daily-leaderboard.sql
@@ -664,3 +664,57 @@ BEGIN
   ORDER BY COALESCE(prof.current_bankroll, 1000) DESC;
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- ============================================================
+-- Phase 5c: "Ghost of yesterday" — compare today's daily result to the caller's
+-- own result yesterday, plus the share of today's field they strictly beat.
+-- SECURITY DEFINER + auth.uid(): a client can only read its own ghost.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_daily_ghost()
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  uid uuid := auth.uid();
+  y RECORD;
+  t RECORD;
+  pct int := NULL;
+  players int := 0;
+BEGIN
+  IF uid IS NULL THEN RETURN NULL; END IF;
+
+  SELECT bankroll_left, won, score INTO y
+  FROM public.game_results
+  WHERE user_id = uid AND game_mode = 'daily' AND played_at::date = CURRENT_DATE - 1
+  ORDER BY played_at DESC LIMIT 1;
+
+  SELECT bankroll_left, won, score INTO t
+  FROM public.game_results
+  WHERE user_id = uid AND game_mode = 'daily' AND played_at::date = CURRENT_DATE
+  ORDER BY played_at DESC LIMIT 1;
+
+  -- Share of today's distinct players whose score is strictly below mine.
+  IF t.score IS NOT NULL THEN
+    SELECT count(*),
+           ROUND(100.0 * count(*) FILTER (WHERE s < t.score) / NULLIF(count(*), 0))::int
+    INTO players, pct
+    FROM (
+      SELECT DISTINCT ON (user_id) score AS s
+      FROM public.game_results
+      WHERE game_mode = 'daily' AND played_at::date = CURRENT_DATE
+      ORDER BY user_id, played_at DESC
+    ) today_all;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'yesterday_played', (y IS NOT NULL),
+    'yesterday_banked', y.bankroll_left,
+    'yesterday_won',    COALESCE(y.won, false),
+    'yesterday_score',  y.score,
+    'today_banked',     t.bankroll_left,
+    'today_score',      t.score,
+    'today_players',    players,
+    'today_percentile', pct
+  );
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.get_daily_ghost() TO authenticated;


### PR DESCRIPTION
Final slice of **Phase 5 — Polish** (completes the phase): the daily result modal races you against your past self.

## What
- **Server** — `get_daily_ghost()` (SECURITY DEFINER, `auth.uid()`-scoped) reads `game_results` and returns: your yesterday + today bank/score, today's player count, and your percentile over today's **distinct** players computed with strict-less (`score < mine`) so you're never counted as ahead of yourself or of ties.
- **Client** — the daily result modal shows `👻 Yesterday you banked $X` and a ▲/▼ delta (*ahead of / behind your ghost*), plus *Ahead of N% of today's players* when ≥5 have played (hidden on a small sample). A first-ever daily shows *"you just set the ghost for tomorrow."* Fetched when the result modal triggers; arcade is unaffected.
- SQL synced to `supabase-daily-leaderboard.sql` and applied to prod.

## Verify
- `svelte-check`: 0 / 0. `npm run build`: ✅.
- RPC unit-tested via impersonation: `{yesterday_banked:520, today_banked:0, today_percentile:…}`.
- Playwright (`scripts/check-ghost.mjs`, seeded yesterday=$520): daily plays to **Busted $0** → ghost block renders `👻 Yesterday you banked $520` / `▼ $520 behind your ghost`. Screenshot confirms styling. All seeded/test data cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)