### PR TITLE
Bank economy Phase B: earn faucets + Arcade cash-out

### DIFF
--- a/BANK_ECONOMY.md
+++ b/BANK_ECONOMY.md
@@ -98,9 +98,14 @@ Wagering virtual currency is fine **only if the currency has no real-money value
 - [x] First earn source: **quest reward pays Bank** (+$1,000) instead of a freeze.
 - [x] Menu **Net Worth chip** → **/bank** screen: Bank, Loan, Net Worth, "pay back loan", history.
       (`supabase-bank.sql`.)
-### Phase B — Earn faucets + Arcade cash-out
-- [ ] Daily-win bonus → Bank ($500 × streak). Achievements/milestone payouts. Optional daily "interest"/stipend.
-- [ ] **Arcade "Bank it"** (press-your-luck): cash the round bankroll into your Bank; bust = lose only house money.
+### Phase B — Earn faucets + Arcade cash-out  ✅ (PR #125)
+- [x] **Daily-win bonus → Bank** ($500 × streak), in `_finalize_daily`.
+- [x] **Arcade "Bank it"** (press-your-luck): banks your **winnings = bankroll − $1,500 house
+      stake** into your Bank and ends the run; **bust before banking = $0**. `arcade_cashout()` +
+      a "Bank $X" button on the arcade HUD + a "Cashed Out!" result modal (vs "Run Over").
+- [ ] (later) Achievements/milestone payouts · optional daily "interest"/stipend.
+      NOTE: cash-out banks *winnings above the house stake*, not the full bankroll
+      (prevents free-money from instant cashouts; supersedes the earlier default).
 ### Phase C — Challenges (Score mode + wager)
 - [ ] `matches` table + deterministic seeded puzzle set; create/accept with **escrow**; play → settle (winner takes pot, tie refunds); 48h expiry; surface pending challenges.
 ### Phase D — Pressure mode

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -4,7 +4,7 @@ import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
 import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
-import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup } from '$lib/stores/statsStore.js';
+import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
@@ -36,6 +36,7 @@ import { track } from '$lib/analytics.js';
  *   gameMode: string,
  *   freeReveals?: number,
  *   arcadeRun?: any,
+ *   arcadeCashedOut?: boolean,
  *   modifier?: string | null,
  *   clue?: string | null
  * }} GameState
@@ -72,6 +73,7 @@ export const gameStore = writable(/** @type {GameState} */ ({
   gameMode: 'daily', // 'daily' | 'arcade'
   freeReveals: 0, // owned Free Reveal power-ups (daily)
   arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
+  arcadeCashedOut: false, // true when the last arcade run ended via "Bank it" (vs bust)
   modifier: null, // today's shared Daily Modifier id (daily only)
   clue: null // witty one-line hint for the current puzzle
 }));
@@ -210,6 +212,7 @@ function reconcileArcadeBoard(resp) {
     gameMode: 'arcade',
     gameState: gs,
     arcadeRun: run,
+    arcadeCashedOut: false,
     freeReveals: 0,
     modifier: null
   }));
@@ -384,6 +387,23 @@ export async function useArcadePowerup(powerup) {
   try {
     const resp = await arcadeUsePowerup(powerup);
     if (resp) reconcileArcadeBoard(resp);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** Cash out the current arcade run's winnings into your Bank (ends the run). */
+export async function arcadeCashOut() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const resp = await arcadeCashout();
+    if (resp) {
+      reconcileArcadeBoard(resp);
+      // reconcile cleared the flag; mark this as a cash-out so the modal differs from a bust
+      gameStore.update(s => ({ ...s, arcadeCashedOut: true }));
+      fx('multiplier');
+    }
   } finally {
     dailyInFlight = false;
   }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -310,6 +310,12 @@ export async function arcadeUsePowerup(powerup) {
   if (error) { console.error('❌ arcade_use_powerup error:', error); return null; }
   return data;
 }
+/** Cash out the current arcade run's winnings into your Bank. @returns {Promise<any>} */
+export async function arcadeCashout() {
+  const { data, error } = await supabase.rpc('arcade_cashout');
+  if (error) { console.error('❌ arcade_cashout error:', error); return null; }
+  return data;
+}
 
 /** Whether the caller already has a session for today (drives the pre-game picker). */
 export async function dailySessionExists() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut } from '$lib/stores/GameStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -226,6 +226,13 @@
   $: arun = $gameStore.arcadeRun;
   $: arcadeMult = ((arun?.multiplier ?? 100) / 100).toFixed(2);
   $: arcadePayout = Math.round(500 * (arun?.multiplier ?? 100) / 100); // next solve is worth this
+  $: arcadeWinnings = Math.max(0, Math.floor(($gameStore.bankroll ?? 0) - 1500)); // bankable above the house stake
+  let cashingOut = false;
+  async function handleBankIt() {
+    if (cashingOut || arcadeWinnings <= 0) return;
+    cashingOut = true;
+    try { await arcadeCashOut(); } finally { cashingOut = false; }
+  }
 
   let shareCopied = false;
   function buildShareText() {
@@ -672,6 +679,11 @@
         <div class="ah-cell ah-mult"><span class="ah-val">×{arcadeMult}</span><span class="ah-label">Streak</span></div>
         <div class="ah-cell"><span class="ah-val ah-gold">+${arcadePayout.toLocaleString()}</span><span class="ah-label">Solve</span></div>
       </div>
+      {#if $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost' && arcadeWinnings > 0}
+        <button class="bank-it-btn" on:click={handleBankIt} disabled={cashingOut}>
+          💰 Bank ${arcadeWinnings.toLocaleString()} <span class="bib-sub">end run, keep winnings</span>
+        </button>
+      {/if}
     {/if}
 
     <!-- 🌍 Category + witty clue -->
@@ -801,10 +813,18 @@
                 <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
                 <button class="next-puzzle-button" on:click={handleArcadeContinue}>Continue</button>
               </div>
+            {:else if $gameStore.arcadeCashedOut}
+              <div class="result-medal">💰</div>
+              <h2>Cashed Out! +${(arun?.last_gain ?? 0).toLocaleString()}</h2>
+              <p class="result-sub">Banked into your account · {arun?.furthest ?? 0} {(arun?.furthest ?? 0) === 1 ? 'puzzle' : 'puzzles'} solved</p>
+              <div class="result-actions">
+                <button class="share-btn" on:click={() => goto('/bank')}>View Bank</button>
+                <button class="next-puzzle-button" on:click={handleArcadeNewRun}>New Run</button>
+              </div>
             {:else}
               <div class="result-medal">🏁</div>
               <h2>Run Over</h2>
-              <p class="result-sub">You ran out of cash.</p>
+              <p class="result-sub">Busted before you could bank it.</p>
               <div class="result-bankroll">
                 <span class="rb-label">Peak Bankroll</span>
                 <span class="rb-amount">${(arun?.banked ?? 0).toLocaleString()}</span>
@@ -848,6 +868,27 @@
     max-width: 360px;
     margin: 0 auto 14px;
   }
+  .bank-it-btn {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 8px;
+    margin: 0 auto 14px;
+    padding: 0.6rem 1.3rem;
+    border: 1px solid rgba(163, 230, 53, 0.5);
+    border-radius: 999px;
+    background: linear-gradient(135deg, rgba(52,211,153,0.16), rgba(163,230,53,0.08));
+    color: var(--brand-2);
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1rem;
+    cursor: pointer;
+    box-shadow: 0 0 16px rgba(163, 230, 53, 0.18);
+    transition: transform 0.15s, box-shadow 0.2s;
+  }
+  .bank-it-btn:hover { transform: translateY(-1px); box-shadow: 0 0 22px rgba(163, 230, 53, 0.3); }
+  .bank-it-btn:active { transform: scale(0.97); }
+  .bank-it-btn:disabled { opacity: 0.6; }
+  .bib-sub { font-family: var(--font-ui); font-weight: 500; font-size: 0.72rem; color: var(--text-faint); }
   .ah-cell {
     flex: 1;
     display: flex;

--- a/supabase-arcade-gauntlet.sql
+++ b/supabase-arcade-gauntlet.sql
@@ -1020,3 +1020,24 @@ BEGIN
   RETURN public._arcade_response(v_uid);
 END; $fn$;
 GRANT EXECUTE ON FUNCTION public.arcade_start() TO authenticated;
+
+-- ============================================================
+-- Bank economy Phase B: Arcade "Bank it" cash-out. Banks your winnings (bankroll
+-- above the $1,500 house stake) into your persistent Bank and ends the run; bust
+-- before banking = $0. See BANK_ECONOMY.md + supabase-bank.sql.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.arcade_cashout()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_uid UUID := auth.uid(); r public.arcade_runs; v_win BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'arcade_cashout: not authenticated'; END IF;
+  SELECT * INTO r FROM public.arcade_runs WHERE user_id = v_uid AND run_date = CURRENT_DATE FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'arcade_cashout: no run'; END IF;
+  IF r.state <> 'active' THEN RETURN public._arcade_response(v_uid); END IF;
+  v_win := GREATEST(0, r.bankroll - 1500);
+  IF v_win > 0 THEN PERFORM public._bank_credit(v_uid, v_win, 'arcade_cashout'); END IF;
+  UPDATE public.arcade_runs SET state = 'over', last_gain = v_win, updated_at = NOW()
+  WHERE user_id = v_uid AND run_date = CURRENT_DATE;
+  RETURN public._arcade_response(v_uid);
+END; $fn$;
+GRANT EXECUTE ON FUNCTION public.arcade_cashout() TO authenticated;

--- a/supabase-streak-freeze.sql
+++ b/supabase-streak-freeze.sql
@@ -69,6 +69,7 @@ BEGIN
     win_streak = GREATEST(user_weekly_stats.win_streak, v_current_streak);
 
   IF p_won THEN
+    PERFORM public._bank_credit(p_uid, 500 * GREATEST(v_current_streak, 1), 'daily_win');  -- Bank bonus
     IF COALESCE(p_incorrect_count, 0) = 0 THEN PERFORM public._award_badge(p_uid, 'flawless'); END IF;
     IF v_bankroll >= 700 THEN PERFORM public._award_badge(p_uid, 'gold_bank'); END IF;
     IF v_current_streak >= 7 THEN PERFORM public._award_badge(p_uid, 'streak_7'); END IF;


### PR DESCRIPTION
The economy starts **feeding** — earn the Bank by playing, with the Arcade press-your-luck loop as the engine.

## What landed
- **Daily-win bonus → Bank** ($500 × streak), added to `_finalize_daily`.
- **Arcade "Bank it" / press-your-luck:** `arcade_cashout()` banks your **winnings = bankroll − $1,500 house stake** into your persistent Bank and ends the run. **Bust before banking = $0** — you only ever risk the house money, never your Bank.
- Client: a **"Bank \$X — end run, keep winnings"** button on the arcade HUD, and a distinct **"Cashed Out! +\$X"** result modal (vs "Run Over").

## Design note
Cash-out banks **winnings above the $1,500 house stake**, not the full bankroll — otherwise instant start→cashout would farm free money. (Supersedes the earlier "full bankroll" default; noted in BANK_ECONOMY.md.)

## Verified
Live: a $4,200 run → button reads **"Bank $2,700"** → tap → **"Cashed Out! +$2,700"** → ledger shows `+2700 arcade_cashout`, balance $7,700. `svelte-check` + build clean; test data cleaned up.

## Next
Phase C — **Challenges** (async friend wager, same seeded puzzles, winner takes the pot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)