### PR TITLE
Strengthen menu hero coin glow

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1882,7 +1882,7 @@
     height: auto;
     object-fit: contain;
     margin-bottom: 4px;
-    filter: drop-shadow(0 10px 38px rgba(251, 191, 36, 0.45));
+    filter: drop-shadow(0 0 26px rgba(251, 191, 36, 0.55)) drop-shadow(0 10px 40px rgba(251, 191, 36, 0.4));
   }
   .menu-wordmark {
     width: min(80vw, 300px);


### PR DESCRIPTION
## Summary
The menu hero coin already uses the transparent glow coin (`logo-coin.png`, shipped in #188). This adds a layered gold drop-shadow so the glow reads clearly on the dark menu background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)