### PR TITLE
v3 R5: Power-up rework (Climb) — one-of-each, pre-commit, cost = spend

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -654,15 +654,11 @@ export async function climbLeaveGame() {
   try { await climbLeave(); } catch { /* non-fatal */ }
 }
 
-/** Use a power-up in the Climb — buys it first if you don't own one. @param {string} id @param {boolean} owned */
-export async function climbPowerup(id, owned) {
+/** Equip a power-up in the Climb (v3: charges Cash on use, counts as spend). @param {string} id */
+export async function climbPowerup(id) {
   if (dailyInFlight) return;
   dailyInFlight = true;
   try {
-    if (!owned) {
-      const res = await buyPowerup(id);
-      if (!res || res.ok === false) return;
-    }
     const board = await climbUsePowerup(id);
     if (board) reconcileClimbBoard(board);
   } finally {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -252,7 +252,7 @@
     _attTimer = setTimeout(() => gameStore.update(s => ({ ...s, dailyAttendance: null })), 4500);
   }
   $: isClimb = $gameStore.gameMode === 'climb';
-  $: climb = $gameStore.climbInfo; // { bounty, heat, attempts, spent, position, stuck, last_gain, state }
+  $: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
   $: isMatch = $gameStore.gameMode === 'match';
   $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, solved, spent, budget, wager, started_at, clock_seconds, combo }
   $: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
@@ -285,15 +285,16 @@
   }
   /** @type {any[]} */
   let climbPups = [];
-  const PUP_ICON = /** @type {Record<string,string>} */ ({ free_reveal: '🔍', half_off: '🏷️', extra_attempt: '➕', insurance: '🛟', heat_shield: '🛡️', double_down: '⚡' });
+  const PUP_ICON = /** @type {Record<string,string>} */ ({ free_reveal: '🔍', half_off: '🏷️', vowel_vision: '👁️', extra_hint: '💡' });
   async function refreshClimbPups() {
     try { const r = await getPowerups(); climbPups = r.items.filter((/** @type {any} */ i) => i.kind === 'climb'); } catch { /* non-fatal */ }
   }
   /** @param {any} item */
   async function handleClimbPup(item) {
     const cash = $gameStore.bankroll ?? 0;
-    if (item.owned <= 0 && cash < item.price) return; // can't afford to buy
-    await climbPowerup(item.id, item.owned > 0);
+    const equipped = (climb?.equipped ?? []).includes(item.id);
+    if (climb?.pups_locked || equipped || cash < item.price) return;
+    await climbPowerup(item.id);
     await refreshClimbPups();
   }
   $: makeupLabel = (() => {
@@ -1149,12 +1150,14 @@
         <div class="ch-cell" class:hot={(climb.heat ?? 100) > 100}><span class="ch-val">×{climbHeat}</span><span class="ch-label">Heat</span></div>
       </div>
       {#if climb.state === 'active' && climbPups.length}
+        <p class="cp-hint">{climb.pups_locked ? 'Loadout locked — equip before your first letter' : 'Equip before you start · cost counts as spend'}</p>
         <div class="climb-pups">
           {#each climbPups as item}
-            <button class="cp" disabled={item.owned <= 0 && ($gameStore.bankroll ?? 0) < item.price}
+            {@const equipped = (climb.equipped ?? []).includes(item.id)}
+            <button class="cp" class:equipped disabled={climb.pups_locked || equipped || ($gameStore.bankroll ?? 0) < item.price}
               on:click={() => handleClimbPup(item)} title={item.name}>
               <span class="cp-ic">{PUP_ICON[item.id] ?? '✨'}</span>
-              <span class="cp-tag">{item.owned > 0 ? '×' + item.owned : '$' + item.price}</span>
+              <span class="cp-tag">{equipped ? '✓' : '$' + item.price}</span>
             </button>
           {/each}
         </div>
@@ -1512,6 +1515,7 @@
   .ch-cell.hot .ch-val { color: #fbbf24; }
   .ch-gold { color: #fcd34d; }
   .ch-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
+  .cp-hint { font-size: 0.66rem; color: var(--text-faint); text-align: center; margin: 0 0 5px; }
   .climb-pups { display: flex; gap: 6px; width: 100%; max-width: 360px; margin: 0 auto 12px; justify-content: space-between; }
   .cp {
     flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 7px 2px;
@@ -1520,6 +1524,8 @@
   }
   .cp:hover:not(:disabled) { transform: translateY(-1px); border-color: rgba(251,191,36,0.5); }
   .cp:disabled { opacity: 0.4; cursor: default; }
+  .cp.equipped { border-color: var(--brand-2); background: rgba(163,230,53,0.12); opacity: 1; }
+  .cp.equipped .cp-tag { color: var(--brand-2); }
   .cp-ic { font-size: 1.1rem; line-height: 1; }
   .cp-tag { font-size: 0.6rem; font-weight: 700; color: var(--text-faint); }
   .climb-stuck {

--- a/supabase-v3-r5-powerup-rework.sql
+++ b/supabase-v3-r5-powerup-rework.sql
@@ -1,0 +1,39 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  v3 R5: Power-up rework (Climb) — one-of-each · pre-commit · cost = spend   ║
+-- ║  (migration: v3_r5_powerup_rework — applied via MCP)                        ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Fifth slice of WORDBANK_MASTER_V3.md. Climb power-ups now serve the efficiency
+-- objective and can't be used as pay-to-win or a reactive escape hatch.
+--
+-- powerups += active BOOLEAN. climb_state += pups_locked BOOLEAN.
+--
+-- CATALOG (climb): trimmed to the efficiency four —
+--   Free Reveal $80 (reveal the most-common letter), Half Off $120 (letters −50%),
+--   Vowel Vision $150 (reveal all vowels), Extra Hint $70 (first letter of each word).
+--   Deactivated (active=false, not deleted): Extra Attempt (unlimited guesses now),
+--   Insurance (no bust), Heat Shield, Double Down (don't fit efficiency). Blitz tools
+--   untouched. (Climb heat is KEPT; Heat Shield is gone, so heat just resets on stuck.)
+--
+-- RULES (climb_use_powerup is now equip-and-charge in one step):
+--   • PRE-COMMIT: only before you engage the puzzle (pups_locked = false). Buying a
+--     letter sets pups_locked = true → no reactive escape-hatching. climb_next resets it.
+--   • ONE OF EACH: can't equip an effect already in active_powerups.
+--   • COST COUNTS AS SPEND: the price is deducted from Cash AND added to climb spent,
+--     so a power-up only helps if it saves more than it costs (anti-pay-to-win).
+--   No more buy-into-inventory then use — you equip and pay at once (cash pool of
+--   user_powerups_v2 is now unused for climb; kept for Free Play / R6).
+--
+-- _climb_board exposes climb.pups_locked + climb.equipped for the loadout UI.
+-- get_powerups filters to active items only.
+--
+-- Verified (rolled-back SQL sim, Chef untouched): equip Free Reveal → −$80 Cash,
+--   spent +$80, a letter revealed; 2nd Free Reveal blocked (one-of-each); buying a
+--   letter locks the loadout; equipping Vowel Vision after engaging blocked.
+--
+-- Client: climb tray shows the 4 power-ups with prices, "✓" when equipped, disabled
+--   when locked / unaffordable / already equipped; a hint explains equip-before-you-
+--   start + cost-counts-as-spend. GameStore.climbPowerup just calls climb_use_powerup.
+--
+-- DEFERRED: power-ups in Challenges/matches (no match_use_powerup yet); Free Play
+--   earned power-ups (R6); a stricter "commit blind before the next puzzle is shown"
+--   screen (current rule = equip before your first letter on the current puzzle).


### PR DESCRIPTION
Fifth slice of **WORDBANK_MASTER_V3.md**. Climb power-ups now serve the efficiency objective — no pay-to-win, no reactive escape hatch.

**DB** (migration `v3_r5_powerup_rework`):
- `powerups += active`; `climb_state += pups_locked`.
- **Catalog trimmed** to the efficiency four: **Free Reveal $80**, **Half Off $120**, **Vowel Vision $150** (reveal all vowels), **Extra Hint $70** (first letter of each word). Deactivated Extra Attempt / Insurance / Heat Shield / Double Down. Heat kept.
- `climb_use_powerup` = **equip-and-charge**: **PRE-COMMIT** (only before you engage; buying a letter locks the loadout, `climb_next` resets it), **ONE OF EACH**, and **COST COUNTS AS SPEND** (price → Cash − and climb `spent` +) so a power-up only helps if it saves more than it costs.
- `_climb_board` exposes `pups_locked` + `equipped`; `get_powerups` filters `active`.
- **Verified** (rolled-back sim): Free Reveal −$80 / spent +$80 / letter revealed; 2nd blocked (one-of-each); buying locks the loadout; equip-after-engage blocked.

**Client:** climb tray shows the 4 power-ups, **"✓" when equipped**, disabled when locked/unaffordable/equipped, with a hint explaining equip-before-you-start + cost-counts-as-spend.

**Deferred:** match power-ups, Free Play earned power-ups (R6), a stricter blind pre-commit screen.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)