### PR TITLE
Fix challenge match: show clue + don't settle before everyone plays

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -698,6 +698,7 @@ function reconcileMatchBoard(board) {
     gameMode: 'match',
     gameState: done ? 'won' : 'default',
     modifier: null, arcadeRun: null,
+    clue: done ? prev.clue : (board.clue ?? null),
     matchInfo: match
   }));
   if (done) { setTimeout(() => launchConfetti(), 250); fx('win'); }


### PR DESCRIPTION
Two bugs from playtesting:
- **Clue missing in matches** — `_match_board` now returns the current puzzle's clue (`daily_puzzles.clue`); the client sets it.
- **Premature settle** — a match declared the host winner the moment they finished, *before the opponent played*, because `_match_maybe_settle` only blocked on `active` participants, not `invited` ones. Now it waits until nobody is `active` **or** `invited`; no-shows are handled by the window-expiry settle.

**Verified (SQL sim):** board carries the clue; host finishing with the opponent still `invited` keeps the match **open**. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)