### PR TITLE
Phase 3: Daily efficiency scoring (shareable Daily Score)

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -59,7 +59,7 @@ auto-repay skims a win. Playwright: loan UI + In-the-Red badge render.
 
 ---
 
-## Phase 3 — Daily revamp (efficiency paycheck)
+## Phase 3 — Daily revamp (efficiency paycheck)  ✅
 
 **Goal:** Daily pays the efficiency **Daily Score** (= shareable score), retire `500×streak`.
 **Depends on:** P1.

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -42,7 +42,8 @@ import { track } from '$lib/analytics.js';
  *   modifier?: string | null,
  *   clue?: string | null,
  *   challengeInfo?: any,
- *   makeupDate?: string | null
+ *   makeupDate?: string | null,
+ *   dailyResult?: any
  * }} GameState
  */
 
@@ -189,7 +190,8 @@ function reconcileDailyBoard(board) {
   gameStore.set(/** @type {GameState} */ ({
     ...prev, ...boardToState(board, prev),
     gameMode: 'daily',
-    gameState: finished ? board.state : 'default'
+    gameState: finished ? board.state : 'default',
+    dailyResult: board.daily_result ?? prev.dailyResult ?? null
   }));
   if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
   else if (finished) fx('bust');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -238,6 +238,7 @@
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
   $: isMakeup = $gameStore.gameMode === 'makeup';
+  $: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
   $: makeupLabel = (() => {
     const d = $gameStore.makeupDate;
     if (!d) return '';
@@ -290,7 +291,10 @@
     // Link to the live origin (never a hardcoded/deleted project URL).
     const link = typeof window !== 'undefined' ? window.location.origin : '';
     if (isDailyResult) {
-      return `🏦 WordBank Daily #${puzzleNumber}\n${resultMedal.emoji} ${resultWon ? resultMedal.name + ' — ' : ''}${br} banked\n${link}`;
+      if (resultWon && dr) {
+        return `🧠 WordBank Daily #${puzzleNumber}\nScore ${(dr.score ?? 0).toLocaleString()} — beat that 👀\n${link}`;
+      }
+      return `🧠 WordBank Daily #${puzzleNumber}\nDidn't crack it today 😬\n${link}`;
     }
     return `🏦 WordBank Arcade\n${resultMedal.emoji} ${br} banked\n${link}`;
   }
@@ -1070,10 +1074,24 @@
             <div class="result-medal {resultMedal.tier}">{resultMedal.emoji}</div>
             <h2>{resultWon ? 'Solved!' : 'Busted'}</h2>
             <p class="result-sub">Daily #{puzzleNumber}{#if resultWon} · {resultMedal.name}{/if}</p>
-            <div class="result-bankroll">
-              <span class="rb-label">Banked</span>
-              <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
-            </div>
+            {#if resultWon && dr}
+              <div class="daily-score">
+                <span class="ds-label">Daily Score</span>
+                <span class="ds-amount">{(dr.score ?? 0).toLocaleString()}</span>
+                <span class="ds-cash">+${(dr.score ?? 0).toLocaleString()} to your Cash</span>
+              </div>
+              <div class="eff-chips">
+                <span class="eff" class:on={dr.clean}>{dr.clean ? '✓' : '✗'} Clean</span>
+                <span class="eff" class:on={dr.no_vowels}>{dr.no_vowels ? '✓' : '✗'} No vowels</span>
+                <span class="eff" class:on={dr.first_try}>{dr.first_try ? '✓' : '✗'} First try</span>
+                <span class="eff" class:on={dr.no_reveals}>{dr.no_reveals ? '✓' : '✗'} No reveals</span>
+              </div>
+            {:else}
+              <div class="result-bankroll">
+                <span class="rb-label">Banked</span>
+                <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
+              </div>
+            {/if}
             {#if ghost}
               <div class="ghost-compare">
                 {#if ghost.yesterday_played}
@@ -2112,6 +2130,21 @@
     color: #fcd34d;
     text-shadow: 0 0 18px rgba(251, 191, 36, 0.4);
   }
+  .daily-score {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    padding: 14px; margin: 0 0 10px; border-radius: var(--r-lg);
+    background: linear-gradient(135deg, rgba(52,211,153,0.12), rgba(163,230,53,0.05));
+    border: 1px solid rgba(163,230,53,0.4);
+  }
+  .ds-label { font-size: 0.6rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  .ds-amount { font-family: var(--font-display); font-weight: 800; font-size: 2.4rem; color: var(--brand-2); line-height: 1; text-shadow: 0 0 18px rgba(163,230,53,0.35); }
+  .ds-cash { font-size: 0.8rem; color: var(--text-muted); }
+  .eff-chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 6px; margin: 0 0 16px; }
+  .eff {
+    font-size: 0.72rem; font-weight: 700; padding: 0.25rem 0.6rem; border-radius: 999px;
+    color: var(--text-faint); background: var(--surface); border: 1px solid var(--border);
+  }
+  .eff.on { color: var(--brand-2); border-color: rgba(163,230,53,0.45); background: rgba(163,230,53,0.08); }
   .ghost-compare {
     margin: 2px auto 16px;
     padding: 10px 14px;

--- a/supabase-daily-v2.sql
+++ b/supabase-daily-v2.sql
@@ -1,0 +1,27 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Phase 3: Daily efficiency scoring (migration: daily_v2_scoring)            ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- The Daily now pays a skill-based **Daily Score** = your Cash paycheck AND your
+-- shareable number — replacing the flat 500×streak bonus. Plays on a fake $1,000
+-- play-budget (no real-Cash downside).
+--
+-- daily_sessions += p_vowels, p_reveals, p_wrong_guesses (tracked in
+--   daily_buy_letter / daily_reveal / daily_submit_guess). daily_start now grants
+--   3 guesses (matches the "three tries" tutorial; efficiency rewards not using them).
+--
+-- _finalize_daily (win path):
+--   eff   = 1.00 + 0.25·(no wrong letters) + 0.25·(no vowels)
+--                + 0.25·(solved first attempt) + 0.15·(no reveals)        (→ ~1.90)
+--   strk  = 1 + min(streak−1,10)×0.05                                      (→ 1.50)
+--   DailyScore = max(100, round(leftover_budget × eff × strk))            (fail → 0)
+--   _bank_credit(uid, DailyScore, 'daily_reward')   -- was 'daily_win' 500×streak
+--   game_results.score = DailyScore  (drives the Daily leaderboard + today_score)
+--
+-- _daily_resolve_and_return merges {daily_result:{score,clean,no_vowels,first_try,
+--   no_reveals}} into the finished board → the client shows the score + the
+--   efficiency breakdown chips + the share text ("Score N — beat that").
+--
+-- Verified (SQL sim): clean solve, $700 left, streak→1 → eff 1.90 → **$1,330**
+-- credited; breakdown all ✓; test user restored.
+--
+-- (Streak-break rule — break only on a missed day, not a played loss — is Phase 9.)


### PR DESCRIPTION
**ROADMAP_V2 Phase 3.** The Daily pays a skill-based **Daily Score** (= Cash paycheck + shareable number), replacing the flat 500×streak bonus. Plays on a fake $1,000 budget — no real-Cash downside.

**DB (`daily_v2_scoring`):** track vowels/reveals/wrong-guesses; 3 guesses; `_finalize_daily` → `DailyScore = max(100, round(leftover × eff × streak))` (eff = 1 + .25 clean + .25 no-vowels + .25 first-try + .15 no-reveals); credit `daily_reward`; `game_results.score` = DailyScore; board carries the breakdown.

**Client:** result modal shows the Daily Score + efficiency chips + "+$X to Cash"; share = "Score N — beat that."

**Verified:** SQL sim — clean solve, $700 left, streak→1 → eff 1.90 → **$1,330**, breakdown all ✓; test user restored. svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)