### PR TITLE
Fix: arcade bust advances to the next puzzle

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -716,7 +716,7 @@
             {:else}
               <div class="result-medal">💥</div>
               <h2>Busted</h2>
-              <p class="result-sub">Multiplier reset to ×1 — retry this puzzle</p>
+              <p class="result-sub">Multiplier reset to ×1 — on to the next puzzle</p>
             {/if}
             <div class="result-bankroll">
               <span class="rb-label">Total Banked</span>
@@ -730,7 +730,7 @@
               {#if arcadeComplete}
                 <button class="next-puzzle-button" on:click={() => { showResultModal = false; goToMainMenu(); }}>Done</button>
               {:else}
-                <button class="next-puzzle-button" on:click={handleArcadeContinue}>{resultWon ? 'Continue' : 'Try Again'}</button>
+                <button class="next-puzzle-button" on:click={handleArcadeContinue}>{resultWon ? 'Continue' : 'Next Puzzle'}</button>
               {/if}
             </div>
           {/if}

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -113,19 +113,21 @@ BEGIN
   IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_next: not authenticated'; END IF;
   SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
   IF NOT FOUND THEN RAISE EXCEPTION 'arcade_next: no run'; END IF;
-  IF r.state = 'solved' THEN
+
+  -- Both a solve and a bust move on to the next rung (you never replay a
+  -- puzzle whose answer you've already seen). The only difference is the
+  -- multiplier: grown on solve, reset to x1 on bust in _arcade_resolve.
+  IF r.state IN ('solved', 'busted') THEN
     IF r.position + 1 >= public._arcade_ladder_size() THEN
-      UPDATE public.arcade_runs SET state = 'complete', updated_at = NOW() WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+      UPDATE public.arcade_runs SET state = 'complete', updated_at = NOW()
+      WHERE user_id = v_uid AND run_date = CURRENT_DATE;
     ELSE
       v_next := public._arcade_puzzle_at(r.position + 1);
       UPDATE public.arcade_runs SET position = position + 1, puzzle_id = v_next, bankroll = 1000,
         guesses_remaining = 3, revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}',
-        last_gain = 0, state = 'active', updated_at = NOW() WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+        last_gain = 0, state = 'active', updated_at = NOW()
+      WHERE user_id = v_uid AND run_date = CURRENT_DATE;
     END IF;
-  ELSIF r.state = 'busted' THEN
-    UPDATE public.arcade_runs SET bankroll = 1000, guesses_remaining = 3, revealed_positions = '{}',
-      incorrect_letters = '{}', active_powerups = '{}', state = 'active', updated_at = NOW()
-    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
   END IF;
   RETURN public._arcade_response(v_uid);
 END;


### PR DESCRIPTION
**Bug:** busting an arcade puzzle revealed the answer but then let you retry the *same* puzzle — a trivial free solve. It also contradicted the intended gauntlet design ("lose puzzle 4 → start on 5").

**Fix:** `arcade_next` now advances on a bust exactly like on a solve (position+1 → next puzzle, or `complete` at the end of the ladder). The only difference between solve and bust is the multiplier — grown on a solve, reset to ×1 on a bust in `_arcade_resolve`.

- Server RPC updated, applied to prod, synced to `supabase-arcade-gauntlet.sql`.
- Client: the bust modal now reads *"Multiplier reset to ×1 — on to the next puzzle"* with a **Next Puzzle** button (was *"retry this puzzle"* / *"Try Again"*).

**Verify:** impersonated SQL — busted run at position 2 → `arcade_next` → position **3**, state active, multiplier ×1, and the new puzzle's board is masked (`phrase: null`). `svelte-check` 0/0, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)