### PR TITLE
Fix auth/share 404s (dead domain) + mobile leaderboard

### DIFF
--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -56,10 +56,10 @@
     return;
   }
 
-  const redirectUrl =
-    import.meta.env.DEV
-      ? 'http://localhost:5173/reset-password'
-      : 'https://wordbanksvelte1.vercel.app/reset-password';
+  // Use the current origin so the link works on whatever domain is serving the
+  // app (localhost in dev, the live Vercel domain in prod) — never a hardcoded
+  // (and now-deleted) project URL.
+  const redirectUrl = `${window.location.origin}/reset-password`;
 
   const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
     redirectTo: redirectUrl
@@ -96,9 +96,7 @@
   }
 
   async function signInWithGoogle() {
-    const redirectUrl = import.meta.env.DEV
-      ? 'http://localhost:5173/auth/callback'
-      : 'https://wordbanksvelte1.vercel.app/auth/callback';
+    const redirectUrl = `${window.location.origin}/auth/callback`;
     await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: { redirectTo: redirectUrl }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -199,7 +199,8 @@
   let shareCopied = false;
   function buildShareText() {
     const br = '$' + resultBankroll.toLocaleString();
-    const link = 'https://wordbanksvelte1.vercel.app';
+    // Link to the live origin (never a hardcoded/deleted project URL).
+    const link = typeof window !== 'undefined' ? window.location.origin : '';
     if (isDailyResult) {
       return `🏦 WordBank Daily #${puzzleNumber}\n${resultMedal.emoji} ${resultWon ? resultMedal.name + ' — ' : ''}${br} banked\n${link}`;
     }

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -395,4 +395,21 @@
     font-size: 0.82rem;
     color: var(--text-faint);
   }
+
+  /* ---- Mobile: fit the table without horizontal scroll ---- */
+  @media (max-width: 560px) {
+    .leaderboard-page { padding: 1.6rem 0.5rem 2.5rem; }
+    h1 { font-size: 1.5rem; }
+    .tab-btn { padding: 0.5rem 1.15rem; font-size: 0.9rem; }
+    .back-btn { margin-bottom: 1.2rem; }
+    .table-wrap { backdrop-filter: none; }
+    table { min-width: 0; }
+    th, td { padding: 0.55rem 0.45rem; font-size: 0.82rem; }
+    th { font-size: 0.6rem; }
+    td.rank { width: 30px; }
+    /* The daily table has 8 columns — too wide for a phone. Keep the essentials
+       (#, Player, Score, Bankroll) and hide Streak/Best/Plays/Win%. The Arcade
+       table only has 4 columns, so these selectors are a no-op there. */
+    th:nth-child(n+5), td:nth-child(n+5) { display: none; }
+  }
 </style>


### PR DESCRIPTION
## The 404s (auth, password reset, share)
All three flows hardcoded **`https://wordbanksvelte1.vercel.app`** — a Vercel project that was **deleted** (`curl` → 404), while the live app is `wordbanksvelte.vercel.app` (→ 200). So every OAuth callback, reset-password link, and shared-score link landed on Vercel's 404 page.

**Fix:** use `window.location.origin` everywhere, so redirects always target the domain actually serving the app (dev or prod, any future rename):
- `Auth.svelte` — Google OAuth + password-reset `redirectTo`
- `+page.svelte` — share-score link

## ⚠️ Manual step required (Supabase auth allow-list)
The code now points at the live origin, but **Supabase only redirects to allow-listed URLs**. To finish the auth/reset fix, in the Supabase dashboard → **Authentication → URL Configuration**:
- **Site URL:** `https://wordbanksvelte.vercel.app`
- **Redirect URLs:** add `https://wordbanksvelte.vercel.app/**` (and `http://localhost:5173/**` for dev)

(Google Cloud OAuth client's authorized redirect URI stays the Supabase callback `https://heckmdvnetatqgnsdtoz.supabase.co/auth/v1/callback` — already set.)

## Mobile leaderboard
The daily table has 8 columns and overflowed the phone viewport. Added a ≤560px media query: shrink padding/font, keep the essentials (**#, Player, Score, Bankroll**), hide Streak/Best/Plays/Win%. Arcade (4 cols) just shrinks. Verified **0px horizontal overflow at 390px** on both tabs (Playwright).

## Not included (by request)
The "Colosseum — had to re-buy E" report: a guess intentionally reveals **only the correct letter in the correct position**, so the E in "colossEum" (a different position you didn't get right) still needs buying — that's expected. I briefly tried making a guess reveal all instances of a correct letter, but per your follow-up that's **not** wanted, so it was reverted (no net DB/SQL change). Server logic is monotonic — a correctly-placed letter can't be dropped — so the E in "THE" persists; flag a repro if you still see one vanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)