### PR TITLE
Cash game hint + silver ATM keyboard

### DIFF
--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -150,7 +150,7 @@
 --------------------------- */
 .main-button-wrapper {
   position: fixed;
-  bottom: 174px; /* clears the 156px-tall keyboard + gap */
+  bottom: 212px; /* clears the taller silver keyboard (~194px) + gap */
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -23,6 +23,12 @@
   const row2: string[] = ['A','S','D','F','G','H','J','K','L'];
   const row3: string[] = ['Z','X','C','V','B','N','M'];
 
+  // Braille (Unicode patterns) for each letter — the tactile dots on ATM-style keys.
+  const BRAILLE: Record<string, string> = {
+    A:'⠁',B:'⠃',C:'⠉',D:'⠙',E:'⠑',F:'⠋',G:'⠛',H:'⠓',I:'⠊',J:'⠚',K:'⠅',L:'⠇',M:'⠍',
+    N:'⠝',O:'⠕',P:'⠏',Q:'⠟',R:'⠗',S:'⠎',T:'⠞',U:'⠥',V:'⠧',W:'⠺',X:'⠭',Y:'⠽',Z:'⠵'
+  };
+
   // Effective per-letter prices after active discount / vowel_vision (server matches this):
   // daily uses the shared modifier; arcade uses the run's armed power-ups.
   $: effCosts = (() => {
@@ -163,6 +169,7 @@
       {incorrectLetters.includes(letter) ? 'incorrect' : ''}"
         on:click={() => handleLetterClick(letter)}
       >
+        <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
         <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
@@ -187,6 +194,7 @@
                 }"
         on:click={() => handleLetterClick(letter)}
       >
+        <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
         <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
@@ -211,16 +219,17 @@
                 }"
         on:click={() => handleLetterClick(letter)}
       >
+        <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
         <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
 
     {#if $gameStore.gameState === 'guess_mode'}
-      <button 
+      <button
       tabindex="-1"
       class="key delete" on:click={deleteGuessLetter}>
-        <div class="letter">Del</div>
+        <div class="letter">⌫</div>
       </button>
     {/if}
   </div>
@@ -232,42 +241,43 @@
   --------------------------- */
   .keyboard-container {
     position: fixed;
-    bottom: 0;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 12px); /* lifted off the bottom edge */
     left: 50%;
     transform: translateX(-50%);
     width: 100%;
     max-width: 600px;
-    box-shadow: none !important; /* ❌ Removes any shadow */
-    background: transparent !important; /* ❌ Ensures no background issue */
-    padding: 6px;
+    box-shadow: none !important;
+    background: transparent !important;
+    padding: 6px 8px; /* side padding so edge keys never clip */
     display: flex;
     flex-direction: column;
-    gap: 3px;
+    gap: 6px;
     z-index: 1000;
   }
   .keyboard-row {
     display: flex;
     justify-content: center;
-    gap: 2px;
+    gap: 6px;
     flex-wrap: nowrap;
   }
   :global(body) {
-    padding-bottom: 132px; /* Space for keyboard */
+    padding-bottom: 196px; /* Space for the taller, lifted keyboard */
     display: flex;
     flex-direction: column;
     align-items: center;
   }
 
   /* ---------------------------
-     Key Styles
+     Key Styles — silver ATM keys
   --------------------------- */
   .key {
-    width: 56px;
-    height: 46px;
-    border: 1px solid var(--border);
-    background: var(--surface);
-    color: var(--text);
-    border-radius: 10px;
+    flex: 1 1 0;
+    min-width: 0;
+    height: 54px;
+    border: 1px solid #aeb2bb;
+    background: linear-gradient(#f7f8fa, #c6c9d1);
+    color: #16181c;
+    border-radius: 9px;
     cursor: pointer;
     display: flex;
     flex-direction: column;
@@ -275,32 +285,52 @@
     justify-content: center;
     gap: 1px;
     padding: 2px;
+    position: relative;
     box-sizing: border-box;
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    transition: transform 0.12s var(--ease-spring), background 0.15s, border-color 0.15s;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.95),
+      inset 0 -2px 3px rgba(0, 0, 0, 0.2),
+      0 3px 0 #9498a0,
+      0 5px 8px rgba(0, 0, 0, 0.45);
+    transition: transform 0.1s var(--ease-spring), box-shadow 0.12s, filter 0.12s;
   }
   .key:hover:not(.purchased):not(.incorrect):not(.disabled) {
-    background: var(--surface-2);
-    border-color: var(--border-strong);
+    filter: brightness(1.05);
     transform: translateY(-1px);
   }
   .key:active,
   .key:focus-visible {
-    transform: scale(0.94);
-    border-color: #fbbf24 !important;
+    transform: translateY(2px) scale(0.97);
+    border-color: #fde047 !important;
     outline: none;
     box-shadow:
-      0 0 0 2px rgba(251, 191, 36, 0.95),
-      0 0 14px rgba(251, 191, 36, 0.9),
-      0 0 30px rgba(251, 191, 36, 0.6) !important;
+      0 0 0 2px rgba(253, 224, 71, 1),
+      0 0 16px rgba(251, 191, 36, 0.95),
+      0 0 34px rgba(251, 191, 36, 0.65) !important;
   }
 
-  .key.delete {
-    background: rgba(251, 90, 90, 0.15);
-    color: #ffb4b4 !important;
-    border-color: rgba(251, 90, 90, 0.4) !important;
+  /* braille pips, top-left of each key */
+  .braille {
+    position: absolute;
+    top: 3px;
+    left: 5px;
+    font-size: 9px;
+    line-height: 1;
+    color: rgba(0, 0, 0, 0.42);
   }
+
+  /* Delete: prominent red key (like an ATM CANCEL), wider so it can't be missed */
+  .key.delete {
+    flex: 1.6 1 0;
+    background: linear-gradient(#ff8074, #d8402f) !important;
+    color: #fff !important;
+    border-color: #b5311f !important;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.4),
+      0 3px 0 #9e2a1c,
+      0 5px 8px rgba(0, 0, 0, 0.45) !important;
+  }
+  .key.delete .letter { font-size: 22px; color: #fff; }
   @keyframes blink {
   0% { opacity: 1; }
   50% { opacity: 0; }
@@ -313,13 +343,14 @@
   .letter {
     line-height: 1;
     font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 15px;
+    font-weight: 800;
+    font-size: 17px;
+    color: inherit; /* so purchased/incorrect state colors on .key apply */
   }
   .price {
     line-height: 1;
     font-size: 9px;
-    color: var(--text-faint);
+    color: #565a62;
     font-variant-numeric: tabular-nums;
   }
 

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,7 +8,7 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
 import { freeplayStart, freeplayNext, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, getPowerups, buyPowerup, climbUsePowerup } from '$lib/stores/statsStore.js';
+import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
 import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
@@ -582,6 +582,14 @@ async function submitGuessMakeup(state) {
 }
 
 /* ===== Cash Game / the Climb (real-Cash, fluid, par/bounty + heat) ===== */
+/** Refresh the clue for the current climb puzzle (changes each rung). */
+async function refreshClimbClue() {
+  try {
+    const clue = await getClimbClue();
+    gameStore.update(s => ({ ...s, clue }));
+  } catch { /* non-fatal */ }
+}
+
 /** @param {any} board */
 function reconcileClimbBoard(board) {
   if (!board) return;
@@ -607,6 +615,7 @@ export async function fetchClimbGame() {
     const board = await climbStart();
     if (!board) return false;
     reconcileClimbBoard(board);
+    await refreshClimbClue();
     return true;
   } catch (err) {
     console.error('❌ Error starting climb:', err instanceof Error ? err.message : String(err));
@@ -652,7 +661,7 @@ export async function climbAdvance() {
   dailyInFlight = true;
   try {
     const board = await climbNext();
-    if (board) reconcileClimbBoard(board);
+    if (board) { reconcileClimbBoard(board); await refreshClimbClue(); }
   } finally {
     dailyInFlight = false;
   }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -368,6 +368,13 @@ export async function getArcadeClue() {
   return data ?? null;
 }
 
+/** Witty clue for the caller's current Cash Game (climb) puzzle. @returns {Promise<string|null>} */
+export async function getClimbClue() {
+  const { data, error } = await supabase.rpc('climb_clue');
+  if (error) { console.error('❌ climb_clue error:', error); return null; }
+  return data ?? null;
+}
+
 /**
  * Today's shared Daily Modifier id (same for every player; rotates by date).
  * @returns {Promise<string|null>}

--- a/supabase-climb-clue.sql
+++ b/supabase-climb-clue.sql
@@ -1,0 +1,11 @@
+-- climb_clue()  (migration: climb_clue)
+-- Witty one-line clue for the player's current Cash Game (climb) puzzle, mirroring
+-- arcade_clue / daily_clue. The Cash Game never wired up a clue before, so the hint
+-- line ($gameStore.clue) was always empty in that mode.
+--
+--   SELECT dp.clue FROM climb_state cs
+--   JOIN daily_puzzles dp ON dp.id = cs.puzzle_id
+--   WHERE cs.user_id = auth.uid();
+--
+-- Frontend: getClimbClue() (statsStore) + refreshClimbClue() called after
+-- fetchClimbGame and climbAdvance in GameStore. Full body in the applied migration.


### PR DESCRIPTION
## Summary
Two fixes for the Cash Game screen.

### Hint was missing in Cash Game
The Cash Game (climb) never fetched a clue — every other mode (daily/arcade/freeplay) has a `*_clue` RPC, climb didn't. Added **`climb_clue()`** (mirrors `arcade_clue`, reads `daily_puzzles.clue` for the active climb puzzle), a `getClimbClue()` wrapper, and `refreshClimbClue()` wired after climb start/advance. Verified live: the clue now renders (e.g. "Mr Darcy slow thaw.").

### Silver ATM keyboard
- **Silver beveled keycaps** with per-key **braille** pips (ATM accessibility look).
- **Responsive key widths** (flex) so all 10 keys fit the viewport — fixes the **Z / Del edge clipping** on phones.
- **Bigger keys**, **lifted off the bottom** (safe-area + 12px).
- **Delete restored** as a prominent red ⌫ key in guess mode (it was getting clipped off-screen); raised the Solve/Cancel button to clear the taller keyboard.

Verified end-to-end via Playwright (cash game clue present, 10-key row no clip, red Del visible in guess mode, 0 page errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)