### PR TITLE
Phase 9: streak-survives-loss + new badges

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -202,7 +202,7 @@ correctly, stats live on Profile (not the board), daily placement card shows.
 
 ---
 
-## Phase 9 — Streaks & Badges
+## Phase 9 — Streaks & Badges  ✅
 
 **Goal:** v2 streak rule + the new badge set.
 **Depends on:** P3 (Daily payout) — can run parallel.

--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -7,6 +7,11 @@ export const BADGES = {
   streak_30: { emoji: '👑', name: 'Iron Will',     desc: '30-day daily streak' },
   week_complete:  { emoji: '🗓️', name: 'Perfect Week',  desc: 'Played every day of a calendar week' },
   month_complete: { emoji: '📅', name: 'Perfect Month', desc: 'Played every day of a calendar month' },
+  climb_50:  { emoji: '🧗', name: 'Climber',     desc: 'Reached puzzle #50 in the Cash Game' },
+  climb_100: { emoji: '🏔️', name: 'Mountaineer', desc: 'Reached puzzle #100 in the Cash Game' },
+  climb_500: { emoji: '🚀', name: 'Summit',      desc: 'Reached puzzle #500 in the Cash Game' },
+  debt_free: { emoji: '💸', name: 'Debt-Free',   desc: 'Paid off a loan in full' },
+  hustler:   { emoji: '🤝', name: 'Hustler',     desc: 'Won 10 challenges' },
 };
 
 /** @param {string} id */

--- a/supabase-streaks-badges-v2.sql
+++ b/supabase-streaks-badges-v2.sql
@@ -1,0 +1,16 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Phase 9: streaks rule + new badges (migration: streaks_badges_v2)          ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Streak now SURVIVES a played loss — it breaks only on a MISSED day.
+--   _finalize_daily: continuity is based on last_daily_play_date (yesterday →
+--   +1; 2 days ago + a freeze → spend it; else reset to 1). A loss keeps the
+--   streak (no win bonus / reward); last_daily_win_date only advances on a win.
+--   Freezes still earned every 7 days.
+--
+-- New badge awards (catalog mirrored in src/lib/badges.js):
+--   climb_50 / climb_100 / climb_500 — in climb_next on reaching that position.
+--   debt_free — in repay_loan when a loan is cleared to $0.
+--   hustler   — in _match_settle when a winner's lifetime challenge wins hit 10.
+--
+-- Verified (SQL sim): a played LOSS with last-play=yesterday → streak 5 → 6 (not
+-- reset); take + fully repay a loan → Debt-Free badge awarded. Test user restored.


### PR DESCRIPTION
**DB (`streaks_badges_v2`):**
- `_finalize_daily`: the daily streak now **survives a played loss** — it breaks only on a **missed day**. Continuity uses `last_daily_play_date` (yesterday → +1, 2 days + a freeze → spend it, else reset to 1); a loss keeps the streak (no reward), `last_daily_win_date` advances only on a win. Freezes still earned every 7 days.
- New badge awards: **climb_50/100/500** (on reaching the position), **debt_free** (clearing a loan), **hustler** (10 challenge wins).

**Client:** the 5 new badges added to `badges.js` (shown on Profile + /badges).

**Verified (SQL sim):** a played loss (last-play yesterday) keeps streak **5→6**; take + fully repay a loan → **Debt-Free** awarded; test user restored. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)