### PR TITLE
Fix friend requests from usernameless accounts

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -188,16 +188,16 @@ export async function addFriend(username) {
   return data;
 }
 
-/** Accept or decline an incoming request. @param {string} username @param {boolean} accept @returns {Promise<{ok:boolean, reason?:string, status?:string}>} */
-export async function respondFriendRequest(username, accept) {
-  const { data, error } = await supabase.rpc('respond_friend_request', { p_username: username, p_accept: accept });
+/** Accept or decline an incoming request, by requester id. @param {string} requesterId @param {boolean} accept @returns {Promise<{ok:boolean, reason?:string, status?:string}>} */
+export async function respondFriendRequest(requesterId, accept) {
+  const { data, error } = await supabase.rpc('respond_friend_request', { p_requester: requesterId, p_accept: accept });
   if (error || !data) { if (error) console.error('❌ respond_friend_request:', error); return { ok: false }; }
   return data;
 }
 
-/** Unfriend by username. @param {string} username @returns {Promise<{ok:boolean}>} */
-export async function removeFriend(username) {
-  const { data, error } = await supabase.rpc('remove_friend', { p_username: username });
+/** Unfriend by user id. @param {string} otherId @returns {Promise<{ok:boolean}>} */
+export async function removeFriend(otherId) {
+  const { data, error } = await supabase.rpc('remove_friend', { p_other: otherId });
   if (error || !data) { if (error) console.error('❌ remove_friend:', error); return { ok: false }; }
   return data;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -610,9 +610,9 @@
   let notifResponded = {};
   /** Accept/decline a friend request straight from the bell panel. @param {any} n @param {boolean} accept */
   async function respondNotif(n, accept) {
-    const uname = n?.data?.from_username;
-    if (!uname || notifResponded[n.id]) return;
-    const res = await respondFriendRequest(uname, accept);
+    const fromId = n?.data?.from_id;
+    if (!fromId || notifResponded[n.id]) return;
+    const res = await respondFriendRequest(fromId, accept);
     if (res?.ok) {
       notifResponded = { ...notifResponded, [n.id]: accept ? 'accepted' : 'declined' };
       fx(accept ? 'win' : 'tap');
@@ -1166,7 +1166,7 @@
                     <span class="ni-title">{n.title}</span>
                     <span class="ni-body">{n.body}</span>
                   </button>
-                  {#if n.type === 'friend_request' && n.data?.from_username}
+                  {#if n.type === 'friend_request' && n.data?.from_id}
                     {#if notifResponded[n.id]}
                       <span class="ni-done {notifResponded[n.id]}">{notifResponded[n.id] === 'accepted' ? '✓ Friends' : 'Declined'}</span>
                     {:else}

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -61,23 +61,26 @@
     }
   }
 
-  /** @param {string} username @param {boolean} accept */
-  async function respond(username, accept) {
+  /** @param {any} u @param {boolean} accept */
+  async function respond(u, accept) {
     if (busy) return;
-    busy = username;
-    const res = await respondFriendRequest(username, accept);
+    busy = u.id;
+    const res = await respondFriendRequest(u.id, accept);
     busy = '';
-    if (res?.ok) { fx(accept ? 'win' : 'tap'); track('friend_respond', { from: username, accept }); await load(); }
+    if (res?.ok) { fx(accept ? 'win' : 'tap'); track('friend_respond', { accept }); await load(); }
   }
 
-  /** @param {string} username */
-  async function unfriend(username) {
+  /** @param {any} u */
+  async function unfriend(u) {
     if (busy) return;
-    busy = username;
-    await removeFriend(username);
+    busy = u.id;
+    await removeFriend(u.id);
     busy = '';
     fx('tap'); await load();
   }
+
+  /** Display label: @username if they have one, else their name. @param {any} u */
+  const label = (u) => (u.username ? '@' + u.username : (u.name || 'Player'));
 </script>
 
 <svelte:head><title>WordBank — Friends</title></svelte:head>
@@ -106,7 +109,7 @@
               {:else if u.status === 'pending_out'}
                 <span class="tag pending">Requested</span>
               {:else if u.status === 'pending_in'}
-                <button class="act accept" disabled={busy === u.username} onclick={() => respond(u.username, true)}>Accept</button>
+                <button class="act accept" disabled={busy === u.id} onclick={() => respond(u, true)}>Accept</button>
               {:else}
                 <button class="act add" disabled={busy === u.username} onclick={() => add(u.username)}>+ Add</button>
               {/if}
@@ -127,10 +130,10 @@
       <div class="list">
         {#each incoming as u}
           <div class="row card">
-            <span class="uname">@{u.username}</span>
+            <span class="uname">{label(u)}</span>
             <div class="row-acts">
-              <button class="act accept" disabled={busy === u.username} onclick={() => respond(u.username, true)}>Accept</button>
-              <button class="act decline" disabled={busy === u.username} onclick={() => respond(u.username, false)}>Decline</button>
+              <button class="act accept" disabled={busy === u.id} onclick={() => respond(u, true)}>Accept</button>
+              <button class="act decline" disabled={busy === u.id} onclick={() => respond(u, false)}>Decline</button>
             </div>
           </div>
         {/each}
@@ -144,8 +147,8 @@
       <div class="list">
         {#each friends as u}
           <div class="row card">
-            <span class="uname">@{u.username}</span>
-            <button class="act remove" disabled={busy === u.username} onclick={() => unfriend(u.username)} title="Remove friend">✕</button>
+            <span class="uname">{label(u)}</span>
+            <button class="act remove" disabled={busy === u.id} onclick={() => unfriend(u)} title="Remove friend">✕</button>
           </div>
         {/each}
       </div>
@@ -156,7 +159,7 @@
       <div class="list">
         {#each outgoing as u}
           <div class="row card dim">
-            <span class="uname">@{u.username}</span>
+            <span class="uname">{label(u)}</span>
             <span class="tag pending">Pending</span>
           </div>
         {/each}

--- a/supabase-friends-by-id.sql
+++ b/supabase-friends-by-id.sql
@@ -1,0 +1,14 @@
+-- Friends keyed by user ID  (migrations: friends_by_id, search_users_include_id)
+-- Accounts can exist without a username (new Google/Apple/email users before they
+-- claim one). The friend system keyed everything on username, so a usernameless
+-- requester rendered blank and Accept/Decline couldn't resolve them.
+--
+-- - list_friends / list_friend_requests / search_users now return `id` + a
+--   display `name` (via _display_name fallback: username → full_name → email
+--   prefix → 'Player').
+-- - respond_friend_request(p_requester uuid, accept) and remove_friend(p_other
+--   uuid) now act by ID (the old text/username overloads are dropped).
+-- - add_friend requires the SENDER to have a username (reason 'need_username')
+--   so the graph has handles going forward, and the friend_request notification
+--   carries data.from_id for the bell-panel inline Accept.
+-- Frontend (friends page + bell) acts by id, displays @username or name.


### PR DESCRIPTION
## What was broken
A request from `sincerely.edithp@icloud.com` showed up **blank** with un-clickable Accept/Decline. Cause: the account hasn't set a username, and the friend system keyed every action on username — so a usernameless requester couldn't be displayed or acted on.

## Fix — key by user id, display by name
- `list_friends` / `list_friend_requests` / `search_users` now return **`id`** + a **display `name`** (`_display_name` fallback: username → full name → email prefix → "Player").
- `respond_friend_request(uuid, bool)` and `remove_friend(uuid)` act **by id** (old username overloads dropped).
- `add_friend` now requires the **sender** to have a username (`need_username`) so the graph keeps handles going forward; the friend-request notification carries `from_id` for the bell-panel inline Accept.
- Friends page + bell panel act by id and show `@username` or the display name.

Verified on the actual stuck request: it now shows as "sincerely.edithp" and **accept-by-id works** (rolled back so the owner accepts it in the UI). Migrations `friends_by_id` + `search_users_include_id` applied.

Follow-up worth doing: prompt users to set a username at signup (the real root cause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)