### PR TITLE
PIN confirm for shop purchases + challenge entry

### DIFF
--- a/src/lib/components/PinConfirm.svelte
+++ b/src/lib/components/PinConfirm.svelte
@@ -1,0 +1,59 @@
+<script>
+  import { get } from 'svelte/store';
+  import PinPad from '$lib/components/PinPad.svelte';
+  import { pinConfirm } from '$lib/pinConfirm.js';
+  import { verifyPin, tooManyFails } from '$lib/pin.js';
+
+  let error = false;
+  let msg = '';
+  /** @type {any} */
+  let pad;
+
+  /** @param {CustomEvent<string>} e */
+  async function onSubmit(e) {
+    const uid = get(pinConfirm)?.uid;
+    if (!uid) return;
+    const ok = await verifyPin(uid, e.detail);
+    if (ok) {
+      const s = get(pinConfirm);
+      pinConfirm.set(null);
+      msg = '';
+      s?.resolve(true);
+    } else {
+      error = true;
+      msg = tooManyFails() ? 'Too many tries.' : 'Wrong PIN — try again.';
+      setTimeout(() => { error = false; pad?.reset(); }, 480);
+    }
+  }
+  function cancel() {
+    const s = get(pinConfirm);
+    pinConfirm.set(null);
+    msg = '';
+    s?.reject(new Error('cancelled'));
+  }
+</script>
+
+{#if $pinConfirm}
+  <div class="pc-overlay" role="dialog" aria-modal="true" aria-label="Confirm with PIN">
+    <div class="pc-card">
+      <h2 class="pc-title">Enter your PIN</h2>
+      <p class="pc-reason">{$pinConfirm.reason}</p>
+      <PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
+      {#if msg}<p class="pc-msg">{msg}</p>{/if}
+      <button class="pc-cancel" on:click={cancel}>Cancel</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .pc-overlay {
+    position: fixed; inset: 0; z-index: 4000; display: grid; place-items: center; padding: 1.2rem;
+    background: radial-gradient(70% 50% at 50% 18%, rgba(251,191,36,0.12), rgba(0,0,0,0) 60%), rgba(5,5,5,0.92);
+    backdrop-filter: blur(4px);
+  }
+  .pc-card { width: 100%; max-width: 360px; text-align: center; }
+  .pc-title { font-family: var(--font-display); font-size: 1.35rem; margin: 0 0 0.2rem; }
+  .pc-reason { color: #fbbf24; font-weight: 700; font-size: 0.95rem; margin: 0 0 1.4rem; }
+  .pc-msg { margin-top: 0.9rem; font-size: 0.86rem; color: #f87171; }
+  .pc-cancel { margin-top: 1.4rem; background: none; border: none; color: var(--text-faint); font-size: 0.85rem; text-decoration: underline; cursor: pointer; }
+</style>

--- a/src/lib/pinConfirm.js
+++ b/src/lib/pinConfirm.js
@@ -1,0 +1,22 @@
+// One-off PIN confirmation for sensitive Cash commitments (shop purchases,
+// entering a wagered challenge). Distinct from the app-lock: this gates a single
+// action, then returns control. requirePin() resolves when verified, rejects on
+// cancel, and is a no-op (resolves) if no device PIN is set.
+import { writable, get } from 'svelte/store';
+import { hasPinFor } from '$lib/pin.js';
+import { user } from '$lib/stores/userStore.js';
+import { supabase } from '$lib/supabaseClient';
+
+/** @type {import('svelte/store').Writable<null | {reason:string, uid:string, resolve:(v:boolean)=>void, reject:(e:any)=>void}>} */
+export const pinConfirm = writable(null);
+
+/** @param {string} reason @returns {Promise<boolean>} */
+export async function requirePin(reason = 'Confirm') {
+  // Resolve the uid from the store, or the session (so it works on any route).
+  let uid = get(user)?.id;
+  if (!uid) { try { const { data } = await supabase.auth.getSession(); uid = data?.session?.user?.id; } catch { /* ignore */ } }
+  if (!uid || !hasPinFor(uid)) return true; // nothing to confirm
+  return await new Promise((resolve, reject) => {
+    pinConfirm.set({ reason, uid, resolve, reject });
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { startNotifications, stopNotifications } from '$lib/stores/notificationStore.js';
   import Toaster from '$lib/components/Toaster.svelte';
+  import PinConfirm from '$lib/components/PinConfirm.svelte';
 
   let { children } = $props();
 
@@ -23,3 +24,4 @@
 
 {@render children()}
 <Toaster />
+<PinConfirm />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,7 @@
   import { startMusic, stopMusic, musicEnabled, musicVolume, setMusicVolume, toggleMusic, TRACKS, currentTrackId, selectTrack } from '$lib/music.js';
   import PinGate from '$lib/components/PinGate.svelte';
   import { pinLocked, hasPinFor, clearPin, markUnlocked, sessionIsUnlocked } from '$lib/pin.js';
+  import { requirePin } from '$lib/pinConfirm.js';
   import { goto } from '$app/navigation';
 
   import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
@@ -702,6 +703,8 @@
     if (mbBusy) return;
     if (mbTarget === 'friend' && !mbOpponent.trim()) { mbMsg = 'Pick an opponent.'; return; }
     if (mbTarget === 'group' && !mbGroupId) { mbMsg = 'Pick a group.'; return; }
+    const w = Math.floor(Number(mbWager) || 0);
+    try { await requirePin(w > 0 ? `Enter challenge · $${w.toLocaleString()} wager` : 'Enter challenge'); } catch { return; }
     mbBusy = true; mbMsg = 'Creating…';
     const res = await startMatch({
       opponent: mbTarget === 'friend' ? mbOpponent.trim() : null,
@@ -726,6 +729,10 @@
   async function respondToMatch(m) {
     if (mbBusy) return;
     if (m.status === 'settled') { matchResults = await getMatch(m.id); return; }
+    // Accepting an invite commits your wager → confirm with PIN (resuming doesn't).
+    if (m.my_state === 'invited') {
+      try { await requirePin(m.wager > 0 ? `Enter challenge · $${Number(m.wager).toLocaleString()} wager` : 'Enter challenge'); } catch { return; }
+    }
     mbBusy = true;
     const ok = m.my_state === 'invited' ? await acceptAndPlayMatch(m.id) : await resumeMatch(m.id);
     mbBusy = false;

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic, getPowerups, buyPowerup } from '$lib/stores/statsStore.js';
+  import { requirePin } from '$lib/pinConfirm.js';
   import { track } from '$lib/analytics.js';
   import { fx } from '$lib/sound.js';
 
@@ -43,6 +44,7 @@
   /** @param {any} item */
   async function buyPup(item) {
     if (busy) return;
+    try { await requirePin(`Buy ${item.name} · $${item.price.toLocaleString()}`); } catch { return; }
     busy = item.id; msg = '';
     const res = await buyPowerup(item.id);
     busy = '';
@@ -60,6 +62,7 @@
   /** @param {any} item */
   async function buy(item) {
     if (busy) return;
+    try { await requirePin(`Buy ${item.label} · $${item.price.toLocaleString()}`); } catch { return; }
     busy = item.id; msg = '';
     const res = await buyCosmetic(item.id);
     busy = '';


### PR DESCRIPTION
## Summary
PR 1 of 2. Requires the device PIN before deliberate Cash commitments — **shop purchases** and **entering a challenge** — but **not** for in-puzzle letter buys (routine gameplay).

- **`requirePin(reason)`** (`pinConfirm.js`) returns a Promise; resolves the uid from the user store *or* the Supabase session so it works on any route; no-op when no device PIN is set.
- **`PinConfirm.svelte`** — a global keypad modal mounted in `+layout`, with verify + cancel and a reason line ("Buy Free Vowel · $50").
- Gated: shop `buyPup` + `buy`; challenge **create** (`submitNewMatch`) and **accept-invite** (`respondToMatch`). **Resuming** an in-progress match is not gated.

Verified via Playwright: buy → PIN modal with the right reason, wrong-PIN error, cancel aborts the purchase. 0 errors.

Next: PR 2 — the **Fold** button + **broke-timer** (Daily + Challenges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)