### PR TITLE
Make-up daily calendar (chess-style past-day replay)

### DIFF
--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -5,6 +5,8 @@ export const BADGES = {
   gold_bank: { emoji: '💎', name: 'Gold Bank',    desc: 'Finished a daily with $700+' },
   streak_7:  { emoji: '🔥', name: 'Week Warrior',  desc: '7-day daily streak' },
   streak_30: { emoji: '👑', name: 'Iron Will',     desc: '30-day daily streak' },
+  week_complete:  { emoji: '🗓️', name: 'Perfect Week',  desc: 'Played every day of a calendar week' },
+  month_complete: { emoji: '📅', name: 'Perfect Month', desc: 'Played every day of a calendar month' },
 };
 
 /** @param {string} id */

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -7,6 +7,7 @@ import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, getDailyModi
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
+import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -40,7 +41,8 @@ import { track } from '$lib/analytics.js';
  *   arcadeCashedOut?: boolean,
  *   modifier?: string | null,
  *   clue?: string | null,
- *   challengeInfo?: any
+ *   challengeInfo?: any,
+ *   makeupDate?: string | null
  * }} GameState
  */
 
@@ -78,7 +80,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   arcadeCashedOut: false, // true when the last arcade run ended via "Bank it" (vs bust)
   modifier: null, // today's shared Daily Modifier id (daily only)
   clue: null, // witty one-line hint for the current puzzle
-  challengeInfo: null // { mode, started_at, limit_seconds, play_state, score } for the active challenge
+  challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
+  makeupDate: null // YYYY-MM-DD of the make-up day being played (makeup mode only)
 }));
 
 /* ================================
@@ -472,6 +475,93 @@ async function submitGuessChallenge(state) {
   }
 }
 
+/* ===== Make-up daily (play a past missed day; no streak/Bank, badges only) ===== */
+/** @type {string|null} */
+let activeMakeupDate = null;
+
+/** @param {any} board */
+function reconcileMakeupBoard(board) {
+  if (!board) return;
+  const prev = get(gameStore);
+  const finished = board.state !== 'active';
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(board, prev),
+    gameMode: 'makeup',
+    gameState: finished ? board.state : 'default',
+    modifier: null, arcadeRun: null,
+    makeupDate: board.makeup?.date ?? prev.makeupDate ?? activeMakeupDate
+  }));
+  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
+  else if (finished) fx('bust');
+  else playMoveCue(prev, board);
+  if (finished && prev.gameState !== 'won' && prev.gameState !== 'lost') {
+    track('makeup_result', { won: board.state === 'won', date: board.makeup?.date });
+  }
+}
+
+/** Begin (or resume) a make-up for a past date. @param {string} date YYYY-MM-DD */
+export async function enterMakeup(date) {
+  track('makeup_start', { date });
+  const board = await makeupStart(date);
+  if (!board) return false;
+  activeMakeupDate = date;
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('gameMode', 'makeup');
+    localStorage.setItem('makeupDate', date);
+  }
+  reconcileMakeupBoard(board);
+  return true;
+}
+
+/** Re-enter the make-up game on the home route (deep link / refresh). */
+export async function fetchMakeupGame() {
+  try {
+    if (!activeMakeupDate && typeof localStorage !== 'undefined') {
+      activeMakeupDate = localStorage.getItem('makeupDate');
+    }
+    if (!activeMakeupDate) return false;
+    const board = await makeupStart(activeMakeupDate);
+    if (!board) return false;
+    reconcileMakeupBoard(board);
+    return true;
+  } catch (err) {
+    console.error('❌ Error starting make-up:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/** @param {GameState} state */
+async function confirmPurchaseMakeup(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight || !activeMakeupDate) return;
+  dailyInFlight = true;
+  try {
+    let board = null;
+    if (purchase.type === 'letter') board = await makeupBuyLetter(activeMakeupDate, purchase.value ?? '');
+    else if (purchase.type === 'hint') board = await makeupReveal(activeMakeupDate);
+    if (board) reconcileMakeupBoard(board);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** @param {GameState} state */
+async function submitGuessMakeup(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight || !activeMakeupDate) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+  dailyInFlight = true;
+  try {
+    const board = await makeupSubmitGuess(activeMakeupDate, guess);
+    if (board) reconcileMakeupBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
 /** Spend an earned power-up during the current arcade run. @param {string} powerup */
 export async function useArcadePowerup(powerup) {
   if (dailyInFlight) return;
@@ -629,6 +719,7 @@ export function confirmPurchase() {
   else if (current.gameMode === 'arcade') confirmPurchaseArcade(current);
   else if (current.gameMode === 'freeplay') confirmPurchaseFreeplay(current);
   else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
+  else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
 }
 /* ================================
    Guess Mode Functions
@@ -730,6 +821,7 @@ export function submitGuess() {
   else if (current.gameMode === 'arcade') submitGuessArcade(current);
   else if (current.gameMode === 'freeplay') submitGuessFreeplay(current);
   else if (current.gameMode === 'challenge') submitGuessChallenge(current);
+  else if (current.gameMode === 'makeup') submitGuessMakeup(current);
 }
 /* ================================
    Puzzle Fetch Functions

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -331,6 +331,34 @@ export async function dailyStart(powerups = []) {
   return data;
 }
 
+/* ===== Make-up daily (play a past missed day in the current month) =====
+   No streak repair, no Bank deposit — fills the calendar + earns week/month badges.
+   Each returns a daily board with an extra { makeup: { date } } marker. */
+/** @param {string} date YYYY-MM-DD @returns {Promise<any>} */
+export async function makeupStart(date) {
+  const { data, error } = await supabase.rpc('makeup_start', { p_date: date });
+  if (error) { console.error('❌ makeup_start error:', error); return null; }
+  return data;
+}
+/** @param {string} date @param {string} letter @returns {Promise<any>} */
+export async function makeupBuyLetter(date, letter) {
+  const { data, error } = await supabase.rpc('makeup_buy_letter', { p_date: date, p_letter: letter });
+  if (error) { console.error('❌ makeup_buy_letter error:', error); return null; }
+  return data;
+}
+/** @param {string} date @returns {Promise<any>} */
+export async function makeupReveal(date) {
+  const { data, error } = await supabase.rpc('makeup_reveal', { p_date: date });
+  if (error) { console.error('❌ makeup_reveal error:', error); return null; }
+  return data;
+}
+/** @param {string} date @param {Record<string,string>} guess @returns {Promise<any>} */
+export async function makeupSubmitGuess(date, guess) {
+  const { data, error } = await supabase.rpc('makeup_submit_guess', { p_date: date, p_guess: guess });
+  if (error) { console.error('❌ makeup_submit_guess error:', error); return null; }
+  return data;
+}
+
 /* ===== Arcade Press-Your-Luck gauntlet (server-authoritative) =====
    Each returns { board, run } where run = { state, banked, multiplier, position,
    total, furthest, last_gain }. */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame } from '$lib/stores/GameStore.js';
   import { getMyChallenges } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -117,6 +117,14 @@
         return;
       }
 
+      // Make-up daily launched from the streak calendar → drop straight into the board.
+      if (localStorage.getItem('gameMode') === 'makeup' && localStorage.getItem('makeupDate')) {
+        showMainMenu = false;
+        hasInitialized = true;
+        await fetchMakeupGame();
+        return;
+      }
+
       // Daily and arcade are both server-authoritative now — start from the menu.
       showMainMenu = true;
       savedGameInfo = null;
@@ -164,6 +172,8 @@
     } else if (gameMode === 'freeplay') {
       // Free Play isn't deep-link restorable — send back to the menu to re-pick.
       showMainMenu = true;
+    } else if (gameMode === 'makeup') {
+      fetchMakeupGame().then((ok) => { if (!ok) showMainMenu = true; });
     } else {
       fetchDailyGame().then((ok) => {
         if (!ok) initError = "Daily puzzle failed to load.";
@@ -227,6 +237,13 @@
   $: isDailyResult = $gameStore.gameMode === 'daily';
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
+  $: isMakeup = $gameStore.gameMode === 'makeup';
+  $: makeupLabel = (() => {
+    const d = $gameStore.makeupDate;
+    if (!d) return '';
+    const dt = new Date(d + 'T00:00:00');
+    return dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  })();
   $: chScore = ($gameStore.challengeInfo?.score ?? Math.floor($gameStore.bankroll || 0));
   $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
   $: resultMedal = medalFor(resultBankroll, resultWon);
@@ -505,6 +522,11 @@
   function goToMainMenu() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
+    // Leaving a make-up: clear it so we land on the menu, not back in the make-up.
+    if ($gameStore.gameMode === 'makeup') {
+      localStorage.setItem('gameMode', 'daily');
+      localStorage.removeItem('makeupDate');
+    }
     saveGameToLocalStorage();
     savedGameInfo = getSavedGameInfo(currentUser.id);
     showMainMenu = true;
@@ -967,6 +989,14 @@
       </div>
     {/if}
 
+    <!-- 🗓️ Make-up daily banner -->
+    {#if isMakeup}
+      <div class="makeup-banner">
+        <span class="mb-tag">🗓️ Make-up</span>
+        <span class="mb-text">Playing {makeupLabel} · fills your calendar (no streak/Bank)</span>
+      </div>
+    {/if}
+
     <!-- 🌍 Category + witty clue -->
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
@@ -1080,6 +1110,22 @@
               <button class="share-btn" on:click={() => { showResultModal = false; showCategorySelect = true; }}>Categories</button>
               <button class="next-puzzle-button" on:click={handleFreeplayContinue}>Next</button>
             </div>
+          {:else if isMakeup}
+            <!-- Make-up daily result (calendar fill; no streak/Bank) -->
+            {#if resultWon}
+              <div class="result-medal">🗓️</div>
+              <h2>Made it up!</h2>
+              <p class="result-sub">{makeupLabel} is on your calendar · {$gameStore.currentPhrase}</p>
+              <p class="arcade-gain">Counts toward 🗓️ Perfect Week / 📅 Perfect Month.</p>
+            {:else}
+              <div class="result-medal">💸</div>
+              <h2>Out of Cash</h2>
+              <p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
+            {/if}
+            <div class="result-actions">
+              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); goto('/streak'); }}>Calendar</button>
+              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
+            </div>
           {:else if isChallenge}
             <!-- Challenge result (settles when the friend plays) -->
             <div class="result-medal">{resultWon ? (isPressure ? '⏱️' : '⚔️') : '⌛'}</div>
@@ -1175,6 +1221,14 @@
   .pressure-hud.danger { border-color: rgba(248,113,113,0.6); background: linear-gradient(135deg, rgba(248,113,113,0.16), rgba(248,113,113,0.04)); animation: pressurePulse 1s ease-in-out infinite; }
   .pressure-hud.danger .ph-clock { color: #f87171; }
   @keyframes pressurePulse { 0%,100% { box-shadow: 0 0 0 rgba(248,113,113,0); } 50% { box-shadow: 0 0 16px rgba(248,113,113,0.35); } }
+  .makeup-banner {
+    display: flex; align-items: center; gap: 8px; justify-content: center;
+    width: 100%; max-width: 360px; margin: 0 auto 12px; padding: 0.5rem 0.9rem;
+    border: 1px solid rgba(56,189,248,0.4); border-radius: 12px;
+    background: linear-gradient(135deg, rgba(56,189,248,0.12), rgba(56,189,248,0.03));
+  }
+  .makeup-banner .mb-tag { font-family: var(--font-display); font-weight: 800; font-size: 0.8rem; color: #38bdf8; white-space: nowrap; }
+  .makeup-banner .mb-text { font-size: 0.74rem; color: var(--text-muted); }
   .bank-it-btn {
     display: inline-flex;
     align-items: baseline;

--- a/src/routes/streak/+page.svelte
+++ b/src/routes/streak/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { getStreakOverview } from '$lib/stores/statsStore.js';
+  import { enterMakeup } from '$lib/stores/GameStore.js';
   import { track } from '$lib/analytics.js';
 
   /** @type {{ current_streak:number, highest_streak:number, freezes:number, days:{d:string,won:boolean}[] }|null} */
@@ -42,7 +43,7 @@
   $: cells = (() => {
     const firstWeekday = new Date(year, month, 1).getDay();
     const daysInMonth = new Date(year, month + 1, 0).getDate();
-    /** @type {{blank?:boolean, day?:number, status?:string, isToday?:boolean}[]} */
+    /** @type {{blank?:boolean, day?:number, key?:string, status?:string, isToday?:boolean, playable?:boolean}[]} */
     const out = [];
     for (let i = 0; i < firstWeekday; i++) out.push({ blank: true });
     for (let d = 1; d <= daysInMonth; d++) {
@@ -50,10 +51,27 @@
       let status = 'none';
       if (d > todayDate) status = 'future';
       else if (dayMap.has(key)) status = dayMap.get(key) ? 'won' : 'lost';
-      out.push({ day: d, status, isToday: d === todayDate });
+      // A past day this month that was never played → make it up.
+      const playable = status === 'none' && d < todayDate;
+      out.push({ day: d, key, status, isToday: d === todayDate, playable });
     }
     return out;
   })();
+
+  let starting = false;
+  /** @param {any} c */
+  async function onCellClick(c) {
+    if (starting) return;
+    if (c.playable && c.key) {
+      starting = true;
+      track('makeup_calendar_click', { date: c.key });
+      const ok = await enterMakeup(c.key);
+      starting = false;
+      if (ok) goto('/');
+    } else if (c.isToday && c.status === 'none') {
+      goto('/'); // today's daily is played from the menu
+    }
+  }
 </script>
 
 <svelte:head><title>WordBank — Streak</title></svelte:head>
@@ -85,6 +103,11 @@
         {#each cells as c}
           {#if c.blank}
             <div class="cell blank"></div>
+          {:else if c.playable}
+            <button class="cell none playable" class:today={c.isToday} disabled={starting}
+              title={`Play ${MONTHS[month]} ${c.day}`} on:click={() => onCellClick(c)}>
+              <span class="cell-day">{c.day}</span><span class="cell-play">▶</span>
+            </button>
           {:else}
             <div class="cell {c.status}" class:today={c.isToday} title={`${MONTHS[month]} ${c.day}`}>
               {#if c.status === 'won'}🔥{:else}{c.day}{/if}
@@ -92,10 +115,11 @@
           {/if}
         {/each}
       </div>
+      <p class="makeup-hint">Tap a ▶ day to play that puzzle and fill your calendar — earns 🗓️ Perfect Week / 📅 Perfect Month badges. (Doesn’t change your streak.)</p>
       <div class="legend">
         <span><i class="dot won"></i> Won</span>
         <span><i class="dot lost"></i> Missed</span>
-        <span><i class="dot none"></i> No play</span>
+        <span><i class="dot play"></i> Make up</span>
       </div>
     </div>
   {/if}
@@ -146,11 +170,22 @@
   .cell.none { color: var(--text-faint); }
   .cell.future { opacity: 0.3; }
   .cell.today { box-shadow: 0 0 0 2px var(--brand-2); }
+  /* make-up (playable) cells */
+  .cell.playable {
+    position: relative; cursor: pointer; color: var(--text);
+    border-color: rgba(56,189,248,0.45); background: rgba(56,189,248,0.08);
+    transition: transform 0.12s, background 0.15s;
+  }
+  .cell.playable:hover { background: rgba(56,189,248,0.16); transform: translateY(-1px); }
+  .cell.playable:disabled { opacity: 0.5; cursor: default; }
+  .cell.playable .cell-day { font-size: 0.8rem; }
+  .cell.playable .cell-play { position: absolute; bottom: 2px; right: 4px; font-size: 0.5rem; color: #38bdf8; }
 
+  .makeup-hint { font-size: 0.74rem; color: var(--text-muted); margin: 0.9rem 0 0; line-height: 1.4; }
   .legend { display: flex; justify-content: center; gap: 1rem; margin-top: 1rem; font-size: 0.75rem; color: var(--text-faint); }
   .legend span { display: inline-flex; align-items: center; gap: 5px; }
   .dot { width: 11px; height: 11px; border-radius: 4px; display: inline-block; }
   .dot.won { background: linear-gradient(135deg,#34d399,#a3e635); }
   .dot.lost { background: rgba(251,113,133,0.4); }
-  .dot.none { background: rgba(255,255,255,0.08); border: 1px solid var(--border); }
+  .dot.play { background: rgba(56,189,248,0.3); border: 1px solid rgba(56,189,248,0.5); }
 </style>

--- a/supabase-makeup.sql
+++ b/supabase-makeup.sql
@@ -1,0 +1,29 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Make-up daily puzzles (migration: makeup_daily)                            ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Chess-style "play a past missed day" from the streak calendar.
+-- LOCKED RULES: make-ups do NOT repair the live consecutive-day streak and pay
+-- NO Bank deposit — they only fill the calendar + earn week/month badges.
+-- Playable window = the CURRENT calendar month (past days only).
+--
+-- _puzzle_id_for_date(date)  -- like _todays_puzzle_id but for any date; assigns +
+--                               persists a deterministic puzzle in daily_puzzle_schedule.
+-- _check_calendar_badges(uid, date)  -- awards 'week_complete' (7-day Mon–Sun fully
+--   played) / 'month_complete' (every day of the month played) from daily_sessions
+--   coverage. Future days can't be played, so these only complete once elapsed.
+-- _finalize_daily  -- now also calls _check_calendar_badges (live daily counts too).
+--
+-- Make-up engine (mirrors the daily engine, keyed on an arbitrary puzzle_date):
+--   makeup_start(date)        -- guards: not future, current month; create or resume.
+--   makeup_buy_letter(date,l) / makeup_reveal(date) / makeup_submit_guess(date,j)
+--   _makeup_resolve_and_return -- marks won/lost; on finish awards calendar badges +
+--     category solve. NEVER touches streak / Bank / game_results / weekly_stats.
+--   Board = _daily_board(...) || { makeup: { date } } for the client HUD.
+--
+-- get_streak_overview  -- calendar 'days' now sourced from daily_sessions (puzzle_date,
+--   state) so make-ups appear on their actual day (was game_results.played_at).
+--
+-- Badges: 'week_complete' (🗓️ Perfect Week), 'month_complete' (📅 Perfect Month)
+-- added to src/lib/badges.js. Client: streak calendar cells are tappable (▶) for
+-- missed past days; GameStore 'makeup' mode (enterMakeup/fetchMakeup) launches the
+-- board on the home route. (Full bodies in the applied migration.)


### PR DESCRIPTION
From the streak calendar, tap a past missed day this month (▶) to play that day's puzzle, fill the calendar, and earn week/month completion badges.

## Locked rules (your A/B/C)
- **No streak repair** — make-ups don't touch the live consecutive-day streak.
- **Current month only**, past days.
- **No Bank deposit** — score + badge credit only (normal dailies pay a streak Bank bonus, so this prevents farming).

## Server (`makeup_daily` migration)
- `_puzzle_id_for_date(date)` — deterministic puzzle for any date, persisted in `daily_puzzle_schedule`.
- Make-up engine mirrors the daily engine keyed on an arbitrary `puzzle_date`: `makeup_start` / `makeup_buy_letter` / `makeup_reveal` / `makeup_submit_guess` + `_makeup_resolve_and_return`, which marks won/lost and (on finish) awards calendar badges + category solve but **never** touches streak / Bank / `game_results` / `weekly_stats`. Guards reject future + out-of-month dates.
- `_check_calendar_badges(uid, date)` awards **week_complete** / **month_complete** from `daily_sessions` coverage (future days can't be played, so they only complete once elapsed); also wired into `_finalize_daily` so the live daily counts too.
- `get_streak_overview` now sources the calendar from `daily_sessions(puzzle_date, state)` so make-ups appear on their real day.

## Client
- `badges.js`: 🗓️ Perfect Week, 📅 Perfect Month.
- `statsStore` make-up wrappers; GameStore **`makeup` mode** (enterMakeup/fetchMakeupGame, reconcile/confirm/submit, routed in dispatchers).
- Streak calendar: missed past days tappable (▶) → launch the make-up board on home; banner "Playing &lt;date&gt; · no streak/Bank"; result modal with Calendar/Menu. Home init + reactive loader detect make-up mode; returning to the menu clears it.

## Verification
- SQL win-path test: make-up plays **won**, **bank/streak/last-play unchanged**, **no `daily_win` ledger**, calendar shows the day; **future + last-month guards reject** — all test mutations reverted.
- Playwright smoke: **20 playable cells**, click → make-up board with banner, **0 page errors**; created session cleaned up.
- `svelte-check` + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)