### PR TITLE
Power-ups Slice 3: Sabotage — hit an opponent in a challenge

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -9,7 +9,7 @@ import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freepla
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
 import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
-import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck, matchUsePowerup } from '$lib/stores/statsStore.js';
+import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -715,6 +715,18 @@ export async function matchPowerup(powerupId) {
   dailyInFlight = true;
   try {
     const board = await matchUsePowerup(activeMatchId, powerupId);
+    if (board) reconcileMatchBoard(board);
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** Sabotage an opponent in the active match. @param {string} targetId @param {string} powerupId */
+export async function matchSabotageOpponent(targetId, powerupId) {
+  if (dailyInFlight || !activeMatchId) return;
+  dailyInFlight = true;
+  try {
+    const board = await matchSabotage(activeMatchId, targetId, powerupId);
     if (board) reconcileMatchBoard(board);
   } finally {
     dailyInFlight = false;

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -574,6 +574,12 @@ export async function matchUsePowerup(id, powerup) {
   if (error) { console.error('❌ match_use_powerup:', error); return null; }
   return data;
 }
+/** Sabotage an opponent in a match. @param {string} id @param {string} target @param {string} powerup @returns {Promise<any|null>} */
+export async function matchSabotage(id, target, powerup) {
+  const { data, error } = await supabase.rpc('match_sabotage', { p_id: id, p_target: target, p_powerup: powerup });
+  if (error) { console.error('❌ match_sabotage:', error); return null; }
+  return data;
+}
 /** @param {string} id @param {Record<string,string>} guess @returns {Promise<any|null>} */
 export async function matchSubmitGuess(id, guess) {
   const { data, error } = await supabase.rpc('match_submit_guess', { p_id: id, p_guess: guess });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
@@ -301,9 +301,26 @@
   }
   /** @type {any[]} */
   let climbPups = [];
-  const PUP_ICON = /** @type {Record<string,string>} */ ({ free_reveal: '🔍', half_off: '🏷️', vowel_vision: '👁️', extra_hint: '💡' });
+  const PUP_ICON = /** @type {Record<string,string>} */ ({ free_reveal: '🔍', half_off: '🏷️', vowel_vision: '👁️', extra_hint: '💡', sabotage_tax: '💸', sabotage_fog: '🌫️' });
+  const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({ tax: '💸 Taxed (letters +50%)', fog: '🌫️ Fogged (clue hidden)' });
+  let pendingSabotage = /** @type {string|null} */ (null); // sabotage powerup id awaiting a target
   async function refreshClimbPups() {
-    try { const r = await getPowerups(); climbPups = r.items.filter((/** @type {any} */ i) => i.kind === 'climb'); } catch { /* non-fatal */ }
+    try { const r = await getPowerups(); climbPups = r.items ?? []; } catch { /* non-fatal */ }
+  }
+  $: selfPups = climbPups.filter((/** @type {any} */ i) => i.kind === 'climb');   // buffs (use on yourself)
+  $: sabPups = climbPups.filter((/** @type {any} */ i) => i.kind === 'sabotage'); // sabotage (target an opponent)
+  /** @param {any} item */
+  async function tapSabotage(item) {
+    const opps = matchInfo?.opponents ?? [];
+    if ((item.owned ?? 0) <= 0 || opps.length === 0) return;
+    if (opps.length === 1) { await matchSabotageOpponent(opps[0].id, item.id); await refreshClimbPups(); }
+    else { pendingSabotage = pendingSabotage === item.id ? null : item.id; }
+  }
+  /** @param {string} oppId */
+  async function pickSabTarget(oppId) {
+    if (!pendingSabotage) return;
+    const pid = pendingSabotage; pendingSabotage = null;
+    await matchSabotageOpponent(oppId, pid); await refreshClimbPups();
   }
   /** @param {any} item */
   async function handleClimbPup(item) {
@@ -1113,10 +1130,10 @@
         <div class="ch-cell"><span class="ch-val ch-gold">${(climb.bounty ?? 0).toLocaleString()}</span><span class="ch-label">Bounty</span></div>
         <div class="ch-cell" class:hot={(climb.heat ?? 100) > 100}><span class="ch-val">×{climbHeat}</span><span class="ch-label">Heat</span></div>
       </div>
-      {#if climb.state === 'active' && climbPups.length}
+      {#if climb.state === 'active' && selfPups.length}
         <p class="cp-hint">Your power-ups · tap to use · stock up in the Shop</p>
         <div class="climb-pups">
-          {#each climbPups as item}
+          {#each selfPups as item}
             {@const used = (climb.equipped ?? []).includes(item.id)}
             {@const owned = item.owned ?? 0}
             <button class="cp" class:equipped={used} class:empty={owned <= 0 && !used}
@@ -1152,10 +1169,13 @@
           <div class="ch-cell" class:hot={matchRemaining <= 10}><span class="ch-val">⏱️{matchRemaining}</span><span class="ch-label">Time</span></div>
         {/if}
       </div>
-      {#if matchInfo.items_allowed && climbPups.length}
+      {#if (matchInfo.my_debuffs ?? []).length}
+        <p class="debuff-banner">{(matchInfo.my_debuffs ?? []).map((/** @type {string} */ d) => DEBUFF_LABEL[d] ?? d).join(' · ')}</p>
+      {/if}
+      {#if matchInfo.items_allowed && selfPups.length}
         <p class="cp-hint">Your power-ups · tap to use — the group is notified</p>
         <div class="climb-pups">
-          {#each climbPups as item}
+          {#each selfPups as item}
             {@const used = (matchInfo.used_powerups ?? []).includes(item.id)}
             {@const owned = item.owned ?? 0}
             <button class="cp" class:equipped={used} class:empty={owned <= 0 && !used}
@@ -1165,6 +1185,27 @@
             </button>
           {/each}
         </div>
+      {/if}
+      {#if matchInfo.items_allowed && sabPups.some((/** @type {any} */ i) => (i.owned ?? 0) > 0) && (matchInfo.opponents ?? []).length}
+        <p class="cp-hint sab">😈 Sabotage · hit an opponent</p>
+        <div class="climb-pups">
+          {#each sabPups as item}
+            {@const owned = item.owned ?? 0}
+            <button class="cp sab" class:empty={owned <= 0} class:arming={pendingSabotage === item.id}
+              disabled={owned <= 0} on:click={() => tapSabotage(item)} title={item.name}>
+              <span class="cp-ic">{PUP_ICON[item.id] ?? '✨'}</span>
+              <span class="cp-tag">{owned > 0 ? '×' + owned : '—'}</span>
+            </button>
+          {/each}
+        </div>
+        {#if pendingSabotage}
+          <div class="sab-targets">
+            <span class="sab-pick">Hit who?</span>
+            {#each matchInfo.opponents ?? [] as opp}
+              <button class="sab-target" on:click={() => pickSabTarget(opp.id)}>{opp.name}</button>
+            {/each}
+          </div>
+        {/if}
       {/if}
     {/if}
 
@@ -1504,6 +1545,21 @@
   .cp.equipped { border-color: var(--brand-2); background: rgba(163,230,53,0.12); opacity: 1; }
   .cp.equipped .cp-tag { color: var(--brand-2); }
   .cp.empty { opacity: 0.35; }
+  .cp.sab { border-color: rgba(244,114,182,0.3); }
+  .cp.sab:hover:not(:disabled) { border-color: rgba(244,114,182,0.6); }
+  .cp.sab.arming { border-color: #f472b6; box-shadow: 0 0 12px rgba(244,114,182,0.4); }
+  .cp-hint.sab { color: #f472b6; }
+  .debuff-banner {
+    text-align: center; font-size: 0.76rem; font-weight: 700; color: #fb7185; margin: 0 auto 8px;
+    max-width: 340px; padding: 5px 10px; border-radius: 999px;
+    background: rgba(251,113,133,0.1); border: 1px solid rgba(251,113,133,0.3);
+  }
+  .sab-targets { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; align-items: center; margin: 2px auto 10px; max-width: 340px; }
+  .sab-pick { font-size: 0.74rem; color: #f472b6; font-weight: 700; }
+  .sab-target {
+    padding: 4px 11px; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.8rem;
+    color: #fff; border: none; background: linear-gradient(135deg, #f472b6, #db2777);
+  }
   .cp-ic { font-size: 1.1rem; line-height: 1; }
   .cp-tag { font-size: 0.6rem; font-weight: 700; color: var(--text-faint); }
   .climb-stuck {

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -18,14 +18,20 @@
     free_reveal:  { icon: '🔍', desc: 'Reveal the most useful letter' },
     half_off:     { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
     vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
-    extra_hint:   { icon: '💡', desc: 'Reveal the first letter of each word' }
+    extra_hint:   { icon: '💡', desc: 'Reveal the first letter of each word' },
+    sabotage_tax: { icon: '💸', desc: "An opponent's letters cost +50%" },
+    sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" }
   });
+
+  /** @type {any[]} */
+  let sabs = $state([]);
 
   async function load() {
     const [shop, pu] = await Promise.all([getShop(), getPowerups()]);
     bank = shop.bank;
     items = shop.items;
     pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
+    sabs = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'sabotage');
   }
 
   /** @param {any} item */
@@ -98,6 +104,27 @@
         </div>
       {/each}
     </div>
+
+    {#if sabs.length}
+      <h2 class="section">😈 Sabotage</h2>
+      <p class="section-note">Bring these to a challenge with power-ups on, then hit an opponent — they get notified.</p>
+      <div class="grid">
+        {#each sabs as item}
+          <div class="card pup" class:owned={item.owned > 0}>
+            <span class="pup-ic">{PUP_META[item.id]?.icon ?? '😈'}</span>
+            <span class="c-label">{item.name}</span>
+            <span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
+            {#if item.owned > 0}
+              <button class="c-btn equip on" disabled>✓ In your bag</button>
+            {:else}
+              <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buyPup(item)}>
+                💰 ${item.price.toLocaleString()}
+              </button>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
 
     <h2 class="section">Titles</h2>
     <div class="grid">

--- a/supabase-v3-slice3-sabotage.sql
+++ b/supabase-v3-slice3-sabotage.sql
@@ -1,0 +1,27 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Power-ups Slice 3: Sabotage (target an opponent in a challenge)            ║
+-- ║  (migration: v3_slice3_sabotage)                                            ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Challenges are ASYNC, so sabotage = persistent DEBUFFS on the target that bite
+-- when they play (not real-time effects). challenge_participants += debuffs text[].
+--
+-- Catalog (kind='sabotage'): 💸 Tax $100 (target's letters cost +50%), 🌫️ Fog $80
+--   (target's clue hidden). Bought in the Store like any power-up.
+--
+-- match_sabotage(match_id, target, powerup): items_allowed only; you must be active,
+--   target must be an active/invited OTHER participant; consume the sabotage item from
+--   inventory; add the debuff to the target; NOTIFY the target ("<name> hit you with
+--   <X> — your letters cost +50%", type 'sabotaged'). Debuffs clear when the target
+--   advances to the next puzzle.
+-- match_buy_letter: 'tax' debuff → letter cost ×1.5 (stacks after Half Off).
+-- _match_board: hides the clue when 'fog' is active; exposes my_debuffs + the
+--   opponents list [{id,name}] for targeting.
+--
+-- Verified (rolled-back sim): Chef buys + uses Tax on Warpocket → Warpocket.debuffs
+--   = {tax}, Warpocket notified, Chef's item consumed, and Warpocket's $70 letter
+--   then cost $105 (ceil 1.5×). ✓
+--
+-- Client: Shop "😈 Sabotage" section; match screen shows a sabotage row (tap → pick
+--   target; auto-targets in 1v1) + a "you're hit" debuff banner; matchSabotageOpponent.
+--
+-- NEXT (last power-up slice): group chat.


### PR DESCRIPTION
Challenges are **async**, so sabotage = persistent **debuffs** that bite when the target plays (not real-time effects). `challenge_participants += debuffs`.

**DB** (`v3_slice3_sabotage`):
- **Catalog** (kind='sabotage'): **💸 Tax $100** (target's letters cost +50%), **🌫️ Fog $80** (target's clue hidden). Bought in the Store.
- **`match_sabotage(match_id, target, powerup)`**: items_allowed only; consume from inventory, apply the debuff to a valid opponent, and **notify them** ("<name> hit you with X — your letters cost +50%"). Debuffs clear on the target's next puzzle.
- `match_buy_letter`: **tax → ×1.5** (stacks after Half Off). `_match_board`: **fog hides the clue**, exposes `my_debuffs` + `opponents [{id,name}]` for targeting.
- **Verified** (rolled-back sim): Chef Tax on Warpocket → `debuffs {tax}`, Warpocket **notified**, item consumed, and Warpocket's $70 letter then cost **$105** (ceil 1.5×). ✓

**Client:** Shop **"😈 Sabotage"** section; the match screen shows a **sabotage row** (tap → pick a target; auto-targets in 1v1) + a **"you're hit" debuff banner**. The hit notification rides the existing Toaster.

**Next (last slice):** group chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)