### PR TITLE
Fix: PIN confirm hidden behind modals (blocked challenges)

### DIFF
--- a/src/lib/components/PinConfirm.svelte
+++ b/src/lib/components/PinConfirm.svelte
@@ -47,7 +47,9 @@
 
 <style>
   .pc-overlay {
-    position: fixed; inset: 0; z-index: 4000; display: grid; place-items: center; padding: 1.2rem;
+    /* above every in-page modal (challenge/shop modals are z-index 9999) so the
+       PIN pad is actually visible + tappable when confirming from inside one */
+    position: fixed; inset: 0; z-index: 100000; display: grid; place-items: center; padding: 1.2rem;
     background: radial-gradient(70% 50% at 50% 18%, rgba(251,191,36,0.12), rgba(0,0,0,0) 60%), rgba(5,5,5,0.92);
     backdrop-filter: blur(4px);
   }


### PR DESCRIPTION
## The bug (found via end-to-end Playwright test)
Creating a challenge silently did nothing for any account with a PIN. Root cause: the global **PIN-confirm overlay was `z-index: 4000`**, but in-page modals (the challenge builder, etc.) are **`z-index: 9999`**. So when you confirm a PIN *from inside a modal*, the keypad rendered **behind** the modal — invisible and un-tappable — so `requirePin()` never resolved and the create never fired. (The shop worked only because it has no high-z modal.)

Since the username/PIN onboarding means **everyone has a PIN**, this blocked **all challenge creation + invite-accept**.

## Fix
Bump `.pc-overlay` to `z-index: 100000` so the confirm keypad is always above any modal.

Verified end-to-end after the fix: two accounts → friend request/accept → create 1v1 → invite → accept → both play → fold → settle → results. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)