### PR TITLE
Bank economy Phase A: persistent Bank + loan + Net Worth

### DIFF
--- a/BANK_ECONOMY.md
+++ b/BANK_ECONOMY.md
@@ -82,15 +82,33 @@ Wagering virtual currency is fine **only if the currency has no real-money value
 - Maybe a **premium tier** (stats, cosmetics) — never a competitive edge, never Bank.
 - The Bank itself stays **100% earned**, forever.
 
-## Build phases
-- [ ] **A — Persistent Bank:** `profiles.bank`, seed new users, show on menu/profile,
-      earn from Daily win + quest bonus.
-- [ ] **B — Arcade cash-out:** "Bank it" + press-your-luck; route winnings to the Bank.
-- [ ] **C — Challenges (Score mode + wager):** matches table, seeded puzzle sets,
-      escrow, accept/play/settle, surface pending challenges.
-- [ ] **D — Pressure mode** variant.
-- [ ] **E — Polish:** challenge history, notifications, friends "richest" flex,
-      username search (the friend *code* already covers adding people).
+## Locked decisions (2026-06)
+- ✅ **Loan + Net Worth confirmed.** Start with a **$5,000 loan**; **Net Worth = Bank − loan**
+  is the headline number and the front-page leaderboard.
+- ✅ One account / one Bank. Daily stays free/fair/clean. Two-currency firewall
+  (Bank earned-only/virtual; real money = cosmetics only). Wagered challenges = clean.
+- Defaults (tune in playtest): starting loan **$5,000**, min wager **$100**, daily-win
+  bonus **$500 × streak**, quest reward **$1,000**, Arcade cash-out = **full round bankroll**.
+
+## Build roadmap
+### Phase A — Persistent Bank + loan + Net Worth  ✅ (PR #124)
+- [x] `profiles.bank` + `profiles.loan`; lazy-seed new/existing users (bank 5000, loan 5000 → Net Worth 0).
+- [x] `bank_ledger` table (auditable history) + `_bank_credit(uid, delta, reason)` helper.
+- [x] `get_bank()` (balance + loan + net worth + recent ledger) and `repay_loan(amount)`.
+- [x] First earn source: **quest reward pays Bank** (+$1,000) instead of a freeze.
+- [x] Menu **Net Worth chip** → **/bank** screen: Bank, Loan, Net Worth, "pay back loan", history.
+      (`supabase-bank.sql`.)
+### Phase B — Earn faucets + Arcade cash-out
+- [ ] Daily-win bonus → Bank ($500 × streak). Achievements/milestone payouts. Optional daily "interest"/stipend.
+- [ ] **Arcade "Bank it"** (press-your-luck): cash the round bankroll into your Bank; bust = lose only house money.
+### Phase C — Challenges (Score mode + wager)
+- [ ] `matches` table + deterministic seeded puzzle set; create/accept with **escrow**; play → settle (winner takes pot, tie refunds); 48h expiry; surface pending challenges.
+### Phase D — Pressure mode
+- [ ] Timed challenge variant (speed × bankroll scoring).
+### Phase E — Spending + leaderboards + polish
+- [ ] Spend sinks: power-up shop (Arcade), cosmetics/avatars/accessories, high-stakes rooms.
+- [ ] **Net Worth leaderboard** (+ friends "richest"), challenge record board.
+- [ ] Cosmetics for real money (firewall), challenge history/notifications, username search.
 
 ## Open decisions 🔒 (let's settle these as we build)
 1. **Naming:** persistent = "Bank", per-round = "bankroll"? Or rename one (e.g. "Vault")

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -76,6 +76,21 @@ export async function getDailyQuests() {
   };
 }
 
+/** My Bank: balance, outstanding loan, net worth, recent ledger.
+ * @returns {Promise<{ bank:number, loan:number, net_worth:number, ledger:any[] }>} */
+export async function getBank() {
+  const { data, error } = await supabase.rpc('get_bank');
+  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, loan: 0, net_worth: 0, ledger: [] }; }
+  return { bank: data.bank ?? 0, loan: data.loan ?? 0, net_worth: data.net_worth ?? 0, ledger: Array.isArray(data.ledger) ? data.ledger : [] };
+}
+
+/** Pay down the starting loan from your Bank. @param {number} amount @returns {Promise<any>} */
+export async function repayLoan(amount) {
+  const { data, error } = await supabase.rpc('repay_loan', { p_amount: amount });
+  if (error) { console.error('❌ repay_loan:', error); return null; }
+  return data;
+}
+
 /** My shareable friend code (generated on first call). @returns {Promise<string|null>} */
 export async function getMyFriendCode() {
   const { data, error } = await supabase.rpc('get_my_friend_code');
@@ -97,7 +112,7 @@ export async function getFriendsDailyLeaderboard() {
   return Array.isArray(data) ? data : [];
 }
 
-/** Claim the all-quests-done reward (a streak freeze). @returns {Promise<{ok:boolean, reason?:string, freezes?:number}>} */
+/** Claim the all-quests-done reward (pays Bank). @returns {Promise<{ok:boolean, reason?:string, amount?:number, bank?:number}>} */
 export async function claimQuestReward() {
   const { data, error } = await supabase.rpc('claim_quest_reward');
   if (error || !data) { if (error) console.error('❌ claim_quest_reward:', error); return { ok: false }; }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, getBank } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -53,6 +53,11 @@
       const q = await getDailyQuests();
       questProgress = { done: q.quests.filter((x) => x.done).length, total: q.quests.length || 3, all_done: q.all_done, reward_claimed: q.reward_claimed };
     } catch { /* non-fatal */ }
+  }
+  /** Net Worth for the menu chip. */
+  let netWorth = /** @type {number|null} */ (null);
+  async function refreshBank() {
+    try { netWorth = (await getBank()).net_worth; } catch { /* non-fatal */ }
   }
 
   // ✅ Load Supabase user profile and sync bankroll (creates profile if missing)
@@ -117,6 +122,7 @@
       dailyStatus = ds;
       menuDailyPlayed = ds.has_played_today;
       refreshQuests();
+      refreshBank();
 
       // Friend invite link: ?add=CODE → add them, then open the Friends board.
       try {
@@ -378,6 +384,7 @@
     // Refresh the daily completion indicator (e.g. just finished today's daily).
     getDailyStatus(currentUser.id).then((s) => { dailyStatus = s; menuDailyPlayed = s.has_played_today; });
     refreshQuests();
+    refreshBank();
   }
 
   let showMyAccount = false;
@@ -484,6 +491,9 @@
     <!-- 🏠 Main Menu (after sign-in) -->
     <div class="main-menu fade-up">
       <div class="menu-hero">
+        <button class="bank-chip" on:click={() => goto('/bank')} title="Your Bank">
+          <span class="bc-coin">💰</span>{netWorth == null ? '—' : '$' + Math.round(netWorth).toLocaleString()}
+        </button>
         <button class="streak-chip" class:lit={(dailyStatus?.current_streak ?? 0) > 0} on:click={() => goto('/streak')} title="Your streak">
           <span class="sc-flame">🔥</span>{dailyStatus?.current_streak ?? 0}
         </button>
@@ -998,6 +1008,27 @@
     text-align: center;
     position: relative;
   }
+  .bank-chip {
+    position: absolute;
+    top: 0;
+    left: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: var(--surface, rgba(255,255,255,0.05));
+    border: 1px solid rgba(163, 230, 53, 0.35);
+    color: var(--brand-2);
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .bank-chip:hover { transform: translateY(-1px); }
+  .bank-chip:active { transform: scale(0.96); }
+  .bank-chip .bc-coin { font-size: 1rem; }
   .streak-chip {
     position: absolute;
     top: 0;

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,0 +1,130 @@
+<script>
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getBank, repayLoan } from '$lib/stores/statsStore.js';
+  import { track } from '$lib/analytics.js';
+  import { fx } from '$lib/sound.js';
+
+  /** @type {{ bank:number, loan:number, net_worth:number, ledger:any[] }|null} */
+  let b = null;
+  let loading = true;
+  let repayAmt = '';
+  let busy = false;
+
+  onMount(async () => {
+    track('bank_view');
+    try { b = await getBank(); } finally { loading = false; }
+  });
+
+  const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+
+  /** @param {string} reason */
+  function reasonLabel(reason) {
+    return ({
+      quest_reward: 'Daily quests reward',
+      daily_win: 'Daily win bonus',
+      loan_payment: 'Loan payment',
+      arcade_cashout: 'Arcade cash-out',
+      wager_win: 'Won a wager',
+      wager_stake: 'Wager staked',
+      interest: 'Bank interest'
+    })[reason] || reason;
+  }
+
+  async function payLoan(/** @type {number} */ amt) {
+    if (busy || !b || b.loan <= 0) return;
+    const pay = Math.min(amt, b.loan, b.bank);
+    if (pay <= 0) return;
+    busy = true;
+    const res = await repayLoan(pay);
+    busy = false;
+    if (res) { b = res; repayAmt = ''; fx('tap'); track('loan_repay', { amount: pay }); }
+  }
+</script>
+
+<svelte:head><title>WordBank — Your Bank</title></svelte:head>
+
+<main class="bank-page">
+  <button class="back-btn" on:click={() => goto('/')}>← Menu</button>
+
+  {#if loading}
+    <p class="loading">Loading…</p>
+  {:else if b}
+    <p class="nw-label">Net Worth</p>
+    <div class="net-worth" class:neg={b.net_worth < 0}>{fmt(b.net_worth)}</div>
+
+    <div class="stat-row">
+      <div class="stat"><span class="sv">{fmt(b.bank)}</span><span class="sc">Bank</span></div>
+      <div class="stat loan"><span class="sv">{fmt(b.loan)}</span><span class="sc">Loan owed</span></div>
+    </div>
+
+    {#if b.loan > 0}
+      <div class="loan-box">
+        <p class="loan-copy">The House fronted you <strong>$5,000</strong> to get started. Pay it back to go debt-free — everything after is pure profit.</p>
+        <div class="pay-row">
+          <input class="amt" type="number" min="1" placeholder="Amount" bind:value={repayAmt} />
+          <button class="pay-btn" disabled={busy} on:click={() => payLoan(Math.floor(Number(repayAmt) || 0))}>Pay</button>
+          <button class="pay-btn ghost" disabled={busy} on:click={() => payLoan(b?.loan ?? 0)}>Pay all</button>
+        </div>
+      </div>
+    {:else}
+      <div class="debt-free">🎉 Debt-free! Your Bank is all yours.</div>
+    {/if}
+
+    <h2 class="hist-title">Recent activity</h2>
+    {#if b.ledger.length === 0}
+      <p class="empty">No transactions yet. Win the Daily, finish quests, or cash out an Arcade run to grow your Bank.</p>
+    {:else}
+      <div class="ledger">
+        {#each b.ledger as e}
+          <div class="led-row">
+            <span class="led-reason">{reasonLabel(e.reason)}</span>
+            <span class="led-delta" class:pos={e.delta > 0} class:neg={e.delta < 0}>{e.delta > 0 ? '+' : '−'}{fmt(Math.abs(e.delta))}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <p class="hint">Your Bank is in-game money — earn it by playing, spend it on wagers and (soon) power-ups &amp; cosmetics. It can't be bought or cashed out.</p>
+  {/if}
+</main>
+
+<style>
+  .bank-page { max-width: 460px; margin: 0 auto; padding: 1.5rem 1rem 3rem; text-align: center; }
+  .back-btn {
+    display: inline-block; margin-bottom: 1rem; padding: 0.55rem 1.1rem;
+    background: var(--surface); color: var(--text); border: 1px solid var(--border);
+    border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem;
+  }
+  .loading { color: var(--text-muted); padding: 2rem; }
+  .nw-label { color: var(--text-faint); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; margin: 0.5rem 0 0; }
+  .net-worth { font-family: var(--font-display); font-weight: 800; font-size: 3rem; line-height: 1.1; color: var(--brand-2); }
+  .net-worth.neg { color: var(--text-muted); }
+
+  .stat-row { display: flex; justify-content: center; gap: 0.6rem; margin: 1.2rem 0 0; }
+  .stat { flex: 1; max-width: 160px; display: flex; flex-direction: column; gap: 3px; padding: 0.8rem 0.5rem;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 14px; }
+  .stat.loan { border-color: rgba(251,113,133,0.3); }
+  .sv { font-family: var(--font-display); font-weight: 700; font-size: 1.25rem; color: var(--text); }
+  .stat.loan .sv { color: #fb7185; }
+  .sc { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint); }
+
+  .loan-box { margin-top: 1.4rem; padding: 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 16px; text-align: left; }
+  .loan-copy { margin: 0 0 0.8rem; color: var(--text-muted); font-size: 0.9rem; }
+  .pay-row { display: flex; gap: 0.5rem; }
+  .amt { flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: var(--text); }
+  .pay-btn { padding: 0.6rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
+  .pay-btn.ghost { background: transparent; color: var(--brand-2); border: 1px solid rgba(163,230,53,0.4); }
+  .pay-btn:disabled { opacity: 0.5; }
+  .debt-free { margin-top: 1.4rem; padding: 0.9rem; border-radius: 14px; background: linear-gradient(135deg, rgba(52,211,153,0.12), rgba(163,230,53,0.05)); border: 1px solid rgba(163,230,53,0.4); font-weight: 700; }
+
+  .hist-title { font-family: var(--font-display); font-size: 1rem; margin: 1.8rem 0 0.6rem; text-align: left; }
+  .empty { color: var(--text-muted); font-size: 0.9rem; }
+  .ledger { display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden; }
+  .led-row { display: flex; justify-content: space-between; padding: 0.7rem 0.9rem; background: var(--surface); }
+  .led-reason { color: var(--text-muted); font-size: 0.9rem; }
+  .led-delta { font-family: var(--font-display); font-weight: 700; font-size: 0.9rem; }
+  .led-delta.pos { color: var(--brand-2); }
+  .led-delta.neg { color: #fb7185; }
+  .hint { margin-top: 1.6rem; font-size: 0.78rem; color: var(--text-faint); }
+</style>

--- a/src/routes/quests/+page.svelte
+++ b/src/routes/quests/+page.svelte
@@ -36,7 +36,7 @@
     if (res?.ok) {
       track('quest_reward_claimed');
       fx('win');
-      claimedMsg = '❄️ Streak Freeze earned!';
+      claimedMsg = `💰 +$${(res.amount ?? 1000).toLocaleString()} to your Bank!`;
       q = { ...q, reward_claimed: true };
     } else if (res?.reason === 'claimed') {
       q = { ...q, reward_claimed: true };
@@ -80,11 +80,11 @@
       {:else if q.all_done}
         <span class="r-title">All quests done! 🎉</span>
         <button class="claim-btn" on:click={claim} disabled={claiming}>
-          {claiming ? 'Claiming…' : 'Claim ❄️ Streak Freeze'}
+          {claiming ? 'Claiming…' : 'Claim 💰 $1,000'}
         </button>
       {:else}
-        <span class="r-title">Finish all 3 to earn ❄️ a Streak Freeze</span>
-        <span class="r-sub">Protects your streak on a missed day.</span>
+        <span class="r-title">Finish all 3 to earn 💰 $1,000</span>
+        <span class="r-sub">Straight into your Bank.</span>
       {/if}
     </div>
   {/if}

--- a/supabase-bank.sql
+++ b/supabase-bank.sql
@@ -1,0 +1,83 @@
+-- ============================================================
+-- Bank economy — Phase A (applied to prod). Persistent, earned-only, virtual
+-- Bank + a $5,000 starting loan; Net Worth = bank - loan. Bank is NEVER
+-- purchasable or cashable. Ledger for auditability. Quest reward pays Bank.
+-- Client: statsStore getBank/repayLoan, /bank screen, Net Worth chip on the menu.
+-- See BANK_ECONOMY.md for the full design + roadmap.
+-- ============================================================
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bank BIGINT;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS loan BIGINT;
+
+CREATE TABLE IF NOT EXISTS public.bank_ledger (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  delta BIGINT NOT NULL,
+  reason TEXT NOT NULL,
+  balance_after BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_bank_ledger_user_time ON public.bank_ledger(user_id, created_at DESC);
+ALTER TABLE public.bank_ledger ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public._ensure_bank(p_uid UUID)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  UPDATE public.profiles SET bank = 5000, loan = 5000 WHERE id = p_uid AND bank IS NULL;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public._bank_credit(p_uid UUID, p_delta BIGINT, p_reason TEXT)
+RETURNS BIGINT LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_new BIGINT;
+BEGIN
+  PERFORM public._ensure_bank(p_uid);
+  UPDATE public.profiles SET bank = GREATEST(0, COALESCE(bank,0) + p_delta) WHERE id = p_uid RETURNING bank INTO v_new;
+  INSERT INTO public.bank_ledger(user_id, delta, reason, balance_after) VALUES (p_uid, p_delta, p_reason, v_new);
+  RETURN v_new;
+END; $$;
+
+CREATE OR REPLACE FUNCTION public.get_bank()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_bank BIGINT; v_loan BIGINT; v_led JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT bank, loan INTO v_bank, v_loan FROM public.profiles WHERE id = v_uid;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('delta',delta,'reason',reason,'balance_after',balance_after,'at',created_at) ORDER BY created_at DESC), '[]'::jsonb)
+    INTO v_led FROM (SELECT * FROM public.bank_ledger WHERE user_id = v_uid ORDER BY created_at DESC LIMIT 12) t;
+  RETURN jsonb_build_object('bank', COALESCE(v_bank,0), 'loan', COALESCE(v_loan,0),
+                            'net_worth', COALESCE(v_bank,0) - COALESCE(v_loan,0), 'ledger', v_led);
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_bank() TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.repay_loan(p_amount BIGINT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_bank BIGINT; v_loan BIGINT; v_pay BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT bank, loan INTO v_bank, v_loan FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  v_pay := LEAST(GREATEST(COALESCE(p_amount,0),0), COALESCE(v_loan,0), COALESCE(v_bank,0));
+  IF v_pay > 0 THEN
+    UPDATE public.profiles SET bank = bank - v_pay, loan = loan - v_pay WHERE id = v_uid;
+    INSERT INTO public.bank_ledger(user_id, delta, reason, balance_after) VALUES (v_uid, -v_pay, 'loan_payment', v_bank - v_pay);
+  END IF;
+  RETURN public.get_bank();
+END; $$;
+GRANT EXECUTE ON FUNCTION public.repay_loan(BIGINT) TO authenticated;
+
+-- Quest reward now pays Bank (was a streak freeze).
+CREATE OR REPLACE FUNCTION public.claim_quest_reward()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_status JSONB; v_bank BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  v_status := public.get_daily_quests();
+  IF v_status IS NULL OR NOT (v_status->>'all_done')::bool THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'not_done');
+  END IF;
+  INSERT INTO public.quest_claims(user_id, day) VALUES (v_uid, CURRENT_DATE) ON CONFLICT DO NOTHING;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok', false, 'reason', 'claimed'); END IF;
+  v_bank := public._bank_credit(v_uid, 1000, 'quest_reward');
+  RETURN jsonb_build_object('ok', true, 'reward', 'bank', 'amount', 1000, 'bank', v_bank);
+END; $$;
+GRANT EXECUTE ON FUNCTION public.claim_quest_reward() TO authenticated;


### PR DESCRIPTION
Kicks off the bank-economy overhaul (full spec + roadmap in **BANK_ECONOMY.md**; loan + Net Worth locked in).

## Server (`supabase-bank.sql`, applied to prod)
- `profiles.bank` + `profiles.loan`; **every user lazily seeded with a $5,000 starting loan** → **Net Worth = bank − loan** (starts at 0).
- `bank_ledger` (auditable history) + `_bank_credit()` helper, `get_bank()`, `repay_loan()`.
- **Bank is earned-only / virtual — never purchasable, never cashable.**
- **Quest reward now pays Bank (+$1,000)** instead of a streak freeze.

## Client
- `getBank` / `repayLoan` in statsStore.
- **Net Worth chip (💰) on the menu** → **`/bank`** screen: Net Worth, Bank, Loan owed, a "pay back the House" flow, and transaction history.
- `/quests` reward copy updated to "Claim $1,000."

## Verified
Live: seeds correctly; chip shows Net Worth; repaying the loan reduces Bank+Loan together (Net Worth unchanged) with ledger entries. `svelte-check` + build clean; test data cleaned up.

## Next
Phase B — earn faucets (Daily-win bonus) + the **Arcade cash-out / press-your-luck** loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)