### PR TITLE
Phase 7: Blitz — timed challenge variant

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -170,7 +170,7 @@ math; no-show forfeits ante; friendly pays nothing; spoiler-lock hides until pla
 
 ---
 
-## Phase 7 — Blitz
+## Phase 7 — Blitz  ✅ (Builder Blitz mode; solo Free-Play Blitz = tail)
 
 **Goal:** timed variant (one clock per pack) in Challenges + a Free-Play practice; time tools.
 **Depends on:** P5 (time-tool power-ups), P6 (challenge packs).

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -9,7 +9,7 @@ import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freepla
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
 import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, takeLoan, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
-import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess } from '$lib/stores/statsStore.js';
+import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -727,6 +727,13 @@ export async function acceptAndPlayMatch(id) {
   const board = await matchStart(id);
   if (board) reconcileMatchBoard(board);
   return true;
+}
+
+/** Blitz: force the server to lock the score when the clock expires. */
+export async function matchTimeoutCheck() {
+  if (!activeMatchId) return;
+  const board = await matchCheck(activeMatchId);
+  if (board) reconcileMatchBoard(board);
 }
 
 /** Resume a match I'm already in. @param {string} id @returns {Promise<boolean>} */

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -595,6 +595,12 @@ export async function matchSubmitGuess(id, guess) {
   if (error) { console.error('❌ match_submit_guess:', error); return null; }
   return data;
 }
+/** Force the server to settle a Blitz match when its clock expires. @param {string} id */
+export async function matchCheck(id) {
+  const { data, error } = await supabase.rpc('match_check', { p_id: id });
+  if (error) { console.error('❌ match_check:', error); return null; }
+  return data;
+}
 
 /* ===== Challenges (friend wagers) ===== */
 /** @param {string} username @param {string} category @param {number} wager @param {string} [mode] */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbBorrow, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbBorrow, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -247,7 +247,22 @@
   $: isClimb = $gameStore.gameMode === 'climb';
   $: climb = $gameStore.climbInfo; // { bounty, heat, attempts, spent, position, stuck, last_gain, state }
   $: isMatch = $gameStore.gameMode === 'match';
-  $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done }
+  $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, started_at, clock_seconds, combo }
+  $: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
+  $: matchCombo = ((matchInfo?.combo ?? 100) / 100).toFixed(2);
+  let matchExpiredFired = false;
+  $: matchRemaining = (() => {
+    if (!matchBlitz || !matchInfo?.started_at) return 0;
+    const start = new Date(matchInfo.started_at).getTime();
+    const clockMs = (matchInfo.clock_seconds ?? 60) * 1000;
+    return Math.max(0, Math.ceil((start + clockMs - pressureNow) / 1000));
+  })();
+  $: if (matchBlitz && matchRemaining > 0) matchExpiredFired = false;
+  $: if (matchBlitz && matchRemaining <= 0 && !matchExpiredFired) fireMatchTimeout();
+  async function fireMatchTimeout() {
+    matchExpiredFired = true;
+    await matchTimeoutCheck();
+  }
   $: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
   $: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
   let climbBorrowing = false;
@@ -470,6 +485,7 @@
   let matchResults = null; // a settled match's results being viewed
   // Builder form
   let mbTarget = 'friend'; // 'friend' | 'group'
+  let mbMode = 'standard'; // 'standard' | 'blitz'
   let mbOpponent = '';
   let mbGroupId = '';
   /** @type {string[]} */
@@ -527,7 +543,7 @@
     const res = await startMatch({
       opponent: mbTarget === 'friend' ? mbOpponent.trim() : null,
       group_id: mbTarget === 'group' ? mbGroupId : null,
-      categories: mbCategories, pack_size: mbPackSize,
+      categories: mbCategories, pack_size: mbPackSize, mode: mbMode,
       wager: Math.floor(Number(mbWager) || 0), payout: mbPayout, window_seconds: mbWindow
     });
     mbBusy = false;
@@ -907,6 +923,12 @@
                 </select>
               {/if}
 
+              <!-- Standard vs Blitz -->
+              <div class="ch-modes">
+                <button type="button" class="ch-mode" class:active={mbMode === 'standard'} on:click={() => mbMode = 'standard'}>🧠 Standard<small>efficiency · spend less</small></button>
+                <button type="button" class="ch-mode" class:active={mbMode === 'blitz'} on:click={() => mbMode = 'blitz'}>⚡ Blitz<small>timed · combo speed</small></button>
+              </div>
+
               <!-- Categories (optional) -->
               <div class="ch-cats">
                 {#each CATEGORIES as c}
@@ -1134,6 +1156,10 @@
       <div class="climb-hud">
         <div class="ch-cell"><span class="ch-val">{matchInfo.position}/{matchInfo.pack_size}</span><span class="ch-label">Puzzle</span></div>
         <div class="ch-cell"><span class="ch-val ch-gold">{(matchInfo.total_score ?? 0).toLocaleString()}</span><span class="ch-label">Score</span></div>
+        {#if matchBlitz}
+          <div class="ch-cell"><span class="ch-val">×{matchCombo}</span><span class="ch-label">Combo</span></div>
+          <div class="ch-cell" class:hot={matchRemaining <= 10}><span class="ch-val">⏱️{matchRemaining}</span><span class="ch-label">Time</span></div>
+        {/if}
       </div>
     {/if}
 

--- a/supabase-challenge-builder.sql
+++ b/supabase-challenge-builder.sql
@@ -40,3 +40,13 @@
 -- Verified 6c (SQL sim): solve puzzle 1 → score 1,900 (= $1,000 × 1.9 eff), advance
 -- to #2; settle Chef 1500 vs War 900 → Chef wins $400 pot (1000→1200, War 1000→800),
 -- status settled, notified. Cleaned up. Builder UI + results card = 6d.
+
+-- ── Phase 7: Blitz (migration challenge_builder_blitz) ────────────────────────
+-- mode='blitz' on a match: one clock for the whole pack (30s × pack_size), combo
+-- scoring instead of efficiency. challenge_participants += started_at, combo_x100.
+-- match_start stamps the clock; _match_tick locks the score (done) once expired
+-- (guards every play action); match_check(id) is the client's countdown-expiry call.
+-- _match_resolve_and_advance: blitz solve = round(300 × combo); combo +0.25 (cap
+-- ×3.0), resets on a failed puzzle. _match_board carries started_at/clock_seconds/
+-- combo for the countdown. Verified (SQL sim): start clock 60s, solve → 300 +
+-- combo ×1.25, clock expiry → done @ 300.


### PR DESCRIPTION
Adds **Blitz** to the Challenge Builder — a single pack clock + combo scoring.

**DB (`challenge_builder_blitz`):** `challenge_participants` += `started_at`, `combo_x100`. For `mode='blitz'`: clock = **30s × pack_size**; `match_start` stamps it; `_match_tick` locks the score once expired (guards every play action); `match_check(id)` is the countdown-expiry call. `_match_resolve_and_advance`: blitz solve = **round(300 × combo)**, combo +0.25 (cap ×3.0), resets on a failed puzzle (standard = efficiency, unchanged). `_match_board` carries the clock + combo.

**Client:** Builder gains a **Standard / Blitz** toggle; blitz HUD adds **Combo** + a **⏱️ countdown** (reusing the pressure ticker); on expiry the client calls `match_check` to lock the result.

**Verified:** SQL sim (clock 60s, solve → 300 @ ×1.25 combo, expiry → done @ 300) + Playwright smoke (Blitz toggle → match launches with **"1/3 · 0 · ×1.00 · ⏱️88"**, clock ticking, 0 page errors). Cleaned up. Build green. *(Solo Free-Play Blitz + time-tool power-up effects = small tail.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)