### PR TITLE
v3 R7: Cutover — refreshed tutorial + one-time reset to $2,000

### DIFF
--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -7,46 +7,37 @@
   const steps = [
     {
       icon: '💰',
-      title: 'Guess the phrase',
-      body: 'Guess the phrase by spending as little as possible. Whatever’s left of your $1,000 is your score.'
+      title: 'Spend less, think more',
+      body: 'Figure out the hidden phrase by buying as few letters as you can. The less you spend to solve it, the better.'
     },
     {
       icon: '🔤',
       title: 'Buy letters',
-      body: 'Buy a letter by tapping it. If it’s in the phrase, every copy appears. If it’s not, you lose what you paid.'
+      body: 'Tap a letter to buy it — every copy appears. A letter that isn’t in the phrase still costs you. Guessing the whole phrase is free, and you get unlimited tries.'
     },
     {
-      icon: '🔍',
-      title: 'Reveal',
-      body: 'Buy a clue with Reveal. It fills in the most useful letter for you, but it costs money, so save it for when you’re stuck.'
-    },
-    {
-      icon: '🎯',
-      title: 'Solve',
-      body: 'Solve the phrase by tapping Solve, typing it in, and submitting. You get three tries, and a wrong guess only costs a try, not money.'
-    },
-    {
-      icon: '🏆',
-      title: 'Daily & Arcade',
-      body: 'Play Daily for one ranked puzzle everyone shares. Play Arcade to keep solving, banking each win and building your multiplier until you bust.'
-    },
-    {
-      icon: '🏦',
-      title: 'Your Cash',
+      icon: '💵',
+      title: 'Cash is your score',
       isNew: true,
-      body: 'You start with $2,000 Cash. Buy as few letters as you can to solve — spend less, keep more. Your Cash balance is your Net Worth: the score you brag about.'
+      body: 'You start with $2,000. It’s your one balance and your Net Worth — the number you climb the leaderboard with. No loans: just spend smart.'
     },
     {
-      icon: '⚔️',
-      title: 'Challenge friends',
+      icon: '📅',
+      title: 'Daily paycheck',
       isNew: true,
-      body: 'Wager your Bank head-to-head on the same puzzle. Score mode: most bankroll left wins. Pressure mode: a 60-second clock, so speed counts. Winner takes the pot.'
+      body: 'One shared puzzle a day. Just showing up pays an attendance reward that grows with your streak — your steady income.'
     },
     {
-      icon: '🛍️',
-      title: 'Shop & friends',
+      icon: '🧗',
+      title: 'Climb & Challenges',
       isNew: true,
-      body: 'Add friends by @username, then race them on the Net Worth board. Spend your Bank in the Shop on titles and name colors that show off your rank.'
+      body: 'Climb an endless ladder of puzzles for Cash bounties, or wager friends: your wager is your budget, and whoever solves spending the least takes the pot.'
+    },
+    {
+      icon: '🎲',
+      title: 'Broke? Free Play',
+      isNew: true,
+      body: 'Free Play never costs Cash and pays a little for every solve. Grind back anytime, then get back in the game.'
     }
   ];
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -387,8 +387,8 @@
   onDestroy(() => clearInterval(pressureTimer));
 
   // Bump this key whenever the tutorial gains new content — it re-shows for
-  // everyone on next login (v2 = Bank economy: loan/net worth, Challenges, Shop).
-  const TUTORIAL_KEY = 'wb_tutorial_v2';
+  // everyone on next login (v3 = persistent Cash, spend-the-least, attendance, no loans).
+  const TUTORIAL_KEY = 'wb_tutorial_v3';
   // First-run guided tutorial: show once a signed-in user reaches the menu.
   $: if (browser && loggedIn && hasInitialized && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
     showTutorial = true;

--- a/supabase-v3-r7-cutover.sql
+++ b/supabase-v3-r7-cutover.sql
@@ -1,0 +1,22 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  v3 R7: Cutover — refreshed tutorial + one-time reset to $2,000             ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Seventh slice of WORDBANK_MASTER_V3.md. Makes the rebuilt economy coherent for
+-- players and does the balance reset that was deliberately deferred from R1.
+--
+-- ONE-TIME RESET (run via execute_sql, not a tracked migration — a data op):
+--   UPDATE profiles SET bank = 2000, loan = 0;   -- everyone starts the v3 economy
+--                                                 -- at $2,000 (Net Worth = Cash)
+--   + a delta-0 'v3_reset' bank_ledger marker for users who already had a balance.
+--   Result: 33/33 profiles at exactly $2,000. (loan column is orphaned since R1;
+--   zeroed here for cleanliness.) Light reset — climb position, streaks, badges,
+--   and challenge history are all KEPT.
+--
+-- TUTORIAL (client): fully rewritten for v3 — 6 slides: spend-less/think-more,
+--   buy letters + free unlimited guesses, Cash IS your score (start $2,000, no
+--   loans), Daily paycheck + attendance, Climb & Challenges (wager = budget,
+--   lowest spend wins), Free Play safety net. TUTORIAL_KEY bumped
+--   wb_tutorial_v2 → wb_tutorial_v3 so it re-shows for everyone on next load.
+--
+-- No new functions. Remaining after R7: R8 tuning (playtest data), and the
+-- deferred tails (R6b Free Play earned power-ups, match power-ups, dead-code cleanup).


### PR DESCRIPTION
Seventh slice of **WORDBANK_MASTER_V3.md** — makes the rebuilt economy coherent for players and does the balance reset deferred from R1.

**One-time reset** (applied via execute_sql): `UPDATE profiles SET bank=2000, loan=0` — everyone starts the v3 economy at **$2,000**; a delta-0 `v3_reset` ledger marker for users who already had a balance. **33/33 profiles now at $2,000.** Light reset — climb position, streaks, badges, challenge history all **kept**.

**Tutorial** fully rewritten for v3 (6 slides): spend-less/think-more · buy letters + free unlimited guesses · Cash **is** your score (start $2,000, no loans) · Daily paycheck + attendance · Climb & Challenges (wager = budget, lowest spend wins) · Free Play safety net. `TUTORIAL_KEY` bumped `wb_tutorial_v2` → `wb_tutorial_v3` so it **re-shows for everyone** on next load.

Remaining after R7: **R8 tuning** (playtest data) + deferred tails (R6b Free Play earned power-ups, match power-ups, dead-code cleanup).

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)