### PR TITLE
Add friends Daily leaderboard (you vs friends)

### DIFF
--- a/IOS_LAUNCH_ROADMAP.md
+++ b/IOS_LAUNCH_ROADMAP.md
@@ -30,8 +30,12 @@ Everything not on this list is intentionally *after* we have testers.
 - [x] **Daily Quests** (`/quests`) — 3 deterministic quests/day (same for everyone),
       progress from the events table (no engine changes), finish all 3 → claim a
       streak freeze. Menu card shows progress. (`supabase-quests.sql`.)
-- [ ] Next candidates: leagues/divisions for the leaderboard · cosmetic currency
-      + shop · profile screen · push notification (native).
+- [x] **Friends Daily leaderboard** (`/leaderboard` Friends tab) — shareable
+      friend code, add by code or `?add=CODE` invite link, you-vs-friends ranking
+      on today's Daily. (`supabase-friends.sql`.) Stepping stone to leagues.
+- [ ] Next candidates: pressure/blitz mode (user-requested) · leagues/divisions
+      (needs players + sweepstakes lock) · cosmetic currency + shop · profile
+      screen · push notification (native).
 
 ### Zero-friction testing (no TestFlight needed)
 WordBank is a live website, so the lowest-friction way to get friends testing is

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -76,6 +76,27 @@ export async function getDailyQuests() {
   };
 }
 
+/** My shareable friend code (generated on first call). @returns {Promise<string|null>} */
+export async function getMyFriendCode() {
+  const { data, error } = await supabase.rpc('get_my_friend_code');
+  if (error) { console.error('❌ get_my_friend_code:', error); return null; }
+  return data ?? null;
+}
+
+/** Add a friend by code. @param {string} code @returns {Promise<{ok:boolean, reason?:string, friend_name?:string}>} */
+export async function addFriend(code) {
+  const { data, error } = await supabase.rpc('add_friend', { p_code: code });
+  if (error || !data) { if (error) console.error('❌ add_friend:', error); return { ok: false }; }
+  return data;
+}
+
+/** Me + friends ranked by today's Daily score. @returns {Promise<any[]>} */
+export async function getFriendsDailyLeaderboard() {
+  const { data, error } = await supabase.rpc('get_friends_daily_leaderboard');
+  if (error) { console.error('❌ get_friends_daily_leaderboard:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
+
 /** Claim the all-quests-done reward (a streak freeze). @returns {Promise<{ok:boolean, reason?:string, freezes?:number}>} */
 export async function claimQuestReward() {
   const { data, error } = await supabase.rpc('claim_quest_reward');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, getDailyQuests } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -117,6 +117,15 @@
       dailyStatus = ds;
       menuDailyPlayed = ds.has_played_today;
       refreshQuests();
+
+      // Friend invite link: ?add=CODE → add them, then open the Friends board.
+      try {
+        const addCode = new URLSearchParams(window.location.search).get('add');
+        if (addCode) {
+          const res = await addFriend(addCode);
+          if (res?.ok) { track('friend_add', { via: 'link' }); goto('/leaderboard?mode=friends'); return; }
+        }
+      } catch { /* non-fatal */ }
 
       await tick();
       hasInitialized = true;

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -4,14 +4,57 @@
   import { page } from '$app/stores';
   import {
     fetchDailyLeaderboard,
-    fetchArcadeLeaderboard
+    fetchArcadeLeaderboard,
+    getMyFriendCode,
+    addFriend,
+    getFriendsDailyLeaderboard
   } from '$lib/stores/statsStore.js';
+  import { track } from '$lib/analytics.js';
 
   /** @typedef {{ rank?: number, display_name?: string, score?: number, bankroll_left?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} DailyRow */
   /** @typedef {{ rank?: number, display_name?: string, banked?: number, furthest?: number, total?: number }} ArcadeRow */
 
-  /** @type {'daily' | 'arcade'} */
+  /** @type {'daily' | 'arcade' | 'friends'} */
   let mode = $state('daily');
+
+  // ---- Friends ----
+  let friendCode = $state('');
+  /** @type {any[]} */
+  let friendsData = $state([]);
+  let addCode = $state('');
+  let addMsg = $state('');
+  let codeCopied = $state(false);
+
+  async function loadFriends() {
+    try {
+      if (!friendCode) friendCode = (await getMyFriendCode()) ?? '';
+      friendsData = await getFriendsDailyLeaderboard();
+    } catch (e) {
+      error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
+    }
+  }
+  async function submitAddFriend() {
+    const code = addCode.trim().toUpperCase();
+    if (!code) return;
+    addMsg = 'Adding…';
+    const res = await addFriend(code);
+    if (res.ok) {
+      addMsg = `✓ Added ${res.friend_name || 'friend'}!`;
+      addCode = '';
+      track('friend_add');
+      await loadFriends();
+    } else {
+      addMsg = res.reason === 'not_found' ? 'No player with that code.'
+        : res.reason === 'self' ? "That's your own code 🙂"
+        : 'Could not add friend.';
+    }
+  }
+  function shareCode() {
+    const origin = typeof window !== 'undefined' ? window.location.origin : 'https://wordbanksvelte.vercel.app';
+    const text = `Add me on WordBank! Tap to add me + play today's puzzle: ${origin}/?add=${friendCode}`;
+    if (typeof navigator !== 'undefined' && navigator.share) { navigator.share({ text }).catch(() => {}); return; }
+    navigator.clipboard?.writeText(text).then(() => { codeCopied = true; setTimeout(() => codeCopied = false, 1800); }, () => {});
+  }
   let dailyPeriod = $state('daily');
   /** @type {'score' | 'bankroll' | 'streak' | 'highest_streak' | 'puzzles' | 'win_pct'} */
   let dailyOrderBy = $state('score');
@@ -61,8 +104,10 @@
     error = '';
     if (mode === 'daily') {
       loadDaily().finally(() => { loading = false; });
-    } else {
+    } else if (mode === 'arcade') {
       loadArcade().finally(() => { loading = false; });
+    } else {
+      loadFriends().finally(() => { loading = false; });
     }
   });
 
@@ -80,6 +125,7 @@
     const modeParam = typeof window !== 'undefined' && $page.url.searchParams.get('mode');
     if (modeParam === 'daily') mode = 'daily';
     else if (modeParam === 'arcade') mode = 'arcade';
+    else if (modeParam === 'friends') mode = 'friends';
   });
 
   /** @param {unknown} n */
@@ -106,6 +152,13 @@
     >
       Arcade
     </button>
+    <button
+      class="tab-btn"
+      class:active={mode === 'friends'}
+      onclick={() => { mode = 'friends'; }}
+    >
+      Friends
+    </button>
   </div>
 
   {#if mode === 'daily'}
@@ -130,7 +183,7 @@
       <button class="sort-btn" class:active={dailyOrderBy === 'puzzles'} onclick={() => { dailyOrderBy = 'puzzles'; }}>Puzzles</button>
       <button class="sort-btn" class:active={dailyOrderBy === 'win_pct'} onclick={() => { dailyOrderBy = 'win_pct'; }}>Win %</button>
     </div>
-  {:else}
+  {:else if mode === 'arcade'}
     <p class="period-label">{periodLabels[arcadePeriod] ?? 'Today'} · peak bankroll</p>
     <div class="period-filters">
       {#each ['daily', 'weekly', 'monthly', 'all'] as p}
@@ -138,6 +191,22 @@
           {periodLabels[p] ?? p}
         </button>
       {/each}
+    </div>
+  {:else}
+    <p class="period-label">Today's Daily · you vs your friends</p>
+    <div class="friend-panel">
+      <div class="my-code">
+        <span class="mc-label">Your code</span>
+        <button class="code-pill" onclick={shareCode} title="Share your code">
+          {friendCode || '······'} <span class="share-ico">{codeCopied ? '✓' : '↗'}</span>
+        </button>
+      </div>
+      <div class="add-row">
+        <input class="code-input" placeholder="Enter a friend's code" bind:value={addCode} maxlength="6"
+          onkeydown={(e) => { if (e.key === 'Enter') submitAddFriend(); }} />
+        <button class="add-btn" onclick={submitAddFriend}>Add</button>
+      </div>
+      {#if addMsg}<p class="add-msg">{addMsg}</p>{/if}
     </div>
   {/if}
 
@@ -187,7 +256,7 @@
         </table>
       </div>
     {/if}
-  {:else}
+  {:else if mode === 'arcade'}
     {#if arcadeData.length === 0}
       <p class="empty">No arcade runs yet. Climb today's gauntlet to appear!</p>
     {:else}
@@ -219,13 +288,40 @@
         </table>
       </div>
     {/if}
+  {:else}
+    <!-- Friends: you + friends ranked by today's Daily score -->
+    {#if friendsData.length <= 1}
+      <p class="empty">Add friends with their code above, then race them on today's Daily!</p>
+    {/if}
+    {#if friendsData.length > 0}
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>#</th><th>Player</th><th>Today's Score</th></tr>
+          </thead>
+          <tbody>
+            {#each friendsData as row}
+              <tr class={row.is_me ? 'me-row' : ((row.rank ?? 0) <= 3 ? 'top-three' : '')}>
+                <td class="rank">
+                  {#if row.rank === 1}🥇{:else if row.rank === 2}🥈{:else if row.rank === 3}🥉{:else}{row.rank}{/if}
+                </td>
+                <td class="name">{row.is_me ? 'You' : (row.name || 'Player')}{#if (row.streak ?? 0) >= 7} 🔥{/if}</td>
+                <td class="score-cell">{row.played ? fmt(row.score) : '—'}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
   {/if}
 
   <p class="hint">
     {#if mode === 'daily'}
       Daily: Score = bankroll × streak multiplier. Medals 🥇$700 / 🥈$400 / 🥉$100. 🔥 = 7+ day streak.
-    {:else}
+    {:else if mode === 'arcade'}
       Arcade: ranked by peak bankroll in a survival run, and how many puzzles you solved before going broke.
+    {:else}
+      Friends: share your code to add friends — everyone plays the same Daily, so it's a head-to-head. "—" = hasn't played today.
     {/if}
   </p>
 </main>
@@ -395,6 +491,30 @@
     font-size: 0.82rem;
     color: var(--text-faint);
   }
+
+  /* ---- Friends ---- */
+  .friend-panel { max-width: 420px; margin: 0 auto 0.5rem; display: flex; flex-direction: column; gap: 0.7rem; }
+  .my-code { display: flex; align-items: center; justify-content: center; gap: 0.6rem; }
+  .mc-label { color: var(--text-faint); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.05em; }
+  .code-pill {
+    font-family: var(--font-display); font-weight: 800; font-size: 1.1rem; letter-spacing: 0.12em;
+    padding: 0.5rem 1rem; border-radius: 999px; cursor: pointer; color: var(--brand-2);
+    background: rgba(163,230,53,0.1); border: 1px solid rgba(163,230,53,0.4);
+    display: inline-flex; align-items: center; gap: 0.5rem;
+  }
+  .share-ico { font-size: 0.85rem; opacity: 0.8; }
+  .add-row { display: flex; gap: 0.5rem; }
+  .code-input {
+    flex: 1; padding: 0.6rem 0.9rem; border-radius: 12px; border: 1px solid var(--border);
+    background: var(--surface); color: var(--text); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.08em;
+  }
+  .add-btn {
+    padding: 0.6rem 1.2rem; border: none; border-radius: 12px; cursor: pointer; font-weight: 700;
+    color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635));
+  }
+  .add-msg { text-align: center; font-size: 0.85rem; color: var(--text-muted); margin: 0; }
+  tr.me-row { background: rgba(56, 189, 248, 0.12); box-shadow: inset 0 0 0 1px rgba(56,189,248,0.25); }
+  tr.me-row td.name { color: #7dd3fc; font-weight: 700; }
 
   /* ---- Mobile: fit the table without horizontal scroll ---- */
   @media (max-width: 560px) {

--- a/supabase-friends.sql
+++ b/supabase-friends.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- Friends + friends Daily leaderboard (applied to prod).
+-- Shareable 6-char friend code on profiles; symmetric friendships; a friends-only
+-- Daily leaderboard (everyone plays the same Daily → rank friends by today's score).
+-- Writes only via SECURITY DEFINER RPCs (tables RLS-locked).
+-- Client: statsStore getMyFriendCode/addFriend/getFriendsDailyLeaderboard,
+-- Friends tab in src/routes/leaderboard/+page.svelte, ?add=CODE invite link in +page.svelte.
+-- ============================================================
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS friend_code TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_profiles_friend_code ON public.profiles(friend_code) WHERE friend_code IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.friendships (
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  friend_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, friend_id)
+);
+ALTER TABLE public.friendships ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.get_my_friend_code()
+RETURNS TEXT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_code TEXT; v_alpha TEXT := 'ABCDEFGHJKMNPQRSTUVWXYZ23456789'; i INT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  SELECT friend_code INTO v_code FROM public.profiles WHERE id = v_uid;
+  IF v_code IS NOT NULL THEN RETURN v_code; END IF;
+  LOOP
+    v_code := '';
+    FOR i IN 1..6 LOOP v_code := v_code || substr(v_alpha, 1 + floor(random() * length(v_alpha))::int, 1); END LOOP;
+    BEGIN
+      UPDATE public.profiles SET friend_code = v_code WHERE id = v_uid;
+      RETURN v_code;
+    EXCEPTION WHEN unique_violation THEN /* retry */ END;
+  END LOOP;
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_my_friend_code() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.add_friend(p_code TEXT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_friend UUID; v_name TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'auth'); END IF;
+  p_code := upper(trim(COALESCE(p_code, '')));
+  IF p_code = '' THEN RETURN jsonb_build_object('ok', false, 'reason', 'empty'); END IF;
+  SELECT id INTO v_friend FROM public.profiles WHERE friend_code = p_code;
+  IF v_friend IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'not_found'); END IF;
+  IF v_friend = v_uid THEN RETURN jsonb_build_object('ok', false, 'reason', 'self'); END IF;
+  INSERT INTO public.friendships(user_id, friend_id) VALUES (v_uid, v_friend), (v_friend, v_uid) ON CONFLICT DO NOTHING;
+  SELECT COALESCE(au.raw_user_meta_data->>'full_name', split_part(au.raw_user_meta_data->>'email','@',1), 'Player')
+    INTO v_name FROM auth.users au WHERE au.id = v_friend;
+  RETURN jsonb_build_object('ok', true, 'friend_name', v_name);
+END; $$;
+GRANT EXECUTE ON FUNCTION public.add_friend(TEXT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_friends_daily_leaderboard()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  WITH circle AS (
+    SELECT v_uid AS id UNION SELECT friend_id FROM public.friendships WHERE user_id = v_uid
+  ),
+  scored AS (
+    SELECT c.id,
+      COALESCE(au.raw_user_meta_data->>'full_name', split_part(au.raw_user_meta_data->>'email','@',1), 'Player') AS name,
+      (SELECT gr.score FROM public.game_results gr
+        WHERE gr.user_id = c.id AND gr.game_mode = 'daily' AND gr.played_at::date = CURRENT_DATE
+        ORDER BY gr.played_at DESC LIMIT 1) AS score,
+      COALESCE(p.current_win_streak, 0) AS streak
+    FROM circle c JOIN auth.users au ON au.id = c.id LEFT JOIN public.profiles p ON p.id = c.id
+  ),
+  ranked AS (
+    SELECT *, row_number() OVER (ORDER BY (score IS NULL), score DESC NULLS LAST, name) AS rank FROM scored
+  )
+  SELECT jsonb_agg(jsonb_build_object('rank', rank, 'name', name, 'score', score, 'streak', streak,
+    'is_me', id = v_uid, 'played', score IS NOT NULL) ORDER BY rank)
+  INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_friends_daily_leaderboard() TO authenticated;


### PR DESCRIPTION
Everyone plays the same Daily, so this turns it into a **real head-to-head among friends** — the highest-value social feature for right now (a friends board with 6 friends beats a global board with 6 testers), and the stepping stone to leagues.

## Server (`supabase-friends.sql`, applied to prod)
- `profiles.friend_code` (unique 6-char) + symmetric `friendships` table (RLS-locked).
- `get_my_friend_code()`, `add_friend(code)`, `get_friends_daily_leaderboard()` (me + friends ranked by today's Daily score). Writes via SECURITY DEFINER RPCs only.

## Client
- **Friends tab** on the leaderboard: your shareable **code**, **add-by-code**, and the **you-vs-friends** ranking (your row highlighted; "—" = hasn't played today).
- **One-tap invite link**: share button builds `?add=CODE`; the menu auto-adds the friend from `?add=` and opens the Friends board. `track('friend_add')`.

## Verified
Live with two accounts: add by code → "Added Charlie Foreman!" → board ranks **Charlie 950 / You 800**, your row highlighted. `svelte-check` + build clean; test data cleaned up.

## Next
Pressure/Blitz mode (your friend's idea) is queued; leagues wait for a real player base + the sweepstakes lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)