### PR TITLE
v3 R3: Daily spends real Cash + attendance rewards

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -47,7 +47,8 @@ import { track } from '$lib/analytics.js';
  *   makeupDate?: string | null,
  *   dailyResult?: any,
  *   climbInfo?: any,
- *   matchInfo?: any
+ *   matchInfo?: any,
+ *   dailyAttendance?: { amount:number, day:number } | null
  * }} GameState
  */
 
@@ -88,7 +89,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
   climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
-  matchInfo: null // { position, pack_size, total_score, last_score, done, status } (challenge match)
+  matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
+  dailyAttendance: null // { amount, day } — transient attendance reward toast (daily start)
 }));
 
 /* ================================
@@ -1046,6 +1048,11 @@ export async function fetchDailyGame() {
       return false;
     }
     reconcileDailyBoard(board);
+    // Attendance reward (paid once on the first open of the day) → transient toast.
+    const ab = /** @type {any} */ (board);
+    if (ab.attendance != null) {
+      gameStore.update(s => ({ ...s, dailyAttendance: { amount: ab.attendance, day: ab.attendance_day } }));
+    }
     // Today's shared modifier (same for everyone) — drives the banner + key pricing.
     try {
       const [mod, clue] = await Promise.all([getDailyModifier(), getDailyClue()]);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -244,6 +244,13 @@
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
   $: isMakeup = $gameStore.gameMode === 'makeup';
+  // Auto-dismiss the attendance toast after a few seconds.
+  /** @type {ReturnType<typeof setTimeout>|undefined} */
+  let _attTimer;
+  $: if ($gameStore.dailyAttendance) {
+    clearTimeout(_attTimer);
+    _attTimer = setTimeout(() => gameStore.update(s => ({ ...s, dailyAttendance: null })), 4500);
+  }
   $: isClimb = $gameStore.gameMode === 'climb';
   $: climb = $gameStore.climbInfo; // { bounty, heat, attempts, spent, position, stuck, last_gain, state }
   $: isMatch = $gameStore.gameMode === 'match';
@@ -739,6 +746,12 @@
 <!-- 📜 Guided tutorial (first run + replayable from ❓) -->
 {#if showTutorial}
   <Tutorial on:close={dismissTutorial} />
+{/if}
+
+{#if $gameStore.dailyAttendance}
+  <button class="attendance-toast" on:click={() => gameStore.update(s => ({ ...s, dailyAttendance: null }))}>
+    📅 Day {$gameStore.dailyAttendance.day} streak · <strong>+${$gameStore.dailyAttendance.amount.toLocaleString()}</strong> for showing up
+  </button>
 {/if}
 
 <main>
@@ -1241,15 +1254,14 @@
             <p class="result-sub">Daily #{puzzleNumber}{#if resultWon} · {resultMedal.name}{/if}</p>
             {#if resultWon && dr}
               <div class="daily-score">
-                <span class="ds-label">Daily Score</span>
+                <span class="ds-label">Daily Reward</span>
                 <span class="ds-amount">{(dr.score ?? 0).toLocaleString()}</span>
-                <span class="ds-cash">+${(dr.score ?? 0).toLocaleString()} to your Cash</span>
+                <span class="ds-cash">+${(dr.score ?? 0).toLocaleString()} to your Cash{#if dr.spent} · ${dr.spent.toLocaleString()} spent refunded{/if}</span>
               </div>
               <div class="eff-chips">
                 <span class="eff" class:on={dr.clean}>{dr.clean ? '✓' : '✗'} Clean</span>
                 <span class="eff" class:on={dr.no_vowels}>{dr.no_vowels ? '✓' : '✗'} No vowels</span>
                 <span class="eff" class:on={dr.first_try}>{dr.first_try ? '✓' : '✗'} First try</span>
-                <span class="eff" class:on={dr.no_reveals}>{dr.no_reveals ? '✓' : '✗'} No reveals</span>
               </div>
               {#if dailyPlacement && dailyPlacement.rank > 0 && dailyPlacement.total > 1}
                 <p class="daily-placement">{dailyPlacement.rank === 1 ? '🥇' : dailyPlacement.rank === 2 ? '🥈' : dailyPlacement.rank === 3 ? '🥉' : '🏅'} #{dailyPlacement.rank} of {dailyPlacement.total} among friends today</p>
@@ -1394,6 +1406,17 @@
 <style>
   @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
   @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap');
+
+  .attendance-toast {
+    position: fixed; top: 14px; left: 50%; transform: translateX(-50%);
+    z-index: 2000; padding: 0.6rem 1.1rem; border-radius: 999px; cursor: pointer;
+    font-family: var(--font-ui); font-size: 0.85rem; color: #06210f;
+    background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635));
+    border: none; box-shadow: var(--glow-brand, 0 8px 24px rgba(52,211,153,0.4));
+    animation: attDrop 0.4s var(--ease-spring, ease) both;
+  }
+  .attendance-toast strong { font-family: var(--font-display); }
+  @keyframes attDrop { from { transform: translate(-50%, -60px); opacity: 0; } to { transform: translate(-50%, 0); opacity: 1; } }
   @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
   @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
 

--- a/supabase-v3-r3-daily-real-cash.sql
+++ b/supabase-v3-r3-daily-real-cash.sql
@@ -1,0 +1,45 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  v3 R3: Daily spends REAL Cash + attendance rewards                          ║
+-- ║  (migration: v3_r3_daily_real_cash_attendance — applied via MCP)            ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Third slice of the WORDBANK_MASTER_V3.md teardown. The Daily stops using the
+-- fake $1,000 play-budget and runs on your persistent Cash balance.
+--
+-- daily_sessions += spent INT (cumulative real-Cash letter spend this puzzle).
+--
+-- daily_start:
+--   • Advances the PLAY-STREAK here now (showing up counts; losses don't break
+--     it) — moved out of _finalize_daily so the streak tracks ATTENDANCE, not wins.
+--   • Pays the ATTENDANCE reward: base $50 + milestone (day%30→$1500, %14→$500,
+--     %7→$250, day3→$100). Once per day (first session creation). Streak badges
+--     (streak_7/30) fire here too. Returns {attendance, attendance_day} on the board.
+--   • No fake budget — the board's "bankroll" field is now your REAL bank.
+--
+-- daily_buy_letter: spends REAL Cash (UPDATE profiles.bank -= cost), accumulates
+--   session.spent; can't afford ⇒ blocked. Board shows real bank.
+--
+-- _daily_resolve_and_return: WIN-ONLY now (free guesses ⇒ no cash-based loss; the
+--   daily ends on solve or you just leave). Daily-result payload drops no_reveals,
+--   adds spent.
+--
+-- _finalize_daily(uid, won, SPENT, incorrect): refunds the letter-spend + pays an
+--   efficiency reward = $100 floor + $600 × (clean .25 + no-vowel .25 + first-try
+--   .25). Net on a solve is ALWAYS ≥ +$100 → the Daily is a true safety net you
+--   can't lose Cash on. No more leftover×streak score; streak rewards are the
+--   attendance milestones. (Dropped gold_bank badge / daily_bankroll writes.)
+--
+-- Verified (rolled-back SQL sim, Chef untouched): start → +$150 attendance;
+--   buy letter → −$90 real Cash, spent=90; solve → +$90 refund +$550 reward
+--   → net exactly +$550 over the post-attendance balance, state won.
+--
+-- CLIMB was already real-Cash (climb_buy_letter spends profiles.bank, bounty
+--   credits it) — confirmed, no change. CHALLENGES keep their per-puzzle budget
+--   until R4 (where wager = spending cap + lowest-spend-settle is the whole point).
+-- MAKEUP is intentionally left on its fake budget (no Cash deposit, per spec).
+--
+-- Client: daily HUD now shows real Cash (board.bankroll = bank); attendance toast
+--   on first daily open of the day; result modal drops "No reveals", shows spend
+--   refunded; "Your Cash" framing.
+--
+-- KNOBS (tune later): attendance base/milestones, reward floor $100 / base $600,
+--   the 3 efficiency multipliers. The 'extra_bank' daily modifier is now a no-op.


### PR DESCRIPTION
Third slice of the **WORDBANK_MASTER_V3.md** teardown — the Daily drops the fake $1,000 budget and runs on persistent Cash.

**DB** (migration `v3_r3_daily_real_cash_attendance`):
- `daily_sessions += spent` (real-Cash letter spend).
- **`daily_start`**: advances the **play-streak** here now (showing up counts; losses don't break it) + pays **attendance** (base $50 + milestones at 3/7/14/30); returns `{attendance, attendance_day}`. Board shows **real bank**.
- **`daily_buy_letter`**: spends real `profiles.bank`; tracks `spent`.
- **`_daily_resolve_and_return`**: win-only (free guesses ⇒ no cash loss).
- **`_finalize_daily`**: **refunds spend + efficiency reward** ($100 floor + $600×(clean/no-vowel/first-try)) → a solve **always nets ≥ +$100** (safety net). Streak rewards are now the attendance milestones.
- **Verified** via rolled-back SQL sim (Chef untouched): +$150 attendance, −$90 letter, solve refunds $90 + $550 reward = net +$550.
- **Climb** already real-Cash (confirmed). **Challenges'** per-puzzle budget stays until **R4** (wager-cap is that slice's whole point). **Makeup** stays on its fake budget by design (no Cash deposit).

**Client:** daily HUD shows real Cash; **attendance toast** on first open; result modal drops "No reveals", notes refunded spend.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)