### PR TITLE
Add /privacy page + hide Google login in the native app

### DIFF
--- a/IOS_LAUNCH_ROADMAP.md
+++ b/IOS_LAUNCH_ROADMAP.md
@@ -102,7 +102,9 @@ team (this sets the provisioning automatically). Bundle id is `com.wordbank.app`
 - [ ] **Sign in with Apple** — required *if/when* we re-add Google or other social login. [4.8]
 - [ ] **In-app account deletion** — required for sign-up apps. [5.1.1(v)] Flow +
       server RPC purging profile/sessions/results.
-- [ ] **Privacy policy** + **App Privacy nutrition label**.
+- [x] **Privacy policy page** at `/privacy` (→ `https://wordbanksvelte.vercel.app/privacy`;
+      needed for external TestFlight). Still TODO: enter the URL in App Store Connect
+      + fill the App Privacy nutrition label.
 - [ ] **Age rating**, **Support URL**, screenshots, description, keywords.
 - [ ] **Push notifications** ("daily ready") — big retention lever + native value. [4.2]
 - [ ] Native auth rework: native Google + password-reset deep-linking (custom URL

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -2,6 +2,7 @@
   "appId": "com.wordbank.app",
   "appName": "WordBank",
   "webDir": "www",
+  "appendUserAgent": "WordBankApp",
   "server": {
     "url": "https://wordbanksvelte.vercel.app",
     "cleartext": false

--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -3,12 +3,25 @@
   import { user, userProfile } from '$lib/stores/userStore.js';
   import { gameStore } from '$lib/stores/GameStore.js';
   import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
+  import { onMount } from 'svelte';
 
   let email = '';
   let password = '';
   let errorMsg = '';
   let isLoading = false;
   let isLogin = true;
+
+  // Inside the native (Capacitor) app, Google blocks OAuth in the embedded
+  // webview so it kicks out to Safari. Hide it there — native testers use
+  // email/password (stays in-app). On the web, Google shows normally.
+  let isNativeApp = false;
+  onMount(() => {
+    try {
+      const c = /** @type {any} */ (window).Capacitor;
+      isNativeApp = !!(c && (c.isNativePlatform ? c.isNativePlatform() : c.isNative))
+        || /WordBankApp/i.test(navigator.userAgent);
+    } catch { isNativeApp = false; }
+  });
 
   let showReset = false;
   let resetEmail = '';
@@ -145,12 +158,14 @@
         {isLoading ? 'Loading…' : (isLogin ? 'Log in' : 'Sign up')}
       </button>
 
-      <div class="divider"><span>or</span></div>
+      {#if !isNativeApp}
+        <div class="divider"><span>or</span></div>
 
-      <button class="btn-ghost full google" on:click={signInWithGoogle}>
-        <img src="/googlelogo.png" alt="Google icon" class="google-icon" />
-        Continue with Google
-      </button>
+        <button class="btn-ghost full google" on:click={signInWithGoogle}>
+          <img src="/googlelogo.png" alt="Google icon" class="google-icon" />
+          Continue with Google
+        </button>
+      {/if}
 
       {#if errorMsg}
         <div class="error-text">{errorMsg}</div>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,112 @@
+<script>
+  // Public, no-auth privacy policy page. URL: /privacy
+  // Used for TestFlight external testing + App Store submission.
+  const CONTACT = 'charlieforeman77@gmail.com'; // ← change to your support email if you prefer
+  const UPDATED = 'June 21, 2026';
+</script>
+
+<svelte:head>
+  <title>WordBank — Privacy Policy</title>
+  <meta name="robots" content="index" />
+</svelte:head>
+
+<main class="legal">
+  <h1>WordBank Privacy Policy</h1>
+  <p class="updated">Last updated: {UPDATED}</p>
+
+  <p>
+    WordBank ("we," "us," or "the app") is a word-puzzle game. This policy explains
+    what we collect, how we use it, and the choices you have. We keep it short
+    because we collect very little.
+  </p>
+
+  <h2>Information we collect</h2>
+  <ul>
+    <li><strong>Account info:</strong> the email address you sign up with. Passwords
+      are handled by our authentication provider and stored only as a secure hash —
+      we never see your password.</li>
+    <li><strong>Gameplay data:</strong> your progress and results — puzzles played,
+      scores, bankrolls, win/loss, streaks, badges, and leaderboard standings.</li>
+    <li><strong>Basic technical data:</strong> standard information needed to run the
+      app reliably (e.g., that comes with normal network requests).</li>
+  </ul>
+
+  <h2>What we do NOT collect</h2>
+  <ul>
+    <li>No payment or financial information (the app has no purchases).</li>
+    <li>No precise location, contacts, photos, microphone, or camera access.</li>
+    <li>No advertising identifiers — we don't run ads.</li>
+  </ul>
+
+  <h2>How we use your information</h2>
+  <ul>
+    <li>To create your account and let you sign in.</li>
+    <li>To save your progress and show your scores, streaks, badges, and leaderboard rank.</li>
+    <li>To operate, maintain, and improve the game.</li>
+  </ul>
+
+  <h2>How your data is stored and shared</h2>
+  <p>
+    We use trusted infrastructure providers to run WordBank: <strong>Supabase</strong>
+    (database and authentication) and <strong>Vercel</strong> (app hosting). Your data
+    is stored on their secure infrastructure on our behalf. We do
+    <strong>not sell your data</strong>, and we do not share it for advertising. We may
+    disclose information if required by law.
+  </p>
+
+  <h2>Data security</h2>
+  <p>
+    Connections use HTTPS encryption, and your answers/scores are validated on the
+    server. No system is perfectly secure, but we take reasonable measures to protect
+    your information.
+  </p>
+
+  <h2>Your choices &amp; deleting your account</h2>
+  <p>
+    You can request deletion of your account and all associated data at any time by
+    emailing <a href={`mailto:${CONTACT}`}>{CONTACT}</a>. We will delete your account
+    and game data promptly. (In-app account deletion is on the way.)
+  </p>
+
+  <h2>Children</h2>
+  <p>
+    WordBank is not directed to children under 13, and we do not knowingly collect
+    personal information from children under 13.
+  </p>
+
+  <h2>Changes to this policy</h2>
+  <p>
+    We may update this policy from time to time. We'll revise the "Last updated" date
+    above when we do.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Questions about privacy? Email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+  </p>
+</main>
+
+<style>
+  .legal {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 2.5rem 1.25rem 4rem;
+    color: var(--text, #e6edf3);
+    line-height: 1.6;
+    font-size: 1rem;
+  }
+  h1 {
+    font-family: var(--font-display, system-ui, sans-serif);
+    font-size: 1.8rem;
+    margin: 0 0 0.25rem;
+  }
+  .updated { color: var(--text-faint, #8b98a9); font-size: 0.9rem; margin: 0 0 1.5rem; }
+  h2 {
+    font-family: var(--font-display, system-ui, sans-serif);
+    font-size: 1.15rem;
+    margin: 1.8rem 0 0.5rem;
+  }
+  ul { padding-left: 1.2rem; }
+  li { margin: 0.3rem 0; }
+  a { color: var(--brand-2, #a3e635); }
+</style>


### PR DESCRIPTION
Two things: the privacy policy needed for external TestFlight, and a fix for Google-login kicking testers out to Safari.

## /privacy (new public page)
Honest, no-auth privacy policy → **`https://wordbanksvelte.vercel.app/privacy`**. Covers: account email, gameplay data, Supabase/Vercel as processors, no data selling, account-deletion-by-email, children, contact. Paste this URL into App Store Connect's Test Information (external TestFlight) and later the app's App Information.

## Hide Google login in the native app
Google **blocks OAuth inside embedded webviews**, so in the Capacitor app "Continue with Google" was bouncing testers to Safari and finishing there. Now it's **hidden inside the native app** (detected via `window.Capacitor.isNativePlatform()` + a `WordBankApp` UA fallback). Web keeps Google; native testers use **email/password**, which stays in-app.

Because the app loads the live site, this takes effect on the **current TestFlight build** as soon as Vercel deploys — no re-upload needed. `appendUserAgent` was added for solid detection on future builds too.

## Verified
- Privacy page renders with no login; has the account-deletion section.
- Google button: visible on web, hidden under the native UA; email/password intact.
- `svelte-check` + build clean.

> Note: privacy contact email is `charlieforeman77@gmail.com` — change in `src/routes/privacy/+page.svelte` if you want a different support address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)