### PR TITLE
ATM PIN unlock + vault balance reveal

### DIFF
--- a/src/lib/components/PinGate.svelte
+++ b/src/lib/components/PinGate.svelte
@@ -1,0 +1,186 @@
+<script>
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { tweened } from 'svelte/motion';
+  import { cubicOut } from 'svelte/easing';
+  import PinPad from '$lib/components/PinPad.svelte';
+  import { setPin, verifyPin, tooManyFails, rememberedName } from '$lib/pin.js';
+  import { getBank } from '$lib/stores/statsStore.js';
+  import { fx } from '$lib/sound.js';
+
+  /** @type {'set'|'unlock'} */
+  export let mode = 'unlock';
+  export let uid = '';
+  /** @type {string|null} */
+  export let name = null;
+  /** @type {number|null} */
+  export let balance = null;
+
+  const dispatch = createEventDispatcher();
+
+  // set-PIN flow
+  let step = 'create'; // 'create' | 'confirm'
+  let firstPin = '';
+  let msg = '';
+  let error = false;
+  /** @type {any} */
+  let pad;
+
+  // vault reveal
+  let revealing = false;
+  let doorOpen = false;
+  const shownBalance = tweened(0, { duration: 1100, easing: cubicOut });
+
+  let displayName = name || rememberedName();
+
+  function flashError(text) {
+    msg = text; error = true;
+    setTimeout(() => { error = false; pad?.reset(); }, 480);
+  }
+
+  /** @param {CustomEvent<string>} e */
+  async function onSubmit(e) {
+    const pin = e.detail;
+    msg = '';
+    if (mode === 'set') {
+      if (step === 'create') {
+        firstPin = pin;
+        step = 'confirm';
+        pad?.reset();
+      } else {
+        if (pin === firstPin) {
+          await setPin(uid, name, pin);
+          fx('win');
+          dispatch('pinset');
+        } else {
+          step = 'create'; firstPin = '';
+          flashError('PINs didn’t match — try again.');
+        }
+      }
+      return;
+    }
+    // unlock
+    const ok = await verifyPin(uid, pin);
+    if (ok) {
+      await openVault();
+    } else if (tooManyFails()) {
+      msg = 'Too many tries — sign in with your password.';
+      setTimeout(() => dispatch('logout'), 900);
+    } else {
+      flashError('Wrong PIN — try again.');
+    }
+  }
+
+  async function openVault() {
+    revealing = true;
+    fx('win');
+    // fetch a fresh balance for the reveal if we weren't handed one
+    let bal = balance;
+    if (bal == null) { try { const b = await getBank(); bal = b?.bank ?? b?.cash ?? 0; } catch { bal = 0; } }
+    // door swings, then number spins up
+    setTimeout(() => { doorOpen = true; }, 250);
+    setTimeout(() => { shownBalance.set(bal ?? 0); }, 900);
+  }
+
+  function enter() { dispatch('unlocked'); }
+  onMount(() => { /* mode-driven render */ });
+
+  $: title = mode === 'set'
+    ? (step === 'create' ? 'Create your PIN' : 'Confirm your PIN')
+    : 'Enter your PIN';
+  $: sub = mode === 'set'
+    ? (step === 'create' ? 'A 4-digit PIN to unlock WordBank fast on this device.' : 'Type it once more to confirm.')
+    : (displayName ? `Welcome back, @${displayName}` : 'Welcome back');
+</script>
+
+{#if revealing}
+  <!-- 🔐 Vault reveal -->
+  <div class="vault" class:open={doorOpen} on:click={enter} role="button" tabindex="0"
+       on:keydown={(e) => { if (e.key === 'Enter') enter(); }}>
+    <div class="vault-stage">
+      <div class="reveal">
+        <span class="reveal-label">Your balance</span>
+        <span class="reveal-amount">${Math.round($shownBalance).toLocaleString()}</span>
+        {#if doorOpen}<span class="reveal-go">Tap to enter →</span>{/if}
+      </div>
+      <div class="door">
+        <div class="door-ring"></div>
+        <div class="door-dial"><span class="spoke"></span><span class="spoke"></span><span class="spoke"></span></div>
+        <img class="door-coin" src="/logo-coin.png" alt="" />
+      </div>
+    </div>
+  </div>
+{:else}
+  <!-- PIN entry (set or unlock) -->
+  <div class="pin-screen">
+    <img class="pin-coin" src="/logo-coin.png" alt="" />
+    <h2 class="pin-title">{title}</h2>
+    <p class="pin-sub">{sub}</p>
+    <PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
+    {#if msg}<p class="pin-msg" class:err={error}>{msg}</p>{/if}
+    {#if mode === 'unlock'}
+      <button class="pin-forgot" on:click={() => dispatch('logout')}>Forgot PIN? Sign in with password</button>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .pin-screen {
+    position: fixed; inset: 0; z-index: 2500; display: flex; flex-direction: column; align-items: center;
+    justify-content: flex-start; padding: 8vh 1.2rem 2rem; text-align: center;
+    background: radial-gradient(70% 50% at 50% 12%, rgba(251,191,36,0.14), rgba(0,0,0,0) 60%), #070707;
+  }
+  .pin-coin { width: 84px; height: auto; filter: drop-shadow(0 6px 22px rgba(251,191,36,0.45)); }
+  .pin-title { font-family: var(--font-display); font-size: 1.5rem; margin: 0.6rem 0 0.2rem; }
+  .pin-sub { color: var(--text-muted); font-size: 0.9rem; margin: 0 0 1.8rem; max-width: 300px; }
+  .pin-msg { margin-top: 1rem; font-size: 0.88rem; color: var(--text-muted); }
+  .pin-msg.err { color: #f87171; }
+  .pin-forgot { margin-top: 1.6rem; background: none; border: none; color: var(--text-faint); font-size: 0.82rem; text-decoration: underline; cursor: pointer; }
+
+  /* ---- vault reveal ---- */
+  .vault {
+    position: fixed; inset: 0; z-index: 2600; display: grid; place-items: center; cursor: pointer;
+    background: radial-gradient(60% 50% at 50% 50%, #14110a, #050505 70%);
+    overflow: hidden;
+  }
+  .vault-stage { position: relative; width: 300px; height: 300px; display: grid; place-items: center; }
+  .reveal {
+    position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 6px; opacity: 0; transform: scale(0.9); transition: opacity 0.6s 0.4s, transform 0.6s 0.4s;
+  }
+  .vault.open .reveal { opacity: 1; transform: scale(1); }
+  .reveal-label { font-size: 0.85rem; letter-spacing: 0.18em; text-transform: uppercase; color: #b9962f; }
+  .reveal-amount {
+    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.6rem; color: #fde047;
+    text-shadow: 0 0 18px rgba(251,191,36,0.7), 0 0 40px rgba(251,191,36,0.4);
+  }
+  .reveal-go { margin-top: 1rem; font-size: 0.82rem; color: var(--text-faint); animation: pulse 1.4s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 0.5; } 50% { opacity: 1; } }
+
+  /* the safe door sitting over the reveal, swings/scales away on open */
+  .door {
+    position: absolute; inset: 0; display: grid; place-items: center; border-radius: 50%;
+    background: radial-gradient(circle at 38% 32%, #3a2f12, #1a1407 70%);
+    box-shadow: inset 0 0 0 10px rgba(251,191,36,0.15), inset 0 0 60px rgba(0,0,0,0.7), 0 18px 50px rgba(0,0,0,0.7);
+    transform-origin: 50% 50%;
+    transition: transform 1s cubic-bezier(0.6,0,0.2,1), opacity 0.9s 0.5s;
+  }
+  .door-ring {
+    position: absolute; inset: 20px; border-radius: 50%;
+    border: 6px solid rgba(251,191,36,0.45); box-shadow: inset 0 0 24px rgba(251,191,36,0.2);
+  }
+  .door-dial {
+    position: absolute; width: 96px; height: 96px; border-radius: 50%;
+    background: radial-gradient(circle at 40% 35%, #fbcf4b, #9a6f12);
+    box-shadow: 0 0 0 8px rgba(0,0,0,0.35), 0 6px 14px rgba(0,0,0,0.6);
+    transition: transform 1s cubic-bezier(0.5,0,0.2,1);
+  }
+  .spoke { position: absolute; top: 50%; left: 50%; width: 54px; height: 6px; border-radius: 3px;
+    background: linear-gradient(90deg, #7a5a0e, #fde047, #7a5a0e); transform-origin: 0 50%; }
+  .spoke:nth-child(1) { transform: translate(-50%,-50%) rotate(0deg); }
+  .spoke:nth-child(2) { transform: translate(-50%,-50%) rotate(60deg); }
+  .spoke:nth-child(3) { transform: translate(-50%,-50%) rotate(120deg); }
+  .door-coin { position: absolute; width: 70px; height: auto; opacity: 0.9; }
+
+  .vault.open .door { transform: rotate(115deg) scale(2.1); opacity: 0; }
+  .vault.open .door-dial { transform: rotate(540deg); }
+</style>

--- a/src/lib/components/PinPad.svelte
+++ b/src/lib/components/PinPad.svelte
@@ -1,0 +1,95 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+  import { fx } from '$lib/sound.js';
+
+  export let length = 4;
+  export let error = false; // parent sets true to flash/shake
+
+  const dispatch = createEventDispatcher();
+  let digits = '';
+
+  export function reset() { digits = ''; }
+
+  /** @param {string} d */
+  function press(d) {
+    if (digits.length >= length) return;
+    digits += d;
+    fx('tap');
+    dispatch('change', digits);
+    if (digits.length === length) dispatch('submit', digits);
+  }
+  function backspace() { if (digits.length) { digits = digits.slice(0, -1); fx('tap'); dispatch('change', digits); } }
+  function clearAll() { digits = ''; fx('tap'); dispatch('change', digits); }
+  function enter() { if (digits.length === length) dispatch('submit', digits); }
+</script>
+
+<div class="pinpad" class:error>
+  <!-- entered-digit dots -->
+  <div class="dots">
+    {#each Array(length) as _, i}
+      <span class="dot" class:filled={i < digits.length}></span>
+    {/each}
+  </div>
+
+  <div class="keys">
+    <button class="key num" on:click={() => press('1')}>1</button>
+    <button class="key num" on:click={() => press('2')}>2</button>
+    <button class="key num" on:click={() => press('3')}>3</button>
+    <button class="key act cancel" on:click={clearAll} aria-label="Cancel">✕</button>
+
+    <button class="key num" on:click={() => press('4')}>4</button>
+    <button class="key num" on:click={() => press('5')}>5</button>
+    <button class="key num" on:click={() => press('6')}>6</button>
+    <button class="key act clear" on:click={backspace} aria-label="Delete">⌫</button>
+
+    <button class="key num" on:click={() => press('7')}>7</button>
+    <button class="key num" on:click={() => press('8')}>8</button>
+    <button class="key num" on:click={() => press('9')}>9</button>
+    <button class="key act enter" on:click={enter} aria-label="Enter">⏎</button>
+
+    <button class="key num zero" on:click={() => press('0')}>0</button>
+  </div>
+</div>
+
+<style>
+  .pinpad { width: 100%; max-width: 320px; margin: 0 auto; }
+  .dots { display: flex; justify-content: center; gap: 16px; margin-bottom: 22px; }
+  .dot {
+    width: 15px; height: 15px; border-radius: 50%;
+    border: 2px solid rgba(251, 191, 36, 0.5); background: transparent;
+    transition: transform 0.12s, background 0.15s, box-shadow 0.15s;
+  }
+  .dot.filled {
+    background: #fde047; border-color: #fde047;
+    box-shadow: 0 0 10px rgba(251, 191, 36, 0.8); transform: scale(1.08);
+  }
+  .pinpad.error .dots { animation: shake 0.4s; }
+  .pinpad.error .dot { border-color: #f87171; }
+  @keyframes shake {
+    0%,100% { transform: translateX(0); }
+    20%,60% { transform: translateX(-8px); }
+    40%,80% { transform: translateX(8px); }
+  }
+
+  .keys { display: grid; grid-template-columns: repeat(4, 1fr); gap: 9px; }
+  .key {
+    height: 56px; border-radius: 12px; cursor: pointer; position: relative;
+    font-family: 'Orbitron', var(--font-display); font-weight: 700; font-size: 22px;
+    border: 1px solid rgba(251, 191, 36, 0.3);
+    background: linear-gradient(160deg, #1c1f28, #0c0e13);
+    color: #f4e7c6;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), 0 2px 0 rgba(0,0,0,0.6), 0 4px 8px rgba(0,0,0,0.5);
+    transition: transform 0.1s, box-shadow 0.12s, border-color 0.15s;
+  }
+  .key:active {
+    transform: translateY(1px) scale(0.97);
+    border-color: #fde047;
+    box-shadow: 0 0 0 2px rgba(253,224,71,1), 0 0 16px rgba(251,191,36,0.9), 0 0 34px rgba(251,191,36,0.6);
+  }
+  .key.zero { grid-column: 1 / 4; }
+  /* ATM colored action keys */
+  .key.act { font-size: 18px; }
+  .key.cancel { background: linear-gradient(160deg, #f0584a, #b5311f); color: #fff; border-color: #b5311f; }
+  .key.clear  { background: linear-gradient(160deg, #f6c945, #c98f12); color: #2a2000; border-color: #c98f12; }
+  .key.enter  { background: linear-gradient(160deg, #46d07e, #1f9b4e); color: #06210f; border-color: #1f9b4e; }
+</style>

--- a/src/lib/pin.js
+++ b/src/lib/pin.js
@@ -1,0 +1,68 @@
+// Device-local PIN unlock (approach A): the real credential stays email+password.
+// The PIN is a fast, on-device privacy lock layered on top of a persistent session.
+// We store only a SHA-256 hash (salted with the user id) in localStorage — never
+// the raw PIN — plus the remembered username and a wrong-attempt counter.
+import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+const HASH_KEY = 'wb_pin_hash';
+const USER_KEY = 'wb_pin_user';   // user id this device's PIN belongs to
+const NAME_KEY = 'wb_pin_name';   // remembered @username for the lock screen
+const FAILS_KEY = 'wb_pin_fails';
+
+export const MAX_PIN_FAILS = 5;
+export const PIN_LENGTH = 4;
+
+/** True while the app is PIN-locked (session valid but awaiting the PIN). */
+export const pinLocked = writable(false);
+
+/** @param {string} pin @param {string} uid */
+async function hashPin(pin, uid) {
+  const data = new TextEncoder().encode(`wb:${uid}:${pin}`);
+  const buf = await crypto.subtle.digest('SHA-256', data);
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Is a PIN set on THIS device for this user? @param {string} uid */
+export function hasPinFor(uid) {
+  return !!(browser && localStorage.getItem(HASH_KEY) && localStorage.getItem(USER_KEY) === uid);
+}
+
+/** Remembered username for the lock screen (this device). */
+export function rememberedName() {
+  return browser ? localStorage.getItem(NAME_KEY) : null;
+}
+
+/** Store a new PIN for this device+user. @param {string} uid @param {string|null} name @param {string} pin */
+export async function setPin(uid, name, pin) {
+  if (!browser) return;
+  localStorage.setItem(HASH_KEY, await hashPin(pin, uid));
+  localStorage.setItem(USER_KEY, uid);
+  if (name) localStorage.setItem(NAME_KEY, name);
+  localStorage.removeItem(FAILS_KEY);
+}
+
+/** Verify an entered PIN; tracks failures. @param {string} uid @param {string} pin */
+export async function verifyPin(uid, pin) {
+  if (!browser) return false;
+  const ok = (await hashPin(pin, uid)) === localStorage.getItem(HASH_KEY);
+  if (ok) localStorage.removeItem(FAILS_KEY);
+  else localStorage.setItem(FAILS_KEY, String(pinFails() + 1));
+  return ok;
+}
+
+export function pinFails() {
+  return browser ? Number(localStorage.getItem(FAILS_KEY) || 0) : 0;
+}
+export function tooManyFails() {
+  return pinFails() >= MAX_PIN_FAILS;
+}
+
+/** Forget the PIN (forgot-PIN / logout). Keeps the remembered name unless full=true. */
+export function clearPin(full = false) {
+  if (!browser) return;
+  localStorage.removeItem(HASH_KEY);
+  localStorage.removeItem(USER_KEY);
+  localStorage.removeItem(FAILS_KEY);
+  if (full) localStorage.removeItem(NAME_KEY);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,8 @@
   import { gameWasRestored } from '$lib/stores/GameStateFlags.js';
   import { soundEnabled, toggleSound, fx } from '$lib/sound.js';
   import { startMusic, stopMusic, musicEnabled, musicVolume, setMusicVolume, toggleMusic, TRACKS, currentTrackId, selectTrack } from '$lib/music.js';
+  import PinGate from '$lib/components/PinGate.svelte';
+  import { pinLocked, hasPinFor, clearPin } from '$lib/pin.js';
   import { goto } from '$app/navigation';
 
   import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
@@ -40,6 +42,8 @@
   let showResultModal = false;
   let hasTriggeredModal = false;
   let hasInitialized = false;
+  let sessionUid = '';     // current session user id (for the PIN gate)
+  let pinNotSet = false;   // logged in on this device with no PIN yet → prompt setup
   /** @type {string | null} */
   let initError = null; // 🔍 Diagnostic: what failed during init
   /** Show main menu (Daily / Arcade / Leaderboard / My account) when true; game when false */
@@ -127,6 +131,12 @@
         return;
       }
 
+      // Device PIN gate (approach A): if a PIN is set on this device, lock until it's
+      // entered; otherwise mark that we should prompt to set one (after username).
+      sessionUid = session.user.id;
+      if (hasPinFor(sessionUid)) pinLocked.set(true);
+      else pinNotSet = true;
+
       // Make-up daily launched from the streak calendar → drop straight into the board.
       if (localStorage.getItem('gameMode') === 'makeup' && localStorage.getItem('makeupDate')) {
         showMainMenu = false;
@@ -209,8 +219,14 @@
 
   // Reactive state values
   $: loggedIn = !!$user?.id;
-  // Lobby music: play while the menu is showing, pause during gameplay / logged out.
-  $: if (browser) { (loggedIn && hasInitialized && showMainMenu) ? startMusic() : stopMusic(); }
+  // PIN gate: unlock screen for returning users; set-PIN after username for new ones.
+  $: showPinUnlock = loggedIn && hasInitialized && $pinLocked;
+  $: showPinSetup = loggedIn && hasInitialized && !$pinLocked && pinNotSet && !needsUsername;
+  function onPinUnlocked() { pinLocked.set(false); }
+  function onPinSet() { pinNotSet = false; }
+  function onPinLogout() { clearPin(); pinLocked.set(false); pinNotSet = false; handleLogout(); }
+  // Lobby music: play in the menu only — not while locked, setting a PIN, or in-game.
+  $: if (browser) { (loggedIn && hasInitialized && showMainMenu && !showPinUnlock && !showPinSetup) ? startMusic() : stopMusic(); }
   $: bankroll = $gameStore.bankroll || 0;
   $: digits = String(bankroll).split('');
 
@@ -496,8 +512,9 @@
   // Bump this key whenever the tutorial gains new content — it re-shows for
   // everyone on next login (v3 = persistent Cash, spend-the-least, attendance, no loans).
   const TUTORIAL_KEY = 'wb_tutorial_v3';
-  // First-run guided tutorial: show once a signed-in user reaches the menu.
-  $: if (browser && loggedIn && hasInitialized && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
+  // First-run guided tutorial: show once a signed-in user is past the username/PIN
+  // gates and on the menu (not while those full-screen gates are up).
+  $: if (browser && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
     showTutorial = true;
   }
   function dismissTutorial() {
@@ -513,6 +530,7 @@
   // ✅ Log out: clear saved game so next login always shows main menu
   const handleLogout = async () => {
     clearSavedGame();
+    clearPin(); // forget this device's PIN so the next person can't unlock the account
     gameWasRestored.set(false);
     await supabase.auth.signOut();
     user.set(null);
@@ -932,6 +950,15 @@
         <p class="claim-hint">3–15 characters · letters, numbers, or _</p>
       </div>
     </div>
+  {/if}
+
+  <!-- 🔐 PIN gate: unlock (returning) or set (new), full-screen over everything -->
+  {#if showPinUnlock}
+    <PinGate mode="unlock" uid={sessionUid} name={maUsername} balance={netWorth}
+      on:unlocked={onPinUnlocked} on:logout={onPinLogout} />
+  {:else if showPinSetup}
+    <PinGate mode="set" uid={sessionUid} name={maUsername}
+      on:pinset={onPinSet} on:logout={onPinLogout} />
   {/if}
 
   {#if !loggedIn}


### PR DESCRIPTION
## Summary
A 4-digit **ATM-style PIN** to unlock the app fast, then a **vault-opening reveal** of your balance — exactly as described, with approach **A** (PIN is a device-local privacy lock; email+password stays the real, recoverable credential).

### Pieces
- **`pin.js`** — stores only a **SHA-256 hash** (salted with the user id) in localStorage, plus the remembered username and a wrong-try counter. **5 wrong tries → falls back to password.** Never stores the raw PIN.
- **`PinPad.svelte`** — the ATM keypad: gold Orbitron numbers + **red CANCEL / yellow CLEAR / green ENTER**, 4 PIN dots, auto-submits on the 4th digit.
- **`PinGate.svelte`** — set-PIN (create → confirm), unlock (verify), and the **vault reveal**: a gold safe door spins + swings open to your **balance counting up**, "Tap to enter."
- **`+page.svelte`** — gate order: **username → set PIN (new device) / unlock (returning) → menu**; the tutorial now waits for the gates; logout forgets the device PIN.

### Flow
- New: sign up → pick username → **create + confirm PIN** → in.
- Returning (same device): **enter PIN → vault opens → balance → menu** (4 taps, no typing).
- New device / forgot PIN: **email + password**, then set a PIN for that device.

Verified end-to-end via Playwright (create→confirm→menu→reload locks→enter→vault, 0 errors). Real security teeth land with the native app (Keychain + Face ID) — this is the on-brand UX now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)