### PR TITLE
Move Daily status chip onto the Daily menu item

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,12 +51,6 @@
   let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, arcade_bankroll: number, current_streak: number, streak_freezes: number, today_score: number } | null} */ (null);
   $: dailyDone = menuDailyPlayed && !(savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
   $: dailyInProgress = savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
-  // At-a-glance Daily status chip for the Play Now card (main menu).
-  $: dailyChip = dailyInProgress
-    ? { cls: 'prog', label: '⏳ Daily' }
-    : dailyDone
-      ? (dailyStatus?.last_daily_won ? { cls: 'won', label: '✅ Daily' } : { cls: 'lost', label: '❌ Daily' })
-      : { cls: 'ready', label: '🎯 Daily' };
   /** Daily-quest progress for the menu card. */
   let questProgress = { done: 0, total: 3, all_done: false, reward_claimed: false };
   async function refreshQuests() {
@@ -786,14 +780,18 @@
         <button class="menu-card primary sheen" class:open={playOpen} style="--i: 0" on:click={() => { playOpen = !playOpen; fx('tap'); }}>
           <span class="mc-icon">🎮</span>
           <span class="mc-title">Play Now</span>
-          <span class="daily-chip {dailyChip.cls}">{dailyChip.label}</span>
           <span class="mc-arrow">{playOpen ? '▾' : '▸'}</span>
         </button>
         {#if playOpen}
           <div class="play-modes">
             <button class="play-mode daily" class:done={dailyDone} disabled={dailyDone} on:click={handleMenuDaily}>
-              <span class="pm-ic">{#if dailyDone}{dailyStatus?.last_daily_won ? '✅' : '❌'}{:else}🎯{/if}</span>
-              <span class="pm-t">{#if savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost'}Resume Daily{:else if dailyDone}Daily Complete{:else}Daily{/if}</span>
+              <span class="pm-ic">🎯</span>
+              <span class="pm-t">{dailyInProgress ? 'Resume Daily' : 'Daily'}</span>
+              {#if dailyDone}
+                <span class="daily-chip {dailyStatus?.last_daily_won ? 'won' : 'lost'}">{dailyStatus?.last_daily_won ? `✅ Solved${dailyStatus?.today_score ? ' · +' + dailyStatus.today_score.toLocaleString() : ''}` : '❌ Missed'}</span>
+              {:else if dailyInProgress}
+                <span class="daily-chip prog">⏳ Resume</span>
+              {/if}
             </button>
             <button class="play-mode cash" on:click={handleMenuClimb}>
               <span class="pm-ic">🎰</span><span class="pm-t">Cash Game</span>
@@ -1820,8 +1818,6 @@
   .daily-chip.won   { color: #34d399; border-color: rgba(52,211,153,0.5);  background: rgba(52,211,153,0.14); }
   .daily-chip.lost  { color: #fb7185; border-color: rgba(251,113,133,0.5); background: rgba(251,113,133,0.14); }
   .daily-chip.prog  { color: #fbbf24; border-color: rgba(251,191,36,0.5);  background: rgba(251,191,36,0.14); }
-  .daily-chip.ready { color: var(--brand-2); border-color: rgba(163,230,53,0.5); background: rgba(163,230,53,0.14); animation: dailyPulse 2s ease-in-out infinite; }
-  @keyframes dailyPulse { 0%,100% { box-shadow: 0 0 0 0 rgba(163,230,53,0.45); } 50% { box-shadow: 0 0 0 5px rgba(163,230,53,0); } }
   .mc-arrow { color: var(--text-faint); font-size: 1.1rem; transition: transform 0.2s, color 0.2s; }
   .mc-count {
     min-width: 22px; height: 22px; padding: 0 6px; border-radius: 999px;


### PR DESCRIPTION
Per feedback — the status belongs on the **Daily row itself**, not the Play Now card.

The Daily row (inside Play Now) now shows a right-aligned status chip:
- **✅ Solved · +<score>** (green) — done & won
- **❌ Missed** (red) — finished without solving
- **⏳ Resume** (amber) — in progress

Removed the chip from the Play Now card + the unused ready/pulse styles. Client-only, svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)