### PR TITLE
Add Daily Quests (/quests) + menu card

### DIFF
--- a/IOS_LAUNCH_ROADMAP.md
+++ b/IOS_LAUNCH_ROADMAP.md
@@ -25,6 +25,14 @@ learning from testers (see *Deferred* at the bottom).
 
 Everything not on this list is intentionally *after* we have testers.
 
+### Engagement features shipped (Duolingo-inspired)
+- [x] **Streak screen** (`/streak`) + menu flame chip.
+- [x] **Daily Quests** (`/quests`) — 3 deterministic quests/day (same for everyone),
+      progress from the events table (no engine changes), finish all 3 → claim a
+      streak freeze. Menu card shows progress. (`supabase-quests.sql`.)
+- [ ] Next candidates: leagues/divisions for the leaderboard · cosmetic currency
+      + shop · profile screen · push notification (native).
+
 ### Zero-friction testing (no TestFlight needed)
 WordBank is a live website, so the lowest-friction way to get friends testing is
 just the **URL** — no app stores, no TestFlight, no downloads:

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -59,6 +59,31 @@ export async function getDailyStatus(userId) {
 }
 
 /**
+ * Today's 3 daily quests (same for everyone) + progress + reward state.
+ * @returns {Promise<{ quests:{id:string,emoji:string,label:string,target:number,progress:number,done:boolean}[], all_done:boolean, reward_claimed:boolean, resets_in_seconds:number }>}
+ */
+export async function getDailyQuests() {
+  const { data, error } = await supabase.rpc('get_daily_quests');
+  if (error || !data) {
+    if (error) console.error('❌ Error fetching daily quests:', error);
+    return { quests: [], all_done: false, reward_claimed: false, resets_in_seconds: 0 };
+  }
+  return {
+    quests: Array.isArray(data.quests) ? data.quests : [],
+    all_done: !!data.all_done,
+    reward_claimed: !!data.reward_claimed,
+    resets_in_seconds: data.resets_in_seconds ?? 0
+  };
+}
+
+/** Claim the all-quests-done reward (a streak freeze). @returns {Promise<{ok:boolean, reason?:string, freezes?:number}>} */
+export async function claimQuestReward() {
+  const { data, error } = await supabase.rpc('claim_quest_reward');
+  if (error || !data) { if (error) console.error('❌ claim_quest_reward:', error); return { ok: false }; }
+  return data;
+}
+
+/**
  * Streak overview: current/longest streak, freezes, and per-day daily outcomes
  * (last ~10 weeks) for the calendar heatmap.
  * @returns {Promise<{ current_streak:number, highest_streak:number, freezes:number, days:{d:string,won:boolean}[] }>}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, getDailyQuests } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -46,6 +46,14 @@
   /** Today's daily result for the menu indicator (won/lost + score). */
   let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, arcade_bankroll: number, current_streak: number, streak_freezes: number, today_score: number } | null} */ (null);
   $: dailyDone = menuDailyPlayed && !(savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
+  /** Daily-quest progress for the menu card. */
+  let questProgress = { done: 0, total: 3, all_done: false, reward_claimed: false };
+  async function refreshQuests() {
+    try {
+      const q = await getDailyQuests();
+      questProgress = { done: q.quests.filter((x) => x.done).length, total: q.quests.length || 3, all_done: q.all_done, reward_claimed: q.reward_claimed };
+    } catch { /* non-fatal */ }
+  }
 
   // ✅ Load Supabase user profile and sync bankroll (creates profile if missing)
   /** @param {string} userId */
@@ -108,6 +116,7 @@
       const ds = await getDailyStatus(session.user.id);
       dailyStatus = ds;
       menuDailyPlayed = ds.has_played_today;
+      refreshQuests();
 
       await tick();
       hasInitialized = true;
@@ -359,6 +368,7 @@
     showMainMenu = true;
     // Refresh the daily completion indicator (e.g. just finished today's daily).
     getDailyStatus(currentUser.id).then((s) => { dailyStatus = s; menuDailyPlayed = s.has_played_today; });
+    refreshQuests();
   }
 
   let showMyAccount = false;
@@ -492,7 +502,17 @@
           </span>
           <span class="mc-arrow">{dailyDone ? '🔒' : '→'}</span>
         </button>
-        <button class="menu-card" style="--i: 1" on:click={handleMenuArcade}>
+        <button class="menu-card" class:done={questProgress.all_done} style="--i: 1" on:click={() => goto('/quests')}>
+          <span class="mc-icon">{questProgress.all_done ? '🏆' : '📋'}</span>
+          <span class="mc-body">
+            <span class="mc-title">Daily Quests</span>
+            <span class="mc-sub">
+              {#if questProgress.all_done && !questProgress.reward_claimed}All done — claim your reward!{:else}{questProgress.done}/{questProgress.total} complete today{/if}
+            </span>
+          </span>
+          <span class="mc-arrow">{#if questProgress.all_done && !questProgress.reward_claimed}🎁{:else}→{/if}</span>
+        </button>
+        <button class="menu-card" style="--i: 2" on:click={handleMenuArcade}>
           <span class="mc-icon">🕹️</span>
           <span class="mc-body">
             <span class="mc-title">{#if savedGameInfo?.gameMode === 'arcade' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}Resume Arcade{:else}Arcade Mode{/if}</span>
@@ -500,7 +520,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 2" on:click={handleMenuFreeplay}>
+        <button class="menu-card" style="--i: 3" on:click={handleMenuFreeplay}>
           <span class="mc-icon">🎲</span>
           <span class="mc-body">
             <span class="mc-title">Free Play</span>
@@ -508,7 +528,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 3" on:click={() => goto('/badges')}>
+        <button class="menu-card" style="--i: 4" on:click={() => goto('/badges')}>
           <span class="mc-icon">🏅</span>
           <span class="mc-body">
             <span class="mc-title">Badges</span>
@@ -516,7 +536,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 4" on:click={handleMenuLeaderboard}>
+        <button class="menu-card" style="--i: 5" on:click={handleMenuLeaderboard}>
           <span class="mc-icon">🏆</span>
           <span class="mc-body">
             <span class="mc-title">Leaderboard</span>
@@ -524,7 +544,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 5" on:click={handleMenuMyAccount}>
+        <button class="menu-card" style="--i: 6" on:click={handleMenuMyAccount}>
           <span class="mc-icon">👤</span>
           <span class="mc-body">
             <span class="mc-title">My Account</span>

--- a/src/routes/quests/+page.svelte
+++ b/src/routes/quests/+page.svelte
@@ -1,0 +1,136 @@
+<script>
+  import { onMount, onDestroy } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getDailyQuests, claimQuestReward } from '$lib/stores/statsStore.js';
+  import { track } from '$lib/analytics.js';
+  import { fx } from '$lib/sound.js';
+
+  /** @type {{ quests:any[], all_done:boolean, reward_claimed:boolean, resets_in_seconds:number }|null} */
+  let q = null;
+  let loading = true;
+  let claiming = false;
+  let claimedMsg = '';
+  let secs = 0;
+  /** @type {ReturnType<typeof setInterval>|undefined} */
+  let timer;
+
+  onMount(async () => {
+    track('quests_view');
+    try { q = await getDailyQuests(); secs = q.resets_in_seconds; }
+    finally { loading = false; }
+    timer = setInterval(() => { if (secs > 0) secs -= 1; }, 1000);
+  });
+  onDestroy(() => clearInterval(timer));
+
+  $: countdown = (() => {
+    const h = Math.floor(secs / 3600), m = Math.floor((secs % 3600) / 60);
+    return h > 0 ? `${h}h ${m}m` : `${m}m`;
+  })();
+  $: doneCount = q ? q.quests.filter((x) => x.done).length : 0;
+
+  async function claim() {
+    if (claiming || !q?.all_done || q?.reward_claimed) return;
+    claiming = true;
+    const res = await claimQuestReward();
+    claiming = false;
+    if (res?.ok) {
+      track('quest_reward_claimed');
+      fx('win');
+      claimedMsg = '❄️ Streak Freeze earned!';
+      q = { ...q, reward_claimed: true };
+    } else if (res?.reason === 'claimed') {
+      q = { ...q, reward_claimed: true };
+    }
+  }
+</script>
+
+<svelte:head><title>WordBank — Daily Quests</title></svelte:head>
+
+<main class="quests-page">
+  <button class="back-btn" on:click={() => goto('/')}>← Menu</button>
+
+  {#if loading}
+    <p class="loading">Loading…</p>
+  {:else if q}
+    <div class="head">
+      <h1>Daily Quests</h1>
+      <span class="resets">resets in {countdown}</span>
+    </div>
+    <p class="sub">{doneCount}/{q.quests.length} complete · same for everyone today</p>
+
+    <div class="qlist">
+      {#each q.quests as quest (quest.id)}
+        <div class="quest" class:done={quest.done}>
+          <span class="q-emoji">{quest.emoji}</span>
+          <div class="q-body">
+            <div class="q-top">
+              <span class="q-label">{quest.label}</span>
+              <span class="q-count">{quest.progress}/{quest.target}{#if quest.done} ✓{/if}</span>
+            </div>
+            <div class="bar"><div class="fill" style="width:{Math.min(100, (quest.progress / quest.target) * 100)}%"></div></div>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <div class="reward" class:ready={q.all_done && !q.reward_claimed} class:claimed={q.reward_claimed}>
+      {#if q.reward_claimed}
+        <span class="r-title">✅ Reward claimed</span>
+        <span class="r-sub">{claimedMsg || 'Come back tomorrow for new quests.'}</span>
+      {:else if q.all_done}
+        <span class="r-title">All quests done! 🎉</span>
+        <button class="claim-btn" on:click={claim} disabled={claiming}>
+          {claiming ? 'Claiming…' : 'Claim ❄️ Streak Freeze'}
+        </button>
+      {:else}
+        <span class="r-title">Finish all 3 to earn ❄️ a Streak Freeze</span>
+        <span class="r-sub">Protects your streak on a missed day.</span>
+      {/if}
+    </div>
+  {/if}
+</main>
+
+<style>
+  .quests-page { max-width: 460px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+  .back-btn {
+    display: inline-block; margin-bottom: 1.2rem; padding: 0.55rem 1.1rem;
+    background: var(--surface); color: var(--text); border: 1px solid var(--border);
+    border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem;
+  }
+  .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
+  .head { display: flex; align-items: baseline; justify-content: space-between; }
+  h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0; }
+  .resets { color: var(--text-faint); font-size: 0.85rem; }
+  .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1.4rem; }
+
+  .qlist { display: flex; flex-direction: column; gap: 0.7rem; }
+  .quest {
+    display: flex; gap: 0.9rem; align-items: center; padding: 0.9rem 1rem;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 16px;
+    transition: border-color 0.2s, background 0.2s;
+  }
+  .quest.done { border-color: rgba(163, 230, 53, 0.4); background: linear-gradient(135deg, rgba(52,211,153,0.1), rgba(163,230,53,0.04)); }
+  .q-emoji { font-size: 1.5rem; width: 40px; height: 40px; display: grid; place-items: center; flex-shrink: 0; }
+  .q-body { flex: 1; min-width: 0; }
+  .q-top { display: flex; justify-content: space-between; gap: 0.5rem; margin-bottom: 0.5rem; }
+  .q-label { font-weight: 600; font-size: 0.98rem; }
+  .q-count { font-family: var(--font-display); font-weight: 700; font-size: 0.85rem; color: var(--brand-2); white-space: nowrap; }
+  .bar { height: 8px; background: rgba(255,255,255,0.06); border-radius: 999px; overflow: hidden; }
+  .fill { height: 100%; background: var(--brand-grad, linear-gradient(90deg,#34d399,#a3e635)); border-radius: 999px; transition: width 0.4s var(--ease-out, ease); }
+
+  .reward {
+    margin-top: 1.6rem; padding: 1.1rem; border-radius: 16px; text-align: center;
+    display: flex; flex-direction: column; gap: 0.6rem; align-items: center;
+    background: var(--surface); border: 1px dashed var(--border);
+  }
+  .reward.ready { border-style: solid; border-color: rgba(251,191,36,0.5); box-shadow: 0 0 18px rgba(251,191,36,0.2); }
+  .reward.claimed { border-color: rgba(163,230,53,0.4); }
+  .r-title { font-family: var(--font-display); font-weight: 700; font-size: 1rem; color: var(--text); }
+  .r-sub { color: var(--text-muted); font-size: 0.85rem; }
+  .claim-btn {
+    font-family: var(--font-display); font-weight: 700; font-size: 0.95rem;
+    padding: 0.7rem 1.4rem; border: none; border-radius: 999px; cursor: pointer;
+    color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635));
+  }
+  .claim-btn:disabled { opacity: 0.6; cursor: default; }
+</style>

--- a/supabase-quests.sql
+++ b/supabase-quests.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- Daily Quests (applied to prod). 3 quests/day, SAME for everyone (deterministic
+-- by date, like the daily modifier). Progress is computed from the events table
+-- (server-stamped user_id) so there are NO game-engine changes. Finishing all 3
+-- lets the player claim a streak freeze (capped at 3, earned-through-play =
+-- sweepstakes-safe). Client: src/lib/stores/statsStore.js getDailyQuests/claim,
+-- src/routes/quests/+page.svelte, menu card in +page.svelte.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.quest_claims (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  day DATE NOT NULL,
+  claimed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, day)
+);
+ALTER TABLE public.quest_claims ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.get_daily_quests()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_quests JSONB; v_all BOOL; v_claimed BOOL;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  WITH pool(id, emoji, label, metric, target) AS (VALUES
+    ('daily_win','🎯','Win today''s Daily','daily_win',1),
+    ('arcade_3','🕹️','Solve 3 Arcade puzzles','arcade_solve',3),
+    ('arcade_5','🕹️','Solve 5 Arcade puzzles','arcade_solve',5),
+    ('arcade_powerup','⚡','Earn a power-up in Arcade','arcade_powerup',1),
+    ('freeplay','🎲','Play a Free Play puzzle','freeplay_play',1),
+    ('arcade_run','🏦','Start an Arcade run','arcade_start',1)
+  ),
+  ranked AS (
+    SELECT *, md5(CURRENT_DATE::text || id) AS h,
+      row_number() OVER (PARTITION BY metric ORDER BY md5(CURRENT_DATE::text || id)) AS rn
+    FROM pool
+  ),
+  chosen AS (SELECT * FROM ranked WHERE rn = 1 ORDER BY h LIMIT 3),
+  prog AS (
+    SELECT c.*, CASE c.metric
+      WHEN 'daily_win' THEN (SELECT count(*) FROM public.events e WHERE e.user_id=v_uid AND e.name='daily_result' AND (e.props->>'won')::bool IS TRUE AND e.created_at::date=CURRENT_DATE)
+      WHEN 'arcade_solve' THEN (SELECT count(*) FROM public.events e WHERE e.user_id=v_uid AND e.name='arcade_solve' AND e.created_at::date=CURRENT_DATE)
+      WHEN 'arcade_powerup' THEN (SELECT count(*) FROM public.events e WHERE e.user_id=v_uid AND e.name='arcade_solve' AND COALESCE(e.props->>'earned','') NOT IN ('','null') AND e.created_at::date=CURRENT_DATE)
+      WHEN 'freeplay_play' THEN (SELECT count(*) FROM public.events e WHERE e.user_id=v_uid AND e.name='freeplay_start' AND e.created_at::date=CURRENT_DATE)
+      WHEN 'arcade_start' THEN (SELECT count(*) FROM public.events e WHERE e.user_id=v_uid AND e.name='arcade_start' AND e.created_at::date=CURRENT_DATE)
+      ELSE 0 END AS progress
+    FROM chosen c
+  )
+  SELECT jsonb_agg(jsonb_build_object('id',id,'emoji',emoji,'label',label,'target',target,
+           'progress', LEAST(progress, target), 'done', progress >= target) ORDER BY h)
+  INTO v_quests FROM prog;
+
+  SELECT bool_and((q->>'done')::bool) FROM jsonb_array_elements(COALESCE(v_quests,'[]'::jsonb)) q INTO v_all;
+  v_claimed := EXISTS (SELECT 1 FROM public.quest_claims WHERE user_id=v_uid AND day=CURRENT_DATE);
+
+  RETURN jsonb_build_object(
+    'quests', COALESCE(v_quests,'[]'::jsonb),
+    'all_done', COALESCE(v_all,false),
+    'reward_claimed', v_claimed,
+    'resets_in_seconds', GREATEST(0, extract(epoch FROM (date_trunc('day', now() AT TIME ZONE 'utc') + interval '1 day' - (now() AT TIME ZONE 'utc')))::int)
+  );
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_daily_quests() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.claim_quest_reward()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_status JSONB; v_fz INT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  v_status := public.get_daily_quests();
+  IF v_status IS NULL OR NOT (v_status->>'all_done')::bool THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'not_done');
+  END IF;
+  INSERT INTO public.quest_claims(user_id, day) VALUES (v_uid, CURRENT_DATE) ON CONFLICT DO NOTHING;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok', false, 'reason', 'claimed'); END IF;
+  UPDATE public.profiles SET streak_freezes = LEAST(COALESCE(streak_freezes,0) + 1, 3)
+    WHERE id = v_uid RETURNING streak_freezes INTO v_fz;
+  RETURN jsonb_build_object('ok', true, 'reward', 'streak_freeze', 'freezes', COALESCE(v_fz,0));
+END; $$;
+GRANT EXECUTE ON FUNCTION public.claim_quest_reward() TO authenticated;


### PR DESCRIPTION
3 quests per day, the **same for everyone** (deterministic by date, like the Daily Modifier). Finish all 3 → **claim a streak freeze** (reinforces the streak loop; earned-through-play so it's **sweepstakes-safe**). Progress is computed from the analytics **events** table (server-stamped `user_id`) — so **zero game-engine changes**.

## Server (`supabase-quests.sql`, applied to prod)
- `quest_claims` table.
- `get_daily_quests()` — picks 3 distinct-metric quests by date, computes today's progress from events, returns quests + done state + reset countdown.
- `claim_quest_reward()` — atomic, one claim/day, awards a streak freeze (capped 3).

## Client
- `getDailyQuests` / `claimQuestReward` in statsStore.
- **`/quests`** — quest cards with progress bars, a resets-in countdown, and the reward claim.
- **Menu card** "Daily Quests" showing `N/3` (→ "claim your reward!" when all done).

## Pool (v1, from existing events — no engine changes)
Win the Daily · Solve 3 / 5 Arcade puzzles · Earn a power-up in Arcade · Play Free Play · Start an Arcade run.

## Verified
Live: today's 3 quests (Earn a power-up, Solve 5 Arcade, Play Free Play) render, complete, and claim → freeze awarded (0→1), double-claim blocked. `svelte-check` + build clean; seed data cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)