### PR TITLE
Phase 2: Loans v2 (borrow anytime, interest, auto-repay, In the Red)

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -19,7 +19,7 @@ P2, P3, P6, P9 can run in parallel after P1. P4 is the critical path.
 
 ---
 
-## Phase 1 — Cash identity & baseline  ◑ (mostly done)
+## Phase 1 — Cash identity & baseline  ✅ (PR #136 + copy sweep)
 
 **Goal:** every surface speaks "Cash / Net Worth"; new + existing users on $1,000 / $0.
 **Done:** `_ensure_bank` → $1,000/$0; migrated all users; Bank screen + home chip relabeled;
@@ -33,7 +33,7 @@ negative Net Worth red. (PR #136)
 
 ---
 
-## Phase 2 — Loans v2
+## Phase 2 — Loans v2  ✅
 
 **Goal:** borrow anytime, interest accrues, repay/auto-repay, $10k cap, "In the Red."
 **Depends on:** P1.

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -76,18 +76,34 @@ export async function getDailyQuests() {
   };
 }
 
-/** My Bank: balance, outstanding loan, net worth, recent ledger.
- * @returns {Promise<{ bank:number, loan:number, net_worth:number, ledger:any[] }>} */
+/** My Cash: balance, outstanding loan, net worth, auto-repay, in-the-red, recent ledger.
+ * @returns {Promise<{ bank:number, loan:number, net_worth:number, auto_repay:boolean, in_the_red:boolean, loan_cap:number, ledger:any[] }>} */
 export async function getBank() {
   const { data, error } = await supabase.rpc('get_bank');
-  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, loan: 0, net_worth: 0, ledger: [] }; }
-  return { bank: data.bank ?? 0, loan: data.loan ?? 0, net_worth: data.net_worth ?? 0, ledger: Array.isArray(data.ledger) ? data.ledger : [] };
+  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, loan: 0, net_worth: 0, auto_repay: false, in_the_red: false, loan_cap: 10000, ledger: [] }; }
+  return { bank: data.bank ?? 0, loan: data.loan ?? 0, net_worth: data.net_worth ?? 0,
+    auto_repay: !!data.auto_repay, in_the_red: !!data.in_the_red, loan_cap: data.loan_cap ?? 10000,
+    ledger: Array.isArray(data.ledger) ? data.ledger : [] };
 }
 
-/** Pay down the starting loan from your Bank. @param {number} amount @returns {Promise<any>} */
+/** Pay down your loan from your Cash. @param {number} amount @returns {Promise<any>} */
 export async function repayLoan(amount) {
   const { data, error } = await supabase.rpc('repay_loan', { p_amount: amount });
   if (error) { console.error('❌ repay_loan:', error); return null; }
+  return data;
+}
+
+/** Borrow Cash (5%/day interest, $10k debt cap). @param {number} amount @returns {Promise<any>} */
+export async function takeLoan(amount) {
+  const { data, error } = await supabase.rpc('take_loan', { p_amount: amount });
+  if (error || !data) { if (error) console.error('❌ take_loan:', error); return { ok: false }; }
+  return data;
+}
+
+/** Toggle auto-repay (skims 10% of winnings toward your loan). @param {boolean} on @returns {Promise<any>} */
+export async function setAutoRepay(on) {
+  const { data, error } = await supabase.rpc('set_auto_repay', { p_on: on });
+  if (error) { console.error('❌ set_auto_repay:', error); return null; }
   return data;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -479,7 +479,7 @@
     if (res?.ok) { launchChallengePlay(); }
     else {
       chMsg = res?.reason === 'no_friend' ? 'No player with that username.'
-        : res?.reason === 'insufficient' ? "Not enough in your Bank for that wager."
+        : res?.reason === 'insufficient' ? "Not enough Cash for that wager."
         : res?.reason === 'min_wager' ? 'Minimum wager is $100.'
         : res?.reason === 'self' ? "You can't challenge yourself."
         : res?.reason === 'no_puzzle' ? 'No puzzles in that category.'
@@ -495,7 +495,7 @@
     } else {
       const res = await acceptAndPlayChallenge(ch.id);
       ok = !!res?.ok;
-      if (!ok) chMsg = res?.reason === 'insufficient' ? 'Not enough in your Bank.' : 'Could not open that challenge.';
+      if (!ok) chMsg = res?.reason === 'insufficient' ? 'Not enough Cash.' : 'Could not open that challenge.';
     }
     chBusy = false;
     if (ok) launchChallengePlay();
@@ -732,7 +732,7 @@
           <span class="mc-icon">⚔️</span>
           <span class="mc-body">
             <span class="mc-title">Challenges</span>
-            <span class="mc-sub">Wager your Bank vs friends</span>
+            <span class="mc-sub">Wager your Cash vs friends</span>
           </span>
           {#if challengeCount > 0}
             <span class="mc-count" title="{challengeCount} waiting for you">{challengeCount}</span>
@@ -751,7 +751,7 @@
           <span class="mc-icon">🛍️</span>
           <span class="mc-body">
             <span class="mc-title">Shop</span>
-            <span class="mc-sub">Spend your Bank on flair</span>
+            <span class="mc-sub">Spend your Cash on flair</span>
           </span>
           <span class="mc-arrow">→</span>
         </button>
@@ -801,7 +801,7 @@
         <div class="modal-content main-menu-modal ch-modal">
           <button class="close-btn" on:click={() => showChallenges = false}>❌</button>
           <h2>⚔️ Challenges</h2>
-          <p class="cat-sub">Wager your Bank head-to-head — same puzzle, best score wins the pot.</p>
+          <p class="cat-sub">Wager your Cash head-to-head — same puzzle, best score wins the pot.</p>
 
           <div class="ch-new">
             <div class="ch-modes">

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,15 +1,17 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getBank, repayLoan } from '$lib/stores/statsStore.js';
+  import { getBank, repayLoan, takeLoan, setAutoRepay } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { fx } from '$lib/sound.js';
 
-  /** @type {{ bank:number, loan:number, net_worth:number, ledger:any[] }|null} */
+  /** @type {{ bank:number, loan:number, net_worth:number, auto_repay:boolean, in_the_red:boolean, loan_cap:number, ledger:any[] }|null} */
   let b = null;
   let loading = true;
   let repayAmt = '';
+  let borrowAmt = '';
   let busy = false;
+  $: loanRoom = b ? Math.max(0, (b.loan_cap ?? 10000) - b.loan) : 0;
 
   onMount(async () => {
     track('bank_view');
@@ -44,6 +46,24 @@
     busy = false;
     if (res) { b = res; repayAmt = ''; fx('tap'); track('loan_repay', { amount: pay }); }
   }
+
+  async function borrow(/** @type {number} */ amt) {
+    if (busy || !b) return;
+    const take = Math.min(amt, loanRoom);
+    if (take <= 0) return;
+    busy = true;
+    const res = await takeLoan(take);
+    busy = false;
+    if (res && res.ok !== false) { b = res; borrowAmt = ''; fx('select'); track('loan_taken', { amount: take }); }
+  }
+
+  async function toggleAutoRepay() {
+    if (busy || !b) return;
+    busy = true;
+    const res = await setAutoRepay(!b.auto_repay);
+    busy = false;
+    if (res) b = res;
+  }
 </script>
 
 <svelte:head><title>WordBank — Cash & Net Worth</title></svelte:head>
@@ -57,20 +77,37 @@
     <p class="nw-label">Net Worth</p>
     <div class="net-worth" class:neg={b.net_worth < 0}>{fmt(b.net_worth)}</div>
     <p class="nw-sub">Cash on hand minus what you owe</p>
+    {#if b.in_the_red}<div class="red-badge">🔴 In the Red — you owe more than you hold</div>{/if}
 
     <div class="stat-row">
       <div class="stat"><span class="sv">{fmt(b.bank)}</span><span class="sc">Cash on hand</span></div>
       <div class="stat loan"><span class="sv">{fmt(b.loan)}</span><span class="sc">Loan owed</span></div>
     </div>
 
+    <!-- Borrow -->
+    <div class="loan-box">
+      <p class="loan-copy">
+        <strong>The House</strong> will front you Cash anytime — <strong>5%/day interest</strong>, up to {fmt(b.loan_cap)} total debt.
+        {#if loanRoom > 0}You can borrow up to <strong>{fmt(loanRoom)}</strong> more.{:else}You're at the borrowing cap.{/if}
+      </p>
+      <div class="pay-row">
+        <input class="amt" type="number" min="1" max={loanRoom} placeholder="Amount" bind:value={borrowAmt} disabled={loanRoom <= 0} />
+        <button class="pay-btn borrow" disabled={busy || loanRoom <= 0} on:click={() => borrow(Math.floor(Number(borrowAmt) || 0))}>Borrow</button>
+      </div>
+    </div>
+
     {#if b.loan > 0}
       <div class="loan-box">
-        <p class="loan-copy">You owe the House <strong>{fmt(b.loan)}</strong>. Interest accrues until it's paid — clear it to go debt-free and grow your Net Worth.</p>
+        <p class="loan-copy">You owe <strong>{fmt(b.loan)}</strong>. Interest accrues daily until it's paid — clear it to go debt-free and grow your Net Worth.</p>
         <div class="pay-row">
           <input class="amt" type="number" min="1" placeholder="Amount" bind:value={repayAmt} />
           <button class="pay-btn" disabled={busy} on:click={() => payLoan(Math.floor(Number(repayAmt) || 0))}>Pay</button>
           <button class="pay-btn ghost" disabled={busy} on:click={() => payLoan(b?.loan ?? 0)}>Pay all</button>
         </div>
+        <button class="auto-row" disabled={busy} on:click={toggleAutoRepay}>
+          <span class="auto-box" class:on={b.auto_repay}>{b.auto_repay ? '✓' : ''}</span>
+          Auto-repay — skim 10% of winnings toward this loan
+        </button>
       </div>
     {:else}
       <div class="debt-free">🎉 Debt-free! Your Cash is all yours.</div>
@@ -121,7 +158,22 @@
   .amt { flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: var(--text); }
   .pay-btn { padding: 0.6rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
   .pay-btn.ghost { background: transparent; color: var(--brand-2); border: 1px solid rgba(163,230,53,0.4); }
+  .pay-btn.borrow { color: #06210f; background: linear-gradient(135deg,#fbbf24,#f59e0b); }
   .pay-btn:disabled { opacity: 0.5; }
+  .red-badge {
+    display: inline-block; margin: 0.6rem auto 0; padding: 0.4rem 0.9rem; border-radius: 999px;
+    font-size: 0.8rem; font-weight: 700; color: #fb7185;
+    background: rgba(251,113,133,0.12); border: 1px solid rgba(251,113,133,0.35);
+  }
+  .auto-row {
+    display: flex; align-items: center; gap: 0.5rem; width: 100%; margin-top: 0.7rem; padding: 0;
+    background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 0.82rem; text-align: left;
+  }
+  .auto-box {
+    width: 18px; height: 18px; flex-shrink: 0; border-radius: 5px; display: grid; place-items: center;
+    border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: #06210f; font-size: 0.7rem; font-weight: 800;
+  }
+  .auto-box.on { background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); border-color: transparent; }
   .debt-free { margin-top: 1.4rem; padding: 0.9rem; border-radius: 14px; background: linear-gradient(135deg, rgba(52,211,153,0.12), rgba(163,230,53,0.05)); border: 1px solid rgba(163,230,53,0.4); font-weight: 700; }
 
   .hist-title { font-family: var(--font-display); font-size: 1rem; margin: 1.8rem 0 0.6rem; text-align: left; }

--- a/src/routes/quests/+page.svelte
+++ b/src/routes/quests/+page.svelte
@@ -36,7 +36,7 @@
     if (res?.ok) {
       track('quest_reward_claimed');
       fx('win');
-      claimedMsg = `💰 +$${(res.amount ?? 1000).toLocaleString()} to your Bank!`;
+      claimedMsg = `💰 +$${(res.amount ?? 1000).toLocaleString()} to your Cash!`;
       q = { ...q, reward_claimed: true };
     } else if (res?.reason === 'claimed') {
       q = { ...q, reward_claimed: true };
@@ -84,7 +84,7 @@
         </button>
       {:else}
         <span class="r-title">Finish all 3 to earn 💰 $1,000</span>
-        <span class="r-sub">Straight into your Bank.</span>
+        <span class="r-sub">Straight into your Cash.</span>
       {/if}
     </div>
   {/if}

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -32,7 +32,7 @@
     const res = await buyCosmetic(item.id);
     busy = '';
     if (res.ok) { fx('win'); track('cosmetic_buy', { id: item.id }); await load(); }
-    else { msg = res.reason === 'insufficient' ? "Not enough in your Bank." : 'Could not buy that.'; }
+    else { msg = res.reason === 'insufficient' ? "Not enough Cash." : 'Could not buy that.'; }
   }
   /** @param {any} item */
   async function equip(item) {
@@ -53,7 +53,7 @@
     <h1>🛍️ Shop</h1>
     <span class="bank-chip">💰 ${bank.toLocaleString()}</span>
   </div>
-  <p class="sub">Spend your Bank on titles &amp; name colors — pure flair, shows on the leaderboards. No pay-to-win.</p>
+  <p class="sub">Spend your Cash on titles &amp; name colors — pure flair, shows on the leaderboards. No pay-to-win.</p>
 
   {#if loading}
     <p class="loading">Loading…</p>

--- a/supabase-loans.sql
+++ b/supabase-loans.sql
@@ -1,0 +1,27 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Phase 2: Loans v2 (migration: loans_v2)                                    ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Borrow Cash anytime; 5%/day simple interest (lazy); $10k debt cap; repay +
+-- auto-repay; "In the Red" status. (DB column stays `bank`; UI says "Cash".)
+--
+-- profiles += loan_accrued_at timestamptz, auto_repay boolean.
+--
+-- _accrue_interest(uid)  -- lazy: loan += round(loan × 0.05 × whole_days_elapsed),
+--                           capped at $10,000; advances loan_accrued_at. Called by
+--                           get_bank / take_loan / repay_loan.
+-- take_loan(amount)      -- clamps to the $10k room; _bank_credit(+amount,'loan_taken').
+--                           Returns get_bank(). reason 'at_cap' when maxed.
+-- repay_loan(amount)     -- accrues first, then pays min(amount, loan, cash).
+-- set_auto_repay(on)     -- toggle.
+-- _bank_credit           -- now skims 10% of *winning* credits toward an outstanding
+--                           loan when auto_repay is on (reason 'auto_repay').
+-- get_bank               -- accrues, returns { bank, loan, net_worth, auto_repay,
+--                           in_the_red, loan_cap, ledger }.
+--
+-- Verified (SQL sim): borrow 2k → cash 3k/loan 2k; +7 days → loan 2,700; 1k win +
+-- auto-repay → loan 2,600/cash 3,900; repay all → 0; borrow 20k capped at 10k;
+-- further borrow → at_cap.
+--
+-- Client: src/routes/bank — Borrow section, auto-repay toggle, 🔴 In-the-Red badge;
+-- statsStore takeLoan/setAutoRepay. Mid-puzzle borrowing hook lands with the Cash
+-- Game (Phase 4).


### PR DESCRIPTION
**ROADMAP_V2 Phase 2.** Borrow Cash anytime, 5%/day simple interest (lazy), $10k debt cap, repay + auto-repay, In-the-Red status.

**DB (`loans_v2`, applied):** `_accrue_interest` (lazy, capped), `take_loan`, `set_auto_repay`, `repay_loan` (accrues first), `_bank_credit` auto-repay skim, `get_bank` returns auto_repay/in_the_red/loan_cap. Column stays `bank`; UI says Cash.

**Client:** Bank screen Borrow section + auto-repay toggle + 🔴 In-the-Red badge; `takeLoan`/`setAutoRepay`.

**Also:** finished the Phase 1 Cash copy sweep (quests/challenges/shop). Arcade "Bank it" left for Phase 4.

**Verified:** SQL sim — borrow 2k → 7-day interest 2,700 → 1k win auto-repays 100 → full repay → $10k cap → at_cap; test user reset. Loan UI renders, 0 page errors. svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)