### PR TITLE
Tagline "Spend Less. Think More." + plainer How to Play

### DIFF
--- a/scripts/check-tut-steps.mjs
+++ b/scripts/check-tut-steps.mjs
@@ -20,8 +20,12 @@ try {
     const body = await p.locator('.tut-body').innerText().catch(()=>'—');
     console.log(`STEP ${s}: ${t} :: ${body}`);
     await p.screenshot({ path: `screenshots/tut-${s}.png` });
-    if (s < 5) { await p.locator('.tut-btn.primary').click().catch(()=>{}); await wait(450); }
+    await p.locator('.tut-btn.primary').click().catch(()=>{}); await wait(450);
   }
+  // After finishing, the menu shows — capture the tagline.
+  await wait(600);
+  console.log('menu tagline:', await p.locator('.menu-tagline').innerText().catch(()=>'—'));
+  await p.screenshot({ path: 'screenshots/menu-tagline.png' });
 } catch (e) {
   console.log('FATAL', e.message);
 } finally {

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -7,28 +7,28 @@
   const steps = [
     {
       icon: '💰',
-      title: 'Crack the phrase',
-      body: 'A phrase is hidden. You’ve got $1,000 to uncover it — and every dollar you keep becomes your score.'
+      title: 'Guess the phrase',
+      body: 'Guess the phrase by spending as little as possible. Whatever’s left of your $1,000 is your score.'
     },
     {
       icon: '🔤',
-      title: 'Letters cost money',
-      body: 'Tap to buy one. In the phrase? Every copy fills in. Not in it? That cash is gone.'
+      title: 'Buy letters',
+      body: 'Tap a letter to buy it. If it’s in the phrase, every copy appears. If it’s not, you lose what it cost.'
     },
     {
       icon: '🔍',
-      title: 'Buy yourself a clue',
-      body: 'Reveal drops the most useful letter on the board. Guaranteed intel, zero luck.'
+      title: 'Reveal',
+      body: 'Reveal buys you the most useful letter — no guessing. It costs money, so use it when you’re stuck.'
     },
     {
       icon: '🎯',
-      title: 'Call it',
-      body: 'Know it? Hit Solve, type the phrase, lock it in. Three tries — a miss costs a try, not a cent.'
+      title: 'Solve',
+      body: 'When you’ve got it, tap Solve, type the phrase, and submit. Three tries — a wrong guess costs a try, not money.'
     },
     {
       icon: '🏆',
-      title: 'Daily or Arcade',
-      body: 'Daily: one phrase, the whole world, ranked. Arcade: solve, bank, ride your multiplier — push it before you bust.'
+      title: 'Daily & Arcade',
+      body: 'Daily is one ranked puzzle for everyone. Arcade keeps going — bank each solve and build your multiplier until you bust.'
     }
   ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -414,7 +414,7 @@
       <div class="menu-hero">
         <div class="menu-mark float">WB</div>
         <h1 class="menu-wordmark"><span class="brand-text">Word</span>Bank</h1>
-        <p class="menu-tagline">Crack the phrase. Bank the win.</p>
+        <p class="menu-tagline">Spend Less. Think More.</p>
       </div>
       <div class="main-menu-buttons stagger">
         <button


### PR DESCRIPTION
- **Menu tagline** → **"Spend Less. Think More."** (was "Crack the phrase. Bank the win.")
- **How to Play** rewritten in a plainer, instructional tone (following your lead), opening with your line:
  - 💰 **Guess the phrase** — "Guess the phrase by spending as little as possible. Whatever's left of your $1,000 is your score."
  - 🔤 **Buy letters** — "Tap a letter to buy it. If it's in the phrase, every copy appears. If it's not, you lose what it cost."
  - 🔍 **Reveal** — "Reveal buys you the most useful letter — no guessing. It costs money, so use it when you're stuck."
  - 🎯 **Solve** — "When you've got it, tap Solve, type the phrase, and submit. Three tries — a wrong guess costs a try, not money."
  - 🏆 **Daily & Arcade** — "Daily is one ranked puzzle for everyone. Arcade keeps going — bank each solve and build your multiplier until you bust."

`svelte-check` 0/0, build ✅. Playwright confirms the tagline + all five steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)