### PR TITLE
Fix Google sign-in: httpOnly session cookies hid the session

### DIFF
--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -32,7 +32,10 @@ export const GET = async ({ url, cookies }) => {
             cookies.set(name, value, {
               ...options,
               path: '/',
-              httpOnly: true,
+              // MUST be JS-readable: the app reads the session with the BROWSER
+              // Supabase client (document.cookie). httpOnly here = the session is
+              // set but invisible to the app → "No session" after Google sign-in.
+              httpOnly: false,
               sameSite: 'lax',
               secure: import.meta.env.PROD
             });

--- a/src/routes/auth/confirm/+server.js
+++ b/src/routes/auth/confirm/+server.js
@@ -23,7 +23,7 @@ export const GET = async ({ url, cookies }) => {
             cookies.set(name, value, {
               ...options,
               path: '/',
-              httpOnly: true,
+              httpOnly: false, // browser Supabase client must read the session via document.cookie
               sameSite: 'lax',
               secure: import.meta.env.PROD
             });


### PR DESCRIPTION
## Root cause
Google sign-in reached Google, exchanged the code successfully, and redirected home — but the app showed **"No session"** and bounced back to the login screen (no error in the URL).

`/auth/callback` (and `/auth/confirm`) wrote the Supabase **session cookies with `httpOnly: true`**. This app has **no server session hook** — it reads the session entirely with the **browser** client (`supabase.auth.getSession()` via `document.cookie`), which **cannot read httpOnly cookies**. So the session was set but invisible → "No session" → bounce.

Email/password worked because `signInWithPassword` runs in the browser client, which sets its own JS-readable cookies.

## Fix
Set `httpOnly: false` on the session cookies in both server callbacks so the browser client can read them — the standard `@supabase/ssr` browser-client cookie model (the access token is meant to be JS-readable here; consistent with the existing auth model). No behavior change for email/password.

Verified the build; confirmed there's no `hooks.server.js`/`+layout.server.js` relying on httpOnly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)