### PR TITLE
Arcade is now endless — drop the gauntlet cap

### DIFF
--- a/scripts/check-hud.mjs
+++ b/scripts/check-hud.mjs
@@ -1,0 +1,20 @@
+// Confirm the arcade HUD shows just the puzzle number (no "/29" cap).
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+p.setDefaultTimeout(6000);
+const wait = (ms) => p.waitForTimeout(ms);
+try {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+  await p.getByRole('button', { name: /arcade/i }).first().click().catch(()=>{}); await wait(2600);
+  const cells = await p.locator('.arcade-hud .ah-cell').allInnerTexts().catch(()=>[]);
+  console.log('HUD cells:', JSON.stringify(cells));
+  await p.screenshot({ path: 'screenshots/hud.png' });
+} catch (e) { console.log('FATAL', e.message); } finally { await b.close(); console.log('done'); }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -173,11 +173,10 @@
   $: resultMedal = medalFor(resultBankroll, resultWon);
   // Arcade gauntlet run state
   $: arun = $gameStore.arcadeRun;
-  $: arcadeComplete = !isDailyResult && arun?.state === 'complete';
   $: arcadeMult = ((arun?.multiplier ?? 100) / 100).toFixed(2);
   // Power-up earned on this solve, and whether a Shield saved a bust (multiplier kept).
   $: arcadeEarn = (!isDailyResult && resultWon && arun?.last_earn) ? powerupInfo(arun.last_earn) : null;
-  $: arcadeShielded = (!isDailyResult && !resultWon && !arcadeComplete && (arun?.multiplier ?? 100) > 100);
+  $: arcadeShielded = (!isDailyResult && !resultWon && (arun?.multiplier ?? 100) > 100);
 
   let shareCopied = false;
   function buildShareText() {
@@ -529,7 +528,7 @@
     <!-- 🕹️ Arcade gauntlet HUD -->
     {#if $gameStore.gameMode === 'arcade' && arun}
       <div class="arcade-hud">
-        <div class="ah-cell"><span class="ah-val">{(arun.position ?? 0) + 1}<span class="ah-sub">/{arun.total}</span></span><span class="ah-label">Puzzle</span></div>
+        <div class="ah-cell"><span class="ah-val">{(arun.position ?? 0) + 1}</span><span class="ah-label">Puzzle</span></div>
         <div class="ah-cell ah-mult"><span class="ah-val">×{arcadeMult}</span><span class="ah-label">Multiplier</span></div>
         <div class="ah-cell"><span class="ah-val ah-gold">${(arun.banked ?? 0).toLocaleString()}</span><span class="ah-label">Banked</span></div>
       </div>
@@ -629,15 +628,11 @@
               <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
             </div>
           {:else}
-            <!-- Arcade Press-Your-Luck transition -->
-            {#if arcadeComplete}
-              <div class="result-medal gold">🏆</div>
-              <h2>Gauntlet Cleared!</h2>
-              <p class="result-sub">All {arun?.total} puzzles solved</p>
-            {:else if resultWon}
+            <!-- Arcade Press-Your-Luck transition (endless — runs never "complete") -->
+            {#if resultWon}
               <div class="result-medal">✅</div>
               <h2>Solved!</h2>
-              <p class="result-sub">Puzzle {(arun?.position ?? 0) + 1}/{arun?.total} · next ×{arcadeMult}</p>
+              <p class="result-sub">Puzzle {(arun?.position ?? 0) + 1} · next ×{arcadeMult}</p>
             {:else if arcadeShielded}
               <div class="result-medal">🔰</div>
               <h2>Busted</h2>
@@ -651,7 +646,7 @@
               <span class="rb-label">Total Banked</span>
               <span class="rb-amount">${(arun?.banked ?? 0).toLocaleString()}</span>
             </div>
-            {#if resultWon && !arcadeComplete && (arun?.last_gain ?? 0) > 0}
+            {#if resultWon && (arun?.last_gain ?? 0) > 0}
               <p class="arcade-gain">+${(arun?.last_gain ?? 0).toLocaleString()} this puzzle</p>
             {/if}
             {#if arcadeEarn}
@@ -659,11 +654,7 @@
             {/if}
             <div class="result-actions">
               <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
-              {#if arcadeComplete}
-                <button class="next-puzzle-button" on:click={() => { showResultModal = false; goToMainMenu(); }}>Done</button>
-              {:else}
-                <button class="next-puzzle-button" on:click={handleArcadeContinue}>{resultWon ? 'Continue' : 'Next Puzzle'}</button>
-              {/if}
+              <button class="next-puzzle-button" on:click={handleArcadeContinue}>{resultWon ? 'Continue' : 'Next Puzzle'}</button>
             </div>
           {/if}
         </div>
@@ -713,7 +704,6 @@
   .ah-val { font-family: var(--font-display); font-weight: 700; font-size: 1.15rem; color: var(--text); font-variant-numeric: tabular-nums; }
   .ah-mult .ah-val { color: var(--brand-2); }
   .ah-gold { color: #fcd34d; }
-  .ah-sub { font-size: 0.7rem; color: var(--text-faint); font-weight: 600; }
   .ah-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
   .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
   .arcade-earn { font-family: var(--font-display); font-weight: 700; color: #fcd34d; margin: -6px 0 14px; font-size: 0.95rem; text-shadow: 0 0 14px rgba(251, 191, 36, 0.35); }

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -212,7 +212,7 @@
                 </td>
                 <td class="name">{row.display_name || 'Player'}</td>
                 <td class="score-cell">${fmt(row.banked)}</td>
-                <td>{fmt(row.furthest)}/{fmt(row.total)}</td>
+                <td>{fmt(row.furthest)}</td>
               </tr>
             {/each}
           </tbody>

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -478,3 +478,96 @@ BEGIN
 END;
 $fn$;
 GRANT EXECUTE ON FUNCTION public.arcade_use_powerup(TEXT) TO authenticated;
+
+-- ============================================================
+-- Endless arcade: no "gauntlet cleared" cap. The ladder wraps once the library
+-- is exhausted (position % size), so a run keeps going — how far you climb is
+-- the score. Redefines _arcade_puzzle_at (wrap), arcade_next + skip (never
+-- 'complete'). Seeding more puzzles pushes the loop point far out.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._arcade_puzzle_at(p_position INT)
+RETURNS UUID LANGUAGE sql STABLE SECURITY DEFINER AS $fn$
+  SELECT id FROM (
+    SELECT id, (row_number() OVER (ORDER BY md5(CURRENT_DATE::text || id::text)) - 1) AS pos
+    FROM public.daily_puzzles
+    WHERE id NOT IN (SELECT puzzle_id FROM public.daily_puzzle_schedule WHERE scheduled_date = CURRENT_DATE)
+  ) t
+  WHERE t.pos = (p_position % NULLIF(public._arcade_ladder_size(), 0));
+$fn$;
+
+CREATE OR REPLACE FUNCTION public.arcade_next()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_next UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_next: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_next: no run'; END IF;
+  IF r.state IN ('solved', 'busted') THEN
+    v_next := public._arcade_puzzle_at(r.position + 1);
+    UPDATE public.arcade_runs SET position = position + 1, puzzle_id = v_next, bankroll = 1000,
+      guesses_remaining = 3, revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}',
+      last_gain = 0, last_earn = NULL, state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_next() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_use_powerup(p_powerup TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_have INT; v_phrase TEXT; v_letter TEXT;
+  v_positions INT[]; v_next UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_use_powerup: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_use_powerup: no run'; END IF;
+  IF r.state <> 'active' THEN RETURN public._arcade_response(v_uid); END IF;
+  v_have := COALESCE((r.inventory ->> p_powerup)::int, 0);
+  IF v_have <= 0 THEN RETURN public._arcade_response(v_uid); END IF;
+  IF p_powerup IN ('discount','vowel_vision','insurance','double_payout','shield')
+     AND p_powerup = ANY(r.active_powerups) THEN
+    RETURN public._arcade_response(v_uid);
+  END IF;
+  r.inventory := jsonb_set(r.inventory, ARRAY[p_powerup], to_jsonb(v_have - 1), true);
+
+  IF p_powerup = 'extra_bank' THEN
+    r.bankroll := r.bankroll + 250;
+  ELSIF p_powerup = 'multiplier_boost' THEN
+    r.multiplier_x100 := LEAST(r.multiplier_x100 + 50, 500);
+  ELSIF p_powerup = 'extra_try' THEN
+    r.guesses_remaining := r.guesses_remaining + 1;
+  ELSIF p_powerup IN ('discount','vowel_vision','insurance','double_payout','shield') THEN
+    r.active_powerups := r.active_powerups || p_powerup;
+  ELSIF p_powerup = 'free_reveal' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+    SELECT t.ch INTO v_letter FROM (
+      SELECT substr(v_phrase, g.i + 1, 1) AS ch, count(*) AS c
+      FROM generate_series(0, length(v_phrase) - 1) g(i)
+      WHERE substr(v_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions))
+      GROUP BY substr(v_phrase, g.i + 1, 1) ORDER BY c DESC, ch LIMIT 1) t;
+    IF v_letter IS NOT NULL THEN
+      SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase) - 1) g(i)
+      WHERE substr(v_phrase, g.i + 1, 1) = v_letter;
+      r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_positions) ORDER BY 1);
+    END IF;
+  ELSIF p_powerup = 'skip' THEN
+    v_next := public._arcade_puzzle_at(r.position + 1);
+    UPDATE public.arcade_runs SET position = position + 1, puzzle_id = v_next, bankroll = 1000,
+      guesses_remaining = 3, revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}',
+      last_gain = 0, last_earn = NULL, inventory = r.inventory, state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+    RETURN public._arcade_response(v_uid);
+  ELSE
+    RETURN public._arcade_response(v_uid);
+  END IF;
+
+  UPDATE public.arcade_runs SET bankroll = r.bankroll, multiplier_x100 = r.multiplier_x100,
+    guesses_remaining = r.guesses_remaining, active_powerups = r.active_powerups,
+    revealed_positions = r.revealed_positions, inventory = r.inventory, updated_at = NOW()
+  WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_resolve(v_uid);
+END;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_use_powerup(TEXT) TO authenticated;


### PR DESCRIPTION
The "29" was never a design choice — it's just the puzzle library (30) minus today's daily (`_arcade_ladder_size()`). With a big seed coming, this removes the hard cap so an arcade run keeps going: **how far you climb is the score.**

## Server (`supabase-arcade-gauntlet.sql`, applied to prod)
- `_arcade_puzzle_at` wraps the ladder (`position % size`) — the sequence loops once the library is exhausted instead of ending. Seeding more puzzles pushes the loop point far out.
- `arcade_next` and `arcade_use_powerup(skip)` always advance — the `complete` / "Gauntlet Cleared" state is gone.

## Client
- HUD shows just **`Puzzle N`** (no `/29`).
- Result modal: removed the Gauntlet Cleared branch + `arcadeComplete`; the solve line reads `Puzzle N · next ×M`.
- Leaderboard **Furthest** shows the rung count alone.
- Removed the orphaned `.ah-sub` style.

## Verify
- Impersonated SQL: a solve at rung 28 → `arcade_next` → **position 29**, puzzle **wraps to the first**, state **active**, multiplier kept — no `complete`.
- Playwright: HUD reads **`8 · ×2.50 · $4,200`**. `svelte-check` 0/0, build ✅.

Note: until the library grows, a run that gets ~30 deep will start seeing already-solved phrases (low risk — almost nobody reaches it). The big seed fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)