### PR TITLE
iOS: declare ITSAppUsesNonExemptEncryption=NO

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -8,6 +8,8 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
         <string>WordBank</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Skips the App Store Connect export-compliance prompt on future builds — the app only uses standard OS-provided HTTPS (exempt). Takes effect on the next archive/upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)