### PR TITLE
Free Play mode + one puzzle per category

### DIFF
--- a/scripts/check-freeplay.mjs
+++ b/scripts/check-freeplay.mjs
@@ -1,0 +1,33 @@
+// Verify Free Play: menu card -> category grid -> pick category -> board + clue.
+import { chromium } from 'playwright';
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 } })).newPage();
+p.setDefaultTimeout(6000);
+const wait = (ms) => p.waitForTimeout(ms);
+const log = (...a) => console.log(...a);
+const errs = []; p.on('pageerror', e => errs.push(String(e)));
+try {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.fill('input[type=email]', EMAIL); await p.fill('input[type=password]', PASS);
+    await p.getByRole('button', { name: /log in/i }).first().click().catch(()=>{}); await wait(2600);
+  }
+  await p.getByRole('button', { name: /free play/i }).first().click().catch((e)=>log('freeplay click', e.message));
+  await wait(800);
+  log('category grid shown:', await p.locator('.cat-grid').count() > 0, ' tiles:', await p.locator('.cat-tile').count());
+  await p.screenshot({ path: 'screenshots/freeplay-cats.png' });
+  await p.locator('.cat-tile', { hasText: 'Movies & TV' }).first().click().catch(()=>{}); await wait(2600);
+  log('board keys:', await p.locator('.key').count());
+  log('clue:', await p.locator('.puzzle-clue').innerText().catch(()=>'—'));
+  log('category chip:', await p.locator('.category-chip').innerText().catch(()=>'—'));
+  await p.screenshot({ path: 'screenshots/freeplay-board.png' });
+  // Buy a couple letters to confirm it plays
+  for (const L of ['E','A']) {
+    await p.locator(`.key:has(.letter:text-is("${L}"))`).first().click({ force: true }).catch(()=>{}); await wait(250);
+    await p.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch(()=>{}); await wait(900);
+  }
+  log('played 2 letters ok, errors:', errs.length, errs.slice(0,3));
+} catch (e) { log('FATAL', e.message); } finally { await b.close(); log('done'); }

--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -1,0 +1,17 @@
+// The 12 puzzle categories. `value` is the exact string stored on
+// daily_puzzles.category (emoji included) and passed to freeplay_start.
+/** @type {{ value: string, label: string, emoji: string }[]} */
+export const CATEGORIES = [
+  { value: 'Movies & TV 🎬',        label: 'Movies & TV',       emoji: '🎬' },
+  { value: 'Music 🎵',             label: 'Music',             emoji: '🎵' },
+  { value: 'Famous People 🌟',     label: 'Famous People',     emoji: '🌟' },
+  { value: 'Food & Drink 🍔',      label: 'Food & Drink',      emoji: '🍔' },
+  { value: 'Places & Travel ✈️',   label: 'Places & Travel',   emoji: '✈️' },
+  { value: 'Sports 🏆',            label: 'Sports',            emoji: '🏆' },
+  { value: 'Phrases & Sayings 🗣️', label: 'Phrases & Sayings', emoji: '🗣️' },
+  { value: 'Science & Nature 🔬',  label: 'Science & Nature',  emoji: '🔬' },
+  { value: 'Books & Characters 📚', label: 'Books & Characters', emoji: '📚' },
+  { value: 'Video Games 🎮',       label: 'Video Games',       emoji: '🎮' },
+  { value: 'Brands & Logos 🏷️',    label: 'Brands & Logos',    emoji: '🏷️' },
+  { value: 'Tech & Internet 💻',   label: 'Tech & Internet',   emoji: '💻' }
+];

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -5,6 +5,7 @@ import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
 import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup } from '$lib/stores/statsStore.js';
+import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 
 /* ================================
    Types (JSDoc for checkJs)
@@ -284,6 +285,89 @@ export async function arcadeContinue() {
   }
 }
 
+/* ===== Free Play (unranked, category-picked, endless) ===== */
+
+/** @param {any} board */
+function reconcileFreeplayBoard(board) {
+  if (!board) return;
+  const prev = get(gameStore);
+  const finished = board.state !== 'active';
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(board, prev),
+    gameMode: 'freeplay',
+    gameState: finished ? board.state : 'default',
+    modifier: null, arcadeRun: null
+  }));
+  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
+  else if (finished) fx('bust');
+  else playMoveCue(prev, board);
+}
+
+async function refreshFreeplayClue() {
+  try {
+    const clue = await getFreeplayClue();
+    gameStore.update(s => ({ ...s, clue }));
+  } catch { /* non-fatal */ }
+}
+
+/** Start Free Play in a category (random puzzle from it). @param {string} category */
+export async function fetchFreeplayGame(category) {
+  try {
+    const board = await freeplayStart(category);
+    if (!board) { console.error('❌ freeplay_start returned nothing'); return false; }
+    reconcileFreeplayBoard(board);
+    await refreshFreeplayClue();
+    return true;
+  } catch (err) {
+    console.error('❌ Error starting free play:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/** Next free-play puzzle in the same category. */
+export async function freeplayContinue() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const board = await freeplayNext();
+    if (board) { reconcileFreeplayBoard(board); await refreshFreeplayClue(); }
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** @param {GameState} state */
+async function confirmPurchaseFreeplay(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    let board = null;
+    if (purchase.type === 'letter') board = await freeplayBuyLetter(purchase.value ?? '');
+    else if (purchase.type === 'hint') board = await freeplayReveal();
+    if (board) reconcileFreeplayBoard(board);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** @param {GameState} state */
+async function submitGuessFreeplay(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+  dailyInFlight = true;
+  try {
+    const board = await freeplaySubmitGuess(guess);
+    if (board) reconcileFreeplayBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
 /** Spend an earned power-up during the current arcade run. @param {string} powerup */
 export async function useArcadePowerup(powerup) {
   if (dailyInFlight) return;
@@ -418,10 +502,11 @@ export function selectHint() {
  * Handles purchase of a letter or hint and updates game state.
  */
 export function confirmPurchase() {
-  // Daily & arcade are both server-authoritative: commit via RPC and reconcile.
+  // All modes are server-authoritative: commit via RPC and reconcile.
   const current = get(gameStore);
   if (current.gameMode === 'daily') confirmPurchaseDaily(current);
   else if (current.gameMode === 'arcade') confirmPurchaseArcade(current);
+  else if (current.gameMode === 'freeplay') confirmPurchaseFreeplay(current);
 }
 /* ================================
    Guess Mode Functions
@@ -517,10 +602,11 @@ export function deleteGuessLetter() {
  * Routes the full guess to the server (daily or arcade), which validates and scores.
  */
 export function submitGuess() {
-  // Daily & arcade are both server-authoritative: the server validates + scores.
+  // All modes are server-authoritative: the server validates + scores.
   const current = get(gameStore);
   if (current.gameMode === 'daily') submitGuessDaily(current);
   else if (current.gameMode === 'arcade') submitGuessArcade(current);
+  else if (current.gameMode === 'freeplay') submitGuessFreeplay(current);
 }
 /* ================================
    Puzzle Fetch Functions

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -74,6 +74,44 @@ export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score')
   return data ?? [];
 }
 
+/* ===== Free Play (unranked, pick-a-category) — return a masked board ===== */
+/** @param {string} category @returns {Promise<object|null>} */
+export async function freeplayStart(category) {
+  const { data, error } = await supabase.rpc('freeplay_start', { p_category: category });
+  if (error) { console.error('❌ freeplay_start error:', error); return null; }
+  return data;
+}
+/** @returns {Promise<object|null>} */
+export async function freeplayNext() {
+  const { data, error } = await supabase.rpc('freeplay_next');
+  if (error) { console.error('❌ freeplay_next error:', error); return null; }
+  return data;
+}
+/** @param {string} letter @returns {Promise<object|null>} */
+export async function freeplayBuyLetter(letter) {
+  const { data, error } = await supabase.rpc('freeplay_buy_letter', { p_letter: letter });
+  if (error) { console.error('❌ freeplay_buy_letter error:', error); return null; }
+  return data;
+}
+/** @returns {Promise<object|null>} */
+export async function freeplayReveal() {
+  const { data, error } = await supabase.rpc('freeplay_reveal');
+  if (error) { console.error('❌ freeplay_reveal error:', error); return null; }
+  return data;
+}
+/** @param {Record<string,string>} guess @returns {Promise<object|null>} */
+export async function freeplaySubmitGuess(guess) {
+  const { data, error } = await supabase.rpc('freeplay_submit_guess', { p_guess: guess });
+  if (error) { console.error('❌ freeplay_submit_guess error:', error); return null; }
+  return data;
+}
+/** @returns {Promise<string|null>} */
+export async function getFreeplayClue() {
+  const { data, error } = await supabase.rpc('freeplay_clue');
+  if (error) { console.error('❌ freeplay_clue error:', error); return null; }
+  return data ?? null;
+}
+
 /** Witty clue for the caller's current daily puzzle. @returns {Promise<string|null>} */
 export async function getDailyClue() {
   const { data, error } = await supabase.rpc('daily_clue');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,8 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue } from '$lib/stores/GameStore.js';
+  import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
   import { hasPlayedDailyToday, getUserBadges, getDailyStatus, getDailyGhost } from '$lib/stores/statsStore.js';
   import { BADGES, badgeInfo } from '$lib/badges.js';
@@ -123,6 +124,9 @@
       fetchArcadeGame().then((ok) => {
         if (!ok) initError = "Arcade failed to load.";
       });
+    } else if (gameMode === 'freeplay') {
+      // Free Play isn't deep-link restorable — send back to the menu to re-pick.
+      showMainMenu = true;
     } else {
       fetchDailyGame().then((ok) => {
         if (!ok) initError = "Daily puzzle failed to load.";
@@ -169,6 +173,7 @@
   }
   $: resultWon = $gameStore.gameState === 'won';
   $: isDailyResult = $gameStore.gameMode === 'daily';
+  $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
   $: resultMedal = medalFor(resultBankroll, resultWon);
   // Arcade gauntlet run state
@@ -286,6 +291,31 @@
     showResultModal = false;
     hasTriggeredModal = false;
     await arcadeContinue();
+  }
+
+  // ----- Free Play (unranked, pick a category) -----
+  let showCategorySelect = false;
+  function handleMenuFreeplay() {
+    if (!get(user)?.id) return;
+    showCategorySelect = true;
+  }
+  /** @param {string} category */
+  async function startFreeplay(category) {
+    showCategorySelect = false;
+    localStorage.setItem('gameMode', 'freeplay');
+    const ok = await fetchFreeplayGame(category);
+    if (ok) {
+      hasInitialized = true;
+      showMainMenu = false;
+    } else {
+      initError = 'Free Play failed to load.';
+    }
+  }
+  // After solving / going broke in Free Play, load the next puzzle in the category.
+  async function handleFreeplayContinue() {
+    showResultModal = false;
+    hasTriggeredModal = false;
+    await freeplayContinue();
   }
 
   function handleMenuLeaderboard() {
@@ -436,7 +466,15 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 2" on:click={handleMenuLeaderboard}>
+        <button class="menu-card" style="--i: 2" on:click={handleMenuFreeplay}>
+          <span class="mc-icon">🎲</span>
+          <span class="mc-body">
+            <span class="mc-title">Free Play</span>
+            <span class="mc-sub">Pick a category · unranked</span>
+          </span>
+          <span class="mc-arrow">→</span>
+        </button>
+        <button class="menu-card" style="--i: 3" on:click={handleMenuLeaderboard}>
           <span class="mc-icon">🏆</span>
           <span class="mc-body">
             <span class="mc-title">Leaderboard</span>
@@ -444,7 +482,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 3" on:click={handleMenuMyAccount}>
+        <button class="menu-card" style="--i: 4" on:click={handleMenuMyAccount}>
           <span class="mc-icon">👤</span>
           <span class="mc-body">
             <span class="mc-title">My Account</span>
@@ -454,6 +492,26 @@
         </button>
       </div>
     </div>
+
+    <!-- Free Play: category picker -->
+    {#if showCategorySelect}
+      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a category">
+        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showCategorySelect = false}></button>
+        <div class="modal-content main-menu-modal cat-modal">
+          <button class="close-btn" on:click={() => showCategorySelect = false}>❌</button>
+          <h2>Free Play</h2>
+          <p class="cat-sub">Pick a category — solve as many as you like. Unranked.</p>
+          <div class="cat-grid">
+            {#each CATEGORIES as c}
+              <button class="cat-tile" on:click={() => startFreeplay(c.value)}>
+                <span class="cat-emoji">{c.emoji}</span>
+                <span class="cat-label">{c.label}</span>
+              </button>
+            {/each}
+          </div>
+        </div>
+      </div>
+    {/if}
 
     <!-- Streak message (when Daily is disabled and user taps it) -->
     {#if showStreakMessage}
@@ -627,6 +685,21 @@
             <div class="result-actions">
               <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
               <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
+            </div>
+          {:else if isFreeplay}
+            <!-- Free Play transition (unranked) -->
+            {#if resultWon}
+              <div class="result-medal">✅</div>
+              <h2>Solved!</h2>
+              <p class="result-sub">{$gameStore.currentPhrase}</p>
+            {:else}
+              <div class="result-medal">💸</div>
+              <h2>Out of Cash</h2>
+              <p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
+            {/if}
+            <div class="result-actions">
+              <button class="share-btn" on:click={() => { showResultModal = false; showCategorySelect = true; }}>Categories</button>
+              <button class="next-puzzle-button" on:click={handleFreeplayContinue}>Next</button>
             </div>
           {:else}
             <!-- Arcade Press-Your-Luck transition (endless — runs never "complete") -->
@@ -929,6 +1002,38 @@
   .main-menu-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
   .main-menu-modal { text-align: center; }
   .main-menu-modal .main-menu-btn { margin-top: 1rem; }
+
+  /* Free Play category picker */
+  .cat-modal { max-width: 420px; }
+  .cat-sub { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 16px; }
+  .cat-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+  .cat-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 14px 8px;
+    border-radius: var(--r-md, 14px);
+    background: var(--surface, rgba(255, 255, 255, 0.05));
+    border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+    color: var(--text);
+    cursor: pointer;
+    transition: transform 0.15s var(--ease-spring, ease), border-color 0.2s, background 0.2s;
+  }
+  .cat-tile:hover { transform: translateY(-2px); border-color: rgba(163, 230, 53, 0.5); background: var(--surface-2, rgba(255, 255, 255, 0.07)); }
+  .cat-tile:active { transform: scale(0.97); }
+  .cat-emoji { font-size: 1.6rem; line-height: 1; }
+  .cat-label {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-size: 0.82rem;
+    text-align: center;
+    line-height: 1.1;
+  }
 
   /* Streak + freeze chips (My Account) */
   .account-stats {

--- a/supabase-freeplay.sql
+++ b/supabase-freeplay.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- Free Play: pick a category and solve endless puzzles from it, unranked.
+-- Same masked-board economy ($1000, buy letters, reveal, 3 tries) as daily/
+-- arcade, but no banking, multiplier, streaks, or leaderboard. One session
+-- per user, replaced when a new category is started.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.freeplay_sessions (
+  user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  puzzle_id UUID NOT NULL REFERENCES public.daily_puzzles(id) ON DELETE CASCADE,
+  bankroll INT NOT NULL DEFAULT 1000,
+  guesses_remaining INT NOT NULL DEFAULT 3,
+  revealed_positions INT[] NOT NULL DEFAULT '{}',
+  incorrect_letters TEXT[] NOT NULL DEFAULT '{}',
+  state TEXT NOT NULL DEFAULT 'active',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE public.freeplay_sessions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "read own freeplay" ON public.freeplay_sessions;
+CREATE POLICY "read own freeplay" ON public.freeplay_sessions FOR SELECT USING (auth.uid() = user_id);
+REVOKE INSERT, UPDATE, DELETE ON public.freeplay_sessions FROM anon, authenticated;
+
+-- _freeplay_response / _freeplay_resolve / freeplay_start / freeplay_next /
+-- freeplay_buy_letter / freeplay_reveal / freeplay_submit_guess / freeplay_clue
+-- are defined in the daily/arcade style (masked board via _daily_board).
+-- See migration "freeplay_engine" for the full function bodies (applied to prod).

--- a/supabase-puzzles-seed.sql
+++ b/supabase-puzzles-seed.sql
@@ -68,3 +68,17 @@ INSERT INTO public.daily_puzzles (phrase, category, subcategory, clue) VALUES
 ('Ted Lasso','Movies & TV 🎬','Comedy','An American coaches British soccer on pure relentless optimism.'),
 ('Arrested Development','Movies & TV 🎬','Comedy','A wealthy family loses everything except their terrible decisions.'),
 ('The Mandalorian','Movies & TV 🎬','Sci-Fi','A lone bounty hunter goes soft for a very small green boss.');
+
+-- ---- One sample per remaining category (placeholders until each is filled to ~50)
+INSERT INTO public.daily_puzzles (phrase, category, subcategory, clue) VALUES
+('Bohemian Rhapsody','Music 🎵','Rock','Six minutes of opera, headbanging, and is this the real life?'),
+('Albert Einstein','Famous People 🌟','Science','Wild hair, wilder physics, and a tongue out for the camera.'),
+('Chicken Parmesan','Food & Drink 🍔','Italian','Breaded, fried, and smothered in sauce and cheese. Comfort on a plate.'),
+('The Eiffel Tower','Places & Travel ✈️','Landmarks','Parisians once hated this iron giant; now everyone proposes under it.'),
+('Hail Mary','Sports 🏆','Football','A desperate last-second heave and a prayer into the end zone.'),
+('Bite the Bullet','Phrases & Sayings 🗣️','Idioms','Grit your teeth and just get the painful thing over with.'),
+('The Solar System','Science & Nature 🔬','Space','Eight planets, one star, and a dwarf we all still feel bad about.'),
+('Sherlock Holmes','Books & Characters 📚','Mystery','A pipe, a violin, and a deduction that makes everyone feel slow.'),
+('Donkey Kong','Video Games 🎮','Retro','A barrel-tossing ape, a trapped girl, and a very determined plumber.'),
+('Coca Cola','Brands & Logos 🏷️','Drinks','A secret recipe, a red can, and the most famous fizz on Earth.'),
+('Artificial Intelligence','Tech & Internet 💻','Tech','Machines that learn, chat, and occasionally just make things up.');


### PR DESCRIPTION
New **Free Play** mode: pick a category, solve endless random puzzles from it, unranked (no banking/multiplier/streaks/leaderboard). Server engine mirrors the puzzle economy via a `freeplay_sessions` table; client adds a category picker + result flow. Also seeded one sample puzzle in each of the 11 non-Movies categories. svelte-check 0/0, build ✅, Playwright verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)