### PR TITLE
Phase 2: friends system (request → accept)

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -163,11 +163,46 @@ export async function markNotificationsRead() {
   if (error) console.error('❌ mark_notifications_read:', error);
 }
 
-/** Add a friend by username. @param {string} username @returns {Promise<{ok:boolean, reason?:string, friend_name?:string}>} */
+/** Send a friend request by username (auto-accepts if they already requested you). @param {string} username @returns {Promise<{ok:boolean, reason?:string, status?:string, friend_name?:string}>} */
 export async function addFriend(username) {
   const { data, error } = await supabase.rpc('add_friend', { p_username: username });
   if (error || !data) { if (error) console.error('❌ add_friend:', error); return { ok: false }; }
   return data;
+}
+
+/** Accept or decline an incoming request. @param {string} username @param {boolean} accept @returns {Promise<{ok:boolean, reason?:string, status?:string}>} */
+export async function respondFriendRequest(username, accept) {
+  const { data, error } = await supabase.rpc('respond_friend_request', { p_username: username, p_accept: accept });
+  if (error || !data) { if (error) console.error('❌ respond_friend_request:', error); return { ok: false }; }
+  return data;
+}
+
+/** Unfriend by username. @param {string} username @returns {Promise<{ok:boolean}>} */
+export async function removeFriend(username) {
+  const { data, error } = await supabase.rpc('remove_friend', { p_username: username });
+  if (error || !data) { if (error) console.error('❌ remove_friend:', error); return { ok: false }; }
+  return data;
+}
+
+/** My accepted friends. @returns {Promise<{username:string,name:string}[]>} */
+export async function listFriends() {
+  const { data, error } = await supabase.rpc('list_friends');
+  if (error) { console.error('❌ list_friends:', error); return []; }
+  return data ?? [];
+}
+
+/** Pending requests. @returns {Promise<{incoming:{username:string,name:string}[], outgoing:{username:string,name:string}[]}>} */
+export async function listFriendRequests() {
+  const { data, error } = await supabase.rpc('list_friend_requests');
+  if (error) { console.error('❌ list_friend_requests:', error); return { incoming: [], outgoing: [] }; }
+  return data ?? { incoming: [], outgoing: [] };
+}
+
+/** Count of incoming friend requests (menu badge). @returns {Promise<number>} */
+export async function getFriendRequestCount() {
+  const { data, error } = await supabase.rpc('get_friend_request_count');
+  if (error) { console.error('❌ get_friend_request_count:', error); return 0; }
+  return data ?? 0;
 }
 
 /** Me + friends ranked by today's Daily score. @returns {Promise<any[]>} */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, getDailyQuests, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount } from '$lib/stores/statsStore.js';
   import { unreadCount, notifications, markAllNotificationsRead, refreshNotifications } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
@@ -602,6 +602,7 @@
   /** @type {any[]} */
   let myGroups = [];
   let challengeCount = 0; // matches awaiting my play (badge on the Challenges card)
+  let friendReqCount = 0; // incoming friend requests (badge on Friends)
   /** @type {any|null} */
   let matchResults = null; // a settled match's results being viewed
   // Builder form
@@ -630,6 +631,7 @@
     try {
       myMatches = await getMyMatches();
       challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
+      friendReqCount = await getFriendRequestCount();
     } catch { /* non-fatal */ }
   }
   async function openChallenges() {
@@ -904,7 +906,7 @@
           <button class="menu-card" style="--i: 1" on:click={() => { menuView = 'challenge'; fx('tap'); }}>
             <span class="mc-icon">⚔️</span>
             <span class="mc-title">Challenge Friends</span>
-            {#if challengeCount > 0}<span class="mc-stat" title="{challengeCount} waiting">{challengeCount}</span>{/if}
+            {#if challengeCount + friendReqCount > 0}<span class="mc-stat" title="{challengeCount} match{challengeCount === 1 ? '' : 'es'}, {friendReqCount} friend request{friendReqCount === 1 ? '' : 's'}">{challengeCount + friendReqCount}</span>{/if}
             <span class="mc-arrow">→</span>
           </button>
           <button class="menu-card" style="--i: 2" on:click={() => { menuView = 'progress'; fx('tap'); }}>
@@ -955,7 +957,9 @@
         </div>
         <div class="main-menu-buttons stagger">
           <button class="menu-card" style="--i: 0" on:click={() => goto('/friends')}>
-            <span class="mc-icon">👥</span><span class="mc-title">Friends</span><span class="mc-arrow">→</span>
+            <span class="mc-icon">👥</span><span class="mc-title">Friends</span>
+            {#if friendReqCount > 0}<span class="mc-stat" title="{friendReqCount} friend request{friendReqCount === 1 ? '' : 's'}">{friendReqCount}</span>{/if}
+            <span class="mc-arrow">→</span>
           </button>
           <button class="menu-card" style="--i: 1" on:click={() => goto('/groups')}>
             <span class="mc-icon">👨‍👩‍👧‍👦</span><span class="mc-title">Groups</span><span class="mc-arrow">→</span>

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -1,21 +1,165 @@
 <script>
+  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
+  import { searchUsers, addFriend, respondFriendRequest, removeFriend, listFriends, listFriendRequests } from '$lib/stores/statsStore.js';
+  import { track } from '$lib/analytics.js';
+  import { fx } from '$lib/sound.js';
+
+  /** @type {{username:string,name:string}[]} */
+  let friends = $state([]);
+  /** @type {{username:string,name:string}[]} */
+  let incoming = $state([]);
+  /** @type {{username:string,name:string}[]} */
+  let outgoing = $state([]);
+  let loading = $state(true);
+  let busy = $state('');
+  let msg = $state('');
+
+  let query = $state('');
+  /** @type {{username:string,status:string,is_friend:boolean}[]} */
+  let results = $state([]);
+  let searching = $state(false);
+
+  async function load() {
+    const [f, r] = await Promise.all([listFriends(), listFriendRequests()]);
+    friends = f;
+    incoming = r.incoming ?? [];
+    outgoing = r.outgoing ?? [];
+  }
+
+  onMount(async () => {
+    track('friends_view');
+    try { await load(); } finally { loading = false; }
+  });
+
+  // debounced typeahead
+  let timer;
+  $effect(() => {
+    const q = query.trim();
+    clearTimeout(timer);
+    if (q.length < 2) { results = []; searching = false; return; }
+    searching = true;
+    timer = setTimeout(async () => {
+      results = await searchUsers(q);
+      searching = false;
+    }, 280);
+  });
+
+  /** @param {string} username */
+  async function add(username) {
+    if (busy) return;
+    busy = username; msg = '';
+    const res = await addFriend(username);
+    busy = '';
+    if (res?.ok) {
+      fx('select'); track('friend_request_send', { to: username });
+      msg = res.status === 'friends' ? `You're now friends with ${res.friend_name ?? username}!` : `Request sent to ${res.friend_name ?? username}.`;
+      results = results.map((u) => u.username === username ? { ...u, status: res.status === 'friends' ? 'friends' : 'pending_out', is_friend: res.status === 'friends' } : u);
+      await load();
+    } else {
+      msg = res?.reason === 'already_friends' ? 'Already friends.' : res?.reason === 'not_found' ? 'No player with that name.' : 'Could not send request.';
+    }
+  }
+
+  /** @param {string} username @param {boolean} accept */
+  async function respond(username, accept) {
+    if (busy) return;
+    busy = username;
+    const res = await respondFriendRequest(username, accept);
+    busy = '';
+    if (res?.ok) { fx(accept ? 'win' : 'tap'); track('friend_respond', { from: username, accept }); await load(); }
+  }
+
+  /** @param {string} username */
+  async function unfriend(username) {
+    if (busy) return;
+    busy = username;
+    await removeFriend(username);
+    busy = '';
+    fx('tap'); await load();
+  }
 </script>
 
 <svelte:head><title>WordBank — Friends</title></svelte:head>
 
 <main class="friends-page">
   <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
+  <h1>👥 Friends</h1>
 
-  <div class="head">
-    <h1>👥 Friends</h1>
+  <div class="search-wrap">
+    <input class="search" type="text" placeholder="Search players by username…" bind:value={query} maxlength="20" autocomplete="off" />
+    {#if query.trim().length >= 2}
+      <div class="results">
+        {#if searching}
+          <p class="muted small pad">Searching…</p>
+        {:else if results.length === 0}
+          <p class="muted small pad">No players found.</p>
+        {:else}
+          {#each results as u}
+            <div class="row">
+              <span class="uname">@{u.username}</span>
+              {#if u.status === 'friends'}
+                <span class="tag friend">✓ Friend</span>
+              {:else if u.status === 'pending_out'}
+                <span class="tag pending">Requested</span>
+              {:else if u.status === 'pending_in'}
+                <button class="act accept" disabled={busy === u.username} onclick={() => respond(u.username, true)}>Accept</button>
+              {:else}
+                <button class="act add" disabled={busy === u.username} onclick={() => add(u.username)}>+ Add</button>
+              {/if}
+            </div>
+          {/each}
+        {/if}
+      </div>
+    {/if}
   </div>
 
-  <div class="soon">
-    <span class="soon-ic">🚧</span>
-    <p class="soon-t">Friends are almost here</p>
-    <p class="soon-d">Soon you'll search players, send friend requests, and challenge friends to cash matches. Add friends to build groups too — no codes needed.</p>
-  </div>
+  {#if msg}<p class="msg">{msg}</p>{/if}
+
+  {#if loading}
+    <p class="muted pad">Loading…</p>
+  {:else}
+    {#if incoming.length > 0}
+      <h2 class="sec">Requests <span class="count">{incoming.length}</span></h2>
+      <div class="list">
+        {#each incoming as u}
+          <div class="row card">
+            <span class="uname">@{u.username}</span>
+            <div class="row-acts">
+              <button class="act accept" disabled={busy === u.username} onclick={() => respond(u.username, true)}>Accept</button>
+              <button class="act decline" disabled={busy === u.username} onclick={() => respond(u.username, false)}>Decline</button>
+            </div>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    <h2 class="sec">Your Friends <span class="count">{friends.length}</span></h2>
+    {#if friends.length === 0}
+      <p class="muted small pad">No friends yet — search above to add some.</p>
+    {:else}
+      <div class="list">
+        {#each friends as u}
+          <div class="row card">
+            <span class="uname">@{u.username}</span>
+            <button class="act remove" disabled={busy === u.username} onclick={() => unfriend(u.username)} title="Remove friend">✕</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+
+    {#if outgoing.length > 0}
+      <h2 class="sec muted-sec">Sent</h2>
+      <div class="list">
+        {#each outgoing as u}
+          <div class="row card dim">
+            <span class="uname">@{u.username}</span>
+            <span class="tag pending">Pending</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
 </main>
 
 <style>
@@ -25,12 +169,41 @@
     background: var(--surface); color: var(--text); border: 1px solid var(--border);
     border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem;
   }
-  .head h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0 0 1.4rem; }
-  .soon {
-    text-align: center; padding: 2.4rem 1.4rem; border: 1px solid var(--border);
-    border-radius: 18px; background: var(--surface);
+  h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0 0 1rem; }
+  .search-wrap { position: relative; }
+  .search {
+    width: 100%; padding: 0.85rem 1rem; border-radius: 14px; font-size: 0.95rem;
+    background: var(--surface); border: 1px solid var(--border); color: var(--text);
   }
-  .soon-ic { font-size: 2.4rem; }
-  .soon-t { font-family: var(--font-display); font-weight: 800; font-size: 1.15rem; margin: 0.6rem 0 0.3rem; }
-  .soon-d { color: var(--text-muted); font-size: 0.9rem; line-height: 1.5; margin: 0; }
+  .search:focus { outline: none; border-color: rgba(251,191,36,0.5); }
+  .results {
+    margin-top: 0.5rem; border: 1px solid var(--border); border-radius: 14px;
+    background: var(--surface); overflow: hidden;
+  }
+  .results .row { padding: 0.7rem 0.9rem; border-bottom: 1px solid var(--border); }
+  .results .row:last-child { border-bottom: none; }
+  .row { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; }
+  .card { padding: 0.8rem 0.9rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); }
+  .card.dim { opacity: 0.7; }
+  .list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .uname { font-family: var(--font-display); font-weight: 700; font-size: 1rem; }
+  .row-acts { display: flex; gap: 0.4rem; }
+  .act {
+    padding: 0.45rem 0.9rem; border-radius: 10px; cursor: pointer; font-weight: 800; font-size: 0.85rem; border: 1px solid var(--border);
+    background: var(--surface-2, rgba(255,255,255,0.06)); color: var(--text);
+  }
+  .act:disabled { opacity: 0.5; cursor: default; }
+  .act.add, .act.accept { color: #06210f; border: none; background: var(--brand-grad, linear-gradient(135deg,#34d399,#a3e635)); }
+  .act.decline { color: #f87171; border-color: rgba(248,113,113,0.4); }
+  .act.remove { color: var(--text-faint); padding: 0.35rem 0.6rem; }
+  .tag { font-size: 0.78rem; font-weight: 800; padding: 0.3rem 0.7rem; border-radius: 999px; }
+  .tag.friend { color: var(--brand-2); background: rgba(163,230,53,0.12); border: 1px solid rgba(163,230,53,0.35); }
+  .tag.pending { color: #fbbf24; background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.3); }
+  .sec { font-family: var(--font-display); font-size: 1.05rem; margin: 1.6rem 0 0.6rem; display: flex; align-items: center; gap: 0.5rem; }
+  .muted-sec { color: var(--text-muted); font-size: 0.95rem; }
+  .count { font-size: 0.8rem; font-weight: 800; color: #fbbf24; background: rgba(251,191,36,0.12); border-radius: 999px; padding: 1px 9px; }
+  .msg { text-align: center; font-size: 0.88rem; color: var(--brand-2); margin: 0.8rem 0 0; }
+  .muted { color: var(--text-muted); }
+  .small { font-size: 0.85rem; }
+  .pad { padding: 1rem 0.2rem; text-align: center; }
 </style>

--- a/supabase-friends-requests.sql
+++ b/supabase-friends-requests.sql
@@ -1,0 +1,30 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Friends: request → accept  (migration: friends_request_accept)            ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Upgrades the old instant `add_friend` to a request/accept model WITHOUT
+-- touching any leaderboard reader. Accepted friends still live in the symmetric
+-- two-row `friendships(user_id, friend_id)` table (so get_*_leaderboard,
+-- get_daily_board, get_friends_daily_leaderboard, search_users' is_friend, etc.
+-- keep working unchanged). Pending requests live in a NEW table.
+--
+-- TABLE  friend_requests(requester, addressee, created_at)  PK(requester,addressee)
+--        RLS enabled, no policies — access only via the SECURITY DEFINER RPCs.
+--
+-- add_friend(username)              → sends a request; AUTO-ACCEPTS if the other
+--                                     person already requested you. Returns
+--                                     {ok, status: requested|friends, friend_name}
+--                                     | {ok:false, reason: auth|empty|not_found|
+--                                        self|already_friends}.
+-- respond_friend_request(username,  → accept (insert symmetric friendship) or
+--   accept bool)                      decline (drop the request). {ok,status}.
+-- remove_friend(username)           → unfriend both directions + clear requests.
+-- list_friends()                    → [{username, name}]  (accepted only).
+-- list_friend_requests()            → {incoming:[…], outgoing:[…]}.
+-- get_friend_request_count()        → int incoming (menu badge).
+-- search_users(query)               → now also returns `status`:
+--                                     friends | pending_out | pending_in | none
+--                                     (keeps is_friend for back-compat).
+--
+-- Verified end-to-end via rolled-back JWT-impersonation (request → inbox →
+-- accept → symmetric friends → already_friends → remove). Full bodies are in the
+-- applied migration.


### PR DESCRIPTION
## Summary
Second phase of the social overhaul — a real **friends system with request → accept**.

### Backend (migration `friends_request_accept`, applied & rolled-back-tested)
- New **`friend_requests`** table holds the pending state; accepted friends remain in the symmetric `friendships` table, so all 6 leaderboard readers stay untouched.
- `add_friend(username)` now **sends a request** (auto-accepts if they already requested you). Added `respond_friend_request`, `remove_friend`, `list_friends`, `list_friend_requests`, `get_friend_request_count`. `search_users` now returns relationship `status` (friends/pending_out/pending_in/none).
- Verified end-to-end via JWT-impersonation (request → inbox → accept → symmetric friends → already_friends → remove), then rolled back — live accounts untouched, `friendships` still empty.

### Frontend
- Full **/friends** page: search-to-add typeahead, **requests inbox** (accept/decline), friends list (remove), and a sent/pending section.
- statsStore wrappers + an incoming-request **badge** on Challenge Friends and the Friends card.

### Next
Phase 3 — codeless groups (add friends directly). Phase 4 — Stats page + challenge-from-friends/groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)