### PR TITLE
Remove dark-mode toggle + tighten How to Play copy

### DIFF
--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -414,11 +414,6 @@
   transform: scale(0.96);
 }
 
-/* Dark mode adjustments */
-:global(body.dark-mode) .guess-phrase-button {
-  background: linear-gradient(180deg, #46a230, #318020); /* Keep it green in dark mode */
-}
-
 /* ---------------------------
    Confirm / Cancel Buttons
 --------------------------- */

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -7,28 +7,28 @@
   const steps = [
     {
       icon: '💰',
-      title: 'You start with $1,000',
-      body: 'Behind the blanks is a hidden phrase. Spend as little as you can to crack it — whatever’s left in the bank is your score.'
+      title: 'Spend less, score more',
+      body: 'A phrase is hidden. The cash you don’t spend cracking it is your score.'
     },
     {
       icon: '🔤',
-      title: 'Buy your letters',
-      body: 'Tap a letter to buy it. Hit, and every copy lights up. Miss, and the cash is gone. Read the phrase, play the odds.'
+      title: 'Buy a letter',
+      body: 'Tap one. In the phrase? Every copy fills in. Not in it? You lose what you paid.'
     },
     {
       icon: '🔍',
-      title: 'Stuck? Buy a clue',
-      body: 'Reveal drops the most useful letter onto the board — every copy of it, guaranteed. No luck, no guesswork.'
+      title: 'Need a hand?',
+      body: 'Reveal buys you the most useful letter. Guaranteed — no guessing.'
     },
     {
       icon: '🎯',
-      title: 'Take your shot',
-      body: 'Think you’ve got it? Hit Solve, fill the blanks, and submit. Three shots at the answer — a miss costs a try, never a dollar.'
+      title: 'Make the call',
+      body: 'Tap Solve, type the phrase, submit. Three tries — a wrong one costs a try, not cash.'
     },
     {
       icon: '🏆',
       title: 'Daily or Arcade',
-      body: 'Daily: one puzzle, everyone plays it, ranked — keep a win streak going to multiply your score. Arcade: a press-your-luck gauntlet — bank each solve, ride your multiplier, don’t go bust.'
+      body: 'Daily: one puzzle, ranked. Arcade: keep solving, stack a multiplier — don’t bust.'
     }
   ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,7 +30,6 @@
 
   // UI state
   let showTutorial = false;
-  let darkMode = false;
   let showResultModal = false;
   let hasTriggeredModal = false;
   let hasInitialized = false;
@@ -211,22 +210,7 @@
     saveGameToLocalStorage();
   }
 
-  // ✅ Dark mode init
-  const applyDarkMode = () => {
-    document.body.classList.toggle('dark-mode', darkMode);
-  };
-
-  const toggleDarkMode = () => {
-    darkMode = !darkMode;
-    localStorage.setItem('darkMode', String(darkMode));
-    applyDarkMode();
-  };
-
   onMount(() => {
-    if (browser) {
-      darkMode = localStorage.getItem('darkMode') === 'true';
-      applyDarkMode();
-    }
     ['click', 'mousedown', 'touchstart'].forEach(event =>
       document.addEventListener(event, removeButtonFocus, true)
     );
@@ -400,11 +384,6 @@
     aria-label="Toggle sound and haptics"
   >
     {$soundEnabled ? '🔊' : '🔇'}
-  </button>
-
-  <!-- 🌙 Dark Mode Toggle -->
-  <button class="icon-button subtle-button" on:click={toggleDarkMode}>
-    {darkMode ? '☀️' : '🌙'}
   </button>
 
   <!-- 🚪 Logout -->
@@ -1043,17 +1022,6 @@
     font-size: 0.95rem;
     color: var(--text-muted);
     margin: 0.5rem 0 0 0;
-  }
-
-  :global(body.dark-mode) .diagnostic-banner {
-    background: rgba(255, 80, 80, 0.2);
-    border-color: #ef5350;
-    color: #ffcdd2;
-  }
-  :global(body.dark-mode) .diagnostic-banner.info {
-    background: rgba(33, 150, 243, 0.2);
-    border-color: #42a5f5;
-    color: #90caf9;
   }
 
   .bankroll-container {


### PR DESCRIPTION
## Dark mode out
The app's default theme is already the dark neon-arcade look (every screenshot to date had `darkMode=false`), so the 🌙/☀️ toggle was redundant. Removed the button, the `darkMode` state, `applyDarkMode`/`toggleDarkMode`, the localStorage init, and the leftover `body.dark-mode` CSS overrides in `+page.svelte` and `GameButtons.svelte`. The app keeps its dark look.

## How to Play — tighter pass
Cut the word count and made each step concrete enough for a true first-timer, still cool:
- 💰 **Spend less, score more** — "A phrase is hidden. The cash you don't spend cracking it is your score."
- 🔤 **Buy a letter** — "Tap one. In the phrase? Every copy fills in. Not in it? You lose what you paid."
- 🔍 **Need a hand?** — "Reveal buys you the most useful letter. Guaranteed — no guessing."
- 🎯 **Make the call** — "Tap Solve, type the phrase, submit. Three tries — a wrong one costs a try, not cash."
- 🏆 **Daily or Arcade** — "Daily: one puzzle, ranked. Arcade: keep solving, stack a multiplier — don't bust."

## Verify
`svelte-check` 0/0, build ✅. Playwright: new copy renders, header has no dark-mode button, **0** page errors. Screenshot confirms the dark theme + tightened step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)