### PR TITLE
Vault polish: clunk sound + gold light burst

### DIFF
--- a/src/lib/components/PinGate.svelte
+++ b/src/lib/components/PinGate.svelte
@@ -72,13 +72,12 @@
 
   async function openVault() {
     revealing = true;
-    fx('win');
     // fetch a fresh balance for the reveal if we weren't handed one
     let bal = balance;
     if (bal == null) { try { const b = await getBank(); bal = b?.bank ?? b?.cash ?? 0; } catch { bal = 0; } }
-    // door swings, then number spins up
-    setTimeout(() => { doorOpen = true; }, 250);
-    setTimeout(() => { shownBalance.set(bal ?? 0); }, 900);
+    // brief pause on the closed door, then CLUNK + light burst + swing open
+    setTimeout(() => { doorOpen = true; fx('vault'); }, 650);
+    setTimeout(() => { shownBalance.set(bal ?? 0); }, 1150);
   }
 
   function enter() { dispatch('unlocked'); }
@@ -97,6 +96,7 @@
   <div class="vault" class:open={doorOpen} on:click={enter} role="button" tabindex="0"
        on:keydown={(e) => { if (e.key === 'Enter') enter(); }}>
     <div class="vault-stage">
+      <div class="burst"></div>
       <div class="reveal">
         <span class="reveal-label">Your balance</span>
         <span class="reveal-amount">${Math.round($shownBalance).toLocaleString()}</span>
@@ -143,6 +143,18 @@
     overflow: hidden;
   }
   .vault-stage { position: relative; width: 300px; height: 300px; display: grid; place-items: center; }
+  /* gold light burst at the moment the door opens */
+  .burst {
+    position: absolute; top: 50%; left: 50%; width: 60px; height: 60px; margin: -30px 0 0 -30px;
+    border-radius: 50%; pointer-events: none; opacity: 0; transform: scale(0);
+    background: radial-gradient(circle, rgba(255,255,255,0.95), rgba(253,224,71,0.85) 28%, rgba(251,191,36,0.45) 50%, rgba(251,191,36,0) 72%);
+  }
+  .vault.open .burst { animation: burst 1s ease-out; }
+  @keyframes burst {
+    0% { opacity: 0; transform: scale(0); }
+    12% { opacity: 1; }
+    100% { opacity: 0; transform: scale(16); }
+  }
   .reveal {
     position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
     gap: 6px; opacity: 0; transform: scale(0.9); transition: opacity 0.6s 0.4s, transform 0.6s 0.4s;

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -91,6 +91,14 @@ const SOUNDS = {
   multiplier: () => {
     tone(880, 0.09, 'sine', 0.13);
     tone(1320, 0.13, 'sine', 0.12, 0.08);
+  },
+  // Heavy metallic vault CLUNK: mechanism click → deep thunk → metal overtone.
+  vault: () => {
+    tone(140, 0.05, 'square', 0.16);            // latch click
+    tone(82, 0.34, 'sine', 0.34, 0.03);         // heavy thunk
+    tone(58, 0.42, 'triangle', 0.24, 0.05);     // low body
+    tone(360, 0.2, 'triangle', 0.07, 0.04);     // metallic ring
+    sweep(520, 180, 0.3, 'sawtooth', 0.06, 0.05); // dampened resonance
   }
 };
 
@@ -103,7 +111,8 @@ const HAPTICS = {
   reveal: [12],
   win: [18, 40, 18, 40, 36],
   bust: [60, 30, 60],
-  multiplier: [10, 24, 10]
+  multiplier: [10, 24, 10],
+  vault: [50, 30, 90]
 };
 
 /** Play an audio cue by name (no-op when disabled). @param {string} name */


### PR DESCRIPTION
## Summary
Polishes the PIN-unlock vault reveal:
- **Clunk** — new synthesised `vault` cue (latch click → deep thunk → metallic overtone → dampened resonance) + a heavy haptic, fired the instant the door swings open.
- **Light burst** — a radial gold flash bursts from the center as the door opens.
- Tweaked timing: a brief beat on the closed door, then clunk + burst + swing together, then the balance counts up.

Verified via Playwright (door-open burst frame + final balance reveal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)