### PR TITLE
Bank economy Phase C: friend Challenges with a Bank wager

### DIFF
--- a/BANK_ECONOMY.md
+++ b/BANK_ECONOMY.md
@@ -106,8 +106,13 @@ Wagering virtual currency is fine **only if the currency has no real-money value
 - [ ] (later) Achievements/milestone payouts · optional daily "interest"/stipend.
       NOTE: cash-out banks *winnings above the house stake*, not the full bankroll
       (prevents free-money from instant cashouts; supersedes the earlier default).
-### Phase C — Challenges (Score mode + wager)
-- [ ] `matches` table + deterministic seeded puzzle set; create/accept with **escrow**; play → settle (winner takes pot, tie refunds); 48h expiry; surface pending challenges.
+### Phase C — Challenges (Score mode + wager)  ✅ (PR #126)
+- [x] `challenges` + `challenge_plays`; **create** (escrow + you play) / **accept**
+      (escrow + play); both play the **same puzzle**; **score = bankroll left on
+      solve** (0 if unsolved); higher score **wins the pot**, tie refunds; 48h
+      **expiry** auto-voids+refunds. Play mirrors the daily engine. Menu
+      **Challenges** modal (new challenge + inbox). (`supabase-challenges.sql`.)
+      Verified: create+escrow, drop-into-play, full play→settle→payout (zero-sum).
 ### Phase D — Pressure mode
 - [ ] Timed challenge variant (speed × bankroll scoring).
 ### Phase E — Spending + leaderboards + polish

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -6,6 +6,7 @@ import { fx } from '$lib/sound.js';
 import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
+import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -380,6 +381,87 @@ async function submitGuessFreeplay(state) {
   }
 }
 
+/* ===== Challenges (friend wager; same puzzle, score = leftover bankroll) ===== */
+/** @type {string|null} */
+let activeChallengeId = null;
+
+/** @param {any} board */
+function reconcileChallengeBoard(board) {
+  if (!board) return;
+  const prev = get(gameStore);
+  const finished = board.state !== 'active';
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(board, prev),
+    gameMode: 'challenge',
+    gameState: finished ? board.state : 'default',
+    modifier: null, arcadeRun: null
+  }));
+  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
+  else if (finished) fx('bust');
+  else playMoveCue(prev, board);
+}
+
+/** Start playing a challenge created/accepted elsewhere. @param {any} resp @returns {boolean} */
+export function enterChallenge(resp) {
+  if (!resp?.ok || !resp.board) return false;
+  activeChallengeId = resp.challenge_id;
+  reconcileChallengeBoard(resp.board);
+  return true;
+}
+
+/** Create a challenge and drop into play. @param {string} code @param {string} category @param {number} wager */
+export async function startChallenge(code, category, wager) {
+  const resp = await createChallenge(code, category, wager);
+  if (resp?.ok) { track('challenge_create', { wager }); return enterChallenge(resp) ? resp : { ok: false, reason: 'board' }; }
+  return resp;
+}
+
+/** Accept an incoming challenge and drop into play. @param {string} id */
+export async function acceptAndPlayChallenge(id) {
+  const resp = await acceptChallenge(id);
+  if (resp?.ok) { track('challenge_accept'); return enterChallenge(resp) ? resp : { ok: false, reason: 'board' }; }
+  return resp;
+}
+
+/** Resume a challenge I've already started. @param {string} id */
+export async function resumeChallenge(id) {
+  const board = await getChallengeBoard(id);
+  if (board) { activeChallengeId = id; reconcileChallengeBoard(board); return true; }
+  return false;
+}
+
+/** @param {GameState} state */
+async function confirmPurchaseChallenge(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight || !activeChallengeId) return;
+  dailyInFlight = true;
+  try {
+    let board = null;
+    if (purchase.type === 'letter') board = await challengeBuyLetter(activeChallengeId, purchase.value ?? '');
+    else if (purchase.type === 'hint') board = await challengeReveal(activeChallengeId);
+    if (board) reconcileChallengeBoard(board);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** @param {GameState} state */
+async function submitGuessChallenge(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight || !activeChallengeId) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+  dailyInFlight = true;
+  try {
+    const board = await challengeSubmitGuess(activeChallengeId, guess);
+    if (board) reconcileChallengeBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
 /** Spend an earned power-up during the current arcade run. @param {string} powerup */
 export async function useArcadePowerup(powerup) {
   if (dailyInFlight) return;
@@ -536,6 +618,7 @@ export function confirmPurchase() {
   if (current.gameMode === 'daily') confirmPurchaseDaily(current);
   else if (current.gameMode === 'arcade') confirmPurchaseArcade(current);
   else if (current.gameMode === 'freeplay') confirmPurchaseFreeplay(current);
+  else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
 }
 /* ================================
    Guess Mode Functions
@@ -636,6 +719,7 @@ export function submitGuess() {
   if (current.gameMode === 'daily') submitGuessDaily(current);
   else if (current.gameMode === 'arcade') submitGuessArcade(current);
   else if (current.gameMode === 'freeplay') submitGuessFreeplay(current);
+  else if (current.gameMode === 'challenge') submitGuessChallenge(current);
 }
 /* ================================
    Puzzle Fetch Functions

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -317,6 +317,50 @@ export async function arcadeCashout() {
   return data;
 }
 
+/* ===== Challenges (friend wagers) ===== */
+/** @param {string} code @param {string} category @param {number} wager */
+export async function createChallenge(code, category, wager) {
+  const { data, error } = await supabase.rpc('create_challenge', { p_code: code, p_category: category, p_wager: wager });
+  if (error || !data) { if (error) console.error('❌ create_challenge:', error); return { ok: false }; }
+  return data;
+}
+/** @param {string} id */
+export async function acceptChallenge(id) {
+  const { data, error } = await supabase.rpc('accept_challenge', { p_id: id });
+  if (error || !data) { if (error) console.error('❌ accept_challenge:', error); return { ok: false }; }
+  return data;
+}
+/** @param {string} id */
+export async function getChallengeBoard(id) {
+  const { data, error } = await supabase.rpc('get_challenge', { p_id: id });
+  if (error) { console.error('❌ get_challenge:', error); return null; }
+  return data;
+}
+/** My challenges inbox. @returns {Promise<any[]>} */
+export async function getMyChallenges() {
+  const { data, error } = await supabase.rpc('get_my_challenges');
+  if (error) { console.error('❌ get_my_challenges:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
+/** @param {string} id @param {string} letter */
+export async function challengeBuyLetter(id, letter) {
+  const { data, error } = await supabase.rpc('challenge_buy_letter', { p_id: id, p_letter: letter });
+  if (error) { console.error('❌ challenge_buy_letter:', error); return null; }
+  return data;
+}
+/** @param {string} id */
+export async function challengeReveal(id) {
+  const { data, error } = await supabase.rpc('challenge_reveal', { p_id: id });
+  if (error) { console.error('❌ challenge_reveal:', error); return null; }
+  return data;
+}
+/** @param {string} id @param {Record<string,string>} guess */
+export async function challengeSubmitGuess(id, guess) {
+  const { data, error } = await supabase.rpc('challenge_submit_guess', { p_id: id, p_guess: guess });
+  if (error) { console.error('❌ challenge_submit_guess:', error); return null; }
+  return data;
+}
+
 /** Whether the caller already has a session for today (drives the pre-game picker). */
 export async function dailySessionExists() {
   const { data, error } = await supabase.rpc('daily_session_exists');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,8 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge } from '$lib/stores/GameStore.js';
+  import { getMyChallenges } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -220,6 +221,7 @@
   $: resultWon = $gameStore.gameState === 'won';
   $: isDailyResult = $gameStore.gameMode === 'daily';
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
+  $: isChallenge = $gameStore.gameMode === 'challenge';
   $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
   $: resultMedal = medalFor(resultBankroll, resultWon);
   // Arcade rolling-survival run state
@@ -370,6 +372,58 @@
       initError = 'Free Play failed to load.';
     }
   }
+  // ===== Challenges (friend wagers) =====
+  let showChallenges = false;
+  /** @type {any[]} */
+  let myChallenges = [];
+  let chCode = '';
+  let chCategory = '';
+  let chWager = 500;
+  let chMsg = '';
+  let chBusy = false;
+  async function openChallenges() {
+    if (!get(user)?.id) return;
+    chMsg = '';
+    showChallenges = true;
+    myChallenges = await getMyChallenges();
+  }
+  async function submitNewChallenge() {
+    if (chBusy) return;
+    if (!chCode.trim() || !chCategory) { chMsg = 'Pick a friend code and a category.'; return; }
+    chBusy = true; chMsg = 'Creating…';
+    const res = await startChallenge(chCode.trim().toUpperCase(), chCategory, Math.floor(Number(chWager) || 0));
+    chBusy = false;
+    if (res?.ok) { launchChallengePlay(); }
+    else {
+      chMsg = res?.reason === 'no_friend' ? 'No player with that code.'
+        : res?.reason === 'insufficient' ? "Not enough in your Bank for that wager."
+        : res?.reason === 'min_wager' ? 'Minimum wager is $100.'
+        : res?.reason === 'self' ? "You can't challenge yourself."
+        : res?.reason === 'no_puzzle' ? 'No puzzles in that category.'
+        : 'Could not create the challenge.';
+    }
+  }
+  async function respondToChallenge(/** @type {any} */ ch) {
+    if (chBusy) return;
+    chBusy = true;
+    let ok = false;
+    if (ch.is_creator) {
+      ok = await resumeChallenge(ch.id); // creators resume their own (can't "accept")
+    } else {
+      const res = await acceptAndPlayChallenge(ch.id);
+      ok = !!res?.ok;
+      if (!ok) chMsg = res?.reason === 'insufficient' ? 'Not enough in your Bank.' : 'Could not open that challenge.';
+    }
+    chBusy = false;
+    if (ok) launchChallengePlay();
+  }
+  function launchChallengePlay() {
+    showChallenges = false;
+    localStorage.setItem('gameMode', 'challenge');
+    hasInitialized = true;
+    showMainMenu = false;
+  }
+
   // After solving / going broke in Free Play, load the next puzzle in the category.
   async function handleFreeplayContinue() {
     showResultModal = false;
@@ -554,7 +608,15 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 4" on:click={() => goto('/badges')}>
+        <button class="menu-card" style="--i: 4" on:click={openChallenges}>
+          <span class="mc-icon">⚔️</span>
+          <span class="mc-body">
+            <span class="mc-title">Challenges</span>
+            <span class="mc-sub">Wager your Bank vs friends</span>
+          </span>
+          <span class="mc-arrow">→</span>
+        </button>
+        <button class="menu-card" style="--i: 5" on:click={() => goto('/badges')}>
           <span class="mc-icon">🏅</span>
           <span class="mc-body">
             <span class="mc-title">Badges</span>
@@ -562,7 +624,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 5" on:click={handleMenuLeaderboard}>
+        <button class="menu-card" style="--i: 6" on:click={handleMenuLeaderboard}>
           <span class="mc-icon">🏆</span>
           <span class="mc-body">
             <span class="mc-title">Leaderboard</span>
@@ -570,7 +632,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 6" on:click={handleMenuMyAccount}>
+        <button class="menu-card" style="--i: 7" on:click={handleMenuMyAccount}>
           <span class="mc-icon">👤</span>
           <span class="mc-body">
             <span class="mc-title">My Account</span>
@@ -597,6 +659,53 @@
               </button>
             {/each}
           </div>
+        </div>
+      </div>
+    {/if}
+
+    <!-- Challenges: wager vs friends -->
+    {#if showChallenges}
+      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Challenges">
+        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showChallenges = false}></button>
+        <div class="modal-content main-menu-modal ch-modal">
+          <button class="close-btn" on:click={() => showChallenges = false}>❌</button>
+          <h2>⚔️ Challenges</h2>
+          <p class="cat-sub">Wager your Bank head-to-head — same puzzle, best score wins the pot.</p>
+
+          <div class="ch-new">
+            <div class="ch-row">
+              <input class="ch-input" placeholder="Friend code" bind:value={chCode} maxlength="6" />
+              <select class="ch-input" bind:value={chCategory}>
+                <option value="" disabled selected>Category</option>
+                {#each CATEGORIES as c}<option value={c.value}>{c.emoji} {c.label}</option>{/each}
+              </select>
+            </div>
+            <div class="ch-row">
+              <input class="ch-input" type="number" min="100" step="100" placeholder="Wager $" bind:value={chWager} />
+              <button class="ch-create" disabled={chBusy} on:click={submitNewChallenge}>Send ⚔️</button>
+            </div>
+            {#if chMsg}<p class="add-msg">{chMsg}</p>{/if}
+          </div>
+
+          {#if myChallenges.length}
+            <div class="ch-list">
+              {#each myChallenges as ch}
+                <div class="ch-item">
+                  <div class="ch-info">
+                    <span class="ch-vs">{ch.is_creator ? 'You vs' : 'From'} {ch.opponent_name}</span>
+                    <span class="ch-meta">${ch.wager?.toLocaleString()} · {ch.category}</span>
+                  </div>
+                  {#if ch.status === 'settled'}
+                    <span class="ch-result {ch.result}">{ch.result === 'win' ? 'Won 🏆' : ch.result === 'loss' ? 'Lost' : 'Tie'}{#if ch.my_score != null} · ${ch.my_score} vs ${ch.their_score}{/if}</span>
+                  {:else if ch.needs_my_play}
+                    <button class="ch-play" disabled={chBusy} on:click={() => respondToChallenge(ch)}>{ch.is_creator ? 'Resume' : 'Play'}</button>
+                  {:else}
+                    <span class="ch-waiting">Waiting…</span>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
         </div>
       </div>
     {/if}
@@ -798,6 +907,16 @@
             <div class="result-actions">
               <button class="share-btn" on:click={() => { showResultModal = false; showCategorySelect = true; }}>Categories</button>
               <button class="next-puzzle-button" on:click={handleFreeplayContinue}>Next</button>
+            </div>
+          {:else if isChallenge}
+            <!-- Challenge result (settles when the friend plays) -->
+            <div class="result-medal">⚔️</div>
+            <h2>Challenge played!</h2>
+            <p class="result-sub">You scored ${resultBankroll.toLocaleString()} · {$gameStore.currentPhrase}</p>
+            <p class="arcade-gain">We'll settle the pot once your friend plays.</p>
+            <div class="result-actions">
+              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; openChallenges(); }}>Challenges</button>
+              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
             </div>
           {:else}
             <!-- Arcade rolling-bankroll survival -->
@@ -1204,6 +1323,29 @@
   /* Free Play category picker */
   .cat-modal { max-width: 420px; }
   .cat-sub { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 16px; }
+
+  /* Challenges modal */
+  .ch-modal { max-width: 440px; }
+  .ch-new { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; }
+  .ch-row { display: flex; gap: 0.5rem; }
+  .ch-input {
+    flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border);
+    background: var(--surface); color: var(--text); font-size: 0.9rem;
+  }
+  .ch-create { padding: 0.6rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
+  .ch-create:disabled { opacity: 0.6; }
+  .ch-list { display: flex; flex-direction: column; gap: 0.5rem; max-height: 280px; overflow-y: auto; }
+  .ch-item { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; padding: 0.7rem 0.8rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; }
+  .ch-info { display: flex; flex-direction: column; gap: 2px; text-align: left; min-width: 0; }
+  .ch-vs { font-weight: 600; font-size: 0.9rem; }
+  .ch-meta { font-size: 0.75rem; color: var(--text-faint); }
+  .ch-play { padding: 0.45rem 0.9rem; border: none; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.85rem; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
+  .ch-play:disabled { opacity: 0.6; }
+  .ch-waiting { font-size: 0.8rem; color: var(--text-faint); }
+  .ch-result { font-family: var(--font-display); font-weight: 700; font-size: 0.8rem; }
+  .ch-result.win { color: var(--brand-2); }
+  .ch-result.loss { color: #fb7185; }
+  .ch-result.tie { color: var(--text-muted); }
   .cat-grid {
     display: grid;
     grid-template-columns: repeat(2, 1fr);

--- a/supabase-challenges.sql
+++ b/supabase-challenges.sql
@@ -1,0 +1,75 @@
+-- ============================================================
+-- Bank economy Phase C: async friend challenges with a Bank wager (applied to
+-- prod across two migrations: challenges_phase_c + challenges_phase_c_play).
+-- Both players play the SAME puzzle (stored on the challenge); score = bankroll
+-- left on solve (0 if unsolved); higher score wins the pot. Stakes escrowed up
+-- front; _challenge_settle pays the winner (tie = refund). Play mirrors the daily
+-- engine (reuses _daily_board + letter_cost), keyed on (challenge_id, user_id).
+-- Client: statsStore create/accept/get/play wrappers; GameStore 'challenge' mode
+-- (enterChallenge/startChallenge/acceptAndPlayChallenge/resumeChallenge); a
+-- Challenges modal on the menu. See BANK_ECONOMY.md.
+--
+-- NOTE: this file documents the schema + the settlement/lifecycle functions. The
+-- full play RPC bodies (challenge_buy_letter / challenge_reveal /
+-- challenge_submit_guess) mirror daily_* and live in the applied migrations.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.challenges (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  creator_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  opponent_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  category TEXT NOT NULL,
+  puzzle_id UUID NOT NULL REFERENCES public.daily_puzzles(id),
+  wager BIGINT NOT NULL,
+  mode TEXT NOT NULL DEFAULT 'score',
+  status TEXT NOT NULL DEFAULT 'open',          -- open | settled | void
+  creator_score INT, opponent_score INT, winner_id UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT now() + interval '48 hours',
+  settled_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_ch_opp ON public.challenges(opponent_id, status);
+CREATE INDEX IF NOT EXISTS idx_ch_creator ON public.challenges(creator_id, status);
+ALTER TABLE public.challenges ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE IF NOT EXISTS public.challenge_plays (
+  challenge_id UUID NOT NULL REFERENCES public.challenges(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  bankroll INT NOT NULL DEFAULT 1000,
+  guesses_remaining INT NOT NULL DEFAULT 3,
+  revealed_positions INT[] NOT NULL DEFAULT '{}',
+  incorrect_letters TEXT[] NOT NULL DEFAULT '{}',
+  state TEXT NOT NULL DEFAULT 'active',          -- active | done
+  score INT,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (challenge_id, user_id)
+);
+ALTER TABLE public.challenge_plays ENABLE ROW LEVEL SECURITY;
+
+-- Settle once both scores are in: higher score takes the pot (2× wager); tie refunds.
+CREATE OR REPLACE FUNCTION public._challenge_settle(p_id UUID)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE c public.challenges; v_winner UUID;
+BEGIN
+  SELECT * INTO c FROM public.challenges WHERE id = p_id FOR UPDATE;
+  IF c.status <> 'open' OR c.creator_score IS NULL OR c.opponent_score IS NULL THEN RETURN; END IF;
+  IF c.creator_score > c.opponent_score THEN v_winner := c.creator_id;
+  ELSIF c.opponent_score > c.creator_score THEN v_winner := c.opponent_id;
+  ELSE v_winner := NULL; END IF;
+  IF v_winner IS NOT NULL THEN
+    PERFORM public._bank_credit(v_winner, c.wager * 2, 'wager_win');
+  ELSE
+    PERFORM public._bank_credit(c.creator_id, c.wager, 'wager_refund');
+    PERFORM public._bank_credit(c.opponent_id, c.wager, 'wager_refund');
+  END IF;
+  UPDATE public.challenges SET status = 'settled', winner_id = v_winner, settled_at = now() WHERE id = p_id;
+END; $$;
+
+-- create_challenge(code, category, wager) — escrows the creator, picks a puzzle from
+--   the category, opens the challenge, and starts the creator's play.
+-- accept_challenge(id) — escrows the opponent + starts their play (idempotent resume).
+-- get_challenge(id) — masked board for the caller's play.
+-- challenge_buy_letter / challenge_reveal / challenge_submit_guess — mirror daily_*,
+--   keyed on (challenge_id, auth.uid()); each calls _challenge_resolve which, on solve,
+--   records score (= bankroll) via _challenge_record_score and triggers _challenge_settle.
+-- get_my_challenges() — inbox (incoming/awaiting/settled); lazily voids+refunds expired opens.
+-- (Full bodies in the applied migrations challenges_phase_c[_play].)


### PR DESCRIPTION
The payoff phase — **stake your Bank head-to-head against a friend.**

## How it works
Pick a friend (by code), a category, and a wager → you both play the **same puzzle** → **higher score (bankroll left on solve) wins the pot.** Async (play anytime). Stakes are **escrowed** up front; settles automatically once both have played; 48h expiry auto-refunds.

## Server (`supabase-challenges.sql`, applied to prod)
- `challenges` + `challenge_plays`. `create_challenge` (escrow + you play first), `accept_challenge` (escrow + play, idempotent resume), `get_challenge`, `get_my_challenges` (inbox; lazily voids+refunds expired).
- Play RPCs mirror the daily engine, keyed on `(challenge_id, user_id)`. `_challenge_resolve` records score = bankroll-on-solve (0 if unsolved); `_challenge_settle` pays the winner the **2× pot** (tie = refund).

## Client
- `statsStore` create/accept/inbox + play wrappers.
- GameStore **`challenge` mode** (reconcile + buy/guess routing + enter/start/accept/resume), wired into the action dispatchers.
- Menu **"Challenges"** card → modal: **new-challenge form** (friend code + category + wager) + **inbox** (respond / waiting / results), and a challenge result screen.

## Verified
- Create + **escrow** (UI drops into play; SQL: creator $5,000 → $4,500).
- Full **play → resolve → settle → payout** chain via the real functions: creator 700 vs opponent 500 → creator takes the **$1,000 pot** (5,500 vs 4,500), **zero-sum**.
- `svelte-check` + build clean; test data cleaned up.

## Notes / next
v1 is **one puzzle, Score mode, friend-by-code**. Next: **Pressure mode** (D) and spending sinks + the **Net Worth leaderboard** (E). Edge: a forfeit (stuck) ends a play at score 0; rare since puzzles are solvable with buys/guesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)