### PR TITLE
Make the in-game WordBank logo bigger

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1082,9 +1082,10 @@
 
   .game-logo {
     display: block;
-    width: min(44vw, 150px);
+    width: min(64vw, 230px);
     height: auto;
-    margin: 4px auto 14px;
+    margin: 6px auto 16px;
+    filter: drop-shadow(0 2px 12px rgba(0, 0, 0, 0.5));
   }
 
   .logo-container {


### PR DESCRIPTION
Bumped the gameplay-screen wordmark (`.game-logo`) from `min(44vw, 150px)` to `min(64vw, 230px)` with a soft drop-shadow so it reads clearly above the HUD.

`svelte-check` 0/0, build ✅. Screenshot confirms the larger logo.