### PR TITLE
v3 R2: unlimited guesses + all-or-nothing + no Reveal button

### DIFF
--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -2,19 +2,11 @@
   import { gameStore, confirmPurchase, submitGuess } from '$lib/stores/GameStore.js';
   import { fx } from '$lib/sound.js';
 
-  // 🧠 Reactive state (daily & arcade are both server-authoritative — no wager)
-  $: bankroll = $gameStore.bankroll;
+  // 🧠 Reactive state (server-authoritative). v3: unlimited guesses, no Reveal button.
   $: guessModeActive = $gameStore.gameState === 'guess_mode';
-  $: isDailyMode = $gameStore.gameMode === 'daily';
   $: purchasePending = !!$gameStore.selectedPurchase;
-  $: hintPending = $gameStore.selectedPurchase?.type === 'hint' && $gameStore.gameState === 'purchase_pending';
-  $: showHintCost = hintPending;
-  $: guessesRemaining = $gameStore.guessesRemaining ?? 3;
-  $: fundsLow = bankroll < 150;
-  $: noGuessesLeft = guessesRemaining <= 0;
   $: gameOver = $gameStore.gameState === 'won' || $gameStore.gameState === 'lost';
   $: buttonsDisabled = gameOver;
-  $: hasFreeReveal = isDailyMode && ($gameStore.freeReveals ?? 0) > 0;
 
   // ✅ Detect full phrase input
   $: guessComplete = guessModeActive && (() => {
@@ -52,16 +44,11 @@
       confirmPurchase();
       return;
     }
-
     if (guessModeActive && guessComplete) {
       submitGuess();
       return;
     }
-
-    if (noGuessesLeft) {
-      gameStore.update(s => ({ ...s, message: 'Out of guesses — buy letters to finish the phrase' }));
-      return;
-    }
+    // Enter guess mode — guesses are unlimited (v3).
     gameStore.update(state => ({
       ...state,
       gameState: 'guess_mode',
@@ -69,17 +56,6 @@
       guessedLetters: {}
     }));
   }
-
-  function toggleHintPurchase() {
-    fx('tap');
-    gameStore.update(state => {
-      if (state.selectedPurchase?.type === 'hint') {
-        return { ...state, selectedPurchase: null, gameState: 'default' };
-      }
-      return { ...state, selectedPurchase: { type: 'hint' }, gameState: 'purchase_pending' };
-    });
-  }
-
 </script>
 
 {#if $gameStore.message}
@@ -87,21 +63,6 @@
 {/if}
 
 <div class="main-button-wrapper">
-  <div class="hint-button-container">
-    {#if showHintCost}
-      <div class="cost-indicator">{hasFreeReveal ? '🎟️ FREE' : '$150'}</div>
-    {/if}
-    <button
-      class="hint-button {(fundsLow && !hasFreeReveal) ? 'disabled-purchase' : ''} {hintPending ? 'glow' : ''}"
-      on:click={toggleHintPurchase}
-      disabled={(fundsLow && !hasFreeReveal) || buttonsDisabled}
-      title={hasFreeReveal ? 'Free Reveal (power-up)' : 'Reveal the most useful letter ($150)'}
-    >
-      Reveal
-      {#if hasFreeReveal}<span class="free-badge">{$gameStore.freeReveals}</span>{/if}
-    </button>
-  </div>
-
   {#if dualButtonMode}
     <div class="dual-button-container">
       <button
@@ -156,63 +117,13 @@
       </button>
     </div>
   {/if}
-
-  <div class="guesses-button-container">
-    <div class="guesses-display" title="Solve attempts remaining">
-      Tries<br /><span class="guesses-count">{guessesRemaining}</span>
-    </div>
-  </div>
 </div>
 <style>
 @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 
-/* ---------------------------
-   Animations
---------------------------- */
-@keyframes softGlow {
-  0% { box-shadow: 0 0 8px #fff, 0 0 16px #318020, 0 0 24px #207b09; }
-  50% { box-shadow: 0 0 12px #fff, 0 0 20px #46a230, 0 0 28px #14860a; }
-  100% { box-shadow: 0 0 8px #fff, 0 0 16px #46a230, 0 0 24px #46a230; }
-}
-@keyframes blinkColor {
-  0%, 100% { color: red; opacity: 1; }
-  50% { color: white; opacity: 0.5; }
-}
-@keyframes blinkDarkGreen {
-  0%, 100% { background-color: #2e7d32; }
-  50% { background-color: #1b5e20; }
-}
-@keyframes blinkGreen {
-  0%, 100% { background-color: green; }
-  50% { background-color: #00cc00; }
-}
-@keyframes pulseGlow {
-  0%, 100% { transform: scale(1); box-shadow: 0 0 8px rgba(0, 255, 0, 0.5); }
-  50% { transform: scale(1.05); box-shadow: 0 0 16px rgba(0, 255, 0, 0.9); }
-}
-
-/* ---------------------------
-   Utility
---------------------------- */
-.disabled-purchase {
-  opacity: 0.5;
-  filter: blur(1px);
-  pointer-events: none;
-}
-.cost-indicator {
-  position: absolute;
-  top: -30px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 13px;
-  color: #fcd34d;
-  background: rgba(251, 191, 36, 0.12);
-  border: 1px solid rgba(251, 191, 36, 0.35);
-  padding: 3px 9px;
-  border-radius: 999px;
-  white-space: nowrap;
+@keyframes solvePulse {
+  0%, 100% { box-shadow: var(--glow-brand); }
+  50% { box-shadow: 0 0 0 1px rgba(163, 230, 53, 0.4), 0 8px 36px rgba(52, 211, 153, 0.5); }
 }
 
 .message-box {
@@ -246,114 +157,6 @@
   align-items: center;
   gap: 12px;
   z-index: 999;
-}
-
-/* ---------------------------
-   Hint Button
---------------------------- */
-.hint-button-container {
-  position: relative;
-}
-.hint-button {
-  position: relative;
-  width: 54px;
-  height: 46px;
-  border-radius: 13px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  color: var(--text);
-  font-family: var(--font-ui);
-  font-size: 9px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-  line-height: 1.15;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  backdrop-filter: blur(10px);
-  transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
-  cursor: pointer;
-}
-.hint-button:hover { transform: translateY(-2px); background: var(--surface-2); border-color: var(--border-strong); }
-.hint-button:active { transform: scale(0.96); }
-.hint-button.glow { border-color: rgba(163, 230, 53, 0.5) !important; box-shadow: var(--glow-brand); }
-.free-badge {
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  display: grid;
-  place-items: center;
-  font-family: var(--font-display);
-  font-size: 10px;
-  font-weight: 700;
-  color: #06210f;
-  background: var(--brand-grad);
-  border-radius: 999px;
-  box-shadow: var(--glow-brand);
-}
-
-/* ---------------------------
-   Guesses Button (blue, right of Solve)
---------------------------- */
-.guesses-button-container {
-  position: relative;
-}
-.guesses-button {
-  width: 54px;
-  height: 46px;
-  border-radius: 13px;
-  background: var(--surface);
-  color: var(--text);
-  font-family: var(--font-ui);
-  font-size: 8px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  line-height: 1.1;
-  backdrop-filter: blur(10px);
-  transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
-  cursor: pointer;
-}
-.guesses-display {
-  width: 54px;
-  height: 46px;
-  border-radius: 13px;
-  background: var(--surface);
-  color: var(--text-muted);
-  font-family: var(--font-ui);
-  font-size: 8px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  border: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  line-height: 1.1;
-  backdrop-filter: blur(10px);
-}
-.guesses-count {
-  font-family: var(--font-display);
-  font-size: 18px;
-  font-weight: 700;
-  color: var(--brand-2);
-  display: block;
-}
-.guesses-button:hover { transform: translateY(-2px); background: var(--surface-2); border-color: var(--border-strong); }
-.guesses-button:active { transform: scale(0.96); }
-.guesses-button.glow {
-  box-shadow: var(--glow-brand);
-  border-color: rgba(163, 230, 53, 0.5);
 }
 
 /* ---------------------------
@@ -394,13 +197,8 @@
   transform: scale(0.97);
 }
 
-.guess-phrase-button.pending,
 .guess-phrase-button.guess-complete {
   animation: solvePulse 1.1s infinite;
-}
-@keyframes solvePulse {
-  0%, 100% { box-shadow: var(--glow-brand); }
-  50% { box-shadow: 0 0 0 1px rgba(163, 230, 53, 0.4), 0 8px 36px rgba(52, 211, 153, 0.5); }
 }
 
 .guess-phrase-button.exit-mode {
@@ -461,7 +259,7 @@
   filter: grayscale(100%);
   cursor: not-allowed;
   box-shadow: none;
-  background: #888 !important; /* Optional: solid gray background */
+  background: #888 !important;
   color: #eee;
   border: 2px solid #666;
 }

--- a/supabase-v3-r2-free-guesses.sql
+++ b/supabase-v3-r2-free-guesses.sql
@@ -1,0 +1,38 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  v3 R2: unlimited guesses · all-or-nothing (no positional feedback)         ║
+-- ║  (migration: v3_r2_free_guesses_no_partial_reveal — applied via MCP)        ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Second slice of the WORDBANK_MASTER_V3.md teardown.
+--
+-- Rewrote every active submit_guess (daily / makeup / freeplay / match / climb):
+--   • Dropped the guess-cap guard (`guesses_remaining <= 0`, climb
+--     `attempts_remaining <= 0`) and stopped decrementing it → UNLIMITED guesses.
+--   • Reveal letters ONLY when the WHOLE guess is correct. A wrong guess now
+--     reveals nothing (was: it locked in the correct letters = a free positional-
+--     feedback leak that breaks the spend-the-least economy). Integrity rule #2.
+--   • Win is still detected by all-positions-revealed; a full-correct guess
+--     reveals everything → win. Loss is still budget-based (bankroll < 30) for
+--     daily/makeup/freeplay/match, and cash-based for the climb — UNCHANGED.
+--
+-- CLIMB specifics:
+--   • Wrong guess no longer burns an attempt or resets heat (guesses are free now,
+--     so nuking heat on every miss made no sense). Heat resets only on stuck/leave.
+--   • _climb_resolve "stuck" is now PURELY cash-based: you're stuck when you can't
+--     afford the cheapest remaining letter (the attempts gate is gone). You can
+--     still free-guess from the stuck state; "Leave & earn" is the escape.
+--
+-- Verified (Free Play SQL sim): wrong guess → 0 revealed, state stays active;
+--   2nd wrong guess → still active (unlimited); correct guess → won, all revealed.
+--
+-- THE BASE REVEAL ACTION IS REMOVED CLIENT-SIDE (it becomes the Free Reveal
+--   power-up in R5). The server reveal RPCs (daily_reveal, climb_reveal, …) and
+--   the GameStore 'hint' branches / statsStore reveal wrappers are left ORPHANED
+--   (dead, never called) for now — dropped in a later cleanup, like the loan cols.
+--
+-- Client changes:
+--   GameButtons.svelte → removed the Reveal button + the "Tries" guess counter;
+--                        unlimited-guess flow (no noGuessesLeft gate).
+--
+-- KNOWN interim cosmetic: the Daily/Match efficiency formula's "no-reveals"
+--   multiplier (+.15 / +.15) now always applies (reveals are gone) → slight score
+--   inflation until the R3/R4 scoring rework. Not a blocker.


### PR DESCRIPTION
Second slice of the **WORDBANK_MASTER_V3.md** teardown.

**DB** (migration `v3_r2_free_guesses_no_partial_reveal`):
- Rewrote every active `submit_guess` (daily/makeup/freeplay/match/climb):
  - Dropped the guess-cap guard + decrement → **unlimited guesses**.
  - Reveal letters **only on a fully-correct guess** — a wrong guess now reveals nothing (was leaking which letters were right, a free info source that breaks spend-the-least). **Integrity rule #2.**
  - Win still = all-revealed; loss still budget/cash-based. Unchanged.
- **Climb:** wrong guess no longer burns an attempt or resets heat; `_climb_resolve` **"stuck" is now purely cash-based**. You can still free-guess while stuck; "Leave & earn" is the escape.
- **Verified** via Free Play SQL sim: wrong→nothing/active, repeat→active, correct→won.

**Client:**
- `GameButtons.svelte`: removed the **Reveal** button + the **"Tries"** counter. The base reveal action is gone (returns as the **Free Reveal power-up** in R5).
- Server reveal RPCs + GameStore `'hint'` branches left orphaned (cleanup later).

**Interim:** the "no-reveals" efficiency multiplier now always applies → minor score inflation until the R3/R4 scoring rework.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)