### PR TITLE
Refreshed onboarding for the Bank economy (re-shows for everyone)

### DIFF
--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -29,6 +29,24 @@
       icon: '🏆',
       title: 'Daily & Arcade',
       body: 'Play Daily for one ranked puzzle everyone shares. Play Arcade to keep solving, banking each win and building your multiplier until you bust.'
+    },
+    {
+      icon: '🏦',
+      title: 'Your Bank',
+      isNew: true,
+      body: 'New: everyone starts with a $5,000 loan from the house. Win games to grow your Bank — your Net Worth is your Bank minus what you still owe. Pay the house back to climb.'
+    },
+    {
+      icon: '⚔️',
+      title: 'Challenge friends',
+      isNew: true,
+      body: 'Wager your Bank head-to-head on the same puzzle. Score mode: most bankroll left wins. Pressure mode: a 60-second clock, so speed counts. Winner takes the pot.'
+    },
+    {
+      icon: '🛍️',
+      title: 'Shop & friends',
+      isNew: true,
+      body: 'Add friends by @username, then race them on the Net Worth board. Spend your Bank in the Shop on titles and name colors that show off your rank.'
     }
   ];
 
@@ -55,6 +73,7 @@
     <button class="tut-skip" on:click={skip}>Skip</button>
 
     {#key i}
+      {#if step.isNew}<span class="tut-new">NEW</span>{/if}
       <div class="tut-icon">{step.icon}</div>
       <h2 class="tut-title">{step.title}</h2>
       <p class="tut-body">{step.body}</p>
@@ -124,6 +143,18 @@
   }
   .tut-skip:hover { color: var(--text, #fff); }
 
+  .tut-new {
+    display: inline-block;
+    margin-bottom: 8px;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-family: var(--font-display, sans-serif);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    color: #06210f;
+    background: var(--brand-grad, linear-gradient(135deg, #34d399, #a3e635));
+  }
   .tut-icon {
     font-size: 3rem;
     line-height: 1;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -302,7 +302,9 @@
   });
   onDestroy(() => clearInterval(pressureTimer));
 
-  const TUTORIAL_KEY = 'wb_tutorial_seen';
+  // Bump this key whenever the tutorial gains new content — it re-shows for
+  // everyone on next login (v2 = Bank economy: loan/net worth, Challenges, Shop).
+  const TUTORIAL_KEY = 'wb_tutorial_v2';
   // First-run guided tutorial: show once a signed-in user reaches the menu.
   $: if (browser && loggedIn && hasInitialized && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
     showTutorial = true;


### PR DESCRIPTION
Pairs the player-facing rules refresh with the light economy reset you approved.

## Tutorial
- 3 new steps with a **NEW** badge: **🏦 Your Bank** (you start with a $5k loan — Net Worth = Bank − what you owe), **⚔️ Challenge friends** (Score vs Pressure, winner takes the pot), **🛍️ Shop & friends** (add by @username, race the Net Worth board, spend Bank on titles/colors).
- Bumped the seen-key (`wb_tutorial_seen` → `wb_tutorial_v2`) so the walkthrough **re-shows once for every returning player** on next login, then never again.

## DB (already applied to prod — light reset, not a wipe)
- All accounts that had touched the economy normalized to **$5,000 Bank / $5,000 loan ($0 net worth)**; `bank_ledger`, `challenges`, `challenge_plays`, `user_cosmetics` cleared so the Net Worth board launches fair.
- **Kept:** logins, daily streaks, badges, category stats, usernames, friendships.
- The 21 accounts that never touched the Bank auto-seed to the identical baseline via `_ensure_bank` on first interaction — no wipe needed to onboard them into the loan system.

## Verification
- `svelte-check` 0 errors, `npm run build` green.
- Playwright smoke: tutorial walks all 8 steps in order — *Guess · Buy · Reveal · Solve · Daily & Arcade · Your Bank [NEW] · Challenge friends [NEW] · Shop & friends [NEW]* — with 0 page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)