### PR TITLE
Dramatic gold glow on button selection

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -104,6 +104,20 @@ h1, h2, h3, h4 {
 
 button { font-family: inherit; }
 
+/* Super-dramatic gold glow on any button press / selection (keyboard, menu,
+   chips — everything). Component rules (.menu-card, .key) layer a stronger
+   version on top. */
+button:active,
+button:focus-visible {
+  outline: none;
+  border-color: #fde047;
+  box-shadow:
+    0 0 0 2px rgba(253, 224, 71, 1),
+    0 0 16px rgba(251, 191, 36, 0.95),
+    0 0 34px rgba(251, 191, 36, 0.7),
+    0 0 66px rgba(251, 191, 36, 0.42);
+}
+
 /* Numbers that should feel like a readout (money, counters) */
 .tabular { font-variant-numeric: tabular-nums; font-feature-settings: 'tnum' 1; }
 

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -285,7 +285,16 @@
     border-color: var(--border-strong);
     transform: translateY(-1px);
   }
-  .key:active { transform: scale(0.94); }
+  .key:active,
+  .key:focus-visible {
+    transform: scale(0.94);
+    border-color: #fbbf24 !important;
+    outline: none;
+    box-shadow:
+      0 0 0 2px rgba(251, 191, 36, 0.95),
+      0 0 14px rgba(251, 191, 36, 0.9),
+      0 0 30px rgba(251, 191, 36, 0.6) !important;
+  }
 
   .key.delete {
     background: rgba(251, 90, 90, 0.15);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1995,7 +1995,18 @@
     border-color: var(--border-strong);
     box-shadow: var(--shadow-md);
   }
-  .menu-card:active:not(.disabled) { transform: scale(0.99); }
+  .menu-card:active:not(.disabled),
+  .menu-card:focus-visible:not(.disabled) {
+    transform: scale(0.985);
+    border-color: #fde047;
+    outline: none;
+    box-shadow:
+      0 0 0 2.5px rgba(253, 224, 71, 1),
+      0 0 24px rgba(251, 191, 36, 1),
+      0 0 52px rgba(251, 191, 36, 0.85),
+      0 0 96px rgba(251, 191, 36, 0.55),
+      0 0 150px rgba(251, 191, 36, 0.3);
+  }
   .menu-card.primary {
     border-color: rgba(163, 230, 53, 0.4);
     background: linear-gradient(135deg, rgba(52, 211, 153, 0.16), rgba(163, 230, 53, 0.06));


### PR DESCRIPTION
## Summary
Super-dramatic **gold glowing outline on button selection**, applied everywhere:
- **Global** — `button:active` / `:focus-visible` get a layered gold bloom + gold border.
- **Menu cards** — a stronger multi-layer gold glow (out to 150px) on press/select.
- **Keyboard keys** — gold glow on press (beats the purchased/delete key borders).

Kept the existing button shapes/layout as-is per request — this is purely the selection feedback. Verified the bloom on pressed menu cards via Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)