### PR TITLE
Fix: re-opening a completed Daily showed winner + confetti

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -204,12 +204,14 @@ function reconcileDailyBoard(board) {
     dailyResult: board.daily_result ?? prev.dailyResult ?? null,
     dailyLive: board.live ?? prev.dailyLive ?? null
   }));
-  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
+  // Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
+  // not when re-opening an already-completed daily (which comes back 'won' with no result).
+  if (board.state === 'won') { if (board.daily_result) { setTimeout(() => launchConfetti(), 300); fx('win'); } }
   else if (finished) fx('bust');
   else playMoveCue(prev, board);
-  // analytics: fire once, on the transition into a finished daily
-  if (finished && prev.gameState !== 'won' && prev.gameState !== 'lost') {
-    track('daily_result', { won: board.state === 'won', bankroll: board.bankroll ?? 0 });
+  // analytics: fire once, only on the actual solve transition
+  if (board.daily_result && prev.gameState !== 'won' && prev.gameState !== 'lost') {
+    track('daily_result', { won: true, bankroll: board.bankroll ?? 0 });
   }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -519,9 +519,15 @@
   async function handleMenuDaily() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
-    // Already solved today -> show the results / come-back summary.
-    if (dailyDone) {
-      showStreakMessage = true;
+    // Status loads non-blocking after login — make sure we know it before deciding,
+    // so an already-completed daily shows the summary instead of re-opening + "winning".
+    if (!dailyStatus) {
+      dailyStatus = await getDailyStatus(currentUser.id);
+      menuDailyPlayed = dailyStatus.has_played_today;
+    }
+    const inProgress = savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
+    if (dailyStatus?.has_played_today && !inProgress) {
+      showStreakMessage = true;  // already solved today → come-back summary
       return;
     }
     // Otherwise start fresh, or resume an in-progress daily (dailyStart resumes).


### PR DESCRIPTION
Fallout from the non-blocking login init (PR #181): `dailyStatus` loads async, so for a moment the menu thinks the Daily isn't done — clicking it ran `fetchDailyGame`, which loads the already-**won** session and the client celebrated it (confetti + winner).

- **`handleMenuDaily`** now awaits `dailyStatus` if it hasn't loaded, and decides from the fresh value (+ `savedGameInfo`) — an already-solved Daily shows the **come-back summary** instead of re-opening the board.
- **`reconcileDailyBoard`** only fires confetti/win-sound (and the `daily_result` analytic) when the board carries `daily_result` — i.e. an actual solve **this session** — not when re-opening a board that's already `won`.

(No double-reward was possible — the server ignores buys/guesses on a `won` session.)

svelte-check + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)