### PR TITLE
Phase D: Pressure mode (timed challenge variant)

### DIFF
--- a/BANK_ECONOMY.md
+++ b/BANK_ECONOMY.md
@@ -113,8 +113,14 @@ Wagering virtual currency is fine **only if the currency has no real-money value
       **expiry** auto-voids+refunds. Play mirrors the daily engine. Menu
       **Challenges** modal (new challenge + inbox). (`supabase-challenges.sql`.)
       Verified: create+escrow, drop-into-play, full play→settle→payout (zero-sum).
-### Phase D — Pressure mode
-- [ ] Timed challenge variant (speed × bankroll scoring).
+### Phase D — Pressure mode  ✅ (PR #127)
+- [x] Timed challenge variant. `mode='pressure'`: a **60s per-player, server-authoritative
+      clock** (`challenge_plays.started_at`). Solve in time → **score = bankroll +
+      floor(60 − elapsed)×10** (blends speed + thrift); run out → **lost, score 0**.
+      Create form has a **Score / Pressure** toggle; play screen shows a live countdown
+      HUD (red-pulse under 10s) that calls `challenge_check` on expiry to settle.
+      Settles vs Score plays exactly the same (higher score wins the pot).
+      Verified by SQL sim: fast-solve 1350, timeout lost/0, settle creator-wins.
 ### Phase E — Spending + leaderboards + polish
 - [ ] Spend sinks: power-up shop (Arcade), cosmetics/avatars/accessories, high-stakes rooms.
 - [ ] **Net Worth leaderboard** (+ friends "richest"), challenge record board.
@@ -127,7 +133,7 @@ Wagering virtual currency is fine **only if the currency has no real-money value
 3. **Starting Bank** for new players (e.g. $5,000) + **min/max wager** limits.
 4. **Challenge no-show:** void+refund vs forfeit to whoever finished.
 5. **Daily / quest Bank bonus** sizes.
-6. **Pressure mode** specifics: clock per puzzle vs whole set; speed×bankroll scoring.
+6. ~~**Pressure mode** specifics~~ ✅ settled: single-puzzle 60s clock; score = bankroll + (60−elapsed)×10.
 7. **Bankruptcy floor / stipend** so broke players can re-enter.
 
 ---

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -6,7 +6,7 @@ import { fx } from '$lib/sound.js';
 import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
-import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess } from '$lib/stores/statsStore.js';
+import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -39,7 +39,8 @@ import { track } from '$lib/analytics.js';
  *   arcadeRun?: any,
  *   arcadeCashedOut?: boolean,
  *   modifier?: string | null,
- *   clue?: string | null
+ *   clue?: string | null,
+ *   challengeInfo?: any
  * }} GameState
  */
 
@@ -76,7 +77,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
   arcadeCashedOut: false, // true when the last arcade run ended via "Bank it" (vs bust)
   modifier: null, // today's shared Daily Modifier id (daily only)
-  clue: null // witty one-line hint for the current puzzle
+  clue: null, // witty one-line hint for the current puzzle
+  challengeInfo: null // { mode, started_at, limit_seconds, play_state, score } for the active challenge
 }));
 
 /* ================================
@@ -394,7 +396,8 @@ function reconcileChallengeBoard(board) {
     ...prev, ...boardToState(board, prev),
     gameMode: 'challenge',
     gameState: finished ? board.state : 'default',
-    modifier: null, arcadeRun: null
+    modifier: null, arcadeRun: null,
+    challengeInfo: board.challenge ?? prev.challengeInfo ?? null
   }));
   if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
   else if (finished) fx('bust');
@@ -409,10 +412,10 @@ export function enterChallenge(resp) {
   return true;
 }
 
-/** Create a challenge and drop into play. @param {string} code @param {string} category @param {number} wager */
-export async function startChallenge(code, category, wager) {
-  const resp = await createChallenge(code, category, wager);
-  if (resp?.ok) { track('challenge_create', { wager }); return enterChallenge(resp) ? resp : { ok: false, reason: 'board' }; }
+/** Create a challenge and drop into play. @param {string} code @param {string} category @param {number} wager @param {string} [mode] */
+export async function startChallenge(code, category, wager, mode = 'score') {
+  const resp = await createChallenge(code, category, wager, mode);
+  if (resp?.ok) { track('challenge_create', { wager, mode }); return enterChallenge(resp) ? resp : { ok: false, reason: 'board' }; }
   return resp;
 }
 
@@ -428,6 +431,13 @@ export async function resumeChallenge(id) {
   const board = await getChallengeBoard(id);
   if (board) { activeChallengeId = id; reconcileChallengeBoard(board); return true; }
   return false;
+}
+
+/** Pressure mode: force the server to settle the active play when the clock expires. */
+export async function challengeTimeoutCheck() {
+  if (!activeChallengeId) return;
+  const board = await challengeCheck(activeChallengeId);
+  if (board) reconcileChallengeBoard(board);
 }
 
 /** @param {GameState} state */

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -318,10 +318,16 @@ export async function arcadeCashout() {
 }
 
 /* ===== Challenges (friend wagers) ===== */
-/** @param {string} code @param {string} category @param {number} wager */
-export async function createChallenge(code, category, wager) {
-  const { data, error } = await supabase.rpc('create_challenge', { p_code: code, p_category: category, p_wager: wager });
+/** @param {string} code @param {string} category @param {number} wager @param {string} [mode] */
+export async function createChallenge(code, category, wager, mode = 'score') {
+  const { data, error } = await supabase.rpc('create_challenge', { p_code: code, p_category: category, p_wager: wager, p_mode: mode });
   if (error || !data) { if (error) console.error('❌ create_challenge:', error); return { ok: false }; }
+  return data;
+}
+/** Force the server to re-check a challenge play (used when a Pressure timer expires). @param {string} id */
+export async function challengeCheck(id) {
+  const { data, error } = await supabase.rpc('challenge_check', { p_id: id });
+  if (error) { console.error('❌ challenge_check:', error); return null; }
   return data;
 }
 /** @param {string} id */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,10 @@
 <script>
-  import { onMount, tick } from 'svelte';
+  import { onMount, onDestroy, tick } from 'svelte';
   import { browser } from '$app/environment';
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck } from '$lib/stores/GameStore.js';
   import { getMyChallenges } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -222,6 +222,7 @@
   $: isDailyResult = $gameStore.gameMode === 'daily';
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
+  $: chScore = ($gameStore.challengeInfo?.score ?? Math.floor($gameStore.bankroll || 0));
   $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
   $: resultMedal = medalFor(resultBankroll, resultWon);
   // Arcade rolling-survival run state
@@ -234,6 +235,31 @@
     if (cashingOut || arcadeWinnings <= 0) return;
     cashingOut = true;
     try { await arcadeCashOut(); } finally { cashingOut = false; }
+  }
+
+  // ⏱️ Pressure-mode challenge clock (server-authoritative; this just displays + triggers the check)
+  let pressureNow = browser ? Date.now() : 0;
+  /** @type {ReturnType<typeof setInterval>|undefined} */
+  let pressureTimer;
+  let pressureFired = false;
+  $: chInfo = $gameStore.gameMode === 'challenge' ? $gameStore.challengeInfo : null;
+  $: isPressure = chInfo?.mode === 'pressure';
+  $: pressureActive = isPressure && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
+  $: pressureRemaining = (() => {
+    if (!isPressure || !chInfo?.started_at) return 0;
+    const start = new Date(chInfo.started_at).getTime();
+    const limitMs = (chInfo.limit_seconds ?? 60) * 1000;
+    return Math.max(0, Math.ceil((start + limitMs - pressureNow) / 1000));
+  })();
+  $: if (pressureActive && pressureRemaining > 0) pressureFired = false;
+  $: if (pressureActive && pressureRemaining <= 0 && !pressureFired) firePressureTimeout();
+  async function firePressureTimeout() {
+    pressureFired = true;
+    await challengeTimeoutCheck();
+    // tolerate minor client/server clock skew — retry shortly if the play didn't settle
+    if ($gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost') {
+      setTimeout(() => { pressureFired = false; }, 1500);
+    }
   }
 
   let shareCopied = false;
@@ -272,7 +298,9 @@
     ['click', 'mousedown', 'touchstart'].forEach(event =>
       document.addEventListener(event, removeButtonFocus, true)
     );
+    pressureTimer = setInterval(() => { pressureNow = Date.now(); }, 250);
   });
+  onDestroy(() => clearInterval(pressureTimer));
 
   const TUTORIAL_KEY = 'wb_tutorial_seen';
   // First-run guided tutorial: show once a signed-in user reaches the menu.
@@ -379,6 +407,7 @@
   let chCode = '';
   let chCategory = '';
   let chWager = 500;
+  let chMode = 'score'; // 'score' (untimed) | 'pressure' (60s clock)
   let chMsg = '';
   let chBusy = false;
   async function openChallenges() {
@@ -391,7 +420,7 @@
     if (chBusy) return;
     if (!chCode.trim() || !chCategory) { chMsg = 'Pick a friend code and a category.'; return; }
     chBusy = true; chMsg = 'Creating…';
-    const res = await startChallenge(chCode.trim().toUpperCase(), chCategory, Math.floor(Number(chWager) || 0));
+    const res = await startChallenge(chCode.trim().toUpperCase(), chCategory, Math.floor(Number(chWager) || 0), chMode);
     chBusy = false;
     if (res?.ok) { launchChallengePlay(); }
     else {
@@ -673,6 +702,14 @@
           <p class="cat-sub">Wager your Bank head-to-head — same puzzle, best score wins the pot.</p>
 
           <div class="ch-new">
+            <div class="ch-modes">
+              <button type="button" class="ch-mode" class:active={chMode === 'score'} on:click={() => chMode = 'score'}>
+                🧠 Score<small>Untimed · most bankroll left wins</small>
+              </button>
+              <button type="button" class="ch-mode" class:active={chMode === 'pressure'} on:click={() => chMode = 'pressure'}>
+                ⏱️ Pressure<small>60s clock · speed + bankroll</small>
+              </button>
+            </div>
             <div class="ch-row">
               <input class="ch-input" placeholder="Friend code" bind:value={chCode} maxlength="6" />
               <select class="ch-input" bind:value={chCategory}>
@@ -693,7 +730,7 @@
                 <div class="ch-item">
                   <div class="ch-info">
                     <span class="ch-vs">{ch.is_creator ? 'You vs' : 'From'} {ch.opponent_name}</span>
-                    <span class="ch-meta">${ch.wager?.toLocaleString()} · {ch.category}</span>
+                    <span class="ch-meta">${ch.wager?.toLocaleString()} · {ch.category} · {ch.mode === 'pressure' ? '⏱️ Pressure' : '🧠 Score'}</span>
                   </div>
                   {#if ch.status === 'settled'}
                     <span class="ch-result {ch.result}">{ch.result === 'win' ? 'Won 🏆' : ch.result === 'loss' ? 'Lost' : 'Tie'}{#if ch.my_score != null} · ${ch.my_score} vs ${ch.their_score}{/if}</span>
@@ -793,6 +830,14 @@
           💰 Bank ${arcadeWinnings.toLocaleString()} <span class="bib-sub">end run, keep winnings</span>
         </button>
       {/if}
+    {/if}
+
+    <!-- ⏱️ Pressure-mode challenge clock -->
+    {#if pressureActive}
+      <div class="pressure-hud" class:danger={pressureRemaining <= 10}>
+        <span class="ph-clock">⏱️ {pressureRemaining}s</span>
+        <span class="ph-label">Pressure — solve fast for a bigger score</span>
+      </div>
     {/if}
 
     <!-- 🌍 Category + witty clue -->
@@ -910,9 +955,14 @@
             </div>
           {:else if isChallenge}
             <!-- Challenge result (settles when the friend plays) -->
-            <div class="result-medal">⚔️</div>
-            <h2>Challenge played!</h2>
-            <p class="result-sub">You scored ${resultBankroll.toLocaleString()} · {$gameStore.currentPhrase}</p>
+            <div class="result-medal">{resultWon ? (isPressure ? '⏱️' : '⚔️') : '⌛'}</div>
+            <h2>{resultWon ? 'Challenge played!' : "Time's up!"}</h2>
+            {#if resultWon}
+              <p class="result-sub">You scored ${chScore.toLocaleString()} · {$gameStore.currentPhrase}</p>
+              {#if isPressure}<p class="arcade-earn">Bankroll ${resultBankroll.toLocaleString()} + speed bonus</p>{/if}
+            {:else}
+              <p class="result-sub">Ran out of time — scored $0 · {$gameStore.currentPhrase}</p>
+            {/if}
             <p class="arcade-gain">We'll settle the pot once your friend plays.</p>
             <div class="result-actions">
               <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; openChallenges(); }}>Challenges</button>
@@ -987,6 +1037,17 @@
     max-width: 360px;
     margin: 0 auto 14px;
   }
+  .pressure-hud {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    width: 100%; max-width: 360px; margin: 0 auto 14px; padding: 0.5rem 1rem;
+    border: 1px solid rgba(251,191,36,0.4); border-radius: 14px;
+    background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.03));
+  }
+  .pressure-hud .ph-clock { font-family: var(--font-display); font-weight: 800; font-size: 1.5rem; color: #fbbf24; line-height: 1; font-variant-numeric: tabular-nums; }
+  .pressure-hud .ph-label { font-size: 0.72rem; color: var(--text-muted); }
+  .pressure-hud.danger { border-color: rgba(248,113,113,0.6); background: linear-gradient(135deg, rgba(248,113,113,0.16), rgba(248,113,113,0.04)); animation: pressurePulse 1s ease-in-out infinite; }
+  .pressure-hud.danger .ph-clock { color: #f87171; }
+  @keyframes pressurePulse { 0%,100% { box-shadow: 0 0 0 rgba(248,113,113,0); } 50% { box-shadow: 0 0 16px rgba(248,113,113,0.35); } }
   .bank-it-btn {
     display: inline-flex;
     align-items: baseline;
@@ -1327,6 +1388,15 @@
   /* Challenges modal */
   .ch-modal { max-width: 440px; }
   .ch-new { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; }
+  .ch-modes { display: flex; gap: 0.5rem; }
+  .ch-mode {
+    flex: 1; display: flex; flex-direction: column; gap: 0.15rem; align-items: flex-start;
+    padding: 0.55rem 0.7rem; border-radius: 10px; cursor: pointer; text-align: left;
+    border: 1px solid var(--border); background: var(--surface); color: var(--text);
+    font-weight: 700; font-size: 0.9rem; transition: border-color 0.15s, background 0.15s;
+  }
+  .ch-mode small { font-weight: 500; font-size: 0.68rem; color: var(--text-muted); }
+  .ch-mode.active { border-color: rgba(251,191,36,0.6); background: linear-gradient(135deg, rgba(251,191,36,0.14), rgba(251,191,36,0.04)); box-shadow: 0 0 12px rgba(251,191,36,0.15); }
   .ch-row { display: flex; gap: 0.5rem; }
   .ch-input {
     flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border);

--- a/supabase-challenges.sql
+++ b/supabase-challenges.sql
@@ -73,3 +73,15 @@ END; $$;
 --   records score (= bankroll) via _challenge_record_score and triggers _challenge_settle.
 -- get_my_challenges() — inbox (incoming/awaiting/settled); lazily voids+refunds expired opens.
 -- (Full bodies in the applied migrations challenges_phase_c[_play].)
+
+-- ── Phase D: Pressure mode (migration challenges_phase_d_pressure) ─────────────
+-- challenges.mode = 'score' (untimed; score = leftover bankroll) | 'pressure'.
+-- challenge_plays gains started_at (the per-player clock start; default now()).
+-- Pressure scoring: a 60s server-authoritative clock. Solve in time →
+--   score = bankroll + floor(60 - elapsed_seconds) * 10 (blends speed + thrift);
+--   exceed 60s unsolved → state 'lost', score 0. Score mode is unchanged.
+-- create_challenge gains p_mode (default 'score').
+-- _challenge_board now carries {challenge:{mode,started_at,limit_seconds,play_state,score}}
+--   and reports 'won'/'lost' (not just 'done') so timeouts render as a loss.
+-- challenge_check(id) — client calls this when its countdown hits 0 to force the
+--   server timeout check; get_challenge + get_my_challenges also resolve stale plays.


### PR DESCRIPTION
Adds **Pressure mode** — a timed alternative to Score-mode challenges (BANK_ECONOMY.md Phase D).

## How it plays
- New-challenge form has a **Score / Pressure** toggle.
- Pressure runs a **60-second, server-authoritative clock per player** (`challenge_plays.started_at`).
- **Solve in time →** `score = bankroll + floor(60 − elapsed)×10` (rewards both speed *and* leftover bankroll).
- **Run out unsolved →** lost, score 0.
- Settles vs Score plays exactly the same: higher score wins the pot, tie refunds.

## Server (`challenges_phase_d_pressure`)
- `challenge_plays.started_at`; `challenges.mode` threaded through `create_challenge(p_mode)`.
- `_challenge_resolve` computes the pressure score + timeout; `_challenge_board` now carries `{mode, started_at, limit_seconds, play_state, score}` and reports **won/lost** (not just `done`) so a timeout renders as a loss (bust sound, no confetti).
- `challenge_check(id)` lets the client force the timeout settle; `get_challenge` + `get_my_challenges` also resolve stale active plays so a player who closes the app still settles.

## Client
- Live countdown HUD during pressure play (red-pulse + shadow under 10s); fires `challengeTimeoutCheck` on expiry.
- Inbox shows a ⏱️ Pressure / 🧠 Score badge; result modal shows the speed-bonus score or "Time's up!".

## Verification
SQL simulation against the live functions: fast-solve → **1350** (800 + 55s×10), timeout → **lost / 0**, settle → **creator wins 1350 vs 0**. Test data cleaned up; creator bank restored. `svelte-check` 0 errors, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)