### PR TITLE
v3 R6: Free Play safety net — capped Cash trickle

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -48,7 +48,7 @@ import { track } from '$lib/analytics.js';
  *   dailyResult?: any,
  *   climbInfo?: any,
  *   matchInfo?: any,
- *   dailyAttendance?: { amount:number, day:number } | null
+ *   cashToast?: { amount:number, label:string } | null
  * }} GameState
  */
 
@@ -90,7 +90,7 @@ export const gameStore = writable(/** @type {GameState} */ ({
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
   climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
   matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
-  dailyAttendance: null // { amount, day } — transient attendance reward toast (daily start)
+  cashToast: null // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
 }));
 
 /* ================================
@@ -325,7 +325,11 @@ function reconcileFreeplayBoard(board) {
     gameState: finished ? board.state : 'default',
     modifier: null, arcadeRun: null
   }));
-  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
+  if (board.state === 'won') {
+    setTimeout(() => launchConfetti(), 300); fx('win');
+    const rw = /** @type {any} */ (board).freeplay_reward;
+    if (rw > 0) gameStore.update(s => ({ ...s, cashToast: { amount: rw, label: 'Free Play reward' } }));
+  }
   else if (finished) fx('bust');
   else playMoveCue(prev, board);
 }
@@ -1046,8 +1050,8 @@ export async function fetchDailyGame() {
     reconcileDailyBoard(board);
     // Attendance reward (paid once on the first open of the day) → transient toast.
     const ab = /** @type {any} */ (board);
-    if (ab.attendance != null) {
-      gameStore.update(s => ({ ...s, dailyAttendance: { amount: ab.attendance, day: ab.attendance_day } }));
+    if (ab.attendance != null && ab.attendance > 0) {
+      gameStore.update(s => ({ ...s, cashToast: { amount: ab.attendance, label: `Day ${ab.attendance_day} streak · for showing up` } }));
     }
     // Today's shared modifier (same for everyone) — drives the banner + key pricing.
     try {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -244,12 +244,12 @@
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
   $: isMakeup = $gameStore.gameMode === 'makeup';
-  // Auto-dismiss the attendance toast after a few seconds.
+  // Auto-dismiss the Cash-earned toast after a few seconds.
   /** @type {ReturnType<typeof setTimeout>|undefined} */
   let _attTimer;
-  $: if ($gameStore.dailyAttendance) {
+  $: if ($gameStore.cashToast) {
     clearTimeout(_attTimer);
-    _attTimer = setTimeout(() => gameStore.update(s => ({ ...s, dailyAttendance: null })), 4500);
+    _attTimer = setTimeout(() => gameStore.update(s => ({ ...s, cashToast: null })), 4000);
   }
   $: isClimb = $gameStore.gameMode === 'climb';
   $: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
@@ -749,9 +749,9 @@
   <Tutorial on:close={dismissTutorial} />
 {/if}
 
-{#if $gameStore.dailyAttendance}
-  <button class="attendance-toast" on:click={() => gameStore.update(s => ({ ...s, dailyAttendance: null }))}>
-    📅 Day {$gameStore.dailyAttendance.day} streak · <strong>+${$gameStore.dailyAttendance.amount.toLocaleString()}</strong> for showing up
+{#if $gameStore.cashToast}
+  <button class="attendance-toast" on:click={() => gameStore.update(s => ({ ...s, cashToast: null }))}>
+    <strong>+${$gameStore.cashToast.amount.toLocaleString()}</strong> · {$gameStore.cashToast.label}
   </button>
 {/if}
 
@@ -821,7 +821,7 @@
           <span class="mc-icon">🎲</span>
           <span class="mc-body">
             <span class="mc-title">Free Play</span>
-            <span class="mc-sub">Pick a category · unranked</span>
+            <span class="mc-sub">Free to play · earn a little Cash</span>
           </span>
           <span class="mc-arrow">→</span>
         </button>

--- a/supabase-v3-r6-freeplay-trickle.sql
+++ b/supabase-v3-r6-freeplay-trickle.sql
@@ -1,0 +1,25 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  v3 R6: Free Play = the broke-recovery safety net (capped Cash trickle)     ║
+-- ║  (migration: v3_r6_freeplay_trickle — applied via MCP)                      ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Sixth slice of WORDBANK_MASTER_V3.md. Free Play stays free (fake budget, no real
+-- Cash spent on letters) but a solve now pays a SMALL, capped Cash trickle — the
+-- way a broke player grinds back to the risk engines.
+--
+-- _freeplay_resolve: on the first win of a session, credit a Cash trickle =
+--   $25, or $50 for a CLEAN solve (no wrong-letter buys), capped at $300/day across
+--   Free Play (cap measured from sum of today's 'freeplay_reward' bank_ledger rows).
+--   Deliberately minimum-wage so Free Play never cannibalizes the Cash Game /
+--   Challenges. Response carries 'freeplay_reward' for the client toast.
+--
+-- Verified (rolled-back SQL sim, Chef untouched): clean solve → +$50; with $290
+--   already earned today → next solve capped to +$10.
+--
+-- Client: a generic Cash-earned toast (renamed dailyAttendance → cashToast) now
+--   covers BOTH the Daily attendance reward and the Free Play reward. Free Play menu
+--   card reads "Free to play · earn a little Cash". Ledger labels freeplay_reward.
+--
+-- DEFERRED (R6b, deferred since v2 as "5b"): Free Play EARNED power-ups — won by
+--   feats in Free Play (user_powerups_v2 'freeplay' pool, _award_powerup) and used
+--   in Free Play. Not built; Free Play currently has no power-up use. The capped
+--   trickle (the user's explicit "earn money from free play" ask) is the R6 core.


### PR DESCRIPTION
Sixth slice of **WORDBANK_MASTER_V3.md**. Free Play stays free to play but a solve now pays a small, capped Cash trickle — the broke-recovery floor.

**DB** (migration `v3_r6_freeplay_trickle`):
- `_freeplay_resolve` credits, on the first win of a session, **$25** (or **$50** for a clean solve), **capped at $300/day** across Free Play (cap from today's `freeplay_reward` ledger rows). Deliberately minimum-wage so it never cannibalizes the Cash Game / Challenges. Response carries `freeplay_reward` for a toast.
- **Verified** (rolled-back sim, Chef untouched): clean solve **+$50**; with $290 already earned today → next solve capped to **+$10**.

**Client:** generalized the Cash-earned toast (`dailyAttendance` → `cashToast`) to cover both the Daily attendance reward and the Free Play reward; Free Play menu card reads "Free to play · earn a little Cash".

**Deferred (R6b, since v2 "5b"):** Free Play **earned power-ups** (freeplay pool + in-Free-Play use) — the capped trickle is the R6 core (your explicit "earn money from free play" ask).

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)