### PR TITLE
Surface real Google OAuth failure reason

### DIFF
--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -27,14 +27,18 @@
     try {
       const params = new URLSearchParams(window.location.search);
       const ae = params.get('auth_error');
+      const detail = params.get('auth_detail');
       if (ae) {
         errorMsg = ae === 'exchange' || ae === 'nocode'
           ? 'Sign-in didn’t complete — please try again, or use email & password.'
           : ae === 'config'
           ? 'Sign-in is temporarily unavailable. Please try again shortly.'
           : `Google sign-in was cancelled or blocked: ${decodeURIComponent(ae)}`;
+        if (detail) errorMsg += ` (${decodeURIComponent(detail)})`;
+        track('oauth_callback_error', { reason: ae, detail: detail ? decodeURIComponent(detail) : '' });
         // strip the param so it doesn't stick around on refresh
         params.delete('auth_error');
+        params.delete('auth_detail');
         const qs = params.toString();
         window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
       }

--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -46,7 +46,7 @@ export const GET = async ({ url, cookies }) => {
       return redirect(303, next);
     }
     console.error('Auth callback exchange error:', error.message);
-    return redirect(303, '/?auth_error=exchange');
+    return redirect(303, '/?auth_error=exchange&auth_detail=' + encodeURIComponent(error.message));
   }
 
   return redirect(303, '/?auth_error=nocode');


### PR DESCRIPTION
## Summary
Diagnostics for the Google sign-in failures (users bounced back to sign-in / stuck on account creation).

- `/auth/callback` now appends the actual GoTrue exchange error to the redirect (`?auth_error=exchange&auth_detail=...`).
- The Auth screen shows that detail and fires an `oauth_callback_error` analytics event, so we capture **why** it failed (missing PKCE verifier cookie, redirect not allow-listed, identity-link conflict, etc.) instead of a generic "didn't complete."

No behavior change on success; this just makes the failure self-reporting so we can pinpoint the config/flow cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)