### PR TITLE
Arcade redesign Phase 1: rolling-bankroll survival + carry-over guesses

### DIFF
--- a/ARCADE_REDESIGN.md
+++ b/ARCADE_REDESIGN.md
@@ -1,14 +1,12 @@
 # Arcade Redesign — Rolling Bankroll + Earned Power-ups
 
-**Status:** 🔒 Design locked · build not started. Living doc — update the phase
+**Status:** 🔒 Design locked · Phase 1 in progress. Living doc — update phase
 checkboxes as we ship.
 
-The arcade moves from "per-puzzle reset + banked × multiplier, endless" to a
-**rolling-bankroll survival run**. Core idea: one bankroll that carries over;
-solving pays you; the run ends when you go broke. The whole economy rewards the
-brand — **Spend Less. Think More.**
-
-Daily and Free Play are mostly unaffected (see §5–6).
+Arcade moves from "per-puzzle reset + banked × multiplier, endless" to a
+**rolling-bankroll survival run**: one bankroll that carries over, solving pays
+you, and the run ends when you go broke. The whole economy rewards the brand —
+**Spend Less. Think More.** Daily and Free Play are barely touched (§5–6).
 
 ---
 
@@ -16,79 +14,83 @@ Daily and Free Play are mostly unaffected (see §5–6).
 - Start a run with **$1,500** (tunable). One bankroll, **carries over** between
   puzzles — unspent money is never reset.
 - **Solve payout = $500 × streak multiplier**, added to bankroll. Shown up front.
-- A **wrong guess** resets the streak multiplier to ×1 **and** costs one of your
-  3 guess attempts.
-- **Run ends** when you can't finish a puzzle (broke + out of guesses, unsolved).
-  Score = **peak bankroll** reached.
+- **Streak multiplier:** +0.25× per clean solve (cap ~×5). A **wrong guess
+  resets it to ×1**.
+- **Guess pool (carries over):** start a run with **5 guesses** for the whole
+  run. A **wrong** guess costs one *and* resets the streak; a **correct** guess
+  is free and unlimited. (Per-run, not per-puzzle.)
+- **Run ends** when you can't finish a puzzle — **broke AND out of guesses,
+  unsolved.** Score = **peak bankroll** reached.
 
 ## 2. Money economy — every way to earn
 | Source | Detail |
 |---|---|
 | Carryover | Unspent bankroll rolls over (saving = banking) |
 | Solve payout | **$500 × streak multiplier** per solve |
-| Streak multiplier | +0.25× per clean solve, cap ~×5; **reset to ×1 on a wrong guess** |
-| 💰 Hot Hand | **+$250** per **3 correct letters in a row** (resets on a dud / each puzzle; set below the cost of 3 letters so it's a rebate, not free money) |
+| 💰 Hot Hand | **+$250** per **3 correct letters in a row** (resets on a dud / each puzzle; below the cost of 3 letters so it's a rebate) |
 | 💎 Double Payout | power-up that doubles one solve's payout |
 
-## 3. Power-ups — 5, earned by **letters bought** (exactly one per solve, no overlap)
-Single-axis earn = a solve can only land in one bucket → impossible to double-earn.
-Accuracy is rewarded separately via the streak multiplier.
+## 3. Power-ups — 3 only, earned by special feats (MOST SOLVES EARN NOTHING)
+Power-ups are rare rewards for a standout solve — not a per-solve drop. An
+ordinary or messy solve earns nothing.
 
-| Letters bought | Earn | Effect | Type |
-|---|---|---|---|
-| **0** (blind solve) | ⚡ Multiplier Boost | +0.5× streak multiplier | instant |
-| **1–2** | 💎 Double Payout | 2× this puzzle's payout | armed |
-| **3–4** | 🎟️ Free Reveal | reveal the most useful letter, free | instant |
-| **5–6** | 🅰️ Vowel Reveal | reveal **all vowels**, free | instant |
-| **7+** | 🏷️ Discount | letters −50% this puzzle | armed |
+| Power-up | Effect | Earned by — the special move |
+|---|---|---|
+| ⚡ **Multiplier Boost** | +0.5× streak | **Blind Solve** — won buying **0 letters** (clue + guesses only) |
+| 💎 **Double Payout** | next solve pays 2× | **Consonant King** — clean solve buying **only consonants, no vowels** |
+| ❤️ **Extra Guess** | +1 to the guess pool (soft-capped) | **Hot Streak** — **3 solves in a row** with no wrong guess |
 
-**Cut:** Extra Try, Shield, Skip, Insurance, +$250 (now the Hot Hand mechanic),
-Vowel Vision (reworked into Vowel Reveal).
+**Definitions:**
+- **Blind** = no letter revealed by paying (no buy, no Reveal). Won on your guesses.
+- **Consonant King** = flawless (no dud buys, no wrong guesses) AND bought ≥1
+  letter AND zero vowels purchased.
+- **Hot Streak** = 3 consecutive solves with no wrong guess (duds OK); a wrong
+  guess resets the counter.
+- Otherwise → no power-up.
+
+**Cut:** Free Reveal, Vowel Reveal, Discount, Shield, Skip, Insurance, +$250
+(now Hot Hand), letters-bought buckets.
 
 ## 4. Infrastructure
 - **No cron.** Daily + arcade order are deterministic per date, picked lazily on
-  first access (already how it works).
-- **Arcade = daily-fresh shared gauntlet (model A):** same puzzle order for
-  everyone today, your own pace, resets automatically tomorrow.
+  first access.
+- **Arcade = daily-fresh shared gauntlet:** same order for everyone today, your
+  own pace, resets automatically tomorrow.
 - **Daily-pool recycle fallback:** when every puzzle has been used as a daily,
   reuse the oldest so the daily never runs dry.
 
-## 5. Daily — keep the shared modifier, refresh the vocab
-- One shared **Daily Modifier**, same for everyone, rotates by date. No earning,
-  no inventory (keeps the ranked daily fair).
-- Pool refreshed to effects that fit a single puzzle: 🏷️ Discount · 🅰️ Vowel
-  Reveal · 🎟️ Free Reveal · 💰 Big Bank (+$250 start). (Drop Double Payout /
-  Multiplier Boost — they need the arcade streak.)
+## 5. Daily — barely changed
+- **One guess** per daily (down from 3): deduce, narrow with letters, commit
+  once. Miss it and you can still win by revealing the rest (lower score).
+- Keep the existing **shared Daily Modifier** (one effect for all, rotates by
+  date: discount / vowels-half / +$250-start / first-wrong-free). No earning.
 
 ## 6. Free Play — no change
-Stays power-up-free; its progression is the category badges.
+Power-up-free; 3 guesses per puzzle; progression is the category badges.
 
 ## 7. UI
-- **Arcade HUD:** Bankroll · Streak ×N · "Solve for +$500 × N." Hot Hand combo
-  flashes when it pops.
-- **Power-up tray:** 5 items; armed ones show "ON."
+- **Arcade HUD:** Bankroll (big) · Puzzle N · Streak ×N · "Solve +$X." Hot Hand
+  combo flashes when it pops.
+- **Power-up tray:** 3 items; armed effects show "ON."
+- **Earned line:** on a qualifying solve, "Earned ⚡ Multiplier Boost — Blind
+  Solve!" (so players learn the feats).
 - **Run-over screen:** peak bankroll + puzzles solved → "New Run."
-- **Leaderboard:** rank arcade by **peak bankroll / furthest survived** (rename
-  from "best banked run").
+- **Leaderboard:** rank arcade by **peak bankroll / furthest survived**.
 
 ---
 
 ## Build phases
-- [ ] **Phase 1 — Rolling economy + run-end.** Server: arcade_runs rolling
-      bankroll (carryover, no reset), $500 × streak payout, streak reset on wrong
-      guess, run-over on broke. Client: reconcile + result/run-over flow.
-- [ ] **Phase 2 — Power-ups + Hot Hand.** Slim to 5; earn by letters-bought
-      spectrum; rework effects (Vowel Reveal, Multiplier Boost on streak, Double
-      Payout on payout, Discount, Free Reveal); Hot Hand +$250 combo.
-- [ ] **Phase 3 — UI.** HUD (bankroll/streak/payout + Hot Hand flash), 5-item
-      tray, run-over screen, leaderboard rename to peak bankroll/furthest.
-- [ ] **Phase 4 — Daily refresh + recycle.** Daily modifier pool update +
-      daily-pool recycle fallback.
+- [ ] **Phase 1 — Rolling economy + run-end + guess pool.** Server ✅ (rolling
+      bankroll, $500 × streak, run-over on broke, applied). Client ✅ (HUD,
+      run-over modal). TODO: carry-over guess pool (start 5) + daily 1-guess.
+- [ ] **Phase 2 — Earned power-ups + Hot Hand.** Solve counters (letters/vowels
+      bought, mistakes, won-by-guess, clean-streak); the 3 feat-based earns; Hot
+      Hand +$250 combo; trim tray to 3 + earned line.
+- [ ] **Phase 3 — UI polish.** HUD payout/streak, Hot Hand flash, run-over
+      screen, leaderboard rename to peak/furthest.
+- [ ] **Phase 4 — Daily-pool recycle fallback.**
 
 ## Tunable values (revisit in playtest)
-- Starting bankroll: **$1,500**
-- Solve payout base: **$500**
-- Streak step / cap: **+0.25× / ~×5**
-- Multiplier Boost step: **+0.5×**
-- Hot Hand: **+$250** per 3-correct-in-a-row
-- Discount: **−50%** · letter-count power-up buckets: **0 / 1–2 / 3–4 / 5–6 / 7+**
+- Starting bankroll **$1,500** · solve base **$500** · streak step/cap
+  **+0.25× / ×5** · Multiplier Boost **+0.5×** · Hot Hand **+$250** · guess pool
+  start **5** · Extra Guess **+1** (cap ~8) · daily guesses **1** · free-play **3**

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -196,10 +196,10 @@ function reconcileArcadeBoard(resp) {
   const prev = get(gameStore);
   const board = resp.board;
   const run = resp.run || {};
-  // Per-puzzle outcome drives gameState: solved/complete -> won, busted -> lost.
+  // Rolling-survival outcome: solved -> won (continue), over -> lost (run ends).
   let gs = 'default';
-  if (run.state === 'solved' || run.state === 'complete') gs = 'won';
-  else if (run.state === 'busted') gs = 'lost';
+  if (run.state === 'solved') gs = 'won';
+  else if (run.state === 'over') gs = 'lost';
   gameStore.set(/** @type {GameState} */ ({
     ...prev, ...boardToState(board, prev),
     gameMode: 'arcade',
@@ -208,11 +208,11 @@ function reconcileArcadeBoard(resp) {
     freeReveals: 0,
     modifier: null
   }));
-  if (run.state === 'solved' || run.state === 'complete') {
+  if (run.state === 'solved') {
     setTimeout(() => launchConfetti(), 300);
     fx('win');
     if ((run.last_gain || 0) > 0) setTimeout(() => fx('multiplier'), 240);
-  } else if (run.state === 'busted') {
+  } else if (run.state === 'over') {
     fx('bust');
   } else {
     playMoveCue(prev, board);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
   import { hasPlayedDailyToday, getDailyStatus, getDailyGhost } from '$lib/stores/statsStore.js';
-  import { powerupInfo, modifierInfo } from '$lib/powerups.js';
+  import { modifierInfo } from '$lib/powerups.js';
   import {
     saveGameToLocalStorage,
     clearSavedGame,
@@ -175,12 +175,10 @@
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
   $: resultMedal = medalFor(resultBankroll, resultWon);
-  // Arcade gauntlet run state
+  // Arcade rolling-survival run state
   $: arun = $gameStore.arcadeRun;
   $: arcadeMult = ((arun?.multiplier ?? 100) / 100).toFixed(2);
-  // Power-up earned on this solve, and whether a Shield saved a bust (multiplier kept).
-  $: arcadeEarn = (!isDailyResult && resultWon && arun?.last_earn) ? powerupInfo(arun.last_earn) : null;
-  $: arcadeShielded = (!isDailyResult && !resultWon && (arun?.multiplier ?? 100) > 100);
+  $: arcadePayout = Math.round(500 * (arun?.multiplier ?? 100) / 100); // next solve is worth this
 
   let shareCopied = false;
   function buildShareText() {
@@ -285,11 +283,18 @@
     }
   }
 
-  // After solving / busting a gauntlet puzzle, advance or retry.
+  // After solving, advance to the next puzzle (bankroll + streak carry over).
   async function handleArcadeContinue() {
     showResultModal = false;
     hasTriggeredModal = false;
     await arcadeContinue();
+  }
+
+  // After a run ends (broke), start a fresh run.
+  async function handleArcadeNewRun() {
+    showResultModal = false;
+    hasTriggeredModal = false;
+    await fetchArcadeGame();
   }
 
   // ----- Free Play (unranked, pick a category) -----
@@ -575,8 +580,8 @@
     {#if $gameStore.gameMode === 'arcade' && arun}
       <div class="arcade-hud">
         <div class="ah-cell"><span class="ah-val">{(arun.position ?? 0) + 1}</span><span class="ah-label">Puzzle</span></div>
-        <div class="ah-cell ah-mult"><span class="ah-val">×{arcadeMult}</span><span class="ah-label">Multiplier</span></div>
-        <div class="ah-cell"><span class="ah-val ah-gold">${(arun.banked ?? 0).toLocaleString()}</span><span class="ah-label">Banked</span></div>
+        <div class="ah-cell ah-mult"><span class="ah-val">×{arcadeMult}</span><span class="ah-label">Streak</span></div>
+        <div class="ah-cell"><span class="ah-val ah-gold">+${arcadePayout.toLocaleString()}</span><span class="ah-label">Solve</span></div>
       </div>
     {/if}
 
@@ -691,34 +696,29 @@
               <button class="next-puzzle-button" on:click={handleFreeplayContinue}>Next</button>
             </div>
           {:else}
-            <!-- Arcade Press-Your-Luck transition (endless — runs never "complete") -->
+            <!-- Arcade rolling-bankroll survival -->
             {#if resultWon}
               <div class="result-medal">✅</div>
-              <h2>Solved!</h2>
-              <p class="result-sub">Puzzle {(arun?.position ?? 0) + 1} · next ×{arcadeMult}</p>
-            {:else if arcadeShielded}
-              <div class="result-medal">🔰</div>
-              <h2>Busted</h2>
-              <p class="result-sub">Shield saved your ×{arcadeMult}! — on to the next puzzle</p>
+              <h2>Solved! +${(arun?.last_gain ?? 0).toLocaleString()}</h2>
+              <p class="result-sub">Bankroll ${resultBankroll.toLocaleString()} · streak ×{arcadeMult}</p>
+              <div class="result-actions">
+                <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
+                <button class="next-puzzle-button" on:click={handleArcadeContinue}>Continue</button>
+              </div>
             {:else}
-              <div class="result-medal">💥</div>
-              <h2>Busted</h2>
-              <p class="result-sub">Multiplier reset to ×1 — on to the next puzzle</p>
+              <div class="result-medal">🏁</div>
+              <h2>Run Over</h2>
+              <p class="result-sub">You ran out of cash.</p>
+              <div class="result-bankroll">
+                <span class="rb-label">Peak Bankroll</span>
+                <span class="rb-amount">${(arun?.banked ?? 0).toLocaleString()}</span>
+              </div>
+              <p class="arcade-gain">{arun?.furthest ?? 0} {(arun?.furthest ?? 0) === 1 ? 'puzzle' : 'puzzles'} solved</p>
+              <div class="result-actions">
+                <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
+                <button class="next-puzzle-button" on:click={handleArcadeNewRun}>New Run</button>
+              </div>
             {/if}
-            <div class="result-bankroll">
-              <span class="rb-label">Total Banked</span>
-              <span class="rb-amount">${(arun?.banked ?? 0).toLocaleString()}</span>
-            </div>
-            {#if resultWon && (arun?.last_gain ?? 0) > 0}
-              <p class="arcade-gain">+${(arun?.last_gain ?? 0).toLocaleString()} this puzzle</p>
-            {/if}
-            {#if arcadeEarn}
-              <p class="arcade-earn">Earned {arcadeEarn.emoji} {arcadeEarn.name}!</p>
-            {/if}
-            <div class="result-actions">
-              <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
-              <button class="next-puzzle-button" on:click={handleArcadeContinue}>{resultWon ? 'Continue' : 'Next Puzzle'}</button>
-            </div>
           {/if}
         </div>
       </div>

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -571,3 +571,120 @@ BEGIN
 END;
 $fn$;
 GRANT EXECUTE ON FUNCTION public.arcade_use_powerup(TEXT) TO authenticated;
+
+-- ============================================================
+-- REDESIGN Phase 1: rolling-bankroll survival (supersedes the gauntlet economy
+-- above). bankroll = rolling balance (carries over), multiplier_x100 = streak,
+-- banked = PEAK bankroll, guesses_remaining = run-level pool (start 5, carries).
+-- Solve pays $500 × streak; wrong guess resets streak; run ends broke + no
+-- guesses. Power-up earning is removed here (Phase 2 re-adds the 3 feat-based
+-- earns); the category-solve badge hook stays.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._arcade_resolve(p_uid UUID)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE r public.arcade_runs; v_phrase TEXT; v_cat TEXT; v_won BOOLEAN; v_payout INT; v_min_needed INT;
+BEGIN
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+  IF r.state <> 'active' THEN RETURN public._arcade_response(p_uid); END IF;  -- never re-resolve
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  v_won := NOT EXISTS (
+    SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions)));
+  IF v_won THEN
+    v_payout := ROUND(500 * r.multiplier_x100 / 100.0)::INT;
+    UPDATE public.arcade_runs SET state = 'solved', bankroll = r.bankroll + v_payout,
+      banked = GREATEST(r.banked, r.bankroll + v_payout), last_gain = v_payout,
+      multiplier_x100 = LEAST(r.multiplier_x100 + 25, 500), furthest = GREATEST(r.furthest, r.position + 1), updated_at = NOW()
+    WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+    PERFORM public._record_category_solve(p_uid, v_cat);
+  ELSE
+    SELECT min(public.letter_cost(t.ch)) INTO v_min_needed FROM (
+      SELECT DISTINCT substr(v_phrase, g.i+1, 1) AS ch
+      FROM generate_series(0, length(v_phrase)-1) g(i)
+      WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions))
+    ) t;
+    IF r.guesses_remaining <= 0 AND (v_min_needed IS NULL OR r.bankroll < v_min_needed) THEN
+      UPDATE public.arcade_runs SET state = 'over', last_gain = 0, updated_at = NOW()
+      WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+    END IF;
+  END IF;
+  RETURN public._arcade_response(p_uid);
+END; $fn$;
+
+CREATE OR REPLACE FUNCTION public.arcade_start()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_start: not authenticated'; END IF;
+  PERFORM public._todays_puzzle_id();
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    v_pid := public._arcade_puzzle_at(0);
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'arcade_start: no puzzles available'; END IF;
+    INSERT INTO public.arcade_runs (user_id, run_date, position, puzzle_id, bankroll, banked, multiplier_x100, guesses_remaining, furthest, last_gain, state)
+    VALUES (v_uid, CURRENT_DATE, 0, v_pid, 1500, 1500, 100, 5, 0, 0, 'active');
+  ELSIF r.state = 'over' THEN
+    v_pid := public._arcade_puzzle_at(0);
+    UPDATE public.arcade_runs SET position = 0, puzzle_id = v_pid, bankroll = 1500, multiplier_x100 = 100,
+      guesses_remaining = 5, last_gain = 0, revealed_positions = '{}', incorrect_letters = '{}',
+      active_powerups = '{}', inventory = '{}', last_earn = NULL, state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;  -- banked + furthest kept (day bests)
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_start() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_submit_guess(p_guess JSONB)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_phrase TEXT;
+  v_editable INT[]; v_correct INT[] := '{}'; v_all_correct BOOLEAN := true; pos INT; v_guess_char TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_submit_guess: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_submit_guess: no run'; END IF;
+  IF r.state <> 'active' OR r.guesses_remaining <= 0 THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+  WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable, 1) THEN
+    RETURN public._arcade_response(v_uid);
+  END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_guess_char := upper(p_guess ->> pos::text);
+    IF v_guess_char IS NULL THEN v_all_correct := false;
+    ELSIF v_guess_char = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all_correct := false; END IF;
+  END LOOP;
+  IF array_length(v_correct, 1) > 0 THEN
+    r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_correct) ORDER BY 1);
+  END IF;
+  IF NOT v_all_correct THEN
+    r.guesses_remaining := GREATEST(0, r.guesses_remaining - 1);
+    r.multiplier_x100 := 100;  -- wrong guess resets the streak
+  END IF;
+  UPDATE public.arcade_runs SET revealed_positions = r.revealed_positions,
+    guesses_remaining = r.guesses_remaining, multiplier_x100 = r.multiplier_x100, updated_at = NOW()
+  WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_resolve(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_submit_guess(JSONB) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_next()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_next UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_next: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_next: no run'; END IF;
+  IF r.state = 'solved' THEN
+    -- Bankroll, streak multiplier AND guess pool carry over (no reset).
+    v_next := public._arcade_puzzle_at(r.position + 1);
+    UPDATE public.arcade_runs SET position = position + 1, puzzle_id = v_next,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}',
+      last_gain = 0, last_earn = NULL, state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_next() TO authenticated;

--- a/supabase-daily-modifier.sql
+++ b/supabase-daily-modifier.sql
@@ -43,7 +43,7 @@ BEGIN
     v_mod := public._daily_modifier();
     IF v_mod = 'extra_bank' THEN v_bonus := 250; END IF;
     INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining, active_powerups)
-    VALUES (v_uid, CURRENT_DATE, v_pid, 1000 + v_bonus, 3, ARRAY[v_mod])
+    VALUES (v_uid, CURRENT_DATE, v_pid, 1000 + v_bonus, 1, ARRAY[v_mod])  -- daily = one guess
     RETURNING * INTO s;
   END IF;
   SELECT upper(phrase), category, COALESCE(subcategory, '')


### PR DESCRIPTION
First phase of the arcade redesign (spec in `ARCADE_REDESIGN.md`).

**Core loop → rolling-bankroll survival** (applied to prod):
- Start $1,500, bankroll **carries over** between puzzles. Solve pays **$500 × streak**.
- Streak multiplier +0.25×/clean solve (cap ×5); **wrong guess resets it to ×1**.
- `banked` repurposed as **peak bankroll** (leaderboard); kept across a New Run.
- **Guess pool is run-level**: start 5, carries over; wrong guess −1; correct free.
- Run ends (`over`) when **broke + out of guesses, unsolved**. `arcade_start` resets an over run.
- Power-up earning removed (Phase 2 re-adds the 3 feat-based earns); category-badge hook kept.
- **Daily → one guess.**

**Client:** reconcile (solved→continue / over→run-ends), HUD (Puzzle · Streak · Solve +$X), result modal (Solved → Continue / Run Over → New Run).

**Verify:** `svelte-check` 0/0, build ✅. SQL: $1500→$2000 on a ×1 solve; bankroll/streak/guesses carry on advance; run-over on broke+no-guesses. HUD reads `1 · ×1.00 · +$500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)