### PR TITLE
Fix challenge creation (stale p_code RPC param)

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -365,9 +365,9 @@ export async function arcadeCashout() {
 }
 
 /* ===== Challenges (friend wagers) ===== */
-/** @param {string} code @param {string} category @param {number} wager @param {string} [mode] */
-export async function createChallenge(code, category, wager, mode = 'score') {
-  const { data, error } = await supabase.rpc('create_challenge', { p_code: code, p_category: category, p_wager: wager, p_mode: mode });
+/** @param {string} username @param {string} category @param {number} wager @param {string} [mode] */
+export async function createChallenge(username, category, wager, mode = 'score') {
+  const { data, error } = await supabase.rpc('create_challenge', { p_username: username, p_category: category, p_wager: wager, p_mode: mode });
   if (error || !data) { if (error) console.error('❌ create_challenge:', error); return { ok: false }; }
   return data;
 }


### PR DESCRIPTION
**Bug:** Sending a challenge failed with "Could not create the challenge."

**Cause:** The `friends_by_username` migration renamed the `create_challenge` DB parameter `p_code` → `p_username`, but `statsStore.createChallenge` still sent `{ p_code }`. PostgREST resolves overloads by argument names, so it couldn't find a matching function and returned an error → the client fell through to the generic failure message.

**Fix:** Pass `p_username`. (Verified it was the only stale `p_code` left in the client after that migration.)

**Verification:** Invoked `create_challenge` directly as a real user — `ok:true` and a challenge row created with the new param; signature mismatch with the old one. svelte-check + build green. Test challenge cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)