### PR TITLE
Wire in puzzle clues + reseed (Movies & TV)

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,7 +3,7 @@
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
-import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup } from '$lib/stores/statsStore.js';
 
 /* ================================
@@ -34,7 +34,8 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
  *   gameMode: string,
  *   freeReveals?: number,
  *   arcadeRun?: any,
- *   modifier?: string | null
+ *   modifier?: string | null,
+ *   clue?: string | null
  * }} GameState
  */
 
@@ -69,7 +70,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   gameMode: 'daily', // 'daily' | 'arcade'
   freeReveals: 0, // owned Free Reveal power-ups (daily)
   arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
-  modifier: null // today's shared Daily Modifier id (daily only)
+  modifier: null, // today's shared Daily Modifier id (daily only)
+  clue: null // witty one-line hint for the current puzzle
 }));
 
 /* ================================
@@ -248,12 +250,21 @@ async function submitGuessArcade(state) {
   }
 }
 
+/** Refresh the clue for the current arcade puzzle (changes each rung). */
+async function refreshArcadeClue() {
+  try {
+    const clue = await getArcadeClue();
+    gameStore.update(s => ({ ...s, clue }));
+  } catch { /* non-fatal */ }
+}
+
 /** Start or resume today's arcade gauntlet. */
 export async function fetchArcadeGame() {
   try {
     const resp = await arcadeStart();
     if (!resp) { console.error('❌ arcade_start returned nothing'); return false; }
     reconcileArcadeBoard(resp);
+    await refreshArcadeClue();
     return true;
   } catch (err) {
     console.error('❌ Error starting arcade:', err instanceof Error ? err.message : String(err));
@@ -267,7 +278,7 @@ export async function arcadeContinue() {
   dailyInFlight = true;
   try {
     const resp = await arcadeNext();
-    if (resp) reconcileArcadeBoard(resp);
+    if (resp) { reconcileArcadeBoard(resp); await refreshArcadeClue(); }
   } finally {
     dailyInFlight = false;
   }
@@ -531,8 +542,8 @@ export async function fetchDailyGame() {
     reconcileDailyBoard(board);
     // Today's shared modifier (same for everyone) — drives the banner + key pricing.
     try {
-      const mod = await getDailyModifier();
-      gameStore.update(s => ({ ...s, modifier: mod }));
+      const [mod, clue] = await Promise.all([getDailyModifier(), getDailyClue()]);
+      gameStore.update(s => ({ ...s, modifier: mod, clue }));
     } catch { /* non-fatal */ }
     console.log('✅ Daily session started/resumed');
     return true;

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -74,6 +74,20 @@ export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score')
   return data ?? [];
 }
 
+/** Witty clue for the caller's current daily puzzle. @returns {Promise<string|null>} */
+export async function getDailyClue() {
+  const { data, error } = await supabase.rpc('daily_clue');
+  if (error) { console.error('❌ daily_clue error:', error); return null; }
+  return data ?? null;
+}
+
+/** Witty clue for the caller's current arcade puzzle. @returns {Promise<string|null>} */
+export async function getArcadeClue() {
+  const { data, error } = await supabase.rpc('arcade_clue');
+  if (error) { console.error('❌ arcade_clue error:', error); return null; }
+  return data ?? null;
+}
+
 /**
  * Today's shared Daily Modifier id (same for every player; rotates by date).
  * @returns {Promise<string|null>}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -533,11 +533,13 @@
       </div>
     {/if}
 
-    <!-- 🌍 Category Display -->
+    <!-- 🌍 Category + witty clue -->
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
-      {#if $gameStore.subcategory}<span class="subcat-chip">{$gameStore.subcategory}</span>{/if}
     </div>
+    {#if $gameStore.clue}
+      <p class="puzzle-clue">{$gameStore.clue}</p>
+    {/if}
 
     <!-- ✨ Today's shared Daily Modifier (same for every player) -->
     {#if dailyMod}
@@ -724,13 +726,15 @@
     padding: 6px 13px;
     border-radius: var(--r-pill);
   }
-  .subcat-chip {
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    background: var(--surface);
-    border: 1px solid var(--border);
-    padding: 6px 13px;
-    border-radius: var(--r-pill);
+  .puzzle-clue {
+    max-width: 340px;
+    margin: 10px auto 18px;
+    font-family: var(--font-ui);
+    font-size: 0.98rem;
+    font-style: italic;
+    line-height: 1.4;
+    color: var(--text);
+    text-wrap: balance;
   }
 
   .daily-modifier {

--- a/supabase-clues.sql
+++ b/supabase-clues.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- Puzzle clues: a witty one-line hint shown during play (the daily_puzzles.clue
+-- column). These RPCs return the clue for the caller's CURRENT puzzle only —
+-- SECURITY DEFINER + auth.uid(), and the clue never reveals the answer.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.daily_clue()
+RETURNS TEXT LANGUAGE sql SECURITY DEFINER AS $fn$
+  SELECT dp.clue FROM public.daily_sessions s
+  JOIN public.daily_puzzles dp ON dp.id = s.puzzle_id
+  WHERE s.user_id = auth.uid() AND s.puzzle_date = CURRENT_DATE;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.daily_clue() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_clue()
+RETURNS TEXT LANGUAGE sql SECURITY DEFINER AS $fn$
+  SELECT dp.clue FROM public.arcade_runs r
+  JOIN public.daily_puzzles dp ON dp.id = r.puzzle_id
+  WHERE r.user_id = auth.uid() AND r.run_date = CURRENT_DATE;
+$fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_clue() TO authenticated;

--- a/supabase-puzzles-seed.sql
+++ b/supabase-puzzles-seed.sql
@@ -1,0 +1,70 @@
+-- ============================================================
+-- WordBank puzzle library (fresh start). Each puzzle: phrase + category +
+-- subcategory + a witty one-line clue (the in-game hint).
+--
+-- The database was wiped to start over. To re-wipe before reseeding:
+--   DELETE FROM public.daily_puzzle_schedule;
+--   DELETE FROM public.arcade_runs;
+--   DELETE FROM public.daily_sessions;
+--   DELETE FROM public.daily_puzzles;
+-- (game_results / profiles have no puzzle FK and are preserved.)
+--
+-- Categories (12): Movies & TV, Music, Famous People, Food & Drink,
+-- Places & Travel, Sports, Phrases & Sayings, Science & Nature,
+-- Books & Characters, Video Games, Brands & Logos, Tech & Internet.
+-- ============================================================
+
+ALTER TABLE public.daily_puzzles ADD COLUMN IF NOT EXISTS clue TEXT;
+
+-- ---- Movies & TV (50) -------------------------------------------------------
+INSERT INTO public.daily_puzzles (phrase, category, subcategory, clue) VALUES
+('Pulp Fiction','Movies & TV 🎬','Crime','A hitman, a boxer, and a briefcase nobody should open.'),
+('The Big Lebowski','Movies & TV 🎬','Cult Comedy','A stolen rug, a kidnapping mix-up, and a guy who just wants to bowl.'),
+('Blade Runner','Movies & TV 🎬','Sci-Fi','Hunting rogue androids in a city that never stops raining.'),
+('There Will Be Blood','Movies & TV 🎬','Drama','An oilman gets rich and loses his soul, one milkshake at a time.'),
+('Jurassic Park','Movies & TV 🎬','Blockbuster','A rich guy clones dinosaurs; the dinosaurs have other plans.'),
+('The Shining','Movies & TV 🎬','Horror','All work and no play makes this hotel extremely murdery.'),
+('Forrest Gump','Movies & TV 🎬','Drama','Life is a box of chocolates and this guy ate the whole sampler.'),
+('Fight Club','Movies & TV 🎬','Cult','The first rule is you do not talk about it. Whoops.'),
+('Groundhog Day','Movies & TV 🎬','Comedy','A grumpy weatherman relives the same awful day on a loop.'),
+('Mean Girls','Movies & TV 🎬','Comedy','A burn book, a new girl, and on Wednesdays we wear pink.'),
+('The Matrix','Movies & TV 🎬','Sci-Fi','Red pill, blue pill, and a whole lot of dodging bullets.'),
+('Home Alone','Movies & TV 🎬','Holiday','A family forgets their kid; two burglars regret everything.'),
+('Mrs Doubtfire','Movies & TV 🎬','Comedy','A dad in a wig and pearls just to babysit his own kids.'),
+('Kill Bill','Movies & TV 🎬','Action','A bride wakes from a coma with a very long revenge list.'),
+('No Country for Old Men','Movies & TV 🎬','Thriller','A briefcase of cash and a killer with a terrible haircut.'),
+('The Grand Budapest Hotel','Movies & TV 🎬','Comedy','A concierge, a stolen painting, and a lot of pink symmetry.'),
+('Get Out','Movies & TV 🎬','Horror','Meeting her parents has never been this terrifying.'),
+('La La Land','Movies & TV 🎬','Musical','Jazz, big dreams, and a bittersweet dance under city stars.'),
+('Black Swan','Movies & TV 🎬','Drama','A ballerina slowly loses her mind chasing the perfect role.'),
+('Parasite','Movies & TV 🎬','Thriller','One broke family schemes its way into a very rich basement.'),
+('Toy Story','Movies & TV 🎬','Animated','What your toys actually get up to the second you leave.'),
+('The Lion King','Movies & TV 🎬','Animated','A prince cub, a wise father, and one very treacherous uncle.'),
+('Shrek','Movies & TV 🎬','Animated','An ogre, a chatty donkey, and a swamp that needs its privacy.'),
+('Finding Nemo','Movies & TV 🎬','Animated','A nervous dad fish crosses an ocean to find his lost son.'),
+('Back to the Future','Movies & TV 🎬','Sci-Fi','A DeLorean, 88 miles per hour, and an awkward run-in with mom.'),
+('Top Gun','Movies & TV 🎬','Action','The need for speed, mirrored aviators, and beach volleyball.'),
+('The Silence of the Lambs','Movies & TV 🎬','Thriller','A rookie agent trades clues with a cannibal to catch a killer.'),
+('Goodfellas','Movies & TV 🎬','Crime','As far back as he can remember, he always wanted to be a gangster.'),
+('The Departed','Movies & TV 🎬','Crime','A cop and a crook quietly swap sides inside the Boston mob.'),
+('Inception','Movies & TV 🎬','Sci-Fi','A heist inside a dream, inside a dream, inside a dream.'),
+('Django Unchained','Movies & TV 🎬','Western','A freed gunslinger shoots his way to rescue his wife.'),
+('The Truman Show','Movies & TV 🎬','Drama','His entire life is a TV set, and he is the last to know.'),
+('Donnie Darko','Movies & TV 🎬','Cult','A troubled teen, a doomsday countdown, and a very creepy rabbit.'),
+('Requiem for a Dream','Movies & TV 🎬','Drama','Four big dreams spiral into one brutal, unforgettable crash.'),
+('Napoleon Dynamite','Movies & TV 🎬','Comedy','Tater tots, llamas, and the best worst dance moves in Idaho.'),
+('Breaking Bad','Movies & TV 🎬','Drama','A mild chemistry teacher cooks up a very illegal retirement plan.'),
+('The Office','Movies & TV 🎬','Comedy','A paper company, a clueless boss, and a documentary nobody wanted.'),
+('Stranger Things','Movies & TV 🎬','Sci-Fi','Small-town kids, a missing boy, and a monster from the Upside Down.'),
+('Game of Thrones','Movies & TV 🎬','Fantasy','Dragons, betrayal, and a pointy chair nobody should sit in.'),
+('The Sopranos','Movies & TV 🎬','Drama','A mob boss spills all his secrets to a very patient therapist.'),
+('Friends','Movies & TV 🎬','Comedy','Six pals, one couch, and a coffee shop they never seem to pay for.'),
+('The Wire','Movies & TV 🎬','Drama','Cops and dealers in Baltimore, told from every angle.'),
+('Mad Men','Movies & TV 🎬','Drama','Cigarettes, secrets, and selling the American dream in the sixties.'),
+('Better Call Saul','Movies & TV 🎬','Drama','Before he was a shady lawyer, he was just a guy named Jimmy.'),
+('Curb Your Enthusiasm','Movies & TV 🎬','Comedy','One man finds a brand-new way to ruin every social situation.'),
+('Twin Peaks','Movies & TV 🎬','Mystery','Who killed Laura Palmer? Also, that is some damn fine coffee.'),
+('Black Mirror','Movies & TV 🎬','Sci-Fi','Technology, but make it your absolute worst nightmare.'),
+('Ted Lasso','Movies & TV 🎬','Comedy','An American coaches British soccer on pure relentless optimism.'),
+('Arrested Development','Movies & TV 🎬','Comedy','A wealthy family loses everything except their terrible decisions.'),
+('The Mandalorian','Movies & TV 🎬','Sci-Fi','A lone bounty hunter goes soft for a very small green boss.');


### PR DESCRIPTION
Makes the witty one-line **clue** the in-game hint, and starts the fresh puzzle library.

- **DB** — added `daily_puzzles.clue`; wiped the old library and seeded **Movies & TV (50)** with witty PG-13 clues (`supabase-puzzles-seed.sql`).
- **Server** — `daily_clue()` / `arcade_clue()` return the clue for the caller's current puzzle (SECURITY DEFINER + `auth.uid()`, never leaks the answer) — `supabase-clues.sql`.
- **Client** — `gameStore.clue` is fetched on daily/arcade load and on each arcade advance; shown as an italic hint line under the category chip. The thin subcategory chip is gone.

**Verify:** `svelte-check` 0/0, build ✅. Playwright: arcade renders "Movies & TV" + clue *"Meeting her parents has never been this terrifying."* above the masked phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)