### PR TITLE
Phase 10 (partial): Declare Bankruptcy + daily-placement card

### DIFF
--- a/ROADMAP_V2.md
+++ b/ROADMAP_V2.md
@@ -217,7 +217,7 @@ climb grants the milestone.
 
 ---
 
-## Phase 10 — Anti-cheat, balance & polish
+## Phase 10 — Anti-cheat, balance & polish  ◑ (bankruptcy + daily-placement done; tuning awaits playtest)
 
 **Goal:** keep wagers fair, tune the economy, ship legal copy, optional bankruptcy.
 **Depends on:** everything.

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -107,6 +107,13 @@ export async function setAutoRepay(on) {
   return data;
 }
 
+/** Declare bankruptcy (only when in the red) — wipes debt, resets to $1,000, 30-day cooldown. @returns {Promise<any>} */
+export async function declareBankruptcy() {
+  const { data, error } = await supabase.rpc('declare_bankruptcy');
+  if (error || !data) { if (error) console.error('❌ declare_bankruptcy:', error); return { ok: false }; }
+  return data;
+}
+
 /** My chosen username (null until claimed). @returns {Promise<string|null>} */
 export async function getMyUsername() {
   const { data, error } = await supabase.rpc('get_my_username');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, searchUsers, getMyUsername, setUsername, getBank } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard } from '$lib/stores/statsStore.js';
   import { unreadCount, notifications, markAllNotificationsRead, refreshNotifications } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
@@ -265,6 +265,17 @@
   }
   $: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
   $: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
+  /** @type {{rank:number, total:number}|null} */
+  let dailyPlacement = null;
+  $: if (showResultModal && isDailyResult && resultWon && dr && dailyPlacement === null) loadDailyPlacement();
+  async function loadDailyPlacement() {
+    dailyPlacement = { rank: 0, total: 0 }; // guard against re-fire
+    try {
+      const board = await getDailyBoard('friends');
+      const me = board.find((/** @type {any} */ r) => r.is_me);
+      dailyPlacement = { rank: me?.rank ?? 0, total: board.length };
+    } catch { dailyPlacement = { rank: 0, total: 0 }; }
+  }
   let climbBorrowing = false;
   async function handleClimbBorrow() {
     if (climbBorrowing) return;
@@ -590,6 +601,7 @@
   function goToMainMenu() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
+    dailyPlacement = null;
     // Leaving a make-up: clear it so we land on the menu, not back in the make-up.
     if ($gameStore.gameMode === 'makeup') {
       localStorage.setItem('gameMode', 'daily');
@@ -1247,6 +1259,9 @@
                 <span class="eff" class:on={dr.first_try}>{dr.first_try ? '✓' : '✗'} First try</span>
                 <span class="eff" class:on={dr.no_reveals}>{dr.no_reveals ? '✓' : '✗'} No reveals</span>
               </div>
+              {#if dailyPlacement && dailyPlacement.rank > 0 && dailyPlacement.total > 1}
+                <p class="daily-placement">{dailyPlacement.rank === 1 ? '🥇' : dailyPlacement.rank === 2 ? '🥈' : dailyPlacement.rank === 3 ? '🥉' : '🏅'} #{dailyPlacement.rank} of {dailyPlacement.total} among friends today</p>
+              {/if}
             {:else}
               <div class="result-bankroll">
                 <span class="rb-label">Banked</span>
@@ -2363,6 +2378,7 @@
     color: var(--text-faint); background: var(--surface); border: 1px solid var(--border);
   }
   .eff.on { color: var(--brand-2); border-color: rgba(163,230,53,0.45); background: rgba(163,230,53,0.08); }
+  .daily-placement { font-family: var(--font-display); font-weight: 700; font-size: 0.9rem; color: #fcd34d; margin: 0 0 14px; }
   .ghost-compare {
     margin: 2px auto 16px;
     padding: 10px 14px;

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getBank, repayLoan, takeLoan, setAutoRepay } from '$lib/stores/statsStore.js';
+  import { getBank, repayLoan, takeLoan, setAutoRepay, declareBankruptcy } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { fx } from '$lib/sound.js';
 
@@ -63,6 +63,17 @@
     const res = await setAutoRepay(!b.auto_repay);
     busy = false;
     if (res) b = res;
+  }
+
+  let bankruptMsg = '';
+  async function goBankrupt() {
+    if (busy || !b) return;
+    if (!confirm('Declare bankruptcy? This wipes your loan but resets your Cash to $1,000 and erases your Net Worth. Once per 30 days.')) return;
+    busy = true; bankruptMsg = '';
+    const res = await declareBankruptcy();
+    busy = false;
+    if (res && res.ok !== false && res.bank != null) { b = res; fx('bust'); track('bankruptcy'); }
+    else { bankruptMsg = res?.reason === 'cooldown' ? 'You already declared bankruptcy in the last 30 days.' : res?.reason === 'solvent' ? "You're not in the red." : 'Could not declare bankruptcy.'; }
   }
 </script>
 
@@ -128,6 +139,14 @@
     {/if}
 
     <p class="hint">Cash is in-game money — earn it by playing, risk it in the Cash Game, wager friends, and spend it on power-ups &amp; cosmetics. It can't be bought with real money or cashed out.</p>
+
+    {#if b.in_the_red}
+      <div class="bankrupt-box">
+        <p class="loan-copy">Underwater? <strong>Declare bankruptcy</strong> to wipe the debt and start fresh at $1,000 — but you lose your Net Worth, and it's only allowed once every 30 days.</p>
+        <button class="bankrupt-btn" disabled={busy} on:click={goBankrupt}>Declare Bankruptcy</button>
+        {#if bankruptMsg}<p class="add-msg">{bankruptMsg}</p>{/if}
+      </div>
+    {/if}
   {/if}
 </main>
 
@@ -154,6 +173,10 @@
 
   .loan-box { margin-top: 1.4rem; padding: 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 16px; text-align: left; }
   .loan-copy { margin: 0 0 0.8rem; color: var(--text-muted); font-size: 0.9rem; }
+  .add-msg { text-align: center; font-size: 0.82rem; color: #f87171; margin: 0.5rem 0 0; }
+  .bankrupt-box { margin-top: 1.4rem; padding: 1rem; border: 1px dashed rgba(251,113,133,0.5); border-radius: 16px; text-align: left; }
+  .bankrupt-btn { width: 100%; padding: 0.65rem; border: 1px solid rgba(251,113,133,0.5); border-radius: 12px; background: rgba(251,113,133,0.1); color: #fb7185; cursor: pointer; font-weight: 700; }
+  .bankrupt-btn:disabled { opacity: 0.5; }
   .pay-row { display: flex; gap: 0.5rem; }
   .amt { flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: var(--text); }
   .pay-btn { padding: 0.6rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }

--- a/supabase-bankruptcy.sql
+++ b/supabase-bankruptcy.sql
@@ -1,0 +1,14 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Phase 10: Declare Bankruptcy (migration: bankruptcy)                        ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- The escape hatch when you're underwater. profiles += last_bankruptcy_at.
+-- declare_bankruptcy(): only when Net Worth < 0 (in the red); 30-day cooldown.
+--   Wipes the loan, resets Cash to the $1,000 sign-up baseline, stamps the
+--   cooldown, writes a 'bankruptcy' ledger entry. Reasons: solvent | cooldown | auth.
+--
+-- Verified (SQL sim): solvent → blocked; in-the-red (bank 100/loan 5000) → reset
+-- to cash 1000/loan 0/NW 1000; immediate retry → cooldown. Test user restored.
+--
+-- Client: Bank/Cash screen shows a "Declare Bankruptcy" box only when In the Red,
+-- with a confirm. (Contextual daily-placement card also shipped this slice — pure
+-- client, via get_daily_board('friends').)


### PR DESCRIPTION
Two mechanical Phase 10 items (the **economy tuning pass awaits playtest data**).

**DB (`bankruptcy`):** `profiles` += `last_bankruptcy_at`; `declare_bankruptcy()` — only when Net Worth < 0, **30-day cooldown**; wipes the loan, resets Cash to the $1,000 baseline, writes a `bankruptcy` ledger entry. Verified by SQL sim (solvent + cooldown guards + the red→reset path); test user restored.

**Client:**
- Bank/Cash screen: a **"Declare Bankruptcy"** box (with confirm), shown only **In the Red**.
- **Contextual daily-placement:** after a daily win, the result modal shows **"🏅 #N of M among friends today"** via `get_daily_board('friends')`.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)