### PR TITLE
Phase 5 (Cash Game tools): power-up economy + in-Climb tray

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -118,7 +118,7 @@ finish; leave → heat cleared, position persists; two users share puzzle #N.
 
 ---
 
-## Phase 5 — Power-ups economy
+## Phase 5 — Power-ups economy  ◑ (Cash Game tools + tray done; Free Play earned = 5b)
 
 **Goal:** the catalog — bought-with-Cash in Climb (mid-puzzle), earned-by-feats in Free Play.
 **Depends on:** P4 (Climb hooks).

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,7 +8,7 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, takeLoan } from '$lib/stores/statsStore.js';
+import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, takeLoan, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -647,6 +647,22 @@ export async function climbAdvance() {
 /** Leave the Cash Game (clears heat; position + Cash persist). */
 export async function climbLeaveGame() {
   try { await climbLeave(); } catch { /* non-fatal */ }
+}
+
+/** Use a power-up in the Climb — buys it first if you don't own one. @param {string} id @param {boolean} owned */
+export async function climbPowerup(id, owned) {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    if (!owned) {
+      const res = await buyPowerup(id);
+      if (!res || res.ok === false) return;
+    }
+    const board = await climbUsePowerup(id);
+    if (board) reconcileClimbBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
 }
 
 /** Borrow mid-climb, then refresh the board with the new Cash. @param {number} amount */

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -406,6 +406,26 @@ export async function getClimbLeaderboard(scope = 'friends') {
   if (error) { console.error('❌ get_climb_leaderboard:', error); return []; }
   return Array.isArray(data) ? data : [];
 }
+
+/* ===== Power-ups (catalog + buy + use-in-Climb) ===== */
+/** @returns {Promise<{cash:number, items:any[]}>} */
+export async function getPowerups() {
+  const { data, error } = await supabase.rpc('get_powerups');
+  if (error || !data) { if (error) console.error('❌ get_powerups:', error); return { cash: 0, items: [] }; }
+  return { cash: data.cash ?? 0, items: Array.isArray(data.items) ? data.items : [] };
+}
+/** @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
+export async function buyPowerup(id) {
+  const { data, error } = await supabase.rpc('buy_powerup', { p_id: id });
+  if (error || !data) { if (error) console.error('❌ buy_powerup:', error); return { ok: false }; }
+  return data;
+}
+/** Use a power-up in the Climb. @param {string} id @returns {Promise<any>} */
+export async function climbUsePowerup(id) {
+  const { data, error } = await supabase.rpc('climb_use_powerup', { p_id: id });
+  if (error) { console.error('❌ climb_use_powerup:', error); return null; }
+  return data;
+}
 /** @param {string} date @returns {Promise<any>} */
 export async function makeupReveal(date) {
   const { data, error } = await supabase.rpc('makeup_reveal', { p_date: date });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,8 +4,8 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbBorrow } from '$lib/stores/GameStore.js';
-  import { getMyChallenges } from '$lib/stores/statsStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbBorrow, climbPowerup } from '$lib/stores/GameStore.js';
+  import { getMyChallenges, getPowerups } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -249,7 +249,20 @@
     if (climbBorrowing) return;
     climbBorrowing = true;
     // Borrow roughly enough to afford a couple of letters / get unstuck.
-    try { await climbBorrow(500); } finally { climbBorrowing = false; }
+    try { await climbBorrow(500); await refreshClimbPups(); } finally { climbBorrowing = false; }
+  }
+  /** @type {any[]} */
+  let climbPups = [];
+  const PUP_ICON = /** @type {Record<string,string>} */ ({ free_reveal: '🔍', half_off: '🏷️', extra_attempt: '➕', insurance: '🛟', heat_shield: '🛡️', double_down: '⚡' });
+  async function refreshClimbPups() {
+    try { const r = await getPowerups(); climbPups = r.items.filter((/** @type {any} */ i) => i.kind === 'climb'); } catch { /* non-fatal */ }
+  }
+  /** @param {any} item */
+  async function handleClimbPup(item) {
+    const cash = $gameStore.bankroll ?? 0;
+    if (item.owned <= 0 && cash < item.price) return; // can't afford to buy
+    await climbPowerup(item.id, item.owned > 0);
+    await refreshClimbPups();
   }
   $: makeupLabel = (() => {
     const d = $gameStore.makeupDate;
@@ -402,6 +415,7 @@
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
+      refreshClimbPups();
     } else {
       initError = 'Cash Game failed to load.';
     }
@@ -1025,6 +1039,17 @@
         <div class="ch-cell"><span class="ch-val ch-gold">${(climb.bounty ?? 0).toLocaleString()}</span><span class="ch-label">Bounty</span></div>
         <div class="ch-cell" class:hot={(climb.heat ?? 100) > 100}><span class="ch-val">×{climbHeat}</span><span class="ch-label">Heat</span></div>
       </div>
+      {#if climb.state === 'active' && climbPups.length}
+        <div class="climb-pups">
+          {#each climbPups as item}
+            <button class="cp" disabled={item.owned <= 0 && ($gameStore.bankroll ?? 0) < item.price}
+              on:click={() => handleClimbPup(item)} title={item.name}>
+              <span class="cp-ic">{PUP_ICON[item.id] ?? '✨'}</span>
+              <span class="cp-tag">{item.owned > 0 ? '×' + item.owned : '$' + item.price}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
       {#if climb.stuck && $gameStore.gameState !== 'won'}
         <div class="climb-stuck">
           <span class="cs-text">Out of guesses &amp; Cash — borrow to finish, or leave.</span>
@@ -1340,6 +1365,16 @@
   .ch-cell.hot .ch-val { color: #fbbf24; }
   .ch-gold { color: #fcd34d; }
   .ch-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  .climb-pups { display: flex; gap: 6px; width: 100%; max-width: 360px; margin: 0 auto 12px; justify-content: space-between; }
+  .cp {
+    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 7px 2px;
+    border-radius: 10px; cursor: pointer; border: 1px solid var(--border); background: var(--surface);
+    transition: transform 0.1s, border-color 0.15s;
+  }
+  .cp:hover:not(:disabled) { transform: translateY(-1px); border-color: rgba(251,191,36,0.5); }
+  .cp:disabled { opacity: 0.4; cursor: default; }
+  .cp-ic { font-size: 1.1rem; line-height: 1; }
+  .cp-tag { font-size: 0.6rem; font-weight: 700; color: var(--text-faint); }
   .climb-stuck {
     display: flex; flex-direction: column; gap: 8px; width: 100%; max-width: 360px; margin: 0 auto 12px; padding: 0.8rem;
     border: 1px solid rgba(248,113,113,0.45); border-radius: 14px; background: rgba(248,113,113,0.08); text-align: center;

--- a/supabase-powerups-v2.sql
+++ b/supabase-powerups-v2.sql
@@ -1,0 +1,31 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Phase 5: power-up economy (migration: powerups_v2)                         ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Two-pool, consumable power-ups (supersedes the legacy supabase-powerups.sql).
+-- Cash Game tools are BOUGHT with Cash (buy + use mid-puzzle); Free Play tools
+-- will be EARNED by feats (Phase 5b).
+--
+-- powerups(id, name, kind 'climb'|'blitz', effect_key, price)  -- catalog (public read).
+--   Climb: free_reveal $80, half_off $120, extra_attempt $120, insurance $150,
+--          heat_shield $100, double_down $250. Blitz time-tools seeded (effects in P7).
+-- user_powerups_v2(user_id, powerup_id, pool 'cash'|'freeplay', qty)  -- self-read.
+--
+-- get_powerups()        -> { cash, items:[{id,name,kind,price,owned(cash-pool)}] }.
+-- buy_powerup(id)       -> -price 'powerup_buy', qty++ in cash pool.
+-- climb_use_powerup(id) -> consume a cash-pool charge, apply the effect, re-resolve:
+--   free_reveal (free best-letter), extra_attempt (+1), half_off / insurance /
+--   heat_shield / double_down (flag on climb_state.active_powerups). _award_powerup
+--   (uid,id,pool) for Free Play feats (5b).
+--
+-- Climb engine now honours the flags:
+--   climb_buy_letter   -- half_off → letters cost ×0.5.
+--   climb_submit_guess -- heat_shield → a wrong guess won't reset heat.
+--   _climb_resolve     -- double_down → bounty ×2 on solve; insurance → refund the
+--     letter-spend before a stuck verdict (often un-sticks you).
+--
+-- Verified (SQL sim): double_down → $620 bounty paid $1,240; half_off → $80 letter
+-- charged $40; insurance on a would-be-stuck → refunded $300 (cash $5→$305, back to
+-- active). Test user reset.
+--
+-- Client: in-Climb power-up tray (tap to use if owned, else buy+use). Free Play
+-- earned set = Phase 5b; the cosmetics Shop stays separate.


### PR DESCRIPTION
Power-ups become a real Bank sink — **bought with Cash, used mid-puzzle** in the Cash Game.

**DB (`powerups_v2`):** catalog (climb tools $80–$250 + blitz tools seeded for P7); `user_powerups_v2` two-pool inventory; `get_powerups`/`buy_powerup`/`climb_use_powerup` (+ `_award_powerup` for 5b). The Climb engine honours the flags — **half_off** (×0.5 letters), **heat_shield** (no heat reset on a wrong guess), **double_down** (bounty ×2), **insurance** (refund letter-spend before a stuck verdict, often un-sticks you), **free_reveal**, **extra_attempt**.

**Client:** in-Climb power-up tray (🔍🏷️➕🛟🛡️⚡) — tap to use if owned, else buy+use; disabled when unaffordable.

**Verified:** SQL sim — double_down $620→$1,240, half_off $80→$40, insurance refunds $300 → recovers to active; test user reset. Tray renders 6 tools at correct prices, 0 page errors. Build green.

*(Free Play earned-by-feats = Phase 5b.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)