### PR TITLE
Make password reset prefetch-safe (defer OTP verify to submit)

### DIFF
--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -56,12 +56,11 @@
     return;
   }
 
-  // Route through /auth/confirm, which verifies the email OTP (token_hash) and
-  // forwards to /reset-password. token_hash needs no local code verifier, so the
-  // link works cross-device. Origin-aware so it's correct in dev and prod.
-  // NOTE: requires the Supabase "Reset Password" email template to link to
-  //   {{ .RedirectTo }}&token_hash={{ .TokenHash }}&type=recovery
-  const redirectUrl = `${window.location.origin}/auth/confirm?next=/reset-password`;
+  // The reset email links straight to /reset-password with a one-time token_hash
+  // (cross-device, no code verifier). redirectTo is just the allow-listed landing
+  // page; the actual link is built by the Supabase email template, which must be:
+  //   {{ .SiteURL }}/reset-password?token_hash={{ .TokenHash }}&type=recovery
+  const redirectUrl = `${window.location.origin}/reset-password`;
 
   const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
     redirectTo: redirectUrl

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -8,39 +8,39 @@
   let message = '';
   let isTokenReady = false;
   let success = false;
+  // A one-time recovery token (token_hash) from the email link. We DON'T verify
+  // it on load — email scanners/prefetchers GET links and would burn the
+  // one-time token. We hold it and verify only when the user submits the form.
+  let tokenHash = '';
+  let otpType = '';
 
   onMount(() => {
-    // Supabase passes errors (expired/used link) back as query params.
     const url = new URL(window.location.href);
+
+    // Supabase passes errors (expired/used link) back as query params.
     const errDesc = url.searchParams.get('error_description');
     if (errDesc) {
       message = `⛔ ${decodeURIComponent(errDesc.replace(/\+/g, ' '))}`;
       return;
     }
 
-    let settled = false;
-    const ready = () => { settled = true; isTokenReady = true; message = ''; };
-
-    // Fallback: if the email template links here directly with a token_hash
-    // (instead of via /auth/confirm), verify it client-side. token_hash needs no
-    // local code verifier, so this works cross-device too.
-    const tokenHash = url.searchParams.get('token_hash');
-    const otpType = url.searchParams.get('type');
+    // Recovery link landed here directly with a token_hash → show the form now,
+    // verify on submit (prefetch-safe, no local code verifier, works cross-device).
+    tokenHash = url.searchParams.get('token_hash') ?? '';
+    otpType = url.searchParams.get('type') ?? '';
     if (tokenHash && otpType) {
-      supabase.auth.verifyOtp({ token_hash: tokenHash, type: /** @type {any} */ (otpType) })
-        .then(({ error }) => {
-          if (error) message = `⛔ ${error.message}`;
-          else ready();
-        });
+      isTokenReady = true;
       return;
     }
 
-    // Otherwise the session was already established (e.g. by /auth/confirm).
+    // Otherwise a session was already established (e.g. via /auth/confirm, or the
+    // user is signed in) — surface the form once we see it.
+    let settled = false;
+    const ready = () => { settled = true; isTokenReady = true; message = ''; };
     supabase.auth.getSession().then(({ data }) => { if (data.session) ready(); });
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
       if (session) ready();
     });
-
     const timer = setTimeout(() => {
       if (!settled) message = '⛔ This reset link is invalid or has expired. Please request a new one.';
     }, 3000);
@@ -59,6 +59,20 @@
       message = '❌ Passwords do not match.';
       success = false;
       return;
+    }
+
+    // Verify the one-time token now (deferred from page load). This establishes
+    // the recovery session; if the link is expired/used, the user finds out here.
+    if (tokenHash && otpType) {
+      const { error: verifyErr } = await supabase.auth.verifyOtp({
+        token_hash: tokenHash, type: /** @type {any} */ (otpType)
+      });
+      if (verifyErr) {
+        message = `⛔ ${verifyErr.message}`;
+        success = false;
+        return;
+      }
+      tokenHash = ''; // consumed
     }
 
     console.log("🔐 Attempting password update...");


### PR DESCRIPTION
Follow-up to #106: still hit "email link is invalid or has expired".

## Most likely cause
Email link **prefetching** — Outlook/SafeLinks/preview panes and some inboxes issue a `GET` on links, which hit `/auth/confirm` and **consumed the one-time recovery token before the user clicked**. (A `{{ .RedirectTo }}` template that rendered empty would also produce a malformed link.)

## Fix — defer verification to form submit
The link now goes straight to `/reset-password?token_hash=…&type=recovery`. The page **does not verify on load** — it shows the new-password form immediately and calls `verifyOtp` only when the user **submits**. A prefetch can't burn the token because nothing submits the form.

- `reset-password`: hold `token_hash`, `verifyOtp` on submit → then `updateUser`.
- `Auth.svelte`: `redirectTo` → `${origin}/reset-password`.
- Self-contained template (`{{ .SiteURL }}`) → no `redirectTo` allow-list dependency, still cross-device.

## ⚠️ Update the email template to this exact line
Dashboard → Authentication → Email Templates → **Reset Password**:
```html
<a href="{{ .SiteURL }}/reset-password?token_hash={{ .TokenHash }}&type=recovery">Reset Password</a>
```
And confirm **Site URL** = `https://wordbanksvelte.vercel.app` (the link is built from it).

## Verified
- Link loads the form with **no error** and the token untouched.
- Submitting a bad/expired token → "invalid or has expired".
- `svelte-check` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)