### PR TITLE
Group chat: instant messages via Supabase Realtime

### DIFF
--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { getMyGroups, getGroup, createGroup, joinGroup, leaveGroup, getGroupMessages, sendGroupMessage } from '$lib/stores/statsStore.js';
+  import { supabase } from '$lib/supabaseClient.js';
   import { track } from '$lib/analytics.js';
 
   /** @type {any[]} */
@@ -23,18 +24,23 @@
   /** @type {HTMLElement|undefined} */
   let chatScroll = $state();
 
-  // Poll messages while a group is open.
+  // Live chat while a group is open: Supabase Realtime for instant messages, with a
+  // slow poll as a safety net (catches anything missed if the socket drops).
   $effect(() => {
     const g = open;
     if (!g?.id) { messages = []; return; }
     let alive = true;
-    const tick = async () => {
+    const reload = async () => {
       const m = await getGroupMessages(g.id);
       if (alive && open?.id === g.id) messages = m;
     };
-    tick();
-    const iv = setInterval(tick, 6000);
-    return () => { alive = false; clearInterval(iv); };
+    reload();
+    const channel = supabase
+      .channel(`group:${g.id}`)
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'group_messages', filter: `group_id=eq.${g.id}` }, reload)
+      .subscribe();
+    const iv = setInterval(reload, 30000);
+    return () => { alive = false; clearInterval(iv); supabase.removeChannel(channel); };
   });
   // Keep the chat scrolled to the latest message.
   $effect(() => { messages; if (chatScroll) chatScroll.scrollTop = chatScroll.scrollHeight; });

--- a/supabase-v3-group-chat-realtime.sql
+++ b/supabase-v3-group-chat-realtime.sql
@@ -1,0 +1,14 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Group chat → Supabase Realtime (instant messages)                          ║
+-- ║  (migration: v3_group_chat_realtime)                                        ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Upgrades the chat from 6s polling to live websocket push.
+-- 1) SELECT RLS policy: group members can read their groups' messages directly
+--    (Realtime enforces RLS; without a policy a subscriber sees nothing). Inserts
+--    still go only through send_group_message (no INSERT policy).
+-- 2) ALTER PUBLICATION supabase_realtime ADD TABLE group_messages (idempotent).
+--
+-- Client (/groups): the chat $effect now opens a Supabase channel subscribed to
+-- INSERTs on group_messages filtered by group_id → on a new message it reloads
+-- instantly. A 30s poll remains as a safety net if the socket drops. Channel is
+-- torn down (removeChannel) when the group view closes.


### PR DESCRIPTION
Upgrades chat from **6s polling → live websocket push**.

**DB** (`v3_group_chat_realtime`):
- **SELECT RLS policy** so members can read their groups' messages directly (Realtime enforces RLS — without a policy a subscriber sees nothing). Inserts still only via `send_group_message`.
- Added `group_messages` to the `supabase_realtime` publication (idempotent).

**Client** (`/groups`): the chat `$effect` opens a Supabase channel subscribed to `INSERT`s on `group_messages` filtered by `group_id` → reloads **instantly** on a new message; a **30s poll stays as a safety net** if the socket drops; the channel is torn down on close.

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)