### PR TITLE
Make the vault burst visible (full-screen flash + hinge swing)

### DIFF
--- a/src/lib/components/PinGate.svelte
+++ b/src/lib/components/PinGate.svelte
@@ -96,18 +96,21 @@
   <div class="vault" class:open={doorOpen} on:click={enter} role="button" tabindex="0"
        on:keydown={(e) => { if (e.key === 'Enter') enter(); }}>
     <div class="vault-stage">
-      <div class="burst"></div>
       <div class="reveal">
         <span class="reveal-label">Your balance</span>
         <span class="reveal-amount">${Math.round($shownBalance).toLocaleString()}</span>
         {#if doorOpen}<span class="reveal-go">Tap to enter →</span>{/if}
       </div>
-      <div class="door">
-        <div class="door-ring"></div>
-        <div class="door-dial"><span class="spoke"></span><span class="spoke"></span><span class="spoke"></span></div>
-        <img class="door-coin" src="/logo-coin.png" alt="" />
+      <div class="door-hinge">
+        <div class="door">
+          <div class="door-ring"></div>
+          <div class="door-dial"><span class="spoke"></span><span class="spoke"></span><span class="spoke"></span></div>
+          <img class="door-coin" src="/logo-coin.png" alt="" />
+        </div>
       </div>
     </div>
+    <!-- full-screen gold flash, on top of everything, at the open moment -->
+    <div class="flash"></div>
   </div>
 {:else}
   <!-- PIN entry (set or unlock) -->
@@ -142,22 +145,23 @@
     background: radial-gradient(60% 50% at 50% 50%, #14110a, #050505 70%);
     overflow: hidden;
   }
-  .vault-stage { position: relative; width: 300px; height: 300px; display: grid; place-items: center; }
-  /* gold light burst at the moment the door opens */
-  .burst {
-    position: absolute; top: 50%; left: 50%; width: 60px; height: 60px; margin: -30px 0 0 -30px;
-    border-radius: 50%; pointer-events: none; opacity: 0; transform: scale(0);
-    background: radial-gradient(circle, rgba(255,255,255,0.95), rgba(253,224,71,0.85) 28%, rgba(251,191,36,0.45) 50%, rgba(251,191,36,0) 72%);
+  .vault-stage { position: relative; width: 300px; height: 300px; display: grid; place-items: center; perspective: 1100px; }
+
+  /* full-screen gold flash, ABOVE everything, at the open moment */
+  .flash {
+    position: fixed; inset: 0; z-index: 50; pointer-events: none; opacity: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.95), rgba(253,224,71,0.85) 22%, rgba(251,191,36,0.5) 42%, rgba(251,191,36,0) 70%);
   }
-  .vault.open .burst { animation: burst 1s ease-out; }
-  @keyframes burst {
-    0% { opacity: 0; transform: scale(0); }
-    12% { opacity: 1; }
-    100% { opacity: 0; transform: scale(16); }
+  .vault.open .flash { animation: flash 0.9s ease-out 0.15s; }
+  @keyframes flash {
+    0% { opacity: 0; }
+    18% { opacity: 1; }
+    100% { opacity: 0; }
   }
+
   .reveal {
     position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
-    gap: 6px; opacity: 0; transform: scale(0.9); transition: opacity 0.6s 0.4s, transform 0.6s 0.4s;
+    gap: 6px; opacity: 0; transform: scale(0.9); transition: opacity 0.7s 0.45s, transform 0.7s 0.45s;
   }
   .vault.open .reveal { opacity: 1; transform: scale(1); }
   .reveal-label { font-size: 0.85rem; letter-spacing: 0.18em; text-transform: uppercase; color: #b9962f; }
@@ -168,13 +172,14 @@
   .reveal-go { margin-top: 1rem; font-size: 0.82rem; color: var(--text-faint); animation: pulse 1.4s ease-in-out infinite; }
   @keyframes pulse { 0%,100% { opacity: 0.5; } 50% { opacity: 1; } }
 
-  /* the safe door sitting over the reveal, swings/scales away on open */
+  /* circular safe door that swings open on a left hinge */
+  .door-hinge { position: absolute; inset: 0; transform-style: preserve-3d; }
   .door {
     position: absolute; inset: 0; display: grid; place-items: center; border-radius: 50%;
     background: radial-gradient(circle at 38% 32%, #3a2f12, #1a1407 70%);
-    box-shadow: inset 0 0 0 10px rgba(251,191,36,0.15), inset 0 0 60px rgba(0,0,0,0.7), 0 18px 50px rgba(0,0,0,0.7);
-    transform-origin: 50% 50%;
-    transition: transform 1s cubic-bezier(0.6,0,0.2,1), opacity 0.9s 0.5s;
+    box-shadow: inset 0 0 0 10px rgba(251,191,36,0.18), inset 0 0 60px rgba(0,0,0,0.7), 0 18px 50px rgba(0,0,0,0.7);
+    transform-origin: left center;
+    transition: transform 1.15s cubic-bezier(0.55,0.06,0.2,1);
   }
   .door-ring {
     position: absolute; inset: 20px; border-radius: 50%;
@@ -184,7 +189,7 @@
     position: absolute; width: 96px; height: 96px; border-radius: 50%;
     background: radial-gradient(circle at 40% 35%, #fbcf4b, #9a6f12);
     box-shadow: 0 0 0 8px rgba(0,0,0,0.35), 0 6px 14px rgba(0,0,0,0.6);
-    transition: transform 1s cubic-bezier(0.5,0,0.2,1);
+    transition: transform 0.85s cubic-bezier(0.5,0,0.2,1);
   }
   .spoke { position: absolute; top: 50%; left: 50%; width: 54px; height: 6px; border-radius: 3px;
     background: linear-gradient(90deg, #7a5a0e, #fde047, #7a5a0e); transform-origin: 0 50%; }
@@ -193,6 +198,7 @@
   .spoke:nth-child(3) { transform: translate(-50%,-50%) rotate(120deg); }
   .door-coin { position: absolute; width: 70px; height: auto; opacity: 0.9; }
 
-  .vault.open .door { transform: rotate(115deg) scale(2.1); opacity: 0; }
+  /* dial spins first, then the whole door swings outward revealing the balance */
   .vault.open .door-dial { transform: rotate(540deg); }
+  .vault.open .door { transform: rotateY(-115deg); box-shadow: 0 18px 60px rgba(0,0,0,0.8); }
 </style>


### PR DESCRIPTION
## Summary
The light burst wasn't showing because it was rendered **behind** the door and got occluded as the door scaled/faded.

- Replaced it with a **full-screen gold flash** layered **above everything** (z on top), peaking right as the door opens.
- The safe door now **swings open on a left hinge** (`rotateY(-115deg)`) instead of fading — so you clearly see it open.
- Kept the dial spin + clunk; balance still counts up after.

Verified via Playwright: captured the full-screen flash frame and the swung-open door with the balance revealed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)