### PR TITLE
Live Daily HUD: Spent, Reward, Net + efficiency pips

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -48,7 +48,8 @@ import { track } from '$lib/analytics.js';
  *   dailyResult?: any,
  *   climbInfo?: any,
  *   matchInfo?: any,
- *   cashToast?: { amount:number, label:string } | null
+ *   cashToast?: { amount:number, label:string } | null,
+ *   dailyLive?: { spent:number, clean:boolean, no_vowels:boolean, first_try:boolean, reward:number, net:number } | null
  * }} GameState
  */
 
@@ -90,7 +91,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
   climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
   matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
-  cashToast: null // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
+  cashToast: null, // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
+  dailyLive: null // { spent, clean, no_vowels, first_try, reward, net } — live Daily HUD metrics
 }));
 
 /* ================================
@@ -199,7 +201,8 @@ function reconcileDailyBoard(board) {
     ...prev, ...boardToState(board, prev),
     gameMode: 'daily',
     gameState: finished ? board.state : 'default',
-    dailyResult: board.daily_result ?? prev.dailyResult ?? null
+    dailyResult: board.daily_result ?? prev.dailyResult ?? null,
+    dailyLive: board.live ?? prev.dailyLive ?? null
   }));
   if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
   else if (finished) fx('bust');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -243,6 +243,9 @@
   }
   $: resultWon = $gameStore.gameState === 'won';
   $: isDailyResult = $gameStore.gameMode === 'daily';
+  // Live Daily HUD metrics (only while actively playing the daily).
+  $: dLive = ($gameStore.gameMode === 'daily' && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
+    ? $gameStore.dailyLive : null;
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
   $: isMakeup = $gameStore.gameMode === 'makeup';
@@ -1161,6 +1164,20 @@
           </span>
         </div>
       </div>
+      {#if dLive}
+        <div class="daily-live">
+          <div class="dl-row">
+            <span class="dl-stat">Spent <b>${dLive.spent.toLocaleString()}</b></span>
+            <span class="dl-stat">Reward <b>${dLive.reward.toLocaleString()}</b></span>
+            <span class="dl-net" class:pos={dLive.net >= 0} class:neg={dLive.net < 0}>Net {dLive.net >= 0 ? '+' : '−'}${Math.abs(dLive.net).toLocaleString()}</span>
+          </div>
+          <div class="dl-pips">
+            <span class="dl-pip" class:on={dLive.clean}>✦ Clean</span>
+            <span class="dl-pip" class:on={dLive.no_vowels}>✦ No Vowels</span>
+            <span class="dl-pip" class:on={dLive.first_try}>✦ First Try</span>
+          </div>
+        </div>
+      {/if}
     </section>
 
     <!-- 💎 Arcade power-up tray (earned this run) -->
@@ -2076,6 +2093,25 @@
     text-transform: uppercase;
     color: var(--text-faint);
   }
+
+  /* Live Daily efficiency HUD */
+  .daily-live {
+    margin: 10px auto 0; max-width: 340px; display: flex; flex-direction: column; gap: 6px;
+    padding: 8px 12px; border-radius: 14px;
+    background: var(--surface, rgba(255,255,255,0.04)); border: 1px solid var(--border);
+  }
+  .dl-row { display: flex; justify-content: space-between; align-items: center; gap: 8px; font-size: 0.78rem; color: var(--text-muted); }
+  .dl-stat b { font-family: var(--font-display); color: var(--text); font-weight: 700; }
+  .dl-net { font-family: var(--font-display); font-weight: 800; font-size: 0.9rem; }
+  .dl-net.pos { color: var(--brand-2); }
+  .dl-net.neg { color: #fb7185; }
+  .dl-pips { display: flex; justify-content: space-between; gap: 6px; }
+  .dl-pip {
+    flex: 1; text-align: center; font-size: 0.66rem; font-weight: 700; padding: 3px 4px; border-radius: 999px;
+    color: var(--text-faint); background: rgba(255,255,255,0.03); border: 1px solid var(--border);
+    transition: color 0.2s, border-color 0.2s, background 0.2s;
+  }
+  .dl-pip.on { color: var(--brand-2); border-color: rgba(163,230,53,0.45); background: rgba(163,230,53,0.08); }
 
   .bankroll-amount {
     display: inline-flex;

--- a/supabase-daily-live-hud.sql
+++ b/supabase-daily-live-hud.sql
@@ -1,0 +1,25 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Live Daily HUD metrics (Strategic display)                                 ║
+-- ║  (migration: v3_daily_live_metrics — applied via MCP)                       ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Surfaces the Daily scoring live so the player can make informed buy-vs-guess
+-- calls while playing.
+--
+-- _daily_live(spent, incorrect[], vowels, wrong) → jsonb:
+--   { spent, clean, no_vowels, first_try, reward, net }
+--   reward = 150 + round(650 × efficiency)  (efficiency = .25 clean + .25 no-vowel
+--   + .25 first-try) — the SAME formula as _finalize_daily, so the live number is
+--   exactly the payout. net = reward − spent.
+--
+-- Wired into daily_start and _daily_resolve_and_return: every Daily board now
+-- carries a 'live' object. (Daily-only — climb/match/freeplay share _daily_board
+-- but don't get 'live'.) Early no-op returns omit it; the client preserves the
+-- previous 'live' when absent.
+--
+-- Verified: _daily_live(0,{},0,0)=reward 638/net 638; (240,{},0,0)=net 398;
+--   (240,{},1,0)=reward 475 (vowel bought); (600,{X},2,2)=reward 150/net −450.
+--
+-- Client (+page.svelte): a "daily-live" strip under the Balance box shows
+--   Spent · Reward · Net (green/red) + three efficiency pips (Clean / No Vowels /
+--   First Try) that light when intact and dim when broken. Shown only while
+--   actively playing the Daily. GameStore: dailyLive state from board.live.


### PR DESCRIPTION
The **Strategic** in-play display for the Daily — so players can make informed buy-vs-guess calls instead of flying blind.

**DB** (migration `v3_daily_live_metrics`):
- `_daily_live(spent, incorrect[], vowels, wrong)` → `{ spent, clean, no_vowels, first_try, reward, net }`. `reward` uses the **exact `_finalize_daily` formula** (`150 + round(650×efficiency)`), so the live number equals the payout; `net = reward − spent`.
- Wired into `daily_start` + `_daily_resolve_and_return` (Daily-only). **Verified:** fresh 638/638, spent 240 → net 398, vowel bought → 475, sloppy → 150/−450.

**Client:** a strip under the Balance box shows **Spent · Reward · Net** (green/red) and three **efficiency pips** (Clean / No Vowels / First Try) that light when intact and dim when broken — only while actively playing the Daily.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)