### PR TITLE
Fix: surface Google sign-in errors + harden OAuth callback

### DIFF
--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -22,6 +22,23 @@
       isNativeApp = !!(c && (c.isNativePlatform ? c.isNativePlatform() : c.isNative))
         || /WordBankApp/i.test(navigator.userAgent);
     } catch { isNativeApp = false; }
+
+    // Surface a failed OAuth/callback round-trip (set by /auth/callback).
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const ae = params.get('auth_error');
+      if (ae) {
+        errorMsg = ae === 'exchange' || ae === 'nocode'
+          ? 'Sign-in didn’t complete — please try again, or use email & password.'
+          : ae === 'config'
+          ? 'Sign-in is temporarily unavailable. Please try again shortly.'
+          : `Google sign-in was cancelled or blocked: ${decodeURIComponent(ae)}`;
+        // strip the param so it doesn't stick around on refresh
+        params.delete('auth_error');
+        const qs = params.toString();
+        window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
+      }
+    } catch { /* non-fatal */ }
   });
 
   let showReset = false;
@@ -112,11 +129,30 @@
   }
 
   async function signInWithGoogle() {
-    const redirectUrl = `${window.location.origin}/auth/callback`;
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: { redirectTo: redirectUrl }
-    });
+    errorMsg = '';
+    isLoading = true;
+    try {
+      const redirectUrl = `${window.location.origin}/auth/callback`;
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: redirectUrl,
+          // Let the user pick which Google account (avoids silently reusing the wrong one).
+          queryParams: { prompt: 'select_account' }
+        }
+      });
+      if (error) {
+        // Surface failures instead of doing nothing (provider disabled, redirect not
+        // allow-listed, popup blocked, etc.).
+        errorMsg = `Google sign-in failed: ${error.message}`;
+        track('google_signin_error', { message: error.message });
+        isLoading = false;
+      }
+      // On success the browser navigates to Google — no further code runs here.
+    } catch (e) {
+      errorMsg = 'Google sign-in failed. Try again, or use email & password.';
+      isLoading = false;
+    }
   }
 </script>
 

--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -1,26 +1,34 @@
 import { redirect } from '@sveltejs/kit';
 import { createServerClient } from '@supabase/ssr';
 
+// OAuth (Google) + magic-link PKCE callback: exchange the ?code for a session.
 export const GET = async ({ url, cookies }) => {
   const code = url.searchParams.get('code');
   const next = url.searchParams.get('next') ?? '/';
+
+  // Provider can also bounce back with an error (cancelled, access_denied, etc.).
+  const providerError = url.searchParams.get('error_description') || url.searchParams.get('error');
+  if (providerError) {
+    console.error('OAuth provider error:', providerError);
+    return redirect(303, '/?auth_error=' + encodeURIComponent(providerError));
+  }
 
   if (code) {
     const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
     const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
     if (!supabaseUrl || !supabaseAnonKey) {
       console.error('Missing Supabase env vars on Vercel');
-      return redirect(303, '/');
+      return redirect(303, '/?auth_error=config');
     }
-    const supabase = createServerClient(
-      supabaseUrl,
-      supabaseAnonKey,
-      {
-        cookies: {
-          get(name) {
-            return cookies.get(name);
-          },
-          set(name, value, options) {
+    const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+      // getAll/setAll is the chunk-safe API in @supabase/ssr >=0.5 — reads the
+      // (possibly chunked) PKCE code-verifier + writes the session cookies.
+      cookies: {
+        getAll() {
+          return cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
             cookies.set(name, value, {
               ...options,
               path: '/',
@@ -28,26 +36,18 @@ export const GET = async ({ url, cookies }) => {
               sameSite: 'lax',
               secure: import.meta.env.PROD
             });
-          },
-          remove(name, options) {
-            cookies.delete(name, {
-              ...options,
-              path: '/',
-              httpOnly: true,
-              sameSite: 'lax',
-              secure: import.meta.env.PROD
-            });
-          }
+          });
         }
       }
-    );
+    });
 
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
       return redirect(303, next);
     }
-    console.error('Auth callback error:', error.message);
+    console.error('Auth callback exchange error:', error.message);
+    return redirect(303, '/?auth_error=exchange');
   }
 
-  return redirect(303, '/');
+  return redirect(303, '/?auth_error=nocode');
 };


### PR DESCRIPTION
Google login works for some (14 users signed in, last **yesterday**) but failed **silently** for others.

**Code fixes:**
- `signInWithGoogle` no longer swallows the error — failures now show a message (was doing nothing); adds `prompt: 'select_account'`.
- `/auth/callback` switched to the chunk-safe **getAll/setAll** cookie API (`@supabase/ssr` 0.6) for a reliable PKCE verifier read + session write; provider errors / exchange failures redirect to `/?auth_error=…` instead of a blank bounce.
- Auth screen reads `?auth_error` and shows a clear message.

**Likely root cause (config, not code):** the intermittent pattern points to the Google OAuth **consent screen in "Testing" mode** — only added test users can sign in. That's a Google Cloud Console setting.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)