### PR TITLE
Phase 4 (4d): Cash Game client — playable Climb

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -82,7 +82,7 @@ auto-repay skims a win. Playwright: loan UI + In-the-Red badge render.
 
 ---
 
-## Phase 4 — Cash Game / the Climb  ★ critical path
+## Phase 4 — Cash Game / the Climb  ◑ (4a–4d done; board UI in P8)  ★ critical path
 
 **Goal:** replace Arcade with the persistent forward-only **Climb** (par/bounty + heat, real Cash).
 **Depends on:** P1, P2 (mid-puzzle loans).

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,6 +8,7 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
+import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, takeLoan } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -43,7 +44,8 @@ import { track } from '$lib/analytics.js';
  *   clue?: string | null,
  *   challengeInfo?: any,
  *   makeupDate?: string | null,
- *   dailyResult?: any
+ *   dailyResult?: any,
+ *   climbInfo?: any
  * }} GameState
  */
 
@@ -82,7 +84,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   modifier: null, // today's shared Daily Modifier id (daily only)
   clue: null, // witty one-line hint for the current puzzle
   challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
-  makeupDate: null // YYYY-MM-DD of the make-up day being played (makeup mode only)
+  makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
+  climbInfo: null // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
 }));
 
 /* ================================
@@ -564,6 +567,103 @@ async function submitGuessMakeup(state) {
   }
 }
 
+/* ===== Cash Game / the Climb (real-Cash, fluid, par/bounty + heat) ===== */
+/** @param {any} board */
+function reconcileClimbBoard(board) {
+  if (!board) return;
+  const prev = get(gameStore);
+  const climb = board.climb || {};
+  // 'solved' shows a win beat (then climbAdvance); 'complete' = reached the top.
+  const solved = climb.state === 'solved';
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(board, prev),
+    gameMode: 'climb',
+    gameState: solved ? 'won' : 'default',
+    modifier: null, arcadeRun: null,
+    climbInfo: climb
+  }));
+  if (solved) { setTimeout(() => launchConfetti(), 250); fx('win'); }
+  else playMoveCue(prev, board);
+}
+
+/** Start or resume the Climb. @returns {Promise<boolean>} */
+export async function fetchClimbGame() {
+  try {
+    track('climb_start');
+    const board = await climbStart();
+    if (!board) return false;
+    reconcileClimbBoard(board);
+    return true;
+  } catch (err) {
+    console.error('❌ Error starting climb:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/** @param {GameState} state */
+async function confirmPurchaseClimb(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    let board = null;
+    if (purchase.type === 'letter') board = await climbBuyLetter(purchase.value ?? '');
+    else if (purchase.type === 'hint') board = await climbReveal();
+    if (board) reconcileClimbBoard(board);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** @param {GameState} state */
+async function submitGuessClimb(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+  dailyInFlight = true;
+  try {
+    const board = await climbSubmitGuess(guess);
+    if (board) reconcileClimbBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** Advance to the next climb puzzle after a solve. */
+export async function climbAdvance() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const board = await climbNext();
+    if (board) reconcileClimbBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** Leave the Cash Game (clears heat; position + Cash persist). */
+export async function climbLeaveGame() {
+  try { await climbLeave(); } catch { /* non-fatal */ }
+}
+
+/** Borrow mid-climb, then refresh the board with the new Cash. @param {number} amount */
+export async function climbBorrow(amount) {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const res = await takeLoan(Math.floor(amount || 0));
+    if (res && res.ok !== false) {
+      const board = await climbStart(); // returns the board with updated Cash
+      if (board) reconcileClimbBoard(board);
+    }
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
 /** Spend an earned power-up during the current arcade run. @param {string} powerup */
 export async function useArcadePowerup(powerup) {
   if (dailyInFlight) return;
@@ -722,6 +822,7 @@ export function confirmPurchase() {
   else if (current.gameMode === 'freeplay') confirmPurchaseFreeplay(current);
   else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
   else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
+  else if (current.gameMode === 'climb') confirmPurchaseClimb(current);
 }
 /* ================================
    Guess Mode Functions
@@ -824,6 +925,7 @@ export function submitGuess() {
   else if (current.gameMode === 'freeplay') submitGuessFreeplay(current);
   else if (current.gameMode === 'challenge') submitGuessChallenge(current);
   else if (current.gameMode === 'makeup') submitGuessMakeup(current);
+  else if (current.gameMode === 'climb') submitGuessClimb(current);
 }
 /* ================================
    Puzzle Fetch Functions

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -362,6 +362,50 @@ export async function makeupBuyLetter(date, letter) {
   if (error) { console.error('❌ makeup_buy_letter error:', error); return null; }
   return data;
 }
+
+/* ===== Cash Game / the Climb (real-Cash forward-only climb) ===== */
+/** @returns {Promise<any>} */
+export async function climbStart() {
+  const { data, error } = await supabase.rpc('climb_start');
+  if (error) { console.error('❌ climb_start:', error); return null; }
+  return data;
+}
+/** @param {string} letter @returns {Promise<any>} */
+export async function climbBuyLetter(letter) {
+  const { data, error } = await supabase.rpc('climb_buy_letter', { p_letter: letter });
+  if (error) { console.error('❌ climb_buy_letter:', error); return null; }
+  return data;
+}
+/** @returns {Promise<any>} */
+export async function climbReveal() {
+  const { data, error } = await supabase.rpc('climb_reveal');
+  if (error) { console.error('❌ climb_reveal:', error); return null; }
+  return data;
+}
+/** @param {Record<string,string>} guess @returns {Promise<any>} */
+export async function climbSubmitGuess(guess) {
+  const { data, error } = await supabase.rpc('climb_submit_guess', { p_guess: guess });
+  if (error) { console.error('❌ climb_submit_guess:', error); return null; }
+  return data;
+}
+/** @returns {Promise<any>} */
+export async function climbNext() {
+  const { data, error } = await supabase.rpc('climb_next');
+  if (error) { console.error('❌ climb_next:', error); return null; }
+  return data;
+}
+/** @returns {Promise<any>} */
+export async function climbLeave() {
+  const { data, error } = await supabase.rpc('climb_leave');
+  if (error) { console.error('❌ climb_leave:', error); return null; }
+  return data;
+}
+/** @param {'friends'|'global'} scope @returns {Promise<any[]>} */
+export async function getClimbLeaderboard(scope = 'friends') {
+  const { data, error } = await supabase.rpc('get_climb_leaderboard', { p_scope: scope });
+  if (error) { console.error('❌ get_climb_leaderboard:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
 /** @param {string} date @returns {Promise<any>} */
 export async function makeupReveal(date) {
   const { data, error } = await supabase.rpc('makeup_reveal', { p_date: date });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbBorrow } from '$lib/stores/GameStore.js';
   import { getMyChallenges } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -174,6 +174,8 @@
       showMainMenu = true;
     } else if (gameMode === 'makeup') {
       fetchMakeupGame().then((ok) => { if (!ok) showMainMenu = true; });
+    } else if (gameMode === 'climb') {
+      fetchClimbGame().then((ok) => { if (!ok) showMainMenu = true; });
     } else {
       fetchDailyGame().then((ok) => {
         if (!ok) initError = "Daily puzzle failed to load.";
@@ -238,7 +240,17 @@
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
   $: isMakeup = $gameStore.gameMode === 'makeup';
+  $: isClimb = $gameStore.gameMode === 'climb';
+  $: climb = $gameStore.climbInfo; // { bounty, heat, attempts, spent, position, stuck, last_gain, state }
+  $: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
   $: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
+  let climbBorrowing = false;
+  async function handleClimbBorrow() {
+    if (climbBorrowing) return;
+    climbBorrowing = true;
+    // Borrow roughly enough to afford a couple of letters / get unstuck.
+    try { await climbBorrow(500); } finally { climbBorrowing = false; }
+  }
   $: makeupLabel = (() => {
     const d = $gameStore.makeupDate;
     if (!d) return '';
@@ -381,18 +393,17 @@
   // Today's shared Daily Modifier banner (id lives in the game store, set by fetchDailyGame).
   $: dailyMod = ($gameStore.gameMode === 'daily' && $gameStore.modifier) ? modifierInfo($gameStore.modifier) : null;
 
-  /** Start or resume today's server-authoritative arcade gauntlet run. */
-  async function handleMenuArcade() {
+  /** Start or resume the Cash Game (the persistent real-Cash Climb). */
+  async function handleMenuClimb() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
-    // Arcade is now the server-authoritative Press-Your-Luck gauntlet (start/resume today's run).
-    localStorage.setItem('gameMode', 'arcade');
-    const ok = await fetchArcadeGame();
+    localStorage.setItem('gameMode', 'climb');
+    const ok = await fetchClimbGame();
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
     } else {
-      initError = 'Arcade failed to load.';
+      initError = 'Cash Game failed to load.';
     }
   }
 
@@ -530,6 +541,11 @@
     if ($gameStore.gameMode === 'makeup') {
       localStorage.setItem('gameMode', 'daily');
       localStorage.removeItem('makeupDate');
+    }
+    // Leaving the Cash Game clears heat (position + Cash persist server-side).
+    if ($gameStore.gameMode === 'climb') {
+      climbLeaveGame();
+      localStorage.setItem('gameMode', 'daily');
     }
     saveGameToLocalStorage();
     savedGameInfo = getSavedGameInfo(currentUser.id);
@@ -716,11 +732,11 @@
           </span>
           <span class="mc-arrow">{#if questProgress.all_done && !questProgress.reward_claimed}🎁{:else}→{/if}</span>
         </button>
-        <button class="menu-card" style="--i: 2" on:click={handleMenuArcade}>
-          <span class="mc-icon">🕹️</span>
+        <button class="menu-card" style="--i: 2" on:click={handleMenuClimb}>
+          <span class="mc-icon">🎰</span>
           <span class="mc-body">
-            <span class="mc-title">{#if savedGameInfo?.gameMode === 'arcade' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}Resume Arcade{:else}Arcade Mode{/if}</span>
-            <span class="mc-sub">Unlimited · build your bankroll</span>
+            <span class="mc-title">Cash Game</span>
+            <span class="mc-sub">Climb the ladder · risk real Cash</span>
           </span>
           <span class="mc-arrow">→</span>
         </button>
@@ -1002,6 +1018,24 @@
       </div>
     {/if}
 
+    <!-- 🎰 Cash Game (Climb) HUD -->
+    {#if isClimb && climb}
+      <div class="climb-hud">
+        <div class="ch-cell"><span class="ch-val">#{climb.position}</span><span class="ch-label">Climb</span></div>
+        <div class="ch-cell"><span class="ch-val ch-gold">${(climb.bounty ?? 0).toLocaleString()}</span><span class="ch-label">Bounty</span></div>
+        <div class="ch-cell" class:hot={(climb.heat ?? 100) > 100}><span class="ch-val">×{climbHeat}</span><span class="ch-label">Heat</span></div>
+      </div>
+      {#if climb.stuck && $gameStore.gameState !== 'won'}
+        <div class="climb-stuck">
+          <span class="cs-text">Out of guesses &amp; Cash — borrow to finish, or leave.</span>
+          <div class="cs-actions">
+            <button class="cs-borrow" on:click={handleClimbBorrow} disabled={climbBorrowing}>💵 Borrow $500</button>
+            <button class="cs-leave" on:click={goToMainMenu}>Leave</button>
+          </div>
+        </div>
+      {/if}
+    {/if}
+
     <!-- 🌍 Category + witty clue -->
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
@@ -1113,6 +1147,16 @@
             <div class="result-actions">
               <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
               <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
+            </div>
+          {:else if isClimb}
+            <!-- Cash Game solve → advance up the Climb -->
+            <div class="result-medal">🎰</div>
+            <h2>Solved! +${(climb?.last_gain ?? 0).toLocaleString()}</h2>
+            <p class="result-sub">{$gameStore.currentPhrase}</p>
+            <p class="arcade-gain">Climb #{climb?.position} · Heat ×{climbHeat}{#if (climb?.heat ?? 100) >= 200} 🔥 maxed{/if}</p>
+            <div class="result-actions">
+              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Leave</button>
+              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance(); }}>Next →</button>
             </div>
           {:else if isFreeplay}
             <!-- Free Play transition (unranked) -->
@@ -1285,6 +1329,26 @@
   .ah-mult .ah-val { color: var(--brand-2); }
   .ah-gold { color: #fcd34d; }
   .ah-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  /* Cash Game (Climb) HUD */
+  .climb-hud { display: flex; gap: 8px; width: 100%; max-width: 360px; margin: 0 auto 12px; }
+  .ch-cell {
+    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; padding: 10px 6px;
+    background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md, 12px);
+  }
+  .ch-cell.hot { border-color: rgba(251,191,36,0.5); background: linear-gradient(135deg, rgba(251,191,36,0.14), rgba(251,191,36,0.04)); }
+  .ch-val { font-family: var(--font-display); font-weight: 700; font-size: 1.15rem; color: var(--text); font-variant-numeric: tabular-nums; }
+  .ch-cell.hot .ch-val { color: #fbbf24; }
+  .ch-gold { color: #fcd34d; }
+  .ch-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  .climb-stuck {
+    display: flex; flex-direction: column; gap: 8px; width: 100%; max-width: 360px; margin: 0 auto 12px; padding: 0.8rem;
+    border: 1px solid rgba(248,113,113,0.45); border-radius: 14px; background: rgba(248,113,113,0.08); text-align: center;
+  }
+  .cs-text { font-size: 0.82rem; color: #fca5a5; }
+  .cs-actions { display: flex; gap: 8px; justify-content: center; }
+  .cs-borrow { padding: 0.5rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: linear-gradient(135deg,#fbbf24,#f59e0b); }
+  .cs-borrow:disabled { opacity: 0.5; }
+  .cs-leave { padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 10px; cursor: pointer; font-weight: 700; color: var(--text-muted); background: transparent; }
   .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
   .arcade-earn {
     font-family: var(--font-display); font-weight: 700; font-size: 0.95rem;


### PR DESCRIPTION
The **Cash Game is now playable.** The menu's Arcade card becomes **Cash Game**, launching the real-Cash Climb.

- **statsStore:** `climbStart/BuyLetter/Reveal/SubmitGuess/Next/Leave` + `getClimbLeaderboard`.
- **GameStore:** `climb` mode — `reconcileClimbBoard` (captures bounty/heat/attempts/spent/position/stuck/last_gain), `fetchClimbGame`, dispatchers routed, `climbAdvance` (next puzzle, heat persists), `climbLeaveGame`, `climbBorrow` (mid-climb loan → refresh).
- **UI:** Cash Game menu card; HUD (Climb # · Bounty · Heat ×N, hot styling); solve modal (+$last_gain · Heat · Next →); stuck panel (Borrow $500 / Leave); leave clears heat; reactive loader + restore handle `climb`.

**Verified:** Playwright smoke — Cash Game launches, HUD reads **#1 Climb · $620 Bounty · ×1.0 Heat**, board renders, **0 page errors**; test user reset. svelte-check + build green. (Arcade backend left intact until the full cutover.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)