### PR TITLE
Fix password reset: handle PKCE recovery flow

### DIFF
--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -56,10 +56,10 @@
     return;
   }
 
-  // Use the current origin so the link works on whatever domain is serving the
-  // app (localhost in dev, the live Vercel domain in prod) — never a hardcoded
-  // (and now-deleted) project URL.
-  const redirectUrl = `${window.location.origin}/reset-password`;
+  // Route through the server callback, which exchanges the PKCE recovery code
+  // for a session (cookie) and then forwards to /reset-password. Using the
+  // current origin keeps it working on any domain (dev or the live Vercel one).
+  const redirectUrl = `${window.location.origin}/auth/callback?next=/reset-password`;
 
   const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
     redirectTo: redirectUrl

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -6,40 +6,33 @@
   let password = '';
   let confirmPassword = '';
   let message = '';
-  let token = '';
-  let refresh_token = '';
   let isTokenReady = false;
   let success = false;
 
   onMount(() => {
-    const hash = window.location.hash;
-    const params = new URLSearchParams(hash.slice(1));
-
-    token = params.get('access_token') ?? '';
-    refresh_token = params.get('refresh_token') ?? '';
-
-    console.log("🔍 Parsed access_token:", token);
-    console.log("🔍 Parsed refresh_token:", refresh_token);
-
-    if (!token || !refresh_token) {
-      message = '⛔ Invalid or missing reset token.';
-      console.warn(message);
+    // Supabase passes errors (expired/used link) back as query params.
+    const url = new URL(window.location.href);
+    const errDesc = url.searchParams.get('error_description');
+    if (errDesc) {
+      message = `⛔ ${decodeURIComponent(errDesc.replace(/\+/g, ' '))}`;
       return;
     }
 
-    supabase.auth.setSession({
-      access_token: token,
-      refresh_token
-    }).then(({ error }) => {
-      if (error) {
-        message = `❌ Auth failed: ${error.message}`;
-        console.error("❌ setSession error:", error.message);
-      } else {
-        isTokenReady = true;
-        message = '';
-        console.log("✅ Supabase session restored.");
-      }
+    // The /auth/callback route already exchanged the recovery code and set the
+    // session cookie before redirecting here, so we just need that session.
+    let settled = false;
+    const ready = () => { settled = true; isTokenReady = true; message = ''; };
+
+    supabase.auth.getSession().then(({ data }) => { if (data.session) ready(); });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) ready();
     });
+
+    const timer = setTimeout(() => {
+      if (!settled) message = '⛔ This reset link is invalid or has expired. Please request a new one.';
+    }, 3000);
+
+    return () => { clearTimeout(timer); sub.subscription.unsubscribe(); };
   });
 
   async function updatePassword() {


### PR DESCRIPTION
## Problem
After the domain fix, the reset link resolved but showed **"Invalid or missing reset token."**

The reset page only read the URL **hash** (`#access_token`/`#refresh_token`) — the old *implicit* flow. But the app uses `@supabase/ssr`'s `createBrowserClient`, which is **PKCE**: the recovery link comes back as `?code=...`. The hash is empty, so it always failed.

## Fix
Route the reset email through the existing `/auth/callback` server route, which already exchanges `?code=` → session cookie:
- `Auth.svelte`: `redirectTo = ${origin}/auth/callback?next=/reset-password`
- `/reset-password`: drop the hash parsing; wait for the session (`getSession` + `onAuthStateChange`) the callback established and show the new-password form, or a clear "link invalid/expired" message (decoded from `error_description`).

## Verified
- With a session → password form renders, no error.
- With `?error_description=...` → shows the decoded message, no form.
- `svelte-check` + `build` clean.

## Caveats (need you / dashboard)
1. **Supabase Redirect URL allow-list** (same as PR #104): `https://wordbanksvelte.vercel.app/**` must be allow-listed, or Supabase won't redirect to the callback.
2. **Cross-device reset**: PKCE stores a code verifier in the requesting browser. Requesting the reset on desktop but opening the email on your phone can't complete (the verifier isn't on the phone) — this is inherent to PKCE. **Same-device** reset (request + open link on the same device) works. If you want true cross-device reset, switch the Supabase recovery email template to the `token_hash` + `verifyOtp` flow — say the word and I'll wire that variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)