### PR TITLE
Phase 6a: shared Daily Modifier (fair daily power-ups)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,6 +92,7 @@ Status: 📋 Planned (Phase 3)
 | **4 — Arcade gauntlet** | Server engine ✅ (4a); client ✅ (4b: arcade=gauntlet, HUD banked/multiplier/position, solve→Continue / bust→Try Again); leaderboard ✅ (4c: best banked run + furthest reached, day/week/month/all). | Server + client | ✅ |
 | **4d — Legacy cleanup** | Removed the dead pre-gauntlet arcade: wager UI + slider, `/select` & `/select/arcade` routes, client-side win/loss/bankroll paths (`fetchRandomGame`, `resetGame`, `reduceBankrollToZero`, `setWager`, `checkLossCondition`, `loadGameFromLocalStorage`, `save/recordArcade/DailyResult`). Both modes are now purely server-authoritative. | Client + stores | ✅ |
 | **5 — Polish** | Sound + haptics ✅ (5a). Guided tutorial ✅ (5b). "Ghost of yesterday" ✅ (5c: daily result modal compares today's bank to your own yesterday — delta ahead/behind — plus share of today's field beaten when ≥5 players, via `get_daily_ghost`). | Client + server | ✅ |
+| **6 — Power-up overhaul** | Fairness split: **Daily** = one shared **Daily Modifier** identical for all, rotating by date (6a ✅: discount/vowel_vision/extra_bank/insurance via `_daily_modifier`; banner + modifier-adjusted keyboard prices; removed random grants + daily picker + inventory free-reveal). **Arcade** = per-run roguelike (earn + spend within a run): engine 6b, tray/badges/toast UI 6c. New arcade power-ups: 💎 double_payout, ⚡ multiplier_boost, 🔰 shield, ⏭️ skip, ❤️ extra_try. | Server + client | 🚧 |
 
 Recommended order de-risks: economy first → cheap-high-impact share → retention (streaks/badges) → big arcade swing.
 

--- a/scripts/check-modifier.mjs
+++ b/scripts/check-modifier.mjs
@@ -1,0 +1,35 @@
+// Verify the Daily Modifier banner shows on a fresh daily (no picker), and that
+// a vowel is half-price when today's modifier is Vowel Vision.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+p.setDefaultTimeout(6000);
+const wait = (ms) => p.waitForTimeout(ms);
+const log = (...a) => console.log(...a);
+try {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+  await p.getByRole('button', { name: /daily/i }).first().click().catch((e)=>log('daily click', e.message));
+  await wait(2600);
+  log('no picker shown (good):', await p.getByText(/use a power-up/i).count() === 0);
+  log('modifier banner present:', await p.locator('.daily-modifier').count() > 0);
+  log('modifier name:', await p.locator('.dm-name').innerText().catch(()=>'—'));
+  log('modifier blurb:', await p.locator('.dm-blurb').innerText().catch(()=>'—'));
+  log('board keys:', await p.locator('.key').count());
+  // Vowel Vision: vowels half price (E 140 -> 70), consonants unchanged (Q 30).
+  const priceOf = async (L) => (await p.locator(`.key:has(.letter:text-is("${L}")) .price`).first().innerText().catch(()=>'?'));
+  log('E (vowel) price:', await priceOf('E'), ' expected $70');
+  log('Q (consonant) price:', await priceOf('Q'), ' expected $30');
+  await p.screenshot({ path: 'screenshots/modifier.png' });
+} catch (e) {
+  log('FATAL', e.message);
+} finally {
+  await b.close();
+  log('done');
+}

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -23,6 +23,19 @@
   const row2: string[] = ['A','S','D','F','G','H','J','K','L'];
   const row3: string[] = ['Z','X','C','V','B','N','M'];
 
+  // Effective per-letter prices after today's shared Daily Modifier (server matches this).
+  $: effCosts = (() => {
+    const m = $gameStore.gameMode === 'daily' ? ($gameStore.modifier ?? null) : null;
+    const out: Record<string, number> = {};
+    for (const k of Object.keys(letterCosts)) {
+      let c = letterCosts[k];
+      if (m === 'discount') c = Math.ceil(c * 0.75);
+      else if (m === 'vowel_vision' && 'AEIOU'.includes(k)) c = Math.ceil(c * 0.5);
+      out[k] = c;
+    }
+    return out;
+  })();
+
   type SelectedPurchase = { type: string; value?: string } | null;
   type LockedLetters = Record<string, unknown>;
   let selectedPurchase: SelectedPurchase = null;
@@ -32,9 +45,9 @@
   $: lockedLetters = ($gameStore.lockedLetters || {}) as LockedLetters;
   $: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
 
-  // 🔹 Disable unaffordable or incorrect keys
+  // 🔹 Disable unaffordable or incorrect keys (uses modifier-adjusted prices)
   $: disabledKeys = Object.keys(letterCosts).filter((letter: string) =>
-    (letterCosts[letter] ?? 0) > $gameStore.bankroll ||
+    (effCosts[letter] ?? 0) > $gameStore.bankroll ||
     incorrectLetters.includes(letter)
   );
 
@@ -143,7 +156,7 @@
         on:click={() => handleLetterClick(letter)}
       >
         <div class="letter">{letter}</div>
-        <div class="price">${letterCosts[letter] ?? 0}</div>
+        <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
   </div>
@@ -167,7 +180,7 @@
         on:click={() => handleLetterClick(letter)}
       >
         <div class="letter">{letter}</div>
-        <div class="price">${letterCosts[letter] ?? 0}</div>
+        <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
   </div>
@@ -191,7 +204,7 @@
         on:click={() => handleLetterClick(letter)}
       >
         <div class="letter">{letter}</div>
-        <div class="price">${letterCosts[letter] ?? 0}</div>
+        <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
 

--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -14,3 +14,18 @@ export const POWERUPS = {
 export function powerupInfo(id) {
   return POWERUPS[id] || { emoji: '⚡', name: id, desc: '' };
 }
+
+// Daily Modifier — the single shared effect active for everyone on a given day.
+// Keys match the server _daily_modifier() pool. `blurb` is the short "twist" line.
+/** @type {Record<string, { emoji: string, name: string, blurb: string }>} */
+export const MODIFIERS = {
+  discount:     { emoji: '🏷️', name: 'Discount Day', blurb: 'Every letter is 25% off' },
+  vowel_vision: { emoji: '👁️', name: 'Vowel Vision', blurb: 'Vowels cost half price' },
+  extra_bank:   { emoji: '💰', name: 'Big Bank',      blurb: 'Start with an extra $250' },
+  insurance:    { emoji: '🛡️', name: 'Insured',       blurb: 'Your first wrong guess is free' }
+};
+
+/** @param {string} id */
+export function modifierInfo(id) {
+  return MODIFIERS[id] || null;
+}

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,7 +3,7 @@
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
-import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getUserPowerups, dailyUseFreeReveal } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext } from '$lib/stores/statsStore.js';
 
 /* ================================
@@ -33,7 +33,8 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
  *   subcategory: string,
  *   gameMode: string,
  *   freeReveals?: number,
- *   arcadeRun?: any
+ *   arcadeRun?: any,
+ *   modifier?: string | null
  * }} GameState
  */
 
@@ -67,7 +68,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   subcategory: '',
   gameMode: 'daily', // 'daily' | 'arcade'
   freeReveals: 0, // owned Free Reveal power-ups (daily)
-  arcadeRun: null // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
+  arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
+  modifier: null // today's shared Daily Modifier id (daily only)
 }));
 
 /* ================================
@@ -200,7 +202,8 @@ function reconcileArcadeBoard(resp) {
     gameMode: 'arcade',
     gameState: gs,
     arcadeRun: run,
-    freeReveals: 0
+    freeReveals: 0,
+    modifier: null
   }));
   if (run.state === 'solved' || run.state === 'complete') {
     setTimeout(() => launchConfetti(), 300);
@@ -281,18 +284,15 @@ async function confirmPurchaseDaily(state) {
   dailyInFlight = true;
   try {
     let board = null;
-    let usedFree = false;
     if (purchase.type === 'letter') {
       board = await dailyBuyLetter(purchase.value ?? '');
     } else if (purchase.type === 'hint') {
-      // Reveal uses a Free Reveal power-up if you own one; otherwise it costs $150.
-      if ((state.freeReveals || 0) > 0) { board = await dailyUseFreeReveal(); usedFree = true; }
-      else board = await dailyReveal();
+      // Daily has no personal power-ups — Reveal always costs $150 (fair for all).
+      board = await dailyReveal();
     }
 
     if (board) {
       reconcileDailyBoard(board);
-      if (usedFree) gameStore.update(s => ({ ...s, freeReveals: Math.max(0, (s.freeReveals || 0) - 1) }));
     } else {
       gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
     }
@@ -507,23 +507,20 @@ export function submitGuess() {
  * fetchDailyGame - Starts or resumes today's server-authoritative daily session.
  * The phrase is held server-side; the client only ever receives a masked board.
  * No localStorage: the server is the source of truth (and prevents replays).
+ * The day's shared modifier is applied server-side at start (no client power-ups).
  */
-/**
- * @param {string[]} [powerups] - pre-game power-ups to activate (applied only on a fresh session)
- */
-export async function fetchDailyGame(powerups = []) {
+export async function fetchDailyGame() {
   try {
-    const board = await dailyStart(powerups);
+    const board = await dailyStart();
     if (!board) {
       console.error('❌ daily_start returned no board');
       return false;
     }
     reconcileDailyBoard(board);
-    // Load Free Reveal inventory for the in-game button.
+    // Today's shared modifier (same for everyone) — drives the banner + key pricing.
     try {
-      const pus = await getUserPowerups();
-      const fr = pus.find(p => p.powerup === 'free_reveal')?.count ?? 0;
-      gameStore.update(s => ({ ...s, freeReveals: fr }));
+      const mod = await getDailyModifier();
+      gameStore.update(s => ({ ...s, modifier: mod }));
     } catch { /* non-fatal */ }
     console.log('✅ Daily session started/resumed');
     return true;

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -75,6 +75,16 @@ export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score')
 }
 
 /**
+ * Today's shared Daily Modifier id (same for every player; rotates by date).
+ * @returns {Promise<string|null>}
+ */
+export async function getDailyModifier() {
+  const { data, error } = await supabase.rpc('get_daily_modifier');
+  if (error) { console.error('❌ get_daily_modifier error:', error); return null; }
+  return data ?? null;
+}
+
+/**
  * "Ghost of yesterday" — today's daily result vs the caller's own result
  * yesterday, plus the share of today's field they beat.
  * @returns {Promise<null | { yesterday_played: boolean, yesterday_banked: number|null, yesterday_won: boolean, yesterday_score: number|null, today_banked: number|null, today_score: number|null, today_players: number, today_percentile: number|null }>}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,9 +6,9 @@
 
   import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getUserPowerups, dailySessionExists, getDailyGhost } from '$lib/stores/statsStore.js';
+  import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getUserPowerups, getDailyGhost } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
-  import { powerupInfo } from '$lib/powerups.js';
+  import { powerupInfo, modifierInfo } from '$lib/powerups.js';
   import {
     saveGameToLocalStorage,
     clearSavedGame,
@@ -252,13 +252,8 @@
     location.reload();
   };
 
-  /** Start daily: resume if in progress, else show "already played" or fetch new daily */
-  let showPowerupPicker = false;
-  /** @type {{powerup: string, count: number}[]} */
-  let pickerPowerups = [];
-  /** @type {Set<string>} */
-  let selectedPowerups = new Set();
-
+  /** Start daily: resume if in progress, else show "already played" or fetch new daily.
+   *  Daily has no personal power-ups — everyone shares the same Daily Modifier. */
   async function handleMenuDaily() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
@@ -267,23 +262,12 @@
       showStreakMessage = true;
       return;
     }
-    // Fresh daily + owns pre-game power-ups -> let the player choose which to use.
-    const [exists, powerups] = await Promise.all([dailySessionExists(), getUserPowerups()]);
-    const pregame = powerups.filter(p => powerupInfo(p.powerup).pregame);
-    if (!exists && pregame.length > 0) {
-      pickerPowerups = pregame;
-      selectedPowerups = new Set();
-      showPowerupPicker = true;
-      return;
-    }
-    await startDaily([]);
+    await startDaily();
   }
 
-  /** @param {string[]} powerups */
-  async function startDaily(powerups) {
-    showPowerupPicker = false;
+  async function startDaily() {
     localStorage.setItem('gameMode', 'daily');
-    const ok = await fetchDailyGame(powerups);
+    const ok = await fetchDailyGame();
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
@@ -292,12 +276,8 @@
     }
   }
 
-  /** @param {string} id */
-  function togglePowerup(id) {
-    if (selectedPowerups.has(id)) selectedPowerups.delete(id);
-    else selectedPowerups.add(id);
-    selectedPowerups = selectedPowerups; // trigger reactivity
-  }
+  // Today's shared Daily Modifier banner (id lives in the game store, set by fetchDailyGame).
+  $: dailyMod = ($gameStore.gameMode === 'daily' && $gameStore.modifier) ? modifierInfo($gameStore.modifier) : null;
 
   /** Start or resume today's server-authoritative arcade gauntlet run. */
   async function handleMenuArcade() {
@@ -496,36 +476,6 @@
         </button>
       </div>
     </div>
-    <!-- Pre-game power-up picker (fresh daily + owned pre-game power-ups) -->
-    {#if showPowerupPicker}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Use power-ups">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showPowerupPicker = false}></button>
-        <div class="modal-content main-menu-modal">
-          <button class="close-btn" on:click={() => showPowerupPicker = false}>❌</button>
-          <h2>Use a power-up?</h2>
-          <p class="picker-sub">Tap to apply before today's daily. They're consumed when you start.</p>
-          <div class="picker-list">
-            {#each pickerPowerups as pu}
-              <button
-                class="picker-item {selectedPowerups.has(pu.powerup) ? 'on' : ''}"
-                on:click={() => togglePowerup(pu.powerup)}
-              >
-                <span class="pi-emoji">{powerupInfo(pu.powerup).emoji}</span>
-                <span class="pi-body">
-                  <span class="pi-name">{powerupInfo(pu.powerup).name} <span class="pi-count">×{pu.count}</span></span>
-                  <span class="pi-desc">{powerupInfo(pu.powerup).desc}</span>
-                </span>
-                <span class="pi-check">{selectedPowerups.has(pu.powerup) ? '✓' : ''}</span>
-              </button>
-            {/each}
-          </div>
-          <div class="picker-actions">
-            <button class="btn-ghost" on:click={() => startDaily([])}>Skip</button>
-            <button class="main-menu-btn" on:click={() => startDaily([...selectedPowerups])}>Start{#if selectedPowerups.size > 0} ({selectedPowerups.size}){/if}</button>
-          </div>
-        </div>
-      </div>
-    {/if}
 
     <!-- Streak message (when Daily is disabled and user taps it) -->
     {#if showStreakMessage}
@@ -626,6 +576,14 @@
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
       {#if $gameStore.subcategory}<span class="subcat-chip">{$gameStore.subcategory}</span>{/if}
     </div>
+
+    <!-- ✨ Today's shared Daily Modifier (same for every player) -->
+    {#if dailyMod}
+      <div class="daily-modifier" title={dailyMod.blurb}>
+        <span class="dm-emoji">{dailyMod.emoji}</span>
+        <span class="dm-text"><span class="dm-name">{dailyMod.name}</span><span class="dm-blurb">{dailyMod.blurb}</span></span>
+      </div>
+    {/if}
 
 
     <!-- 🔤 Phrase Display -->
@@ -810,6 +768,28 @@
     padding: 6px 13px;
     border-radius: var(--r-pill);
   }
+
+  .daily-modifier {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin: -10px auto 20px;
+    padding: 8px 16px;
+    border-radius: var(--r-pill, 999px);
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(163, 230, 53, 0.1));
+    border: 1px solid rgba(251, 191, 36, 0.32);
+    box-shadow: 0 0 18px rgba(251, 191, 36, 0.12);
+  }
+  .dm-emoji { font-size: 1.25rem; line-height: 1; }
+  .dm-text { display: flex; flex-direction: column; text-align: left; line-height: 1.2; }
+  .dm-name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.82rem;
+    color: #fcd34d;
+    letter-spacing: 0.01em;
+  }
+  .dm-blurb { font-family: var(--font-ui); font-size: 0.7rem; color: var(--text-muted); }
 
   .phrase-section {
     width: 100%;
@@ -1023,37 +1003,6 @@
     text-transform: uppercase;
     color: var(--text-faint);
   }
-
-  /* Pre-game power-up picker */
-  .picker-sub { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 14px; }
-  .picker-list { display: flex; flex-direction: column; gap: 8px; margin-bottom: 16px; }
-  .picker-item {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    text-align: left;
-    padding: 12px 14px;
-    border-radius: var(--r-md);
-    border: 1px solid var(--border);
-    background: var(--surface);
-    color: var(--text);
-    cursor: pointer;
-    transition: background 0.18s, border-color 0.18s, transform 0.15s var(--ease-spring);
-  }
-  .picker-item:hover { transform: translateY(-1px); border-color: var(--border-strong); }
-  .picker-item.on {
-    border-color: rgba(163, 230, 53, 0.5);
-    background: linear-gradient(135deg, rgba(52, 211, 153, 0.14), rgba(163, 230, 53, 0.05));
-    box-shadow: var(--glow-brand);
-  }
-  .pi-emoji { font-size: 1.5rem; line-height: 1; }
-  .pi-body { display: flex; flex-direction: column; gap: 2px; flex: 1; }
-  .pi-name { font-family: var(--font-display); font-weight: 600; font-size: 0.98rem; }
-  .pi-count { color: var(--brand-2); }
-  .pi-desc { font-size: 0.76rem; color: var(--text-muted); }
-  .pi-check { color: var(--brand-2); font-weight: 700; font-size: 1.1rem; width: 16px; }
-  .picker-actions { display: flex; gap: 10px; }
-  .picker-actions > * { flex: 1; margin-top: 0; }
 
   /* Badges + power-ups (My Account) */
   .badges-section { margin: 18px 0 8px; }

--- a/supabase-daily-modifier.sql
+++ b/supabase-daily-modifier.sql
@@ -1,0 +1,119 @@
+-- ============================================================
+-- WordBank V2 Phase 6a: Daily Modifier (shared, fair)
+-- Run AFTER supabase-powerups.sql and supabase-pregame-powerups.sql.
+--
+-- A ranked daily must be identical for everyone, so the old "random power-up
+-- grant on win" is removed. Instead, ONE modifier is active for every player
+-- that day, chosen deterministically from the date (rotates daily). It is
+-- applied to the daily session's active_powerups at start, so the existing
+-- discount / vowel_vision / insurance / extra_bank effects "just work".
+-- ============================================================
+
+-- Today's modifier id — same for everyone, rotates by date.
+CREATE OR REPLACE FUNCTION public._daily_modifier()
+RETURNS TEXT LANGUAGE sql STABLE AS $$
+  SELECT (ARRAY['discount','vowel_vision','extra_bank','insurance'])[
+    1 + (get_byte(decode(md5(CURRENT_DATE::text), 'hex'), 0) % 4)
+  ];
+$$;
+
+-- Public accessor so the client can show "Today's twist".
+CREATE OR REPLACE FUNCTION public.get_daily_modifier()
+RETURNS TEXT LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT public._daily_modifier();
+$$;
+GRANT EXECUTE ON FUNCTION public.get_daily_modifier() TO authenticated, anon;
+
+-- daily_start applies the shared modifier (ignores client-supplied power-ups —
+-- daily no longer has a personal inventory). p_powerups kept for signature compat.
+DROP FUNCTION IF EXISTS public.daily_start(TEXT[]);
+CREATE OR REPLACE FUNCTION public.daily_start(p_powerups TEXT[] DEFAULT '{}')
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT;
+  s public.daily_sessions;
+  v_mod TEXT; v_bonus INT := 0;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_start: not authenticated'; END IF;
+  v_pid := public._todays_puzzle_id();
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
+    v_mod := public._daily_modifier();
+    IF v_mod = 'extra_bank' THEN v_bonus := 250; END IF;
+    INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining, active_powerups)
+    VALUES (v_uid, CURRENT_DATE, v_pid, 1000 + v_bonus, 3, ARRAY[v_mod])
+    RETURNING * INTO s;
+  END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+  RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining,
+                             s.revealed_positions, s.incorrect_letters, v_cat, v_sub);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_start(TEXT[]) TO authenticated;
+
+-- _finalize_daily WITHOUT the random power-up grant (daily is now fair/shared).
+-- Otherwise identical to the supabase-powerups.sql version.
+CREATE OR REPLACE FUNCTION public._finalize_daily(p_uid UUID, p_won BOOLEAN, p_bankroll INT, p_incorrect_count INT DEFAULT 0)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  v_week_start DATE; v_current_streak INT; v_highest_streak INT; v_last_win DATE;
+  v_bankroll INT; v_score INT; v_freezes INT;
+BEGIN
+  v_bankroll := LEAST(GREATEST(COALESCE(p_bankroll, 0), 0), 1000);
+  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1;
+
+  SELECT current_win_streak, highest_win_streak, last_daily_win_date, COALESCE(streak_freezes, 0)
+  INTO v_current_streak, v_highest_streak, v_last_win, v_freezes
+  FROM public.profiles WHERE id = p_uid;
+
+  IF p_won THEN
+    IF v_last_win = CURRENT_DATE - 1 THEN
+      v_current_streak := COALESCE(v_current_streak, 0) + 1;
+    ELSIF v_last_win = CURRENT_DATE - 2 AND v_freezes > 0 AND COALESCE(v_current_streak, 0) > 0 THEN
+      v_freezes := v_freezes - 1; v_current_streak := v_current_streak + 1;
+    ELSIF v_last_win IS DISTINCT FROM CURRENT_DATE THEN
+      v_current_streak := 1;
+    END IF;
+    IF v_current_streak > 0 AND v_current_streak % 7 = 0 THEN v_freezes := LEAST(v_freezes + 1, 3); END IF;
+    v_highest_streak := GREATEST(COALESCE(v_highest_streak, 0), v_current_streak);
+    UPDATE public.profiles SET
+      current_win_streak = v_current_streak, highest_win_streak = v_highest_streak,
+      last_daily_win_date = CURRENT_DATE, last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll, last_daily_won = true, streak_freezes = v_freezes
+    WHERE id = p_uid;
+  ELSE
+    v_current_streak := 0;
+    UPDATE public.profiles SET
+      current_win_streak = 0, last_daily_play_date = CURRENT_DATE,
+      daily_bankroll = v_bankroll, last_daily_won = false
+    WHERE id = p_uid;
+  END IF;
+
+  v_score := ROUND(v_bankroll * (1 + LEAST(GREATEST(COALESCE(v_current_streak, 0) - 1, 0), 10) * 0.1))::INT;
+
+  INSERT INTO public.game_results (user_id, played_at, won, bankroll_left, game_mode, score)
+  VALUES (p_uid, NOW(), p_won, v_bankroll, 'daily', v_score);
+
+  INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
+  VALUES (p_uid, v_week_start,
+    CASE WHEN p_won THEN 1 ELSE 0 END, CASE WHEN p_won THEN v_bankroll ELSE 0 END, v_bankroll,
+    CASE WHEN p_won THEN 1 ELSE 0 END, 1, COALESCE(v_current_streak, 0))
+  ON CONFLICT (user_id, week_start) DO UPDATE SET
+    total_played = user_weekly_stats.total_played + 1,
+    total_wins = user_weekly_stats.total_wins + CASE WHEN p_won THEN 1 ELSE 0 END,
+    puzzles_completed = user_weekly_stats.puzzles_completed + CASE WHEN p_won THEN 1 ELSE 0 END,
+    bankroll_earned = user_weekly_stats.bankroll_earned + CASE WHEN p_won THEN v_bankroll ELSE 0 END,
+    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, v_bankroll),
+    win_streak = GREATEST(user_weekly_stats.win_streak, v_current_streak);
+
+  IF p_won THEN
+    IF COALESCE(p_incorrect_count, 0) = 0 THEN PERFORM public._award_badge(p_uid, 'flawless'); END IF;
+    IF v_bankroll >= 700 THEN PERFORM public._award_badge(p_uid, 'gold_bank'); END IF;
+    IF v_current_streak >= 7 THEN PERFORM public._award_badge(p_uid, 'streak_7'); END IF;
+    IF v_current_streak >= 30 THEN PERFORM public._award_badge(p_uid, 'streak_30'); END IF;
+  END IF;
+END;
+$fn$;


### PR DESCRIPTION
First slice of the **Phase 6 power-up overhaul**. Fixes the fairness problem you flagged: a ranked daily can't have per-player advantages, so the old "random power-up grant on win" is removed.

## Daily = one shared modifier, identical for everyone
Each day, **one** modifier is active for *every* player, chosen deterministically from the date (rotates daily). No personal inventory, nothing to hoard — the daily leaderboard stays a pure, equal skill test.

**Server** (`supabase-daily-modifier.sql`, applied to prod):
- `_daily_modifier()` → today's effect from `discount` / `vowel_vision` / `extra_bank` / `insurance` (same for all, via `md5(date)`).
- `daily_start` applies it to the session's `active_powerups` (and +$250 for `extra_bank`); the existing buy/guess effect logic just works. `p_powerups` is ignored.
- `get_daily_modifier()` exposes today's id to the client.
- `_finalize_daily` no longer grants a random power-up.

**Client:**
- "Today's twist" banner under the category (name + blurb).
- **Keyboard prices reflect the modifier** (vowels half / all −25%), matching the server charge — including the affordability check.
- Removed the daily pre-game picker and the inventory free-reveal path (leftover legacy `free_reveal` can no longer be used in daily — fairness).
- `gameStore.modifier` is the single source (set in `fetchDailyGame`, null in arcade).

## Verify
- `svelte-check` 0/0, build ✅.
- Modifier rotates deterministically (today=`vowel_vision`), identical for all.
- Playwright (`scripts/check-modifier.mjs`): no picker, banner *"Vowel Vision / Vowels cost half price"*, keyboard **E=$70** (half of 140), **Q=$30** (unchanged). Screenshot confirms styling.

Next: **6b** arcade per-run roguelike engine (earn + spend within a run), then **6c** the tray/badges/toast UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)