### PR TITLE
v3 R1: Net Worth = Cash, seed $2,000, remove the loan system

### DIFF
--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -10,7 +10,6 @@ export const BADGES = {
   climb_50:  { emoji: '🧗', name: 'Climber',     desc: 'Reached puzzle #50 in the Cash Game' },
   climb_100: { emoji: '🏔️', name: 'Mountaineer', desc: 'Reached puzzle #100 in the Cash Game' },
   climb_500: { emoji: '🚀', name: 'Summit',      desc: 'Reached puzzle #500 in the Cash Game' },
-  debt_free: { emoji: '💸', name: 'Debt-Free',   desc: 'Paid off a loan in full' },
   hustler:   { emoji: '🤝', name: 'Hustler',     desc: 'Won 10 challenges' },
 };
 

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -32,9 +32,9 @@
     },
     {
       icon: '🏦',
-      title: 'Your Bank',
+      title: 'Your Cash',
       isNew: true,
-      body: 'New: everyone starts with a $5,000 loan from the house. Win games to grow your Bank — your Net Worth is your Bank minus what you still owe. Pay the house back to climb.'
+      body: 'You start with $2,000 Cash. Buy as few letters as you can to solve — spend less, keep more. Your Cash balance is your Net Worth: the score you brag about.'
     },
     {
       icon: '⚔️',

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,7 +8,7 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, takeLoan, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
+import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
 import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
@@ -663,21 +663,6 @@ export async function climbPowerup(id, owned) {
     }
     const board = await climbUsePowerup(id);
     if (board) reconcileClimbBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** Borrow mid-climb, then refresh the board with the new Cash. @param {number} amount */
-export async function climbBorrow(amount) {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const res = await takeLoan(Math.floor(amount || 0));
-    if (res && res.ok !== false) {
-      const board = await climbStart(); // returns the board with updated Cash
-      if (board) reconcileClimbBoard(board);
-    }
   } finally {
     dailyInFlight = false;
   }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -76,42 +76,13 @@ export async function getDailyQuests() {
   };
 }
 
-/** My Cash: balance, outstanding loan, net worth, auto-repay, in-the-red, recent ledger.
- * @returns {Promise<{ bank:number, loan:number, net_worth:number, auto_repay:boolean, in_the_red:boolean, loan_cap:number, ledger:any[] }>} */
+/** My Cash: balance (= Net Worth) and recent ledger. (v3: loans removed.)
+ * @returns {Promise<{ bank:number, net_worth:number, ledger:any[] }>} */
 export async function getBank() {
   const { data, error } = await supabase.rpc('get_bank');
-  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, loan: 0, net_worth: 0, auto_repay: false, in_the_red: false, loan_cap: 10000, ledger: [] }; }
-  return { bank: data.bank ?? 0, loan: data.loan ?? 0, net_worth: data.net_worth ?? 0,
-    auto_repay: !!data.auto_repay, in_the_red: !!data.in_the_red, loan_cap: data.loan_cap ?? 10000,
+  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, net_worth: 0, ledger: [] }; }
+  return { bank: data.bank ?? 0, net_worth: data.net_worth ?? data.bank ?? 0,
     ledger: Array.isArray(data.ledger) ? data.ledger : [] };
-}
-
-/** Pay down your loan from your Cash. @param {number} amount @returns {Promise<any>} */
-export async function repayLoan(amount) {
-  const { data, error } = await supabase.rpc('repay_loan', { p_amount: amount });
-  if (error) { console.error('❌ repay_loan:', error); return null; }
-  return data;
-}
-
-/** Borrow Cash (5%/day interest, $10k debt cap). @param {number} amount @returns {Promise<any>} */
-export async function takeLoan(amount) {
-  const { data, error } = await supabase.rpc('take_loan', { p_amount: amount });
-  if (error || !data) { if (error) console.error('❌ take_loan:', error); return { ok: false }; }
-  return data;
-}
-
-/** Toggle auto-repay (skims 10% of winnings toward your loan). @param {boolean} on @returns {Promise<any>} */
-export async function setAutoRepay(on) {
-  const { data, error } = await supabase.rpc('set_auto_repay', { p_on: on });
-  if (error) { console.error('❌ set_auto_repay:', error); return null; }
-  return data;
-}
-
-/** Declare bankruptcy (only when in the red) — wipes debt, resets to $1,000, 30-day cooldown. @returns {Promise<any>} */
-export async function declareBankruptcy() {
-  const { data, error } = await supabase.rpc('declare_bankruptcy');
-  if (error || !data) { if (error) console.error('❌ declare_bankruptcy:', error); return { ok: false }; }
-  return data;
 }
 
 /** My chosen username (null until claimed). @returns {Promise<string|null>} */
@@ -194,7 +165,7 @@ export async function getFriendsDailyLeaderboard() {
   return Array.isArray(data) ? data : [];
 }
 
-/** Net Worth leaderboard (bank − loan). @param {'friends'|'global'} scope @returns {Promise<any[]>} */
+/** Net Worth leaderboard (= Cash). @param {'friends'|'global'} scope @returns {Promise<any[]>} */
 export async function getNetworthLeaderboard(scope = 'friends') {
   const { data, error } = await supabase.rpc('get_networth_leaderboard', { p_scope: scope });
   if (error) { console.error('❌ get_networth_leaderboard:', error); return []; }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbBorrow, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -275,13 +275,6 @@
       const me = board.find((/** @type {any} */ r) => r.is_me);
       dailyPlacement = { rank: me?.rank ?? 0, total: board.length };
     } catch { dailyPlacement = { rank: 0, total: 0 }; }
-  }
-  let climbBorrowing = false;
-  async function handleClimbBorrow() {
-    if (climbBorrowing) return;
-    climbBorrowing = true;
-    // Borrow roughly enough to afford a couple of letters / get unstuck.
-    try { await climbBorrow(500); await refreshClimbPups(); } finally { climbBorrowing = false; }
   }
   /** @type {any[]} */
   let climbPups = [];
@@ -1154,10 +1147,9 @@
       {/if}
       {#if climb.stuck && $gameStore.gameState !== 'won'}
         <div class="climb-stuck">
-          <span class="cs-text">Out of guesses &amp; Cash — borrow to finish, or leave.</span>
+          <span class="cs-text">Out of Cash for this one — leave and earn in the Daily, then come back to finish it.</span>
           <div class="cs-actions">
-            <button class="cs-borrow" on:click={handleClimbBorrow} disabled={climbBorrowing}>💵 Borrow $500</button>
-            <button class="cs-leave" on:click={goToMainMenu}>Leave</button>
+            <button class="cs-leave" on:click={goToMainMenu}>Leave &amp; earn</button>
           </div>
         </div>
       {/if}
@@ -1508,8 +1500,6 @@
   }
   .cs-text { font-size: 0.82rem; color: #fca5a5; }
   .cs-actions { display: flex; gap: 8px; justify-content: center; }
-  .cs-borrow { padding: 0.5rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: linear-gradient(135deg,#fbbf24,#f59e0b); }
-  .cs-borrow:disabled { opacity: 0.5; }
   .cs-leave { padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 10px; cursor: pointer; font-weight: 700; color: var(--text-muted); background: transparent; }
   .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
   .arcade-earn {

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,17 +1,12 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getBank, repayLoan, takeLoan, setAutoRepay, declareBankruptcy } from '$lib/stores/statsStore.js';
+  import { getBank } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
-  import { fx } from '$lib/sound.js';
 
-  /** @type {{ bank:number, loan:number, net_worth:number, auto_repay:boolean, in_the_red:boolean, loan_cap:number, ledger:any[] }|null} */
+  /** @type {{ bank:number, net_worth:number, ledger:any[] }|null} */
   let b = null;
   let loading = true;
-  let repayAmt = '';
-  let borrowAmt = '';
-  let busy = false;
-  $: loanRoom = b ? Math.max(0, (b.loan_cap ?? 10000) - b.loan) : 0;
 
   onMount(async () => {
     track('bank_view');
@@ -25,55 +20,16 @@
     return ({
       quest_reward: 'Daily quests reward',
       daily_win: 'Daily reward',
-      loan_payment: 'Loan payment',
-      loan_taken: 'Loan taken',
-      loan_interest: 'Loan interest',
+      attendance: 'Daily attendance reward',
       arcade_cashout: 'Cash Game cash-out',
+      climb_bounty: 'Climb bounty',
+      freeplay_reward: 'Free Play reward',
       cosmetic_buy: 'Shop purchase',
+      powerup_buy: 'Power-up purchase',
       wager_win: 'Won a wager',
       wager_stake: 'Wager staked',
-      wager_refund: 'Wager refunded',
-      interest: 'Loan interest'
+      wager_refund: 'Wager refunded'
     })[reason] || reason;
-  }
-
-  async function payLoan(/** @type {number} */ amt) {
-    if (busy || !b || b.loan <= 0) return;
-    const pay = Math.min(amt, b.loan, b.bank);
-    if (pay <= 0) return;
-    busy = true;
-    const res = await repayLoan(pay);
-    busy = false;
-    if (res) { b = res; repayAmt = ''; fx('tap'); track('loan_repay', { amount: pay }); }
-  }
-
-  async function borrow(/** @type {number} */ amt) {
-    if (busy || !b) return;
-    const take = Math.min(amt, loanRoom);
-    if (take <= 0) return;
-    busy = true;
-    const res = await takeLoan(take);
-    busy = false;
-    if (res && res.ok !== false) { b = res; borrowAmt = ''; fx('select'); track('loan_taken', { amount: take }); }
-  }
-
-  async function toggleAutoRepay() {
-    if (busy || !b) return;
-    busy = true;
-    const res = await setAutoRepay(!b.auto_repay);
-    busy = false;
-    if (res) b = res;
-  }
-
-  let bankruptMsg = '';
-  async function goBankrupt() {
-    if (busy || !b) return;
-    if (!confirm('Declare bankruptcy? This wipes your loan but resets your Cash to $1,000 and erases your Net Worth. Once per 30 days.')) return;
-    busy = true; bankruptMsg = '';
-    const res = await declareBankruptcy();
-    busy = false;
-    if (res && res.ok !== false && res.bank != null) { b = res; fx('bust'); track('bankruptcy'); }
-    else { bankruptMsg = res?.reason === 'cooldown' ? 'You already declared bankruptcy in the last 30 days.' : res?.reason === 'solvent' ? "You're not in the red." : 'Could not declare bankruptcy.'; }
   }
 </script>
 
@@ -86,47 +42,12 @@
     <p class="loading">Loading…</p>
   {:else if b}
     <p class="nw-label">Net Worth</p>
-    <div class="net-worth" class:neg={b.net_worth < 0}>{fmt(b.net_worth)}</div>
-    <p class="nw-sub">Cash on hand minus what you owe</p>
-    {#if b.in_the_red}<div class="red-badge">🔴 In the Red — you owe more than you hold</div>{/if}
-
-    <div class="stat-row">
-      <div class="stat"><span class="sv">{fmt(b.bank)}</span><span class="sc">Cash on hand</span></div>
-      <div class="stat loan"><span class="sv">{fmt(b.loan)}</span><span class="sc">Loan owed</span></div>
-    </div>
-
-    <!-- Borrow -->
-    <div class="loan-box">
-      <p class="loan-copy">
-        <strong>The House</strong> will front you Cash anytime — <strong>5%/day interest</strong>, up to {fmt(b.loan_cap)} total debt.
-        {#if loanRoom > 0}You can borrow up to <strong>{fmt(loanRoom)}</strong> more.{:else}You're at the borrowing cap.{/if}
-      </p>
-      <div class="pay-row">
-        <input class="amt" type="number" min="1" max={loanRoom} placeholder="Amount" bind:value={borrowAmt} disabled={loanRoom <= 0} />
-        <button class="pay-btn borrow" disabled={busy || loanRoom <= 0} on:click={() => borrow(Math.floor(Number(borrowAmt) || 0))}>Borrow</button>
-      </div>
-    </div>
-
-    {#if b.loan > 0}
-      <div class="loan-box">
-        <p class="loan-copy">You owe <strong>{fmt(b.loan)}</strong>. Interest accrues daily until it's paid — clear it to go debt-free and grow your Net Worth.</p>
-        <div class="pay-row">
-          <input class="amt" type="number" min="1" placeholder="Amount" bind:value={repayAmt} />
-          <button class="pay-btn" disabled={busy} on:click={() => payLoan(Math.floor(Number(repayAmt) || 0))}>Pay</button>
-          <button class="pay-btn ghost" disabled={busy} on:click={() => payLoan(b?.loan ?? 0)}>Pay all</button>
-        </div>
-        <button class="auto-row" disabled={busy} on:click={toggleAutoRepay}>
-          <span class="auto-box" class:on={b.auto_repay}>{b.auto_repay ? '✓' : ''}</span>
-          Auto-repay — skim 10% of winnings toward this loan
-        </button>
-      </div>
-    {:else}
-      <div class="debt-free">🎉 Debt-free! Your Cash is all yours.</div>
-    {/if}
+    <div class="net-worth">{fmt(b.bank)}</div>
+    <p class="nw-sub">Your Cash — this is your score</p>
 
     <h2 class="hist-title">Recent activity</h2>
     {#if b.ledger.length === 0}
-      <p class="empty">No transactions yet. Win the Daily, finish quests, or cash out a Cash Game run to grow your Cash.</p>
+      <p class="empty">No transactions yet. Win the Daily, show up for attendance rewards, or climb the Cash Game to grow your Cash.</p>
     {:else}
       <div class="ledger">
         {#each b.ledger as e}
@@ -139,14 +60,6 @@
     {/if}
 
     <p class="hint">Cash is in-game money — earn it by playing, risk it in the Cash Game, wager friends, and spend it on power-ups &amp; cosmetics. It can't be bought with real money or cashed out.</p>
-
-    {#if b.in_the_red}
-      <div class="bankrupt-box">
-        <p class="loan-copy">Underwater? <strong>Declare bankruptcy</strong> to wipe the debt and start fresh at $1,000 — but you lose your Net Worth, and it's only allowed once every 30 days.</p>
-        <button class="bankrupt-btn" disabled={busy} on:click={goBankrupt}>Declare Bankruptcy</button>
-        {#if bankruptMsg}<p class="add-msg">{bankruptMsg}</p>{/if}
-      </div>
-    {/if}
   {/if}
 </main>
 
@@ -160,44 +73,7 @@
   .loading { color: var(--text-muted); padding: 2rem; }
   .nw-label { color: var(--text-faint); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em; margin: 0.5rem 0 0; }
   .net-worth { font-family: var(--font-display); font-weight: 800; font-size: 3rem; line-height: 1.1; color: var(--brand-2); }
-  .net-worth.neg { color: #fb7185; }
   .nw-sub { color: var(--text-faint); font-size: 0.78rem; margin: 0.2rem 0 0; }
-
-  .stat-row { display: flex; justify-content: center; gap: 0.6rem; margin: 1.2rem 0 0; }
-  .stat { flex: 1; max-width: 160px; display: flex; flex-direction: column; gap: 3px; padding: 0.8rem 0.5rem;
-    background: var(--surface); border: 1px solid var(--border); border-radius: 14px; }
-  .stat.loan { border-color: rgba(251,113,133,0.3); }
-  .sv { font-family: var(--font-display); font-weight: 700; font-size: 1.25rem; color: var(--text); }
-  .stat.loan .sv { color: #fb7185; }
-  .sc { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint); }
-
-  .loan-box { margin-top: 1.4rem; padding: 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 16px; text-align: left; }
-  .loan-copy { margin: 0 0 0.8rem; color: var(--text-muted); font-size: 0.9rem; }
-  .add-msg { text-align: center; font-size: 0.82rem; color: #f87171; margin: 0.5rem 0 0; }
-  .bankrupt-box { margin-top: 1.4rem; padding: 1rem; border: 1px dashed rgba(251,113,133,0.5); border-radius: 16px; text-align: left; }
-  .bankrupt-btn { width: 100%; padding: 0.65rem; border: 1px solid rgba(251,113,133,0.5); border-radius: 12px; background: rgba(251,113,133,0.1); color: #fb7185; cursor: pointer; font-weight: 700; }
-  .bankrupt-btn:disabled { opacity: 0.5; }
-  .pay-row { display: flex; gap: 0.5rem; }
-  .amt { flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: var(--text); }
-  .pay-btn { padding: 0.6rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #06210f; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
-  .pay-btn.ghost { background: transparent; color: var(--brand-2); border: 1px solid rgba(163,230,53,0.4); }
-  .pay-btn.borrow { color: #06210f; background: linear-gradient(135deg,#fbbf24,#f59e0b); }
-  .pay-btn:disabled { opacity: 0.5; }
-  .red-badge {
-    display: inline-block; margin: 0.6rem auto 0; padding: 0.4rem 0.9rem; border-radius: 999px;
-    font-size: 0.8rem; font-weight: 700; color: #fb7185;
-    background: rgba(251,113,133,0.12); border: 1px solid rgba(251,113,133,0.35);
-  }
-  .auto-row {
-    display: flex; align-items: center; gap: 0.5rem; width: 100%; margin-top: 0.7rem; padding: 0;
-    background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 0.82rem; text-align: left;
-  }
-  .auto-box {
-    width: 18px; height: 18px; flex-shrink: 0; border-radius: 5px; display: grid; place-items: center;
-    border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: #06210f; font-size: 0.7rem; font-weight: 800;
-  }
-  .auto-box.on { background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); border-color: transparent; }
-  .debt-free { margin-top: 1.4rem; padding: 0.9rem; border-radius: 14px; background: linear-gradient(135deg, rgba(52,211,153,0.12), rgba(163,230,53,0.05)); border: 1px solid rgba(163,230,53,0.4); font-weight: 700; }
 
   .hist-title { font-family: var(--font-display); font-size: 1rem; margin: 1.8rem 0 0.6rem; text-align: left; }
   .empty { color: var(--text-muted); font-size: 0.9rem; }

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -25,8 +25,8 @@
   {:else if s}
     <h1>{s.username ? '@' + s.username : 'Your Profile'}</h1>
     <p class="nw-label">Net Worth</p>
-    <div class="nw" class:neg={s.net_worth < 0}>{fmt(s.net_worth)}</div>
-    <p class="nw-sub">{fmt(s.cash)} Cash · {fmt(s.loan)} owed</p>
+    <div class="nw">{fmt(s.net_worth)}</div>
+    <p class="nw-sub">Your Cash — this is your score</p>
 
     <div class="grid">
       <div class="stat"><span class="sv">🔥 {s.current_streak}</span><span class="sc">Day streak</span></div>
@@ -64,7 +64,6 @@
   h1 { font-family: var(--font-display); font-size: 1.6rem; margin: 0.3rem 0 0.8rem; }
   .nw-label { color: var(--text-faint); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; margin: 0; }
   .nw { font-family: var(--font-display); font-weight: 800; font-size: 2.6rem; line-height: 1.1; color: var(--brand-2); }
-  .nw.neg { color: #fb7185; }
   .nw-sub { color: var(--text-faint); font-size: 0.82rem; margin: 0.2rem 0 1.4rem; }
   .grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 0.6rem; }
   .stat { display: flex; flex-direction: column; gap: 3px; padding: 0.8rem 0.4rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; }

--- a/supabase-v3-r1-remove-loans.sql
+++ b/supabase-v3-r1-remove-loans.sql
@@ -1,0 +1,39 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  v3 R1: Net Worth = Cash · seed $2,000 · remove the loan system            ║
+-- ║  (migration: v3_r1_remove_loans — applied via MCP)                          ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- First slice of the WORDBANK_MASTER_V3.md teardown. Loans are gone entirely.
+--
+-- CHANGED functions:
+--   _ensure_bank      → seeds new accounts at bank = 2000 (was 1000); no loan.
+--   _bank_credit      → dropped the auto-repay skim; networth_snapshots stamps
+--                       Net Worth = bank (was bank − loan).
+--   get_bank          → no _accrue_interest; net_worth = bank. Still returns
+--                       loan:0 / auto_repay:false / in_the_red:false / loan_cap:0
+--                       for back-compat with the deployed client during rollout.
+--   get_networth_leaderboard / get_wealth_leaderboard / get_profile_stats /
+--   get_group         → Net Worth = bank everywhere (dropped the − loan term).
+--
+-- DROPPED functions (client no longer calls them):
+--   _accrue_interest, take_loan, repay_loan, set_auto_repay, declare_bankruptcy
+--
+-- KEPT FOR NOW (drop in a later cleanup once the new client is fully deployed):
+--   profiles.loan, profiles.loan_accrued_at, profiles.auto_repay,
+--   profiles.last_bankruptcy_at  — physical columns left in place so the
+--   currently-deployed client doesn't hard-break in the deploy window.
+--
+-- DEFERRED to the R7 cutover (with the refreshed tutorial): the mass reset of
+--   EXISTING players' Cash to the $2,000 baseline. We don't reset live balances
+--   mid-rebuild — new accounts seed at 2000; everyone resets once, at cutover.
+--
+-- Client changes in this slice:
+--   bank/+page.svelte    → pure Cash wallet (balance + ledger); no loan/borrow/
+--                          repay/auto-repay/bankruptcy/in-the-red UI.
+--   statsStore.js        → getBank() returns { bank, net_worth, ledger };
+--                          removed repayLoan/takeLoan/setAutoRepay/declareBankruptcy.
+--   GameStore.js         → removed climbBorrow + takeLoan import.
+--   +page.svelte         → Climb "stuck" panel is now "Leave & earn" (no Borrow).
+--   profile/+page.svelte → Net Worth = Cash; dropped "owed"/negative styling.
+--   badges.js            → removed debt_free badge.
+--   Tutorial.svelte      → "Your Cash" slide (start $2,000, spend-less-keep-more);
+--                          full tutorial refresh still comes in R7.


### PR DESCRIPTION
First slice of the **WORDBANK_MASTER_V3.md** teardown — loans gone entirely.

**DB** (migration `v3_r1_remove_loans`, applied via MCP):
- New accounts seed at **$2,000** (was $1,000).
- `_bank_credit` drops the auto-repay skim; Net Worth snapshot = `bank`.
- `get_bank`: no interest accrual; `net_worth = bank` (keeps `loan:0` fields for back-compat in the deploy window).
- **Net Worth = `bank`** in the leaderboard/profile/group readers.
- **Dropped** `take_loan`, `repay_loan`, `set_auto_repay`, `declare_bankruptcy`, `_accrue_interest`. Loan *columns* kept physically (cleanup later).

**Client:**
- **Bank page** → pure Cash wallet (balance + ledger); all loan/borrow/repay/auto-repay/bankruptcy/in-the-red UI removed.
- `statsStore.getBank()` → `{ bank, net_worth, ledger }`; removed the 4 loan RPC wrappers.
- **GameStore** → removed `climbBorrow`; Climb **"stuck"** panel is now **"Leave & earn"** (no Borrow).
- **Profile** → Net Worth = Cash. **Badges** → removed Debt-Free. **Tutorial** → "Your Cash" slide (start $2,000).

**Deferred:** mass reset of existing balances to $2,000 → R7 cutover (don't reset live players mid-rebuild).

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)