### PR TITLE
Usernames replace friend codes + Phase E (shop + Net Worth board)

### DIFF
--- a/BANK_ECONOMY.md
+++ b/BANK_ECONOMY.md
@@ -51,7 +51,8 @@ no gambling.**
 
 ## Challenges (the headline)
 **Async, friend-vs-friend, same puzzles, winner takes the pot.**
-1. **Create:** pick a friend, a **category**, a **mode** (Score / Pressure), a **wager**.
+1. **Create:** pick a friend **by username** (typeahead search), a **category**, a
+   **mode** (Score / Pressure), a **wager**.
 2. Both stakes are **escrowed** up front (can't bet money you don't have).
 3. Both get the **exact same puzzle set** (deterministic seed from the match id —
    same category, puzzles, order).
@@ -121,10 +122,18 @@ Wagering virtual currency is fine **only if the currency has no real-money value
       HUD (red-pulse under 10s) that calls `challenge_check` on expiry to settle.
       Settles vs Score plays exactly the same (higher score wins the pot).
       Verified by SQL sim: fast-solve 1350, timeout lost/0, settle creator-wins.
-### Phase E — Spending + leaderboards + polish
-- [ ] Spend sinks: power-up shop (Arcade), cosmetics/avatars/accessories, high-stakes rooms.
-- [ ] **Net Worth leaderboard** (+ friends "richest"), challenge record board.
-- [ ] Cosmetics for real money (firewall), challenge history/notifications, username search.
+### Phase E — Spending + leaderboards + polish  ◑ (PR #128)
+- [x] **Usernames replace friend codes:** claimable `@username` (set in Friends tab
+      + My Account), add friends by **username typeahead search**, challenge by
+      username. `_display_name()` (username → full_name → email) used everywhere.
+      (`supabase-social.sql`.)
+- [x] **Cosmetics shop** (`/shop`) — the Bank's first spend sink. Titles + name
+      colors, **earned-Bank-only** (firewall) & **no pay-to-win**; auto-equip on
+      buy, equip/unequip; they flex on the boards. (`supabase-shop.sql`.)
+- [x] **Net Worth leaderboard** (Bank − Loan), Friends + Global scopes, with
+      equipped title/color flair. New tab on the Leaderboard page.
+- [ ] Deferred: avatars/accessories, high-stakes rooms, power-up shop (Arcade),
+      challenge history/notifications, real-money cosmetics, Net-Worth medals.
 
 ## Open decisions 🔒 (let's settle these as we build)
 1. **Naming:** persistent = "Bank", per-round = "bankroll"? Or rename one (e.g. "Vault")
@@ -135,6 +144,7 @@ Wagering virtual currency is fine **only if the currency has no real-money value
 5. **Daily / quest Bank bonus** sizes.
 6. ~~**Pressure mode** specifics~~ ✅ settled: single-puzzle 60s clock; score = bankroll + (60−elapsed)×10.
 7. **Bankruptcy floor / stipend** so broke players can re-enter.
+8. ~~**Friend identity**~~ ✅ settled: claimable **@username** + typeahead search (codes retired).
 
 ---
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -91,16 +91,30 @@ export async function repayLoan(amount) {
   return data;
 }
 
-/** My shareable friend code (generated on first call). @returns {Promise<string|null>} */
-export async function getMyFriendCode() {
-  const { data, error } = await supabase.rpc('get_my_friend_code');
-  if (error) { console.error('❌ get_my_friend_code:', error); return null; }
+/** My chosen username (null until claimed). @returns {Promise<string|null>} */
+export async function getMyUsername() {
+  const { data, error } = await supabase.rpc('get_my_username');
+  if (error) { console.error('❌ get_my_username:', error); return null; }
   return data ?? null;
 }
 
-/** Add a friend by code. @param {string} code @returns {Promise<{ok:boolean, reason?:string, friend_name?:string}>} */
-export async function addFriend(code) {
-  const { data, error } = await supabase.rpc('add_friend', { p_code: code });
+/** Claim / change my username. @param {string} name @returns {Promise<{ok:boolean, reason?:string, username?:string}>} */
+export async function setUsername(name) {
+  const { data, error } = await supabase.rpc('set_username', { p_username: name });
+  if (error || !data) { if (error) console.error('❌ set_username:', error); return { ok: false }; }
+  return data;
+}
+
+/** Username typeahead search. @param {string} query @returns {Promise<{username:string,is_friend:boolean}[]>} */
+export async function searchUsers(query) {
+  const { data, error } = await supabase.rpc('search_users', { p_query: query });
+  if (error) { console.error('❌ search_users:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
+
+/** Add a friend by username. @param {string} username @returns {Promise<{ok:boolean, reason?:string, friend_name?:string}>} */
+export async function addFriend(username) {
+  const { data, error } = await supabase.rpc('add_friend', { p_username: username });
   if (error || !data) { if (error) console.error('❌ add_friend:', error); return { ok: false }; }
   return data;
 }
@@ -110,6 +124,39 @@ export async function getFriendsDailyLeaderboard() {
   const { data, error } = await supabase.rpc('get_friends_daily_leaderboard');
   if (error) { console.error('❌ get_friends_daily_leaderboard:', error); return []; }
   return Array.isArray(data) ? data : [];
+}
+
+/** Net Worth leaderboard (bank − loan). @param {'friends'|'global'} scope @returns {Promise<any[]>} */
+export async function getNetworthLeaderboard(scope = 'friends') {
+  const { data, error } = await supabase.rpc('get_networth_leaderboard', { p_scope: scope });
+  if (error) { console.error('❌ get_networth_leaderboard:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
+
+/* ===== Cosmetics shop (Bank spending sink; earned-Bank-only, no pay-to-win) ===== */
+/** Shop catalog + owned/equipped flags + my Bank. @returns {Promise<{bank:number, items:any[]}>} */
+export async function getShop() {
+  const { data, error } = await supabase.rpc('get_shop');
+  if (error || !data) { if (error) console.error('❌ get_shop:', error); return { bank: 0, items: [] }; }
+  return { bank: data.bank ?? 0, items: Array.isArray(data.items) ? data.items : [] };
+}
+/** Buy a cosmetic with Bank. @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
+export async function buyCosmetic(id) {
+  const { data, error } = await supabase.rpc('buy_cosmetic', { p_id: id });
+  if (error || !data) { if (error) console.error('❌ buy_cosmetic:', error); return { ok: false }; }
+  return data;
+}
+/** Equip an owned cosmetic. @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
+export async function equipCosmetic(id) {
+  const { data, error } = await supabase.rpc('equip_cosmetic', { p_id: id });
+  if (error || !data) { if (error) console.error('❌ equip_cosmetic:', error); return { ok: false }; }
+  return data;
+}
+/** Unequip the current title or color. @param {'title'|'color'} kind @returns {Promise<{ok:boolean}>} */
+export async function unequipCosmetic(kind) {
+  const { data, error } = await supabase.rpc('unequip_cosmetic', { p_kind: kind });
+  if (error || !data) { if (error) console.error('❌ unequip_cosmetic:', error); return { ok: false }; }
+  return data;
 }
 
 /** Claim the all-quests-done reward (pays Bank). @returns {Promise<{ok:boolean, reason?:string, amount?:number, bank?:number}>} */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, getBank } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, searchUsers, getMyUsername, setUsername, getBank } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -125,11 +125,11 @@
       refreshQuests();
       refreshBank();
 
-      // Friend invite link: ?add=CODE → add them, then open the Friends board.
+      // Friend invite link: ?add=USERNAME → add them, then open the Friends board.
       try {
-        const addCode = new URLSearchParams(window.location.search).get('add');
-        if (addCode) {
-          const res = await addFriend(addCode);
+        const addName = new URLSearchParams(window.location.search).get('add');
+        if (addName) {
+          const res = await addFriend(addName);
           if (res?.ok) { track('friend_add', { via: 'link' }); goto('/leaderboard?mode=friends'); return; }
         }
       } catch { /* non-fatal */ }
@@ -404,27 +404,39 @@
   let showChallenges = false;
   /** @type {any[]} */
   let myChallenges = [];
-  let chCode = '';
+  let chOpp = '';
   let chCategory = '';
   let chWager = 500;
   let chMode = 'score'; // 'score' (untimed) | 'pressure' (60s clock)
   let chMsg = '';
   let chBusy = false;
+  /** @type {{username:string,is_friend:boolean}[]} */
+  let chResults = [];
+  /** @type {ReturnType<typeof setTimeout>|undefined} */
+  let chSearchTimer;
   async function openChallenges() {
     if (!get(user)?.id) return;
     chMsg = '';
     showChallenges = true;
     myChallenges = await getMyChallenges();
   }
+  function onChOppInput() {
+    clearTimeout(chSearchTimer);
+    const q = chOpp.trim();
+    if (q.length < 2) { chResults = []; return; }
+    chSearchTimer = setTimeout(async () => { chResults = await searchUsers(q); }, 220);
+  }
+  /** @param {string} username */
+  function pickChOpp(username) { chOpp = username; chResults = []; }
   async function submitNewChallenge() {
     if (chBusy) return;
-    if (!chCode.trim() || !chCategory) { chMsg = 'Pick a friend code and a category.'; return; }
+    if (!chOpp.trim() || !chCategory) { chMsg = 'Pick an opponent and a category.'; return; }
     chBusy = true; chMsg = 'Creating…';
-    const res = await startChallenge(chCode.trim().toUpperCase(), chCategory, Math.floor(Number(chWager) || 0), chMode);
+    const res = await startChallenge(chOpp.trim(), chCategory, Math.floor(Number(chWager) || 0), chMode);
     chBusy = false;
     if (res?.ok) { launchChallengePlay(); }
     else {
-      chMsg = res?.reason === 'no_friend' ? 'No player with that code.'
+      chMsg = res?.reason === 'no_friend' ? 'No player with that username.'
         : res?.reason === 'insufficient' ? "Not enough in your Bank for that wager."
         : res?.reason === 'min_wager' ? 'Minimum wager is $100.'
         : res?.reason === 'self' ? "You can't challenge yourself."
@@ -481,13 +493,34 @@
   let showStreakMessage = false;
   let accountStreak = 0;
   let accountFreezes = 0;
+  let maUsername = '';
+  let maInput = '';
+  let maEditing = false;
+  let maMsg = '';
   async function handleMenuMyAccount() {
     showMyAccount = true;
+    maMsg = '';
     const u = get(user);
     if (u?.id) {
       const status = await getDailyStatus(u.id);
       accountStreak = status.current_streak ?? 0;
       accountFreezes = status.streak_freezes ?? 0;
+      maUsername = (await getMyUsername()) ?? '';
+      maEditing = !maUsername;
+      maInput = maUsername;
+    }
+  }
+  async function saveMaUsername() {
+    const name = maInput.trim();
+    if (!name) return;
+    maMsg = 'Saving…';
+    const res = await setUsername(name);
+    if (res.ok) { maUsername = res.username ?? name; maEditing = false; maMsg = ''; track('username_set'); }
+    else {
+      maMsg = res.reason === 'taken' ? 'That username is taken.'
+        : res.reason === 'reserved' ? 'That username is reserved.'
+        : res.reason === 'invalid' ? '3–15 letters, numbers or _ only.'
+        : 'Could not save username.';
     }
   }
   /** @param {KeyboardEvent} e */
@@ -653,7 +686,15 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 6" on:click={handleMenuLeaderboard}>
+        <button class="menu-card" style="--i: 6" on:click={() => goto('/shop')}>
+          <span class="mc-icon">🛍️</span>
+          <span class="mc-body">
+            <span class="mc-title">Shop</span>
+            <span class="mc-sub">Spend your Bank on flair</span>
+          </span>
+          <span class="mc-arrow">→</span>
+        </button>
+        <button class="menu-card" style="--i: 7" on:click={handleMenuLeaderboard}>
           <span class="mc-icon">🏆</span>
           <span class="mc-body">
             <span class="mc-title">Leaderboard</span>
@@ -661,7 +702,7 @@
           </span>
           <span class="mc-arrow">→</span>
         </button>
-        <button class="menu-card" style="--i: 7" on:click={handleMenuMyAccount}>
+        <button class="menu-card" style="--i: 8" on:click={handleMenuMyAccount}>
           <span class="mc-icon">👤</span>
           <span class="mc-body">
             <span class="mc-title">My Account</span>
@@ -710,8 +751,19 @@
                 ⏱️ Pressure<small>60s clock · speed + bankroll</small>
               </button>
             </div>
+            <div class="ch-search-wrap">
+              <input class="ch-input" placeholder="Opponent username" bind:value={chOpp} on:input={onChOppInput} autocomplete="off" />
+              {#if chResults.length}
+                <div class="ch-results">
+                  {#each chResults as r}
+                    <button type="button" class="ch-result-item" on:click={() => pickChOpp(r.username)}>
+                      @{r.username}{#if r.is_friend} <span class="ch-friend-tag">friend</span>{/if}
+                    </button>
+                  {/each}
+                </div>
+              {/if}
+            </div>
             <div class="ch-row">
-              <input class="ch-input" placeholder="Friend code" bind:value={chCode} maxlength="6" />
               <select class="ch-input" bind:value={chCategory}>
                 <option value="" disabled selected>Category</option>
                 {#each CATEGORIES as c}<option value={c.value}>{c.emoji} {c.label}</option>{/each}
@@ -784,6 +836,18 @@
             <p class="account-email">{$user.email}</p>
           {/if}
 
+          <div class="ma-username">
+            {#if maUsername && !maEditing}
+              <span class="ma-uname">@{maUsername}</span>
+              <button class="ma-edit" on:click={() => { maEditing = true; maInput = maUsername; maMsg = ''; }}>edit</button>
+            {:else}
+              <input class="ma-input" placeholder="pick a username" bind:value={maInput} maxlength="15"
+                on:keydown={(e) => { if (e.key === 'Enter') saveMaUsername(); }} />
+              <button class="ma-save" on:click={saveMaUsername}>Save</button>
+            {/if}
+          </div>
+          {#if maMsg}<p class="ma-msg">{maMsg}</p>{/if}
+
           <div class="account-stats">
             <div class="stat-chip"><span class="stat-emoji">🔥</span> {accountStreak}<span class="stat-cap">day streak</span></div>
             <div class="stat-chip" title="Auto-protects your streak across one missed day. Earn one every 7-day streak.">
@@ -792,6 +856,7 @@
           </div>
 
           <button class="main-menu-btn ghost-btn" on:click={() => goto('/badges')}>🏅 View Badges</button>
+          <button class="main-menu-btn ghost-btn" on:click={() => goto('/shop')}>🛍️ Shop</button>
           <button class="main-menu-btn" on:click={() => { showMyAccount = false; handleLogout(); }}>Log Out</button>
         </div>
       </div>
@@ -1397,6 +1462,18 @@
   }
   .ch-mode small { font-weight: 500; font-size: 0.68rem; color: var(--text-muted); }
   .ch-mode.active { border-color: rgba(251,191,36,0.6); background: linear-gradient(135deg, rgba(251,191,36,0.14), rgba(251,191,36,0.04)); box-shadow: 0 0 12px rgba(251,191,36,0.15); }
+  .ch-search-wrap { position: relative; display: flex; flex-direction: column; }
+  .ch-search-wrap .ch-input { width: 100%; }
+  .ch-results {
+    display: flex; flex-direction: column; gap: 2px; margin-top: 4px;
+    border: 1px solid var(--border); border-radius: 10px; padding: 4px; background: var(--surface);
+  }
+  .ch-result-item {
+    text-align: left; padding: 0.45rem 0.6rem; border: none; border-radius: 8px; cursor: pointer;
+    background: none; color: var(--text); font-weight: 600; font-size: 0.9rem;
+  }
+  .ch-result-item:hover { background: rgba(255,255,255,0.06); }
+  .ch-friend-tag { font-size: 0.7rem; color: var(--brand-2); font-weight: 700; }
   .ch-row { display: flex; gap: 0.5rem; }
   .ch-input {
     flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border);
@@ -1506,6 +1583,15 @@
     color: var(--text-muted);
     margin: 0.5rem 0 0 0;
   }
+  .ma-username { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin: 0.7rem 0 0.2rem; }
+  .ma-uname { font-family: var(--font-display); font-weight: 800; font-size: 1.1rem; color: var(--brand-2); }
+  .ma-edit { background: none; border: none; color: var(--text-faint); font-size: 0.8rem; cursor: pointer; text-decoration: underline; }
+  .ma-input {
+    padding: 0.5rem 0.8rem; border-radius: 10px; border: 1px solid var(--border);
+    background: var(--surface); color: var(--text); font-size: 0.95rem; max-width: 180px;
+  }
+  .ma-save { padding: 0.5rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
+  .ma-msg { text-align: center; font-size: 0.82rem; color: #f87171; margin: 0.2rem 0 0; }
 
   .bankroll-container {
     display: flex;

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -5,55 +5,102 @@
   import {
     fetchDailyLeaderboard,
     fetchArcadeLeaderboard,
-    getMyFriendCode,
+    getMyUsername,
+    setUsername,
+    searchUsers,
     addFriend,
-    getFriendsDailyLeaderboard
+    getFriendsDailyLeaderboard,
+    getNetworthLeaderboard
   } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
 
   /** @typedef {{ rank?: number, display_name?: string, score?: number, bankroll_left?: number, current_streak?: number, highest_streak?: number, total_played?: number, win_rate?: number }} DailyRow */
   /** @typedef {{ rank?: number, display_name?: string, banked?: number, furthest?: number, total?: number }} ArcadeRow */
 
-  /** @type {'daily' | 'arcade' | 'friends'} */
+  /** @type {'daily' | 'arcade' | 'friends' | 'networth'} */
   let mode = $state('daily');
 
-  // ---- Friends ----
-  let friendCode = $state('');
+  // ---- Username + Friends ----
+  let myUsername = $state('');
+  let usernameInput = $state('');
+  let usernameMsg = $state('');
+  let editingUsername = $state(false);
+  let usernameCopied = $state(false);
   /** @type {any[]} */
   let friendsData = $state([]);
-  let addCode = $state('');
+  let addQuery = $state('');
   let addMsg = $state('');
-  let codeCopied = $state(false);
+  /** @type {{username:string,is_friend:boolean}[]} */
+  let searchResults = $state([]);
+  /** @type {ReturnType<typeof setTimeout>|undefined} */
+  let searchTimer;
+  // ---- Net Worth ----
+  /** @type {'friends'|'global'} */
+  let networthScope = $state('friends');
+  /** @type {any[]} */
+  let networthData = $state([]);
 
   async function loadFriends() {
     try {
-      if (!friendCode) friendCode = (await getMyFriendCode()) ?? '';
+      if (!myUsername) myUsername = (await getMyUsername()) ?? '';
       friendsData = await getFriendsDailyLeaderboard();
     } catch (e) {
       error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
     }
   }
-  async function submitAddFriend() {
-    const code = addCode.trim().toUpperCase();
-    if (!code) return;
-    addMsg = 'Adding…';
-    const res = await addFriend(code);
+  async function loadNetworth() {
+    try {
+      if (!myUsername) myUsername = (await getMyUsername()) ?? '';
+      networthData = await getNetworthLeaderboard(networthScope);
+    } catch (e) {
+      error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
+    }
+  }
+  async function submitUsername() {
+    const name = usernameInput.trim();
+    if (!name) return;
+    usernameMsg = 'Saving…';
+    const res = await setUsername(name);
     if (res.ok) {
-      addMsg = `✓ Added ${res.friend_name || 'friend'}!`;
-      addCode = '';
+      myUsername = res.username ?? name;
+      usernameMsg = '';
+      editingUsername = false;
+      track('username_set');
+    } else {
+      usernameMsg = res.reason === 'taken' ? 'That username is taken.'
+        : res.reason === 'reserved' ? 'That username is reserved.'
+        : res.reason === 'invalid' ? '3–15 letters, numbers or _ only.'
+        : 'Could not save username.';
+    }
+  }
+  function onAddInput() {
+    addMsg = '';
+    clearTimeout(searchTimer);
+    const q = addQuery.trim();
+    if (q.length < 2) { searchResults = []; return; }
+    searchTimer = setTimeout(async () => { searchResults = await searchUsers(q); }, 220);
+  }
+  /** @param {string} username */
+  async function addByUsername(username) {
+    addMsg = 'Adding…';
+    const res = await addFriend(username);
+    if (res.ok) {
+      addMsg = `✓ Added ${res.friend_name || username}!`;
+      addQuery = ''; searchResults = [];
       track('friend_add');
       await loadFriends();
     } else {
-      addMsg = res.reason === 'not_found' ? 'No player with that code.'
-        : res.reason === 'self' ? "That's your own code 🙂"
+      addMsg = res.reason === 'not_found' ? 'No player with that username.'
+        : res.reason === 'self' ? "That's you 🙂"
         : 'Could not add friend.';
     }
   }
-  function shareCode() {
+  function shareUsername() {
+    if (!myUsername) return;
     const origin = typeof window !== 'undefined' ? window.location.origin : 'https://wordbanksvelte.vercel.app';
-    const text = `Add me on WordBank! Tap to add me + play today's puzzle: ${origin}/?add=${friendCode}`;
+    const text = `Add me on WordBank — I'm @${myUsername}. Play today's puzzle: ${origin}/?add=${myUsername}`;
     if (typeof navigator !== 'undefined' && navigator.share) { navigator.share({ text }).catch(() => {}); return; }
-    navigator.clipboard?.writeText(text).then(() => { codeCopied = true; setTimeout(() => codeCopied = false, 1800); }, () => {});
+    navigator.clipboard?.writeText(text).then(() => { usernameCopied = true; setTimeout(() => usernameCopied = false, 1800); }, () => {});
   }
   let dailyPeriod = $state('daily');
   /** @type {'score' | 'bankroll' | 'streak' | 'highest_streak' | 'puzzles' | 'win_pct'} */
@@ -106,6 +153,8 @@
       loadDaily().finally(() => { loading = false; });
     } else if (mode === 'arcade') {
       loadArcade().finally(() => { loading = false; });
+    } else if (mode === 'networth') {
+      loadNetworth().finally(() => { loading = false; });
     } else {
       loadFriends().finally(() => { loading = false; });
     }
@@ -118,6 +167,9 @@
     if (mode === 'arcade' && arcadePeriod) {
       loadArcade();
     }
+    if (mode === 'networth' && networthScope) {
+      loadNetworth();
+    }
   });
 
   // Open in daily tab when coming from daily finish (?mode=daily)
@@ -126,6 +178,7 @@
     if (modeParam === 'daily') mode = 'daily';
     else if (modeParam === 'arcade') mode = 'arcade';
     else if (modeParam === 'friends') mode = 'friends';
+    else if (modeParam === 'networth') mode = 'networth';
   });
 
   /** @param {unknown} n */
@@ -158,6 +211,13 @@
       onclick={() => { mode = 'friends'; }}
     >
       Friends
+    </button>
+    <button
+      class="tab-btn"
+      class:active={mode === 'networth'}
+      onclick={() => { mode = 'networth'; }}
+    >
+      💰 Net Worth
     </button>
   </div>
 
@@ -192,21 +252,55 @@
         </button>
       {/each}
     </div>
+  {:else if mode === 'networth'}
+    <p class="period-label">Richest players · Bank − Loan</p>
+    <div class="period-filters">
+      <button class="period-btn" class:active={networthScope === 'friends'} onclick={() => { networthScope = 'friends'; }}>Friends</button>
+      <button class="period-btn" class:active={networthScope === 'global'} onclick={() => { networthScope = 'global'; }}>Global</button>
+    </div>
   {:else}
     <p class="period-label">Today's Daily · you vs your friends</p>
     <div class="friend-panel">
       <div class="my-code">
-        <span class="mc-label">Your code</span>
-        <button class="code-pill" onclick={shareCode} title="Share your code">
-          {friendCode || '······'} <span class="share-ico">{codeCopied ? '✓' : '↗'}</span>
-        </button>
+        <span class="mc-label">Your username</span>
+        {#if myUsername && !editingUsername}
+          <button class="code-pill" onclick={shareUsername} title="Share your username">
+            @{myUsername} <span class="share-ico">{usernameCopied ? '✓' : '↗'}</span>
+          </button>
+          <button class="edit-uname" onclick={() => { editingUsername = true; usernameInput = myUsername; usernameMsg = ''; }}>edit</button>
+        {:else}
+          <div class="add-row">
+            <input class="code-input" placeholder="pick a username" bind:value={usernameInput} maxlength="15"
+              onkeydown={(e) => { if (e.key === 'Enter') submitUsername(); }} />
+            <button class="add-btn" onclick={submitUsername}>Save</button>
+          </div>
+          {#if usernameMsg}<p class="add-msg">{usernameMsg}</p>{/if}
+        {/if}
       </div>
-      <div class="add-row">
-        <input class="code-input" placeholder="Enter a friend's code" bind:value={addCode} maxlength="6"
-          onkeydown={(e) => { if (e.key === 'Enter') submitAddFriend(); }} />
-        <button class="add-btn" onclick={submitAddFriend}>Add</button>
-      </div>
-      {#if addMsg}<p class="add-msg">{addMsg}</p>{/if}
+
+      {#if myUsername}
+        <div class="add-row search-row">
+          <input class="code-input" placeholder="Find friends by username" bind:value={addQuery}
+            oninput={onAddInput} autocomplete="off" />
+        </div>
+        {#if searchResults.length}
+          <div class="search-results">
+            {#each searchResults as r}
+              <div class="search-item">
+                <span class="si-name">@{r.username}</span>
+                {#if r.is_friend}
+                  <span class="si-added">✓ Friend</span>
+                {:else}
+                  <button class="si-add" onclick={() => addByUsername(r.username)}>+ Add</button>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+        {#if addMsg}<p class="add-msg">{addMsg}</p>{/if}
+      {:else}
+        <p class="add-msg">Pick a username first — that's how friends find you.</p>
+      {/if}
     </div>
   {/if}
 
@@ -288,10 +382,38 @@
         </table>
       </div>
     {/if}
+  {:else if mode === 'networth'}
+    <!-- Net Worth: richest by Bank − Loan -->
+    {#if networthData.length === 0}
+      <p class="empty">{networthScope === 'friends' ? 'Add friends to see who’s richest!' : 'No players yet.'}</p>
+    {:else}
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>#</th><th>Player</th><th>Net Worth</th><th>Bank</th></tr>
+          </thead>
+          <tbody>
+            {#each networthData as row}
+              <tr class={row.is_me ? 'me-row' : ((row.rank ?? 0) <= 3 ? 'top-three' : '')}>
+                <td class="rank">
+                  {#if row.rank === 1}🥇{:else if row.rank === 2}🥈{:else if row.rank === 3}🥉{:else}{row.rank}{/if}
+                </td>
+                <td class="name">
+                  <span style={row.color ? `color:${row.color}` : ''}>{row.is_me ? 'You' : (row.name || 'Player')}</span>
+                  {#if row.title}<span class="nw-title">{row.title}</span>{/if}
+                </td>
+                <td class="score-cell" class:negative={(row.net_worth ?? 0) < 0}>${fmt(row.net_worth)}</td>
+                <td>${fmt(row.bank)}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
   {:else}
     <!-- Friends: you + friends ranked by today's Daily score -->
     {#if friendsData.length <= 1}
-      <p class="empty">Add friends with their code above, then race them on today's Daily!</p>
+      <p class="empty">Find friends by username above, then race them on today's Daily!</p>
     {/if}
     {#if friendsData.length > 0}
       <div class="table-wrap">
@@ -320,8 +442,10 @@
       Daily: Score = bankroll × streak multiplier. Medals 🥇$700 / 🥈$400 / 🥉$100. 🔥 = 7+ day streak.
     {:else if mode === 'arcade'}
       Arcade: ranked by peak bankroll in a survival run, and how many puzzles you solved before going broke.
+    {:else if mode === 'networth'}
+      Net Worth = Bank − Loan. Pay off your loan and bank your winnings to climb. Titles & colors come from the Shop.
     {:else}
-      Friends: share your code to add friends — everyone plays the same Daily, so it's a head-to-head. "—" = hasn't played today.
+      Friends: pick a username, then search to add friends — everyone plays the same Daily, so it's head-to-head. "—" = hasn't played today.
     {/if}
   </p>
 </main>
@@ -506,13 +630,28 @@
   .add-row { display: flex; gap: 0.5rem; }
   .code-input {
     flex: 1; padding: 0.6rem 0.9rem; border-radius: 12px; border: 1px solid var(--border);
-    background: var(--surface); color: var(--text); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.08em;
+    background: var(--surface); color: var(--text); font-size: 0.95rem;
   }
   .add-btn {
     padding: 0.6rem 1.2rem; border: none; border-radius: 12px; cursor: pointer; font-weight: 700;
     color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635));
   }
   .add-msg { text-align: center; font-size: 0.85rem; color: var(--text-muted); margin: 0; }
+  .edit-uname { background: none; border: none; color: var(--text-faint); font-size: 0.8rem; cursor: pointer; text-decoration: underline; }
+  .search-row { max-width: 420px; }
+  .search-results {
+    max-width: 420px; margin: 0 auto; display: flex; flex-direction: column; gap: 0.35rem;
+    border: 1px solid var(--border); border-radius: 12px; padding: 0.4rem; background: var(--surface);
+  }
+  .search-item { display: flex; align-items: center; justify-content: space-between; padding: 0.35rem 0.5rem; }
+  .si-name { font-weight: 600; }
+  .si-added { color: var(--brand-2); font-size: 0.8rem; font-weight: 700; }
+  .si-add {
+    padding: 0.3rem 0.8rem; border: none; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.82rem;
+    color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635));
+  }
+  .nw-title { font-size: 0.72rem; color: var(--text-faint); margin-left: 0.4rem; white-space: nowrap; }
+  td.score-cell.negative { color: #f87171; }
   tr.me-row { background: rgba(56, 189, 248, 0.12); box-shadow: inset 0 0 0 1px rgba(56,189,248,0.25); }
   tr.me-row td.name { color: #7dd3fc; font-weight: 700; }
 

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -1,0 +1,130 @@
+<script>
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic } from '$lib/stores/statsStore.js';
+  import { track } from '$lib/analytics.js';
+  import { fx } from '$lib/sound.js';
+
+  let bank = $state(0);
+  /** @type {any[]} */
+  let items = $state([]);
+  let loading = $state(true);
+  let busy = $state('');
+  let msg = $state('');
+
+  async function load() {
+    const shop = await getShop();
+    bank = shop.bank;
+    items = shop.items;
+  }
+  onMount(async () => {
+    track('shop_view');
+    try { await load(); } finally { loading = false; }
+  });
+
+  let titles = $derived(items.filter((i) => i.kind === 'title'));
+  let colors = $derived(items.filter((i) => i.kind === 'color'));
+
+  /** @param {any} item */
+  async function buy(item) {
+    if (busy) return;
+    busy = item.id; msg = '';
+    const res = await buyCosmetic(item.id);
+    busy = '';
+    if (res.ok) { fx('win'); track('cosmetic_buy', { id: item.id }); await load(); }
+    else { msg = res.reason === 'insufficient' ? "Not enough in your Bank." : 'Could not buy that.'; }
+  }
+  /** @param {any} item */
+  async function equip(item) {
+    if (busy) return;
+    busy = item.id;
+    const res = item.equipped ? await unequipCosmetic(item.kind) : await equipCosmetic(item.id);
+    busy = '';
+    if (res.ok) { await load(); }
+  }
+</script>
+
+<svelte:head><title>WordBank — Shop</title></svelte:head>
+
+<main class="shop-page">
+  <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
+
+  <div class="head">
+    <h1>🛍️ Shop</h1>
+    <span class="bank-chip">💰 ${bank.toLocaleString()}</span>
+  </div>
+  <p class="sub">Spend your Bank on titles &amp; name colors — pure flair, shows on the leaderboards. No pay-to-win.</p>
+
+  {#if loading}
+    <p class="loading">Loading…</p>
+  {:else}
+    {#if msg}<p class="msg">{msg}</p>{/if}
+
+    <h2 class="section">Titles</h2>
+    <div class="grid">
+      {#each titles as item}
+        <div class="card" class:owned={item.owned}>
+          <span class="c-label">{item.label}</span>
+          {#if item.owned}
+            <button class="c-btn equip" class:on={item.equipped} disabled={busy === item.id} onclick={() => equip(item)}>
+              {item.equipped ? '✓ Equipped' : 'Equip'}
+            </button>
+          {:else}
+            <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buy(item)}>
+              💰 ${item.price.toLocaleString()}
+            </button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <h2 class="section">Name Colors</h2>
+    <div class="grid">
+      {#each colors as item}
+        <div class="card" class:owned={item.owned}>
+          <span class="c-label" style="color:{item.value}">{item.label}</span>
+          {#if item.owned}
+            <button class="c-btn equip" class:on={item.equipped} disabled={busy === item.id} onclick={() => equip(item)}>
+              {item.equipped ? '✓ Equipped' : 'Equip'}
+            </button>
+          {:else}
+            <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buy(item)}>
+              💰 ${item.price.toLocaleString()}
+            </button>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  {/if}
+</main>
+
+<style>
+  .shop-page { max-width: 480px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+  .back-btn {
+    display: inline-block; margin-bottom: 1.2rem; padding: 0.55rem 1.1rem;
+    background: var(--surface); color: var(--text); border: 1px solid var(--border);
+    border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem;
+  }
+  .head { display: flex; align-items: baseline; justify-content: space-between; }
+  h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0; }
+  .bank-chip { font-family: var(--font-display); font-weight: 800; color: #fbbf24; font-size: 1.05rem; }
+  .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1.4rem; }
+  .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
+  .msg { text-align: center; color: #f87171; font-size: 0.88rem; margin: 0 0 1rem; }
+  .section { font-family: var(--font-display); font-size: 1.05rem; margin: 1.4rem 0 0.7rem; }
+  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
+  .card {
+    display: flex; flex-direction: column; gap: 0.6rem; align-items: flex-start;
+    padding: 0.9rem; border-radius: 14px; border: 1px solid var(--border); background: var(--surface);
+  }
+  .card.owned { border-color: rgba(163,230,53,0.35); }
+  .c-label { font-family: var(--font-display); font-weight: 700; font-size: 1rem; }
+  .c-btn {
+    width: 100%; padding: 0.5rem 0.7rem; border-radius: 10px; cursor: pointer; font-weight: 700; font-size: 0.85rem;
+    border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: var(--text);
+  }
+  .c-btn.buy { color: #06210f; border: none; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
+  .c-btn.buy:disabled { opacity: 0.45; cursor: default; }
+  .c-btn.equip.on { color: var(--brand-2); border-color: rgba(163,230,53,0.5); background: rgba(163,230,53,0.1); }
+  .c-btn:disabled { opacity: 0.6; }
+</style>

--- a/supabase-challenges.sql
+++ b/supabase-challenges.sql
@@ -64,8 +64,9 @@ BEGIN
   UPDATE public.challenges SET status = 'settled', winner_id = v_winner, settled_at = now() WHERE id = p_id;
 END; $$;
 
--- create_challenge(code, category, wager) — escrows the creator, picks a puzzle from
---   the category, opens the challenge, and starts the creator's play.
+-- create_challenge(username, category, wager, mode) — escrows the creator, picks a
+--   puzzle from the category, opens the challenge, and starts the creator's play.
+--   (Opponent resolved by USERNAME since migration friends_by_username.)
 -- accept_challenge(id) — escrows the opponent + starts their play (idempotent resume).
 -- get_challenge(id) — masked board for the caller's play.
 -- challenge_buy_letter / challenge_reveal / challenge_submit_guess — mirror daily_*,

--- a/supabase-shop.sql
+++ b/supabase-shop.sql
@@ -1,0 +1,27 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Phase E: cosmetics shop + Net Worth leaderboard                           ║
+-- ║  (migration: phase_e_cosmetics_networth)                                   ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- The Bank's first spending sink. Cosmetics are EARNED-BANK-ONLY (never bought
+-- with real money — preserves the two-currency firewall) and purely visual
+-- (no pay-to-win); they flex on the leaderboards.
+--
+-- Tables:
+--   cosmetics(id, kind 'title'|'color', label, value, price, sort)  -- catalog, public read
+--   user_cosmetics(user_id, cosmetic_id, acquired_at)               -- ownership, self read
+--   profiles.equipped_title / equipped_color                        -- equipped cosmetic ids
+--
+-- Catalog seed: 5 titles ($2k–$100k) + 5 name colors ($5k each).
+--
+-- RPCs:
+--   get_shop()            → { bank, items:[{id,kind,label,value,price,owned,equipped}] }
+--   buy_cosmetic(id)      → spends Bank via _bank_credit('cosmetic_buy'), grants +
+--                           auto-equips. {ok} | reason no_item|owned|insufficient|auth.
+--   equip_cosmetic(id)    → equip an owned cosmetic (by kind slot).
+--   unequip_cosmetic(kind)→ clear the title or color slot.
+--
+-- get_networth_leaderboard(scope 'friends'|'global')
+--   → top 50 by net worth (bank − loan), with equipped title/color for flair:
+--     [{rank, name, net_worth, bank, title, color, is_me}].
+--
+-- (Full bodies in the applied migration.)

--- a/supabase-social.sql
+++ b/supabase-social.sql
@@ -1,0 +1,25 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Username-based social identity (migration: friends_by_username)           ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Replaces the old 6-char friend_code with a claimable @username. Friends are
+-- added by username (typeahead search), and challenges target a username.
+--
+-- profiles.username TEXT + UNIQUE INDEX on lower(username).
+--
+-- _display_name(uid)  → username → auth full_name → email prefix → 'Player'.
+--                       Used everywhere a player name is shown (friends board,
+--                       challenge inbox, net-worth board).
+-- get_my_username()   → my username (null until claimed).
+-- set_username(name)  → claim/change; 3–15 chars [A-Za-z0-9_], case-insensitive
+--                       unique, a few reserved words blocked.
+--                       {ok} | {ok:false, reason: invalid|reserved|taken|auth}.
+-- search_users(query) → up to 8 username-prefix matches (min 2 chars), excludes
+--                       self, flags existing friends: [{username, is_friend}].
+-- add_friend(username)→ resolves by username, inserts the symmetric friendship.
+--                       (Old add_friend(p_code) dropped.)
+--
+-- create_challenge(p_username, …) now resolves the opponent by username.
+-- get_friends_daily_leaderboard / get_my_challenges use _display_name.
+--
+-- The legacy friend_code column + get_my_friend_code() are left in place but
+-- unused by the app. (Full bodies in the applied migration.)


### PR DESCRIPTION
Two things in one go: an easier **username**-based friend system, then a **Phase E** slice.

## Part 1 — Usernames (easier friends)
Retire the 6-char friend code for a claimable **@username**.
- `profiles.username` (unique, case-insensitive) + `_display_name(uid)` helper (username → full_name → email) used everywhere a name shows.
- `set_username` / `get_my_username` / `search_users` (debounced typeahead, flags existing friends).
- `add_friend` resolves by username; `create_challenge` targets a username.
- **Friends tab** + **My Account**: claim/edit your @username, share it (`?add=<username>` invite link), and **add friends via search typeahead** — no codes to exchange.
- **Challenge create** picks the opponent by username typeahead.

## Part 2 — Phase E
- **Cosmetics shop** (`/shop`) — the Bank's first real **spend sink**. Titles + name colors, **earned-Bank-only** (preserves the two-currency firewall) and **no pay-to-win**; auto-equip on buy, equip/unequip. New `cosmetics` + `user_cosmetics` tables; `get_shop`/`buy_cosmetic`/`equip_cosmetic`/`unequip_cosmetic`.
- **Net Worth leaderboard** (Bank − Loan) with **Friends + Global** scopes and equipped title/color flair — new tab on the Leaderboard page.
- Shop reachable from a menu card and My Account.

**Deferred** (roadmap-noted): avatars/accessories, high-stakes rooms, Arcade power-up shop, challenge history/notifications, real-money cosmetics.

## Verification
- Full DB layer via JWT-impersonation SQL: `set_username` (incl. taken/invalid/reserved), `search_users`, `add_friend` by username, `buy_cosmetic` (spends Bank 5000→0), net-worth ranks by bank−loan with equipped color — then **all test mutations reverted to pristine**.
- Playwright render smoke (test account): `/shop` shows $5k bank + 5 titles + 5 colors + 10 buy buttons; Net Worth tab renders (2 scopes); Friends username/search panel renders; **0 page errors**.
- `svelte-check` 0 errors, `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)