### PR TITLE
PIN locks on cold open only, not on menu navigation

### DIFF
--- a/src/lib/pin.js
+++ b/src/lib/pin.js
@@ -58,11 +58,21 @@ export function tooManyFails() {
   return pinFails() >= MAX_PIN_FAILS;
 }
 
+// Session unlock flag (sessionStorage): survives in-app navigation + refresh, but
+// is cleared when the app/tab is closed. So the PIN is asked on a cold open — not
+// every time you return to the menu.
+const UNLOCKED_KEY = 'wb_unlocked';
+export function markUnlocked() { if (browser) sessionStorage.setItem(UNLOCKED_KEY, '1'); }
+export function sessionIsUnlocked() { return !!(browser && sessionStorage.getItem(UNLOCKED_KEY) === '1'); }
+/** Force a re-lock this session (e.g. before a purchase). */
+export function relock() { if (browser) sessionStorage.removeItem(UNLOCKED_KEY); pinLocked.set(true); }
+
 /** Forget the PIN (forgot-PIN / logout). Keeps the remembered name unless full=true. */
 export function clearPin(full = false) {
   if (!browser) return;
   localStorage.removeItem(HASH_KEY);
   localStorage.removeItem(USER_KEY);
   localStorage.removeItem(FAILS_KEY);
+  sessionStorage.removeItem(UNLOCKED_KEY);
   if (full) localStorage.removeItem(NAME_KEY);
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,7 @@
   import { soundEnabled, toggleSound, fx } from '$lib/sound.js';
   import { startMusic, stopMusic, musicEnabled, musicVolume, setMusicVolume, toggleMusic, TRACKS, currentTrackId, selectTrack } from '$lib/music.js';
   import PinGate from '$lib/components/PinGate.svelte';
-  import { pinLocked, hasPinFor, clearPin } from '$lib/pin.js';
+  import { pinLocked, hasPinFor, clearPin, markUnlocked, sessionIsUnlocked } from '$lib/pin.js';
   import { goto } from '$app/navigation';
 
   import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
@@ -134,7 +134,9 @@
       // Device PIN gate (approach A): if a PIN is set on this device, lock until it's
       // entered; otherwise mark that we should prompt to set one (after username).
       sessionUid = session.user.id;
-      if (hasPinFor(sessionUid)) pinLocked.set(true);
+      // Lock only on a cold open (close → reopen), not on in-app navigation back
+      // to the menu — sessionIsUnlocked() persists the unlock for this app session.
+      if (hasPinFor(sessionUid)) { if (!sessionIsUnlocked()) pinLocked.set(true); }
       else pinNotSet = true;
 
       // Make-up daily launched from the streak calendar → drop straight into the board.
@@ -222,8 +224,8 @@
   // PIN gate: unlock screen for returning users; set-PIN after username for new ones.
   $: showPinUnlock = loggedIn && hasInitialized && $pinLocked;
   $: showPinSetup = loggedIn && hasInitialized && !$pinLocked && pinNotSet && !needsUsername;
-  function onPinUnlocked() { pinLocked.set(false); }
-  function onPinSet() { pinNotSet = false; }
+  function onPinUnlocked() { markUnlocked(); pinLocked.set(false); }
+  function onPinSet() { markUnlocked(); pinNotSet = false; }
   function onPinLogout() { clearPin(); pinLocked.set(false); pinNotSet = false; handleLogout(); }
   // Lobby music: play in the menu only — not while locked, setting a PIN, or in-game.
   $: if (browser) { (loggedIn && hasInitialized && showMainMenu && !showPinUnlock && !showPinSetup) ? startMusic() : stopMusic(); }


### PR DESCRIPTION
## Summary
The PIN was re-prompting every time you returned to the menu (each `/`-route mount re-locked). Now it locks **only on a cold open** (close → reopen).

- Unlock is persisted in **sessionStorage** (`wb_unlocked`) — survives in-app navigation **and** refresh, cleared when the app/tab is closed.
- `onMount` locks only if `!sessionIsUnlocked()`; `markUnlocked()` is called after a successful unlock or set-PIN.
- Added `relock()` for the upcoming "require PIN before a purchase" gate (pending your definition of what counts as a purchase).

Verified via Playwright: set PIN → menu (no lock) → shop → back to menu (**not** re-locked) → simulated app-close (sessionStorage cleared) → **locked**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)