### PR TITLE
Expand power-up catalog: more self-buffs + sabotage

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -301,8 +301,14 @@
   }
   /** @type {any[]} */
   let climbPups = [];
-  const PUP_ICON = /** @type {Record<string,string>} */ ({ free_reveal: '🔍', half_off: '🏷️', vowel_vision: '👁️', extra_hint: '💡', sabotage_tax: '💸', sabotage_fog: '🌫️' });
-  const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({ tax: '💸 Taxed (letters +50%)', fog: '🌫️ Fogged (clue hidden)' });
+  const PUP_ICON = /** @type {Record<string,string>} */ ({
+    free_reveal: '🔍', half_off: '🏷️', vowel_vision: '👁️', extra_hint: '💡', reveal_word: '📖', free_vowel: '🅰️', last_letters: '🔚',
+    sabotage_tax: '💸', sabotage_fog: '🌫️', sabotage_toll: '🚧', sabotage_vowel_block: '🚫', sabotage_lock: '🔒'
+  });
+  const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({
+    tax: '💸 Taxed (letters +50%)', fog: '🌫️ Fogged (clue hidden)',
+    toll: '🚧 Tolled (next letter 3×)', vowel_block: '🚫 Vowel-blocked (vowels 3×)'
+  });
   let pendingSabotage = /** @type {string|null} */ (null); // sabotage powerup id awaiting a target
   async function refreshClimbPups() {
     try { const r = await getPowerups(); climbPups = r.items ?? []; } catch { /* non-fatal */ }

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -16,11 +16,17 @@
 
   const PUP_META = /** @type {Record<string,{icon:string,desc:string}>} */ ({
     free_reveal:  { icon: '🔍', desc: 'Reveal the most useful letter' },
+    free_vowel:   { icon: '🅰️', desc: 'Reveal one vowel free' },
     half_off:     { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
     vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
+    reveal_word:  { icon: '📖', desc: 'Reveal a whole word' },
     extra_hint:   { icon: '💡', desc: 'Reveal the first letter of each word' },
+    last_letters: { icon: '🔚', desc: 'Reveal the last letter of each word' },
     sabotage_tax: { icon: '💸', desc: "An opponent's letters cost +50%" },
-    sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" }
+    sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" },
+    sabotage_toll:        { icon: '🚧', desc: "An opponent's next letter costs 3×" },
+    sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
+    sabotage_lock:        { icon: '🔒', desc: 'Wipe a letter an opponent revealed' }
   });
 
   /** @type {any[]} */

--- a/supabase-v3-powerups-expanded.sql
+++ b/supabase-v3-powerups-expanded.sql
@@ -1,0 +1,23 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Expanded power-up catalog (more self-buffs + sabotage)                     ║
+-- ║  (migrations: v3_powerups_expanded_catalog, _expanded_sabotage)             ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- _powerup_reveal(phrase, effect, revealed[]) — shared reveal helper for all
+-- reveal-type self-buffs, used by climb_use_powerup AND match_use_powerup (one
+-- place to define reveals). Verified: reveal_word→full first word, last_letters→
+-- last of each word, free_vowel→most-common vowel, extra_hint→first of each word.
+--
+-- NEW self-buffs (kind='climb'): 📖 Reveal Word $200 (a whole word), 🅰️ Free Vowel
+--   $50 (one vowel), 🔚 Last Letters $70 (last of each word).
+-- NEW sabotage (kind='sabotage'): 🚧 Toll $90 (target's NEXT letter ×3, one-shot —
+--   consumed in match_buy_letter), 🚫 Vowel Block $110 (target's vowels ×3 this
+--   puzzle), 🔒 Lock $130 (immediately WIPES a random letter the target revealed).
+--
+-- match_buy_letter cost stack: Half Off → Tax(+50%) → Vowel Block(×3 on vowels) →
+--   Toll(×3, then removed). match_sabotage: Lock acts immediately (un-reveals all
+--   positions of one random revealed letter); the rest are persistent debuffs that
+--   clear on the target's next puzzle. All notify the target.
+--
+-- Full catalog now: self-buffs = Free Reveal/Free Vowel/Half Off/Vowel Vision/Reveal
+--   Word/Extra Hint/Last Letters; sabotage = Tax/Fog/Toll/Vowel Block/Lock.
+-- Client: icons + shop descriptions + debuff labels added; trays render dynamically.


### PR DESCRIPTION
**DB** (`v3_powerups_expanded_catalog`, `_expanded_sabotage`):
- **`_powerup_reveal(phrase, effect, revealed[])`** — shared reveal helper used by both `climb_use_powerup` and `match_use_powerup` (reveals defined once). Verified for reveal_word / last_letters / free_vowel / extra_hint.
- **New self-buffs:** 📖 **Reveal Word** $200 (a whole word), 🅰️ **Free Vowel** $50, 🔚 **Last Letters** $70 (last of each word).
- **New sabotage:** 🚧 **Toll** $90 (target's next letter ×3, one-shot), 🚫 **Vowel Block** $110 (vowels ×3), 🔒 **Lock** $130 (immediately **wipes a letter** the target revealed).
- `match_buy_letter` cost stack: Half Off → Tax → Vowel Block → Toll (consumed). `match_sabotage`: Lock acts immediately; others are debuffs; all notify the target.

**Full catalog now:** self-buffs = Free Reveal / Free Vowel / Half Off / Vowel Vision / Reveal Word / Extra Hint / Last Letters · sabotage = Tax / Fog / Toll / Vowel Block / Lock.

Client: icons, shop descriptions, debuff labels added; trays render dynamically. svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)