### PR TITLE
Power-ups v2: store-bought inventory, used free on puzzles (Climb slice)

### DIFF
--- a/WORDBANK_MASTER_V3.md
+++ b/WORDBANK_MASTER_V3.md
@@ -173,15 +173,19 @@ spend stays the real skill**, while you're never locked out by a guess cap.
 
 ## 6. Power-ups
 
-**Universal rules (v3):**
-- **One of each, max.** A loadout, not a stockpile.
-- **Pre-committed before the puzzle is revealed** — applied to the *next* puzzle. No
-  reactive panic-buying / mid-puzzle escape hatches. A power-up is a *strategic pre-bet.*
-- **Cost counts toward your spend.** A power-up only helps if it saves you *more than it
-  costs* — so buying them is itself a skill bet, and a rich player who buys them all just
-  spends more and **loses the efficiency race.** This is the anti-pay-to-win lock.
-- Every power-up must **reduce your spend** or **give free info** (i.e., serve the
-  efficiency objective). Nothing else.
+**Universal rules (v3 — STORE-INVENTORY model, supersedes the earlier pre-commit model):**
+- **Bought in the STORE only** (never on the puzzle screen). Buy ahead with Cash, carry an
+  inventory, bring them to games. The **store price IS the cost** — using one is free
+  (economically identical to the old "counts as spend", just paid up front).
+- **One of each, max.** Hold ≤1 of each; after you use one, re-buy it. Consumed on use.
+- **Used on the puzzle from your inventory** — a small "your items" tray, *use anytime*
+  (no pre-commit lock; you already paid in the store). One of each *effect* per puzzle.
+- Every power-up either **reduces your spend** or **gives free info.**
+- **Where they're allowed:** ✅ Cash Game (Climb), ✅ Challenges *if the host toggles items
+  on*. ❌ **Daily stays power-up-free** (the one shared, identical fair-fight; only the
+  shared daily Modifier applies). This keeps the per-puzzle leaderboards honest.
+- **Social layer (group games):** using a power-up notifies the group ("Sam used X").
+  Future: **sabotage** power-ups (target an opponent) and **group chat.**
 
 ### Cash catalog (bought with Cash; in Cash Game / Challenges)
 | Power-up | Effect | Serves objective by |

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -307,9 +307,8 @@
   }
   /** @param {any} item */
   async function handleClimbPup(item) {
-    const cash = $gameStore.bankroll ?? 0;
-    const equipped = (climb?.equipped ?? []).includes(item.id);
-    if (climb?.pups_locked || equipped || cash < item.price) return;
+    const usedThisPuzzle = (climb?.equipped ?? []).includes(item.id);
+    if ((item.owned ?? 0) <= 0 || usedThisPuzzle) return;  // must own one, can't reuse this puzzle
     await climbPowerup(item.id);
     await refreshClimbPups();
   }
@@ -1101,14 +1100,16 @@
         <div class="ch-cell" class:hot={(climb.heat ?? 100) > 100}><span class="ch-val">×{climbHeat}</span><span class="ch-label">Heat</span></div>
       </div>
       {#if climb.state === 'active' && climbPups.length}
-        <p class="cp-hint">{climb.pups_locked ? 'Loadout locked — equip before your first letter' : 'Equip before you start · cost counts as spend'}</p>
+        <p class="cp-hint">Your power-ups · tap to use · stock up in the Shop</p>
         <div class="climb-pups">
           {#each climbPups as item}
-            {@const equipped = (climb.equipped ?? []).includes(item.id)}
-            <button class="cp" class:equipped disabled={climb.pups_locked || equipped || ($gameStore.bankroll ?? 0) < item.price}
+            {@const used = (climb.equipped ?? []).includes(item.id)}
+            {@const owned = item.owned ?? 0}
+            <button class="cp" class:equipped={used} class:empty={owned <= 0 && !used}
+              disabled={owned <= 0 || used}
               on:click={() => handleClimbPup(item)} title={item.name}>
               <span class="cp-ic">{PUP_ICON[item.id] ?? '✨'}</span>
-              <span class="cp-tag">{equipped ? '✓' : '$' + item.price}</span>
+              <span class="cp-tag">{used ? '✓' : owned > 0 ? '×' + owned : '—'}</span>
             </button>
           {/each}
         </div>
@@ -1474,6 +1475,7 @@
   .cp:disabled { opacity: 0.4; cursor: default; }
   .cp.equipped { border-color: var(--brand-2); background: rgba(163,230,53,0.12); opacity: 1; }
   .cp.equipped .cp-tag { color: var(--brand-2); }
+  .cp.empty { opacity: 0.35; }
   .cp-ic { font-size: 1.1rem; line-height: 1; }
   .cp-tag { font-size: 0.6rem; font-weight: 700; color: var(--text-faint); }
   .climb-stuck {

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -1,21 +1,41 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic } from '$lib/stores/statsStore.js';
+  import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic, getPowerups, buyPowerup } from '$lib/stores/statsStore.js';
   import { track } from '$lib/analytics.js';
   import { fx } from '$lib/sound.js';
 
   let bank = $state(0);
   /** @type {any[]} */
   let items = $state([]);
+  /** @type {any[]} */
+  let pups = $state([]);
   let loading = $state(true);
   let busy = $state('');
   let msg = $state('');
 
+  const PUP_META = /** @type {Record<string,{icon:string,desc:string}>} */ ({
+    free_reveal:  { icon: '🔍', desc: 'Reveal the most useful letter' },
+    half_off:     { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
+    vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
+    extra_hint:   { icon: '💡', desc: 'Reveal the first letter of each word' }
+  });
+
   async function load() {
-    const shop = await getShop();
+    const [shop, pu] = await Promise.all([getShop(), getPowerups()]);
     bank = shop.bank;
     items = shop.items;
+    pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
+  }
+
+  /** @param {any} item */
+  async function buyPup(item) {
+    if (busy) return;
+    busy = item.id; msg = '';
+    const res = await buyPowerup(item.id);
+    busy = '';
+    if (res?.ok) { fx('win'); track('powerup_buy', { id: item.id }); await load(); }
+    else { msg = res?.reason === 'insufficient' ? 'Not enough Cash.' : res?.reason === 'owned' ? 'You already own one — use it first.' : 'Could not buy that.'; }
   }
   onMount(async () => {
     track('shop_view');
@@ -53,12 +73,31 @@
     <h1>🛍️ Shop</h1>
     <span class="bank-chip">💰 ${bank.toLocaleString()}</span>
   </div>
-  <p class="sub">Spend your Cash on titles &amp; name colors — pure flair, shows on the leaderboards. No pay-to-win.</p>
+  <p class="sub">Stock up on power-ups to bring into the Cash Game &amp; challenges, and spend on flair. Cosmetics are pure show — no pay-to-win.</p>
 
   {#if loading}
     <p class="loading">Loading…</p>
   {:else}
     {#if msg}<p class="msg">{msg}</p>{/if}
+
+    <h2 class="section">⚡ Power-ups</h2>
+    <p class="section-note">Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like — the Daily stays power-up-free.</p>
+    <div class="grid">
+      {#each pups as item}
+        <div class="card pup" class:owned={item.owned > 0}>
+          <span class="pup-ic">{PUP_META[item.id]?.icon ?? '✨'}</span>
+          <span class="c-label">{item.name}</span>
+          <span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
+          {#if item.owned > 0}
+            <button class="c-btn equip on" disabled>✓ In your bag</button>
+          {:else}
+            <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buyPup(item)}>
+              💰 ${item.price.toLocaleString()}
+            </button>
+          {/if}
+        </div>
+      {/each}
+    </div>
 
     <h2 class="section">Titles</h2>
     <div class="grid">
@@ -111,7 +150,12 @@
   .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1.4rem; }
   .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
   .msg { text-align: center; color: #f87171; font-size: 0.88rem; margin: 0 0 1rem; }
-  .section { font-family: var(--font-display); font-size: 1.05rem; margin: 1.4rem 0 0.7rem; }
+  .section { font-family: var(--font-display); font-size: 1.05rem; margin: 1.4rem 0 0.4rem; }
+  .section-note { font-size: 0.76rem; color: var(--text-faint); margin: 0 0 0.8rem; }
+  .card.pup { align-items: center; text-align: center; gap: 0.3rem; }
+  .pup-ic { font-size: 1.7rem; line-height: 1; }
+  .pup-desc { font-size: 0.72rem; color: var(--text-muted); line-height: 1.3; min-height: 2.1em; }
+  .card.pup .c-btn { margin-top: 0.3rem; }
   .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
   .card {
     display: flex; flex-direction: column; gap: 0.6rem; align-items: flex-start;

--- a/supabase-v3-powerups-store-inventory.sql
+++ b/supabase-v3-powerups-store-inventory.sql
@@ -1,0 +1,28 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Power-ups v2: store-bought inventory, used free on puzzles                 ║
+-- ║  (migration: v3_powerups_store_inventory — applied via MCP)                 ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- New model (supersedes R5's buy-and-equip-on-puzzle): power-ups live in the STORE.
+-- You buy them ahead with Cash into an inventory (one of each), carry them, and use
+-- them from the inventory on a puzzle FOR FREE (the store price is the cost). The
+-- economics are identical to R5's "counts as spend" — the cost just moves to the
+-- store. Decisions: Daily stays power-up-free; Challenges get a host toggle (future
+-- slice); used-in-group notifies the group (future slice); sabotage + chat (future).
+--
+-- buy_powerup: one-of-each cap (reject 'owned' if you already hold 1); deduct Cash;
+--   grant to user_powerups_v2 'cash' pool. (price from active powerups only.)
+-- get_powerups: returns each active item + how many you OWN (cash pool).
+-- climb_use_powerup: CONSUME one from inventory (qty−1) and apply the effect — FREE
+--   (no Cash charge), NOT counted as spend, NO pre-commit lock (use anytime). Still
+--   one-of-each effect per puzzle (active_powerups). climb_state.pups_locked is now
+--   unused (left in place, harmless).
+--
+-- Verified (rolled-back sim, Chef): buy −$80 / owned 1; 2nd buy → reason 'owned';
+--   use → free (bank unchanged), owned 0, spent 0 (not counted), letter revealed.
+--
+-- Client: Shop (/shop) has a "⚡ Power-ups" section (buy, one-of-each, "in your bag").
+--   Climb tray now shows OWNED items (×N), tap to use; unowned dimmed; used = ✓; no
+--   buying on the puzzle screen. (Removed the old pre-commit/cost-as-spend tray.)
+--
+-- NEXT SLICES: challenge host toggle + match_use_powerup + group "Sam used X" notify;
+--   sabotage power-ups; group chat.


### PR DESCRIPTION
New model (supersedes R5's buy-and-equip-on-puzzle): power-ups live in the **Store**. Buy ahead with Cash into an **inventory** (one of each), carry them, and **use them from inventory for free** — the store price is the cost (economically identical to R5's counts-as-spend, just paid up front).

**Locked decisions:** Daily stays **power-up-free**; Challenges get a **host toggle** (next slice); group "Sam used X" notify + sabotage + chat are future.

**DB** (`v3_powerups_store_inventory`):
- `buy_powerup`: **one-of-each cap** (reject `owned`); deduct Cash; grant to `cash` pool.
- `get_powerups`: returns **owned** qty per active item.
- `climb_use_powerup`: **consume from inventory**, apply effect — **free**, **not counted as spend**, **no pre-commit lock** (use anytime); still one-of-each effect per puzzle.
- **Verified** (rolled-back sim): buy −$80/owned 1; 2nd→`owned`; use free/owned 0/spent 0/letter revealed.

**Client:** Shop has a **"⚡ Power-ups"** section (buy, one-of-each, "in your bag"); the Climb tray shows **owned items (×N)** — tap to use, unowned dimmed, used = ✓, no buying on the puzzle screen.

**Next slices:** challenge host toggle + `match_use_powerup` + group "Sam used X" notify; sabotage; group chat.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)