### PR TITLE
Friend search matches name/email, not just username

### DIFF
--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -97,7 +97,10 @@
         {:else}
           {#each results as u}
             <div class="row">
-              <span class="uname">@{u.username}</span>
+              <span class="who">
+                {#if u.name && u.name !== u.username}<span class="rname">{u.name}</span>{/if}
+                <span class="uname">@{u.username}</span>
+              </span>
               {#if u.status === 'friends'}
                 <span class="tag friend">✓ Friend</span>
               {:else if u.status === 'pending_out'}
@@ -186,6 +189,9 @@
   .card { padding: 0.8rem 0.9rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); }
   .card.dim { opacity: 0.7; }
   .list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .who { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+  .rname { font-family: var(--font-display); font-weight: 700; font-size: 0.95rem; line-height: 1.1; }
+  .who .uname { font-weight: 600; font-size: 0.78rem; color: var(--text-muted); }
   .uname { font-family: var(--font-display); font-weight: 700; font-size: 1rem; }
   .row-acts { display: flex; gap: 0.4rem; }
   .act {

--- a/supabase-search-by-name.sql
+++ b/supabase-search-by-name.sql
@@ -1,0 +1,6 @@
+-- search_users by name  (migration: search_users_by_name)
+-- Was username-PREFIX only, so searching a person's real name (e.g. "sam" when
+-- the username is "sbrand21") found nothing. Now matches username (anywhere),
+-- the auth full_name/name, or email prefix, and also returns the person's
+-- display name so results read as "Sam Brandstrader · @sbrand21".
+-- Frontend: friends search rows show name over @handle. Full body in migration.


### PR DESCRIPTION
## Summary
**Why Sam didn't come up:** his username is `sbrand21`, and `search_users` only matched the **username as a prefix** — so typing "sam" returned nothing (same on local and prod; it's one shared DB).

Upgraded `search_users` (migration `search_users_by_name`, already applied) to match:
- username **anywhere** (contains),
- the auth **full name / name**,
- **email** prefix,

and to return the person's **display name**. Friends search rows now show the real name over the `@handle` (e.g. "Sam Brandstrader · @sbrand21"). Verified: searching "sam", "brand", or "sbrand" all find him.

🤖 Generated with [Claude Code](https://claude.com/claude-code)