### PR TITLE
Challenge notifications (any screen) + Challenges count badge

### DIFF
--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -1,0 +1,70 @@
+<script>
+  import { goto } from '$app/navigation';
+  import { toasts, dismissToast } from '$lib/stores/notificationStore.js';
+  import { fx } from '$lib/sound.js';
+
+  /** @param {any} t */
+  function open(t) {
+    fx('select');
+    dismissToast(t.id);
+    // Challenge toasts (incoming + result) all live in the home Challenges inbox.
+    goto('/?challenges=1');
+  }
+</script>
+
+<div class="toaster" aria-live="polite">
+  {#each $toasts as t (t.id)}
+    <button class="toast" on:click={() => open(t)}>
+      <span class="t-title">{t.title}</span>
+      <span class="t-body">{t.body}</span>
+      <span class="t-x" role="presentation" on:click|stopPropagation={() => dismissToast(t.id)}>✕</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .toaster {
+    position: fixed;
+    top: max(10px, env(safe-area-inset-top));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 5000;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: calc(100% - 24px);
+    max-width: 420px;
+    pointer-events: none;
+  }
+  .toast {
+    pointer-events: auto;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-align: left;
+    padding: 12px 34px 12px 14px;
+    border-radius: 14px;
+    border: 1px solid rgba(163, 230, 53, 0.4);
+    background: linear-gradient(135deg, rgba(20, 26, 38, 0.96), rgba(16, 22, 32, 0.96));
+    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45), 0 0 18px rgba(52, 211, 153, 0.18);
+    color: var(--text, #fff);
+    cursor: pointer;
+    backdrop-filter: blur(8px);
+    animation: toastIn 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  @keyframes toastIn {
+    from { transform: translateY(-14px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+  .t-title { font-family: var(--font-display, sans-serif); font-weight: 800; font-size: 0.95rem; }
+  .t-body { font-size: 0.82rem; color: var(--text-muted, #c2cbd8); }
+  .t-x {
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    font-size: 0.8rem;
+    color: var(--text-faint, #6b7686);
+    line-height: 1;
+  }
+</style>

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -1,0 +1,76 @@
+// Global notification service: polls the server, exposes the unread count + list,
+// and surfaces brand-new items as transient toasts (visible from any screen).
+import { writable } from 'svelte/store';
+import { getNotifications, markNotificationsRead } from '$lib/stores/statsStore.js';
+
+/** @type {import('svelte/store').Writable<any[]>} */
+export const notifications = writable([]);
+export const unreadCount = writable(0);
+/** @type {import('svelte/store').Writable<{id:string,title:string,body:string,data:any}[]>} */
+export const toasts = writable([]);
+
+const POLL_MS = 45000;
+/** @type {ReturnType<typeof setInterval>|undefined} */
+let pollTimer;
+/** @type {Set<string>} */
+let knownIds = new Set();
+let started = false;
+let primed = false; // first poll seeds knownIds without toasting history
+/** @type {(() => void)|undefined} */
+let onVis;
+
+async function poll() {
+  const res = await getNotifications();
+  const items = res.items ?? [];
+  notifications.set(items);
+  unreadCount.set(res.unread_count ?? 0);
+  if (primed) {
+    // newest first; toast anything new + still unread, oldest-of-the-new first
+    const fresh = items.filter((n) => !knownIds.has(n.id) && !n.read).reverse();
+    for (const n of fresh) pushToast(n);
+  }
+  for (const n of items) knownIds.add(n.id);
+  primed = true;
+}
+
+/** @param {any} n */
+function pushToast(n) {
+  toasts.update((t) => [...t, { id: n.id, title: n.title, body: n.body, data: n.data }]);
+  setTimeout(() => dismissToast(n.id), 6000);
+}
+/** @param {string} id */
+export function dismissToast(id) {
+  toasts.update((t) => t.filter((x) => x.id !== id));
+}
+
+export function startNotifications() {
+  if (started || typeof window === 'undefined') return;
+  started = true;
+  poll();
+  pollTimer = setInterval(poll, POLL_MS);
+  onVis = () => { if (!document.hidden) poll(); };
+  document.addEventListener('visibilitychange', onVis);
+}
+
+export function stopNotifications() {
+  started = false;
+  primed = false;
+  knownIds = new Set();
+  notifications.set([]);
+  unreadCount.set(0);
+  toasts.set([]);
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = undefined;
+  if (onVis && typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVis);
+}
+
+/** Force an immediate refresh (e.g. after acting on a challenge). */
+export async function refreshNotifications() {
+  if (started) await poll();
+}
+
+export async function markAllNotificationsRead() {
+  await markNotificationsRead();
+  unreadCount.set(0);
+  notifications.update((list) => list.map((n) => ({ ...n, read: true })));
+}

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -112,6 +112,19 @@ export async function searchUsers(query) {
   return Array.isArray(data) ? data : [];
 }
 
+/* ===== Notifications ===== */
+/** @returns {Promise<{items:any[], unread_count:number}>} */
+export async function getNotifications() {
+  const { data, error } = await supabase.rpc('get_notifications');
+  if (error || !data) { if (error) console.error('❌ get_notifications:', error); return { items: [], unread_count: 0 }; }
+  return { items: Array.isArray(data.items) ? data.items : [], unread_count: data.unread_count ?? 0 };
+}
+/** Mark all my notifications read. */
+export async function markNotificationsRead() {
+  const { error } = await supabase.rpc('mark_notifications_read');
+  if (error) console.error('❌ mark_notifications_read:', error);
+}
+
 /** Add a friend by username. @param {string} username @returns {Promise<{ok:boolean, reason?:string, friend_name?:string}>} */
 export async function addFriend(username) {
   const { data, error } = await supabase.rpc('add_friend', { p_username: username });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,25 @@
 <script>
   import '../app.css';
+  import { onMount } from 'svelte';
+  import { supabase } from '$lib/supabaseClient';
+  import { startNotifications, stopNotifications } from '$lib/stores/notificationStore.js';
+  import Toaster from '$lib/components/Toaster.svelte';
+
   let { children } = $props();
+
+  onMount(() => {
+    // Start the global notification poller whenever a session is present,
+    // and react to sign-in / sign-out across every route.
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) startNotifications();
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) startNotifications();
+      else stopNotifications();
+    });
+    return () => sub.subscription.unsubscribe();
+  });
 </script>
 
 {@render children()}
+<Toaster />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,7 @@
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
   import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, searchUsers, getMyUsername, setUsername, getBank } from '$lib/stores/statsStore.js';
+  import { unreadCount, notifications, markAllNotificationsRead, refreshNotifications } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -124,14 +125,18 @@
       menuDailyPlayed = ds.has_played_today;
       refreshQuests();
       refreshBank();
+      refreshChallengeCount();
 
       // Friend invite link: ?add=USERNAME → add them, then open the Friends board.
       try {
-        const addName = new URLSearchParams(window.location.search).get('add');
+        const params = new URLSearchParams(window.location.search);
+        const addName = params.get('add');
         if (addName) {
           const res = await addFriend(addName);
           if (res?.ok) { track('friend_add', { via: 'link' }); goto('/leaderboard?mode=friends'); return; }
         }
+        // Deep link from a notification toast → open the Challenges inbox.
+        if (params.get('challenges')) openChallenges();
       } catch { /* non-fatal */ }
 
       await tick();
@@ -406,6 +411,7 @@
   let showChallenges = false;
   /** @type {any[]} */
   let myChallenges = [];
+  let challengeCount = 0; // challenges awaiting my play (badge on the Challenges card)
   let chOpp = '';
   let chCategory = '';
   let chWager = 500;
@@ -416,11 +422,28 @@
   let chResults = [];
   /** @type {ReturnType<typeof setTimeout>|undefined} */
   let chSearchTimer;
+  /** Count of challenges that need my action, for the menu badge. */
+  async function refreshChallengeCount() {
+    if (!get(user)?.id) return;
+    try {
+      const list = await getMyChallenges();
+      myChallenges = list;
+      challengeCount = list.filter((c) => c.needs_my_play).length;
+    } catch { /* non-fatal */ }
+  }
   async function openChallenges() {
     if (!get(user)?.id) return;
     chMsg = '';
     showChallenges = true;
     myChallenges = await getMyChallenges();
+    challengeCount = myChallenges.filter((c) => c.needs_my_play).length;
+  }
+
+  // ===== Notifications panel (bell) =====
+  let showNotifications = false;
+  async function openNotifications() {
+    showNotifications = true;
+    await markAllNotificationsRead();
   }
   function onChOppInput() {
     clearTimeout(chSearchTimer);
@@ -489,6 +512,8 @@
     getDailyStatus(currentUser.id).then((s) => { dailyStatus = s; menuDailyPlayed = s.has_played_today; });
     refreshQuests();
     refreshBank();
+    refreshChallengeCount();
+    refreshNotifications();
   }
 
   let showMyAccount = false;
@@ -572,6 +597,14 @@
   {#if loggedIn && !showMainMenu}
     <button class="icon-button subtle-button" title="Main menu" on:click={goToMainMenu}>
       ☰
+    </button>
+  {/if}
+
+  <!-- 🔔 Notifications -->
+  {#if loggedIn}
+    <button class="icon-button subtle-button bell-button" title="Notifications" on:click={openNotifications}>
+      🔔
+      {#if $unreadCount > 0}<span class="bell-badge">{$unreadCount > 9 ? '9+' : $unreadCount}</span>{/if}
     </button>
   {/if}
 
@@ -678,6 +711,9 @@
             <span class="mc-title">Challenges</span>
             <span class="mc-sub">Wager your Bank vs friends</span>
           </span>
+          {#if challengeCount > 0}
+            <span class="mc-count" title="{challengeCount} waiting for you">{challengeCount}</span>
+          {/if}
           <span class="mc-arrow">→</span>
         </button>
         <button class="menu-card" style="--i: 5" on:click={() => goto('/badges')}>
@@ -794,6 +830,30 @@
                     <span class="ch-waiting">Waiting…</span>
                   {/if}
                 </div>
+              {/each}
+            </div>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    <!-- 🔔 Notifications panel -->
+    {#if showNotifications}
+      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Notifications">
+        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showNotifications = false}></button>
+        <div class="modal-content main-menu-modal ch-modal">
+          <button class="close-btn" on:click={() => showNotifications = false}>❌</button>
+          <h2>🔔 Notifications</h2>
+          {#if $notifications.length === 0}
+            <p class="cat-sub">No notifications yet. Challenge a friend to get started!</p>
+          {:else}
+            <div class="notif-list">
+              {#each $notifications as n (n.id)}
+                <button class="notif-item" class:fresh={!n.read}
+                  on:click={() => { showNotifications = false; if (n.data?.challenge_id) openChallenges(); }}>
+                  <span class="ni-title">{n.title}</span>
+                  <span class="ni-body">{n.body}</span>
+                </button>
               {/each}
             </div>
           {/if}
@@ -1422,6 +1482,31 @@
   .mc-title { font-family: var(--font-display); font-weight: 600; font-size: 1.06rem; }
   .mc-sub { font-size: 0.8rem; color: var(--text-muted); }
   .mc-arrow { color: var(--text-faint); font-size: 1.1rem; transition: transform 0.2s, color 0.2s; }
+  .mc-count {
+    min-width: 22px; height: 22px; padding: 0 6px; border-radius: 999px;
+    display: inline-grid; place-items: center; font-family: var(--font-display);
+    font-weight: 800; font-size: 0.78rem; color: #06210f; line-height: 1;
+    background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635));
+    box-shadow: 0 0 12px rgba(52,211,153,0.4);
+  }
+  /* notification bell */
+  .bell-button { position: relative; }
+  .bell-badge {
+    position: absolute; top: -4px; right: -4px; min-width: 17px; height: 17px;
+    padding: 0 4px; border-radius: 999px; display: grid; place-items: center;
+    font-size: 0.62rem; font-weight: 800; color: #fff; line-height: 1;
+    background: #f43f5e; box-shadow: 0 0 0 2px var(--bg, #0a0e14);
+  }
+  /* notifications panel */
+  .notif-list { display: flex; flex-direction: column; gap: 0.5rem; max-height: 60vh; overflow-y: auto; }
+  .notif-item {
+    text-align: left; display: flex; flex-direction: column; gap: 2px;
+    padding: 0.7rem 0.85rem; border-radius: 12px; cursor: pointer;
+    background: var(--surface); border: 1px solid var(--border); color: var(--text);
+  }
+  .notif-item.fresh { border-color: rgba(163,230,53,0.45); background: linear-gradient(135deg, rgba(52,211,153,0.08), rgba(163,230,53,0.03)); }
+  .ni-title { font-family: var(--font-display); font-weight: 700; font-size: 0.92rem; }
+  .ni-body { font-size: 0.82rem; color: var(--text-muted); }
   .menu-card:hover:not(.disabled) .mc-arrow { transform: translateX(3px); color: var(--brand-2); }
 
   /* Modal action button (reused brand button) */

--- a/supabase-notifications.sql
+++ b/supabase-notifications.sql
@@ -1,0 +1,24 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Cross-screen notifications (migration: notifications)                      ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Persistent per-user notifications, surfaced as a global bell + toast pop-ups
+-- that show on ANY screen (poller mounted in +layout.svelte).
+--
+-- Table:
+--   notifications(id, user_id, type, title, body, data jsonb, read_at, created_at)
+--   RLS: SELECT own only. Writes go through SECURITY DEFINER helpers.
+--
+-- _notify(uid, type, title, body, data)  -- insert a notification
+-- get_notifications()   -> { items:[{id,type,title,body,data,read,created_at}], unread_count }  (latest 30)
+-- mark_notifications_read()  -> marks all of my unread read
+--
+-- Hooks (server-authoritative, so they fire no matter how the action happens):
+--   create_challenge   -> _notify(opponent, 'challenge_incoming', '⚔️ New challenge', …)
+--   _challenge_settle  -> _notify(BOTH players, 'challenge_result', win/lose/tie + amount + scores)
+--
+-- Client: src/lib/stores/notificationStore.js polls every 45s + on tab focus,
+-- raises new unread items as <Toaster/> pop-ups, and exposes unreadCount for the
+-- 🔔 bell on the home top bar. (data.challenge_id deep-links to the Challenges inbox.)
+--
+-- Future: swap polling for Supabase Realtime (instant in-app) and native push
+-- (closed-app) on the same table — no schema change needed.


### PR DESCRIPTION
Players get notified about challenges from anywhere in the app, and the home Challenges card shows how many duels are waiting.

## Server (`notifications` migration)
- `notifications` table (RLS self-read) + `_notify()` helper.
- `get_notifications()` (latest 30 + `unread_count`) and `mark_notifications_read()`.
- **Hooks:** `create_challenge` → notify the **opponent** ("⚔️ New challenge — X challenged you — $Y · Mode"); `_challenge_settle` → notify **both** players with the result ("🏆 You won your duel · +$Z (scores)"). Server-authoritative, so they fire the moment the match resolves regardless of who finishes.

## Client
- `notificationStore.js`: a global poller (45s + on tab focus) mounted in `+layout.svelte` that raises brand-new unread items as **`<Toaster/>` pop-ups visible on any screen**, and exposes `unreadCount`.
- **🔔 bell** with unread badge on the home top bar + a notifications panel (tap an item to open the related challenge; opening marks all read).
- **Challenges menu card count badge** — number of duels awaiting your play. Toasts deep-link to the inbox via `?challenges=1`.

## Verification
- Full notify flow via JWT-impersonation SQL: opponent gets the incoming notification on create; **both** get the correct result on settle ("🏆 You won your duel — vs Warpocket · +$200 (500 vs 300)") — then cleaned up.
- Playwright smoke (test account): bell badge shows **1**, panel renders the injected notification with correct title/body, **0 page errors**; injected row removed.
- `svelte-check` + build green. (Also confirmed the 2 live challenges / 5 ledger rows on prod are **real players** post-reset and left untouched.)

*Next up (queued): the chess-style make-up daily calendar — A/B/C defaults confirmed.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)