### PR TITLE
Arcade Phase 3 (UI polish) + Phase 4 (daily recycle)

### DIFF
--- a/ARCADE_REDESIGN.md
+++ b/ARCADE_REDESIGN.md
@@ -1,6 +1,6 @@
 # Arcade Redesign — Rolling Bankroll + Earned Power-ups
 
-**Status:** 🔒 Design locked · Phases 1–2 shipped. Living doc — update phase
+**Status:** 🔒 Design locked · Phases 1–4 shipped. Living doc — update phase
 checkboxes as we ship.
 
 Arcade moves from "per-puzzle reset + banked × multiplier, endless" to a
@@ -90,9 +90,13 @@ Power-up-free; 3 guesses per puzzle; progression is the category badges.
       +$250 per 3 correct letters in `arcade_buy_letter`; `arcade_use_powerup`
       reworked to the 3 effects; tray + `powerups.js` trimmed to 3; "Earned …"
       line in the solve modal.
-- [ ] **Phase 3 — UI polish.** HUD payout/streak, Hot Hand flash, run-over
-      screen, leaderboard rename to peak/furthest.
-- [ ] **Phase 4 — Daily-pool recycle fallback.**
+- [x] **Phase 3 — UI polish.** ✅ HUD payout/streak (Phase 1), Hot Hand flash
+      (`last_bonus` from the server → floating "🔥 Hot Hand +$250" over the
+      bankroll), run-over screen (Phase 1), arcade leaderboard relabelled to
+      Peak $ / Solved.
+- [x] **Phase 4 — Daily-pool recycle fallback.** ✅ `_todays_puzzle_id` prefers
+      an unused puzzle, then recycles the one used longest ago (least-recently
+      scheduled) so the daily never runs dry. Deterministic; arcade unaffected.
 
 ## Tunable values (revisit in playtest)
 - Starting bankroll **$1,500** · solve base **$500** · streak step/cap

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -160,6 +160,21 @@
     if (typeof b === 'number') _prevBankroll = b;
   }
 
+  // 🔥 Hot Hand flash — +$250 per 3 correct letters in a row (arcade). The
+  // server sends last_bonus on the buy that pops it; flash only while playing.
+  let hotHandFlash = false;
+  let _prevBonus = 0;
+  $: {
+    const lb = $gameStore.arcadeRun?.last_bonus ?? 0;
+    const playing = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
+    if (lb > 0 && lb !== _prevBonus && playing) {
+      hotHandFlash = true;
+      fx('multiplier');
+      setTimeout(() => { hotHandFlash = false; }, 1300);
+    }
+    _prevBonus = lb;
+  }
+
   // ---- Daily result: medal + shareable card ----
   const PUZZLE_EPOCH = Date.UTC(2026, 5, 1); // 2026-06-01
   $: puzzleNumber = Math.max(1, Math.floor((Date.now() - PUZZLE_EPOCH) / 86400000) + 1);
@@ -614,6 +629,9 @@
         <div class="bankroll-box" class:pulse-up={bankrollPulse === 'up'} class:pulse-down={bankrollPulse === 'down'}>
           {#if bankrollPulse}
             <span class="bankroll-delta {bankrollPulse}">{bankrollDelta > 0 ? '+' : '−'}${Math.abs(bankrollDelta)}</span>
+          {/if}
+          {#if hotHandFlash}
+            <span class="hot-hand-flash">🔥 Hot Hand +$250</span>
           {/if}
           <span class="bankroll-label">Balance</span>
           <span class="bankroll-amount">
@@ -1136,6 +1154,33 @@
     0% { opacity: 0; transform: translateY(-8px); }
     25% { opacity: 1; }
     100% { opacity: 0; transform: translateY(24px); }
+  }
+  .hot-hand-flash {
+    position: absolute;
+    top: -14px;
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.9rem;
+    color: #fcd34d;
+    background: rgba(120, 53, 15, 0.85);
+    border: 1px solid rgba(251, 191, 36, 0.55);
+    border-radius: 999px;
+    padding: 4px 12px;
+    pointer-events: none;
+    text-shadow: 0 0 10px rgba(251, 191, 36, 0.6);
+    box-shadow: 0 0 18px rgba(251, 191, 36, 0.35);
+    animation: hotHandPop 1.3s var(--ease-out) forwards;
+    z-index: 5;
+  }
+  @keyframes hotHandPop {
+    0% { opacity: 0; transform: translateX(-50%) translateY(8px) scale(0.8); }
+    18% { opacity: 1; transform: translateX(-50%) translateY(0) scale(1.05); }
+    32% { transform: translateX(-50%) translateY(0) scale(1); }
+    80% { opacity: 1; }
+    100% { opacity: 0; transform: translateX(-50%) translateY(-22px) scale(1); }
   }
 
   .bankroll-label {

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -131,7 +131,7 @@
       <button class="sort-btn" class:active={dailyOrderBy === 'win_pct'} onclick={() => { dailyOrderBy = 'win_pct'; }}>Win %</button>
     </div>
   {:else}
-    <p class="period-label">{periodLabels[arcadePeriod] ?? 'Today'} · best run</p>
+    <p class="period-label">{periodLabels[arcadePeriod] ?? 'Today'} · peak bankroll</p>
     <div class="period-filters">
       {#each ['daily', 'weekly', 'monthly', 'all'] as p}
         <button class="period-btn" class:active={arcadePeriod === p} onclick={() => { arcadePeriod = p; }}>
@@ -197,8 +197,8 @@
             <tr>
               <th>#</th>
               <th>Player</th>
-              <th>Banked</th>
-              <th>Furthest</th>
+              <th>Peak $</th>
+              <th>Solved</th>
             </tr>
           </thead>
           <tbody>
@@ -225,7 +225,7 @@
     {#if mode === 'daily'}
       Daily: Score = bankroll × streak multiplier. Medals 🥇$700 / 🥈$400 / 🥉$100. 🔥 = 7+ day streak.
     {:else}
-      Arcade: your best banked run in the period (Press-Your-Luck gauntlet), and how far you climbed.
+      Arcade: ranked by peak bankroll in a survival run, and how many puzzles you solved before going broke.
     {/if}
   </p>
 </main>

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -915,3 +915,108 @@ BEGIN
   RETURN public._arcade_response(v_uid);
 END; $fn$;
 GRANT EXECUTE ON FUNCTION public.arcade_start() TO authenticated;
+
+-- ============================================================
+-- Arcade Phase 3: surface Hot Hand (+$250) for the client flash.
+-- last_bonus is written fresh on every letter buy (250 when Hot Hand pops, else
+-- 0) and cleared at each puzzle boundary. The client flashes only on a
+-- letter-buy response, and two Hot Hands can't land on back-to-back buys, so
+-- the value always changes (0↔250) between pops — no stale flashes.
+-- ============================================================
+ALTER TABLE public.arcade_runs ADD COLUMN IF NOT EXISTS last_bonus INT NOT NULL DEFAULT 0;
+
+CREATE OR REPLACE FUNCTION public._arcade_response(p_uid UUID)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE r public.arcade_runs; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_bstate TEXT;
+BEGIN
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = p_uid AND run_date = CURRENT_DATE;
+  SELECT upper(phrase), category, COALESCE(subcategory, '')
+  INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  v_bstate := CASE r.state WHEN 'solved' THEN 'won' WHEN 'complete' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  RETURN jsonb_build_object(
+    'board', public._daily_board(v_phrase, v_bstate, r.bankroll, r.guesses_remaining, r.revealed_positions, r.incorrect_letters, v_cat, v_sub),
+    'run', jsonb_build_object('state', r.state, 'banked', r.banked, 'multiplier', r.multiplier_x100,
+                              'position', r.position, 'total', public._arcade_ladder_size(),
+                              'furthest', r.furthest, 'last_gain', r.last_gain, 'last_bonus', r.last_bonus,
+                              'inventory', r.inventory, 'active', to_jsonb(r.active_powerups), 'last_earn', r.last_earn)
+  );
+END; $fn$;
+
+CREATE OR REPLACE FUNCTION public.arcade_buy_letter(p_letter TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[]; v_bonus INT := 0;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'arcade_buy_letter: invalid letter'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_buy_letter: no run'; END IF;
+  IF r.state <> 'active' THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  IF v_letter = ANY(r.incorrect_letters) OR r.bankroll < v_cost THEN RETURN public._arcade_response(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i)
+  WHERE substr(v_phrase, g.i+1, 1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ r.revealed_positions THEN RETURN public._arcade_response(v_uid); END IF;
+  r.bankroll := r.bankroll - v_cost;
+  r.p_buys := r.p_buys + 1;
+  IF v_letter IN ('A','E','I','O','U') THEN r.p_vowels := r.p_vowels + 1; END IF;
+  IF v_positions IS NULL THEN
+    r.incorrect_letters := array_append(r.incorrect_letters, v_letter);
+    r.p_combo := 0;
+  ELSE
+    r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_positions) ORDER BY 1);
+    r.p_combo := r.p_combo + 1;
+    IF r.p_combo % 3 = 0 THEN r.bankroll := r.bankroll + 250; v_bonus := 250; END IF;  -- Hot Hand
+  END IF;
+  r.banked := GREATEST(r.banked, r.bankroll);
+  UPDATE public.arcade_runs SET bankroll = r.bankroll, incorrect_letters = r.incorrect_letters,
+    revealed_positions = r.revealed_positions, p_buys = r.p_buys, p_vowels = r.p_vowels,
+    p_combo = r.p_combo, banked = r.banked, last_bonus = v_bonus, updated_at = NOW()
+  WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_resolve(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_buy_letter(TEXT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_next()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_next UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_next: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_next: no run'; END IF;
+  IF r.state = 'solved' THEN
+    v_next := public._arcade_puzzle_at(r.position + 1);
+    UPDATE public.arcade_runs SET position = position + 1, puzzle_id = v_next,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}',
+      p_buys = 0, p_vowels = 0, p_reveals = 0, p_wrong_guess = false, p_combo = 0,
+      last_gain = 0, last_bonus = 0, last_earn = NULL, state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_next() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.arcade_start()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_start: not authenticated'; END IF;
+  PERFORM public._todays_puzzle_id();
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    v_pid := public._arcade_puzzle_at(0);
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'arcade_start: no puzzles available'; END IF;
+    INSERT INTO public.arcade_runs (user_id, run_date, position, puzzle_id, bankroll, banked, multiplier_x100, guesses_remaining, furthest, last_gain, state)
+    VALUES (v_uid, CURRENT_DATE, 0, v_pid, 1500, 1500, 100, 5, 0, 0, 'active');
+  ELSIF r.state = 'over' THEN
+    v_pid := public._arcade_puzzle_at(0);
+    UPDATE public.arcade_runs SET position = 0, puzzle_id = v_pid, bankroll = 1500, multiplier_x100 = 100,
+      guesses_remaining = 5, last_gain = 0, last_bonus = 0, revealed_positions = '{}', incorrect_letters = '{}',
+      active_powerups = '{}', inventory = '{}', last_earn = NULL, clean_streak = 0,
+      p_buys = 0, p_vowels = 0, p_reveals = 0, p_wrong_guess = false, p_combo = 0,
+      state = 'active', updated_at = NOW()
+    WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  END IF;
+  RETURN public._arcade_response(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_start() TO authenticated;

--- a/supabase-daily-server-authoritative.sql
+++ b/supabase-daily-server-authoritative.sql
@@ -55,14 +55,19 @@ CREATE OR REPLACE FUNCTION public._todays_puzzle_id()
 RETURNS UUID LANGUAGE plpgsql SECURITY DEFINER AS $$
 DECLARE v_pid UUID;
 BEGIN
-  -- First caller of the day assigns a not-yet-used puzzle deterministically; others no-op.
+  -- First caller of the day assigns a puzzle deterministically; others no-op.
+  -- Prefer one never used as a daily; once the pool is exhausted, recycle the
+  -- one used longest ago (Phase 4 fallback) so the daily never runs dry.
   INSERT INTO public.daily_puzzle_schedule (scheduled_date, puzzle_id)
   SELECT CURRENT_DATE, sub.pid FROM (
-    SELECT (
-      SELECT p2.id FROM public.daily_puzzles p2
-      WHERE p2.id NOT IN (SELECT puzzle_id FROM public.daily_puzzle_schedule)
-      ORDER BY md5(CURRENT_DATE::text || p2.id::text)
-      LIMIT 1
+    SELECT COALESCE(
+      (SELECT p2.id FROM public.daily_puzzles p2
+        WHERE p2.id NOT IN (SELECT puzzle_id FROM public.daily_puzzle_schedule)
+        ORDER BY md5(CURRENT_DATE::text || p2.id::text) LIMIT 1),
+      (SELECT p3.id FROM public.daily_puzzles p3
+        LEFT JOIN (SELECT puzzle_id, MAX(scheduled_date) AS last_used
+                   FROM public.daily_puzzle_schedule GROUP BY puzzle_id) u ON u.puzzle_id = p3.id
+        ORDER BY u.last_used ASC NULLS FIRST, md5(CURRENT_DATE::text || p3.id::text) LIMIT 1)
     ) AS pid
   ) sub
   WHERE sub.pid IS NOT NULL


### PR DESCRIPTION
Final two phases of the arcade rolling-bankroll redesign (`ARCADE_REDESIGN.md`).

## Phase 3 — UI polish
- **Hot Hand flash.** Server returns `last_bonus` (250 on the buy that pops the +$250 combo, else 0; cleared at each puzzle boundary). Client shows a floating **🔥 Hot Hand +$250** badge over the bankroll while playing. Flash triggers only on a letter-buy response and two Hot Hands can't land on back-to-back buys, so the value always toggles 0↔250 between pops — no stale flashes.
- **Leaderboard** relabelled to the survival model: **Peak $** / **Solved** (was Banked / Furthest), with matching subtitle + footer copy. (The `get_arcade_gauntlet_leaderboard` RPC already ranks by `banked DESC, furthest DESC`.)
- HUD payout/streak and the run-over screen landed in Phase 1.

## Phase 4 — daily-pool recycle fallback
- `_todays_puzzle_id` now prefers a puzzle never used as a daily, then **recycles the one scheduled longest ago** (least-recently-used) once the pool is exhausted — so the daily never runs dry. Still deterministic per date; arcade is unaffected (it uses `_arcade_puzzle_at`'s wrapping ladder).

## Verification
- Hot Hand flash + bankroll math (`$3000 − $90 buy + $250 = $3160`, peak updated, `last_bonus=250`) via Playwright.
- Recycle picks least-recently-used + normal path still resolves today's puzzle, via SQL.
- `svelte-check` + `build` clean. Test data cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)