### PR TITLE
Cross-device password reset via token_hash + verifyOtp

### DIFF
--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -56,10 +56,12 @@
     return;
   }
 
-  // Route through the server callback, which exchanges the PKCE recovery code
-  // for a session (cookie) and then forwards to /reset-password. Using the
-  // current origin keeps it working on any domain (dev or the live Vercel one).
-  const redirectUrl = `${window.location.origin}/auth/callback?next=/reset-password`;
+  // Route through /auth/confirm, which verifies the email OTP (token_hash) and
+  // forwards to /reset-password. token_hash needs no local code verifier, so the
+  // link works cross-device. Origin-aware so it's correct in dev and prod.
+  // NOTE: requires the Supabase "Reset Password" email template to link to
+  //   {{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=recovery
+  const redirectUrl = `${window.location.origin}/auth/confirm?next=/reset-password`;
 
   const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
     redirectTo: redirectUrl

--- a/src/routes/auth/confirm/+server.js
+++ b/src/routes/auth/confirm/+server.js
@@ -1,0 +1,58 @@
+import { redirect } from '@sveltejs/kit';
+import { createServerClient } from '@supabase/ssr';
+
+// Email-OTP confirmation (password recovery, email change, signup confirm).
+// Unlike the PKCE ?code= flow (/auth/callback), verifyOtp with a token_hash
+// needs NO local code verifier, so the link works on ANY device — request the
+// reset on a laptop, open the email on your phone, and it still completes.
+export const GET = async ({ url, cookies }) => {
+  const token_hash = url.searchParams.get('token_hash');
+  const type = url.searchParams.get('type');
+  const next = url.searchParams.get('next') ?? '/';
+
+  if (token_hash && type) {
+    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    if (supabaseUrl && supabaseAnonKey) {
+      const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+        cookies: {
+          get(name) {
+            return cookies.get(name);
+          },
+          set(name, value, options) {
+            cookies.set(name, value, {
+              ...options,
+              path: '/',
+              httpOnly: true,
+              sameSite: 'lax',
+              secure: import.meta.env.PROD
+            });
+          },
+          remove(name, options) {
+            cookies.delete(name, {
+              ...options,
+              path: '/',
+              httpOnly: true,
+              sameSite: 'lax',
+              secure: import.meta.env.PROD
+            });
+          }
+        }
+      });
+
+      const { error } = await supabase.auth.verifyOtp({
+        type: /** @type {any} */ (type),
+        token_hash
+      });
+      if (!error) {
+        return redirect(303, next);
+      }
+      console.error('Auth confirm error:', error.message);
+    } else {
+      console.error('Missing Supabase env vars on Vercel');
+    }
+  }
+
+  // Verification failed → land on the reset page with a clear message.
+  return redirect(303, '/reset-password?error_description=Email+link+is+invalid+or+has+expired');
+};

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -18,11 +18,24 @@
       return;
     }
 
-    // The /auth/callback route already exchanged the recovery code and set the
-    // session cookie before redirecting here, so we just need that session.
     let settled = false;
     const ready = () => { settled = true; isTokenReady = true; message = ''; };
 
+    // Fallback: if the email template links here directly with a token_hash
+    // (instead of via /auth/confirm), verify it client-side. token_hash needs no
+    // local code verifier, so this works cross-device too.
+    const tokenHash = url.searchParams.get('token_hash');
+    const otpType = url.searchParams.get('type');
+    if (tokenHash && otpType) {
+      supabase.auth.verifyOtp({ token_hash: tokenHash, type: /** @type {any} */ (otpType) })
+        .then(({ error }) => {
+          if (error) message = `⛔ ${error.message}`;
+          else ready();
+        });
+      return;
+    }
+
+    // Otherwise the session was already established (e.g. by /auth/confirm).
     supabase.auth.getSession().then(({ data }) => { if (data.session) ready(); });
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       if (session) ready();


### PR DESCRIPTION
Makes password reset work when the email is opened on a **different device** than the one that requested it.

## Why PKCE couldn't do it
The `?code=` (PKCE) flow needs a code verifier stored in the *requesting* browser. Open the email on your phone after requesting on your laptop → no verifier → fails. The **OTP `token_hash`** flow verifies server-side with no local secret, so any device works.

## Code
- **New `/auth/confirm` server route** — `verifyOtp({ token_hash, type })` sets the session cookie, redirects to `?next` (default `/reset-password`); on failure forwards with an `error_description`.
- **`Auth.svelte`** — reset `redirectTo` → `${origin}/auth/confirm?next=/reset-password`.
- **`/reset-password`** — also verifies a `token_hash` client-side as a fallback (covers templates that link straight to the page), then shows the new-password form.

## ⚠️ Required: update the Supabase email template
Dashboard → **Authentication → Email Templates → Reset Password**, set the link to:
```html
<a href="{{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=recovery">Reset Password</a>
```
(Plus the existing **URL Configuration**: Site URL `https://wordbanksvelte.vercel.app`, Redirect URLs include `https://wordbanksvelte.vercel.app/**` and `http://localhost:5173/**`.)

Final link becomes `…/auth/confirm?next=/reset-password&token_hash=…&type=recovery` → verified on any device → session set → new-password form.

## Verified (Playwright)
- Bad token → clean "link invalid/expired" on **both** the server route and the client fallback.
- Existing session → the password form renders.
- `svelte-check` + `build` clean.

(The valid-token happy path needs a real recovery email, so confirm once the template is live — but the verify mechanics and error handling are exercised.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)