### PR TITLE
Polish: tidy My Account + rewrite How to Play copy

### DIFF
--- a/scripts/check-polish.mjs
+++ b/scripts/check-polish.mjs
@@ -1,0 +1,35 @@
+// Screenshot the rewritten tutorial step 1 and the tidied My Account (no power-ups).
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+p.setDefaultTimeout(6000);
+const wait = (ms) => p.waitForTimeout(ms);
+const log = (...a) => console.log(...a);
+const errs = []; p.on('pageerror', e => errs.push(String(e)));
+try {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(700);
+  await p.evaluate(() => localStorage.removeItem('wb_tutorial_seen'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+  await p.evaluate(() => localStorage.removeItem('wb_tutorial_seen'));
+  await p.reload({ waitUntil: 'networkidle' }); await wait(2200);
+  log('tutorial title:', await p.locator('.tut-title').innerText().catch(()=>'—'));
+  log('tutorial body:', await p.locator('.tut-body').innerText().catch(()=>'—'));
+  await p.screenshot({ path: 'screenshots/tut-step1.png' });
+  await p.locator('.tut-skip').click().catch(()=>{}); await wait(500);
+  // Open My Account
+  await p.getByRole('button', { name: /my account/i }).first().click().catch(()=>{}); await wait(1500);
+  log('account has Power-ups section:', await p.getByText(/^Power-ups$/).count() > 0, '(want false)');
+  log('account has Badges section:', await p.getByText(/Badges/).count() > 0);
+  await p.screenshot({ path: 'screenshots/account.png' });
+  log('page errors:', errs.length, errs.slice(0,3));
+} catch (e) {
+  log('FATAL', e.message);
+} finally {
+  await b.close();
+  log('done');
+}

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -6,29 +6,29 @@
 
   const steps = [
     {
-      icon: '🧠',
-      title: 'Welcome to WordBank',
-      body: 'Uncover the hidden phrase for the lowest cost. Whatever you don’t spend becomes your score.'
+      icon: '💰',
+      title: 'You start with $1,000',
+      body: 'Behind the blanks is a hidden phrase. Spend as little as you can to crack it — whatever’s left in the bank is your score.'
     },
     {
       icon: '🔤',
-      title: 'Buy letters',
-      body: 'Tap a letter to buy it. If it’s in the phrase, every copy lights up. If not, you lose that money — so spend on likely letters first.'
+      title: 'Buy your letters',
+      body: 'Tap a letter to buy it. Hit, and every copy lights up. Miss, and the cash is gone. Read the phrase, play the odds.'
     },
     {
       icon: '🔍',
-      title: 'Reveal',
-      body: 'Stuck? Reveal ($150) uncovers every copy of the single most useful letter — guaranteed, never random.'
+      title: 'Stuck? Buy a clue',
+      body: 'Reveal drops the most useful letter onto the board — every copy of it, guaranteed. No luck, no guesswork.'
     },
     {
-      icon: '✏️',
-      title: 'Solve the phrase',
-      body: 'Think you’ve got it? Hit Solve, fill the blanks, and Submit. You get 3 free tries — a wrong guess just costs a try, never money.'
+      icon: '🎯',
+      title: 'Take your shot',
+      body: 'Think you’ve got it? Hit Solve, fill the blanks, and submit. Three shots at the answer — a miss costs a try, never a dollar.'
     },
     {
       icon: '🏆',
-      title: 'Daily & Arcade',
-      body: 'Daily: one ranked puzzle a day — score = bankroll × your win streak. Arcade: a press-your-luck gauntlet — bank each solve and grow your multiplier before you bust.'
+      title: 'Daily or Arcade',
+      body: 'Daily: one puzzle, everyone plays it, ranked — keep a win streak going to multiply your score. Arcade: a press-your-luck gauntlet — bank each solve, ride your multiplier, don’t go bust.'
     }
   ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 
   import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue } from '$lib/stores/GameStore.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getUserPowerups, getDailyGhost } from '$lib/stores/statsStore.js';
+  import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getDailyGhost } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
   import { powerupInfo, modifierInfo } from '$lib/powerups.js';
   import {
@@ -325,18 +325,15 @@
   let badgesLoaded = false;
   let accountStreak = 0;
   let accountFreezes = 0;
-  /** @type {{powerup: string, count: number}[]} */
-  let accountPowerups = [];
   async function handleMenuMyAccount() {
     showMyAccount = true;
     badgesLoaded = false;
     const u = get(user);
     if (u?.id) {
-      const [badges, status, powerups] = await Promise.all([getUserBadges(u.id), getDailyStatus(u.id), getUserPowerups()]);
+      const [badges, status] = await Promise.all([getUserBadges(u.id), getDailyStatus(u.id)]);
       accountBadges = badges;
       accountStreak = status.current_streak ?? 0;
       accountFreezes = status.streak_freezes ?? 0;
-      accountPowerups = powerups;
     }
     badgesLoaded = true;
   }
@@ -509,22 +506,6 @@
             <div class="stat-chip" title="Auto-protects your streak across one missed day. Earn one every 7-day streak.">
               <span class="stat-emoji">🧊</span> {accountFreezes}<span class="stat-cap">freeze{accountFreezes === 1 ? '' : 's'}</span>
             </div>
-          </div>
-
-          <div class="badges-section">
-            <p class="badges-title">Power-ups</p>
-            {#if badgesLoaded && accountPowerups.length === 0}
-              <p class="powerups-empty">Win daily puzzles to earn power-ups 🎟️</p>
-            {:else}
-              <div class="badge-grid">
-                {#each accountPowerups as pu}
-                  <div class="badge earned" title={powerupInfo(pu.powerup).desc}>
-                    <span class="badge-emoji">{powerupInfo(pu.powerup).emoji}</span>
-                    <span class="badge-name">{powerupInfo(pu.powerup).name} ×{pu.count}</span>
-                  </div>
-                {/each}
-              </div>
-            {/if}
           </div>
 
           <div class="badges-section">
@@ -1021,7 +1002,6 @@
 
   /* Badges + power-ups (My Account) */
   .badges-section { margin: 18px 0 8px; }
-  .powerups-empty { font-size: 0.82rem; color: var(--text-faint); margin: 0; }
   .badges-title {
     font-family: var(--font-display);
     font-weight: 600;


### PR DESCRIPTION
Two small polish items from playtest feedback.

## My Account
Removed the now-obsolete **Power-ups** section — after the Phase 6 redesign, daily has no personal inventory and arcade power-ups are per-run, so it only ever showed empty/stale. Dropped the `accountPowerups` + `getUserPowerups` load and the orphaned `.powerups-empty` style. The modal is now streak + freezes + badges + log out.

## How to Play
Rewrote all 5 tutorial steps in a sharper, more confident voice — leads with **"You start with $1,000"**, hooks on the risk/reward, and trims the stiff phrasing. Fun and intriguing without being corny:
- *You start with $1,000* — "Behind the blanks is a hidden phrase. Spend as little as you can to crack it — whatever's left in the bank is your score."
- *Buy your letters* — "Tap a letter to buy it. Hit, and every copy lights up. Miss, and the cash is gone. Read the phrase, play the odds."
- *Stuck? Buy a clue* — "Reveal drops the most useful letter onto the board — every copy of it, guaranteed. No luck, no guesswork."
- *Take your shot* — "Think you've got it? Hit Solve, fill the blanks, and submit. Three shots at the answer — a miss costs a try, never a dollar."
- *Daily or Arcade* — "Daily: one puzzle, everyone plays it, ranked… Arcade: a press-your-luck gauntlet — bank each solve, ride your multiplier, don't go bust."

## Verify
`svelte-check` 0/0, build ✅. Playwright (`scripts/check-polish.mjs`): tutorial step 1 shows the new copy, My Account has **no** Power-ups section, **0** page errors. Screenshots confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)