### PR TITLE
Power-ups Slice 2: challenge toggle + use-in-match + social notify

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -9,7 +9,7 @@ import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freepla
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
 import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
-import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck } from '$lib/stores/statsStore.js';
+import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck, matchUsePowerup } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -707,6 +707,18 @@ export async function startMatch(opts) {
     if (board) reconcileMatchBoard(board);
   }
   return resp;
+}
+
+/** Use an owned power-up in the active match (if items allowed). @param {string} powerupId */
+export async function matchPowerup(powerupId) {
+  if (dailyInFlight || !activeMatchId) return;
+  dailyInFlight = true;
+  try {
+    const board = await matchUsePowerup(activeMatchId, powerupId);
+    if (board) reconcileMatchBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
 }
 
 /** Accept (escrow) an invited match and start playing. @param {string} id @returns {Promise<boolean>} */

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -518,7 +518,7 @@ export async function arcadeCashout() {
 /* ===== Challenge Builder (configurable N-player packs) ===== */
 /**
  * @param {{ opponent?:string|null, group_id?:string|null, categories?:string[], pack_size?:number,
- *   mode?:string, wager?:number, payout?:string, window_seconds?:number }} opts
+ *   mode?:string, wager?:number, payout?:string, window_seconds?:number, items_allowed?:boolean }} opts
  * @returns {Promise<{ok:boolean, reason?:string, match?:any}>}
  */
 export async function createMatch(opts) {
@@ -526,7 +526,8 @@ export async function createMatch(opts) {
     p_opponent: opts.opponent ?? null, p_group_id: opts.group_id ?? null,
     p_categories: opts.categories ?? [], p_pack_size: opts.pack_size ?? 1,
     p_mode: opts.mode ?? 'standard', p_wager: opts.wager ?? 0,
-    p_payout: opts.payout ?? 'winner', p_window_seconds: opts.window_seconds ?? 172800
+    p_payout: opts.payout ?? 'winner', p_window_seconds: opts.window_seconds ?? 172800,
+    p_items_allowed: opts.items_allowed ?? false
   });
   if (error || !data) { if (error) console.error('❌ create_match:', error); return { ok: false }; }
   return data;
@@ -565,6 +566,12 @@ export async function matchBuyLetter(id, letter) {
 export async function matchReveal(id) {
   const { data, error } = await supabase.rpc('match_reveal', { p_id: id });
   if (error) { console.error('❌ match_reveal:', error); return null; }
+  return data;
+}
+/** Use an owned power-up in a match (if items are allowed). @param {string} id @param {string} powerup @returns {Promise<any|null>} */
+export async function matchUsePowerup(id, powerup) {
+  const { data, error } = await supabase.rpc('match_use_powerup', { p_id: id, p_powerup: powerup });
+  if (error) { console.error('❌ match_use_powerup:', error); return null; }
   return data;
 }
 /** @param {string} id @param {Record<string,string>} guess @returns {Promise<any|null>} */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -260,7 +260,7 @@
   $: isClimb = $gameStore.gameMode === 'climb';
   $: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
   $: isMatch = $gameStore.gameMode === 'match';
-  $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, solved, spent, budget, wager, started_at, clock_seconds, combo }
+  $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, solved, spent, budget, wager, items_allowed, used_powerups, started_at, clock_seconds, combo }
   $: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
   $: matchCombo = ((matchInfo?.combo ?? 100) / 100).toFixed(2);
   let matchExpiredFired = false;
@@ -522,6 +522,7 @@
   let mbWager = 0;
   let mbPayout = 'winner'; // 'winner' | 'top3' | 'even'
   let mbWindow = 172800; // seconds
+  let mbItemsAllowed = false; // host toggle: allow power-ups in this challenge
   let mbMsg = '';
   let mbBusy = false;
   /** @type {{username:string,is_friend:boolean}[]} */
@@ -572,7 +573,8 @@
       opponent: mbTarget === 'friend' ? mbOpponent.trim() : null,
       group_id: mbTarget === 'group' ? mbGroupId : null,
       categories: mbCategories, pack_size: mbPackSize, mode: mbMode,
-      wager: Math.floor(Number(mbWager) || 0), payout: mbPayout, window_seconds: mbWindow
+      wager: Math.floor(Number(mbWager) || 0), payout: mbPayout, window_seconds: mbWindow,
+      items_allowed: mbItemsAllowed
     });
     mbBusy = false;
     if (res?.ok) { launchMatchPlay(); }
@@ -601,6 +603,14 @@
     localStorage.setItem('gameMode', 'match');
     hasInitialized = true;
     showMainMenu = false;
+    refreshClimbPups(); // load owned power-ups for the match tray
+  }
+  /** @param {any} item */
+  async function handleMatchPup(item) {
+    const used = (matchInfo?.used_powerups ?? []).includes(item.id);
+    if ((item.owned ?? 0) <= 0 || used) return;
+    await matchPowerup(item.id);
+    await refreshClimbPups();
   }
 
   // After solving / going broke in Free Play, load the next puzzle in the category.
@@ -924,6 +934,10 @@
                   <select class="ch-input" bind:value={mbWindow}>{#each WINDOWS as w}<option value={w.s}>{w.l}</option>{/each}</select>
                 </label>
               </div>
+              <button class="ch-toggle" class:on={mbItemsAllowed} on:click={() => { mbItemsAllowed = !mbItemsAllowed; fx('tap'); }}>
+                <span class="ch-tog-box">{mbItemsAllowed ? '✓' : ''}</span>
+                ⚡ Allow power-ups — players can bring & use items they own
+              </button>
               <p class="ch-objective">Your wager is your spending budget (min $500). Buy as few letters as you can — <strong>solve spending the least and you take the pot.</strong> Guesses are free.</p>
               <button class="ch-create" disabled={mbBusy} on:click={submitNewMatch} style="width:100%;">Send challenge ⚔️</button>
               {#if mbMsg}<p class="add-msg">{mbMsg}</p>{/if}
@@ -1138,6 +1152,20 @@
           <div class="ch-cell" class:hot={matchRemaining <= 10}><span class="ch-val">⏱️{matchRemaining}</span><span class="ch-label">Time</span></div>
         {/if}
       </div>
+      {#if matchInfo.items_allowed && climbPups.length}
+        <p class="cp-hint">Your power-ups · tap to use — the group is notified</p>
+        <div class="climb-pups">
+          {#each climbPups as item}
+            {@const used = (matchInfo.used_powerups ?? []).includes(item.id)}
+            {@const owned = item.owned ?? 0}
+            <button class="cp" class:equipped={used} class:empty={owned <= 0 && !used}
+              disabled={owned <= 0 || used} on:click={() => handleMatchPup(item)} title={item.name}>
+              <span class="cp-ic">{PUP_ICON[item.id] ?? '✨'}</span>
+              <span class="cp-tag">{used ? '✓' : owned > 0 ? '×' + owned : '—'}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
     {/if}
 
     <!-- 🌍 Category + today's modifier chip + witty clue -->
@@ -1883,6 +1911,16 @@
   .ch-create:disabled { opacity: 0.6; }
   .ch-objective { font-size: 0.74rem; line-height: 1.4; color: var(--text-muted); margin: 0 0 10px; }
   .ch-objective strong { color: var(--brand-2); }
+  .ch-toggle {
+    display: flex; align-items: center; gap: 8px; width: 100%; margin: 2px 0 10px; padding: 0;
+    background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 0.8rem; text-align: left; font-weight: 600;
+  }
+  .ch-toggle.on { color: var(--brand-2); }
+  .ch-tog-box {
+    width: 20px; height: 20px; flex-shrink: 0; border-radius: 6px; display: grid; place-items: center;
+    border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: #06210f; font-size: 0.75rem; font-weight: 800;
+  }
+  .ch-toggle.on .ch-tog-box { background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); border-color: transparent; }
   .ch-cats { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; }
   .ch-cat { width: 34px; height: 34px; border-radius: 9px; cursor: pointer; font-size: 1rem; border: 1px solid var(--border); background: var(--surface); opacity: 0.5; transition: opacity 0.15s, border-color 0.15s; }
   .ch-cat.on { opacity: 1; border-color: rgba(163,230,53,0.55); background: rgba(163,230,53,0.08); }

--- a/supabase-v3-slice2-match-powerups.sql
+++ b/supabase-v3-slice2-match-powerups.sql
@@ -1,0 +1,25 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Power-ups Slice 2: challenges (host toggle) + "Sam used X" social notify   ║
+-- ║  (migrations: v3_slice2_match_powerups, v3_slice2_match_board_expose)        ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- challenge_matches += items_allowed BOOLEAN (host toggle, default off).
+-- challenge_participants += active_powerups text[] (effects used this puzzle).
+--
+-- create_match: +p_items_allowed (9th param, defaulted for back-compat) → sets the flag.
+-- match_buy_letter: applies Half Off if active.
+-- match_use_powerup(match_id, powerup): only if items_allowed; consumes one from the
+--   'cash' inventory (FREE, like climb), applies the effect to your match puzzle, and
+--   NOTIFIES every other participant ("<name> used <Power-up>", type 'powerup_used').
+--   One-of-each effect per puzzle; active_powerups reset on advancing to the next.
+-- _match_board / get_match: expose items_allowed + used_powerups for the tray.
+--
+-- Verified (rolled-back sim): friendly match items_allowed=true; Chef buys Free Reveal,
+--   uses it → revealed 2, owned→0; Warpocket received notification "Chefcharles used
+--   Free Reveal". The social moment fires. ✓
+--
+-- Client: Challenge Builder has an "⚡ Allow power-ups" toggle (host). The match game
+--   screen shows the owned-items tray when items_allowed (tap to use). createMatch
+--   passes items_allowed; GameStore.matchPowerup → match_use_powerup. The "Sam used X"
+--   notification surfaces via the existing notification poller + Toaster on any screen.
+--
+-- NEXT: sabotage power-ups (target an opponent); group chat.


### PR DESCRIPTION
**The social heart of the power-up system.**

**DB** (`v3_slice2_match_powerups`, `v3_slice2_match_board_expose`):
- `challenge_matches += items_allowed` (host toggle); `challenge_participants += active_powerups`.
- `create_match`: **+p_items_allowed** (back-compat default). `match_buy_letter` applies Half Off.
- **`match_use_powerup`**: only if `items_allowed`; consumes from the `cash` inventory (free, like climb), applies the effect to your match puzzle, and **notifies every other participant** ("<name> used <Power-up>"). One-of-each per puzzle; reset on advance. `_match_board`/`get_match` expose `items_allowed` + `used_powerups`.
- **Verified** (rolled-back sim): `items_allowed=true`; Chef buys + uses Free Reveal → revealed / owned→0; **Warpocket got "Chefcharles used Free Reveal."** 🎉

**Client:** Challenge Builder **"⚡ Allow power-ups"** toggle; the match game shows the **owned-items tray** when allowed (tap to use); `GameStore.matchPowerup`; the social notify rides the existing notification poller + Toaster (pops on any screen).

**Next:** sabotage power-ups (target an opponent); group chat.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)