### PR TITLE
Economy v3.2: bigger bounties + cheaper letters

### DIFF
--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -13,10 +13,11 @@
   import { fx } from '$lib/sound.js';
 
   type LetterCosts = Record<string, number>;
+  // Mirror of server public.letter_cost() (economy v3.2: −25%, cheapest $20).
   const letterCosts: LetterCosts = {
-    Q: 30, W: 50, E: 140, R: 120, T: 120, Y: 60, U: 80, I: 110, O: 90, P: 80,
-    A: 130, S: 120, D: 80, F: 60, G: 70, H: 70, J: 30, K: 50, L: 80,
-    Z: 40, X: 40, C: 80, V: 50, B: 60, N: 100, M: 70
+    Q: 20, W: 40, E: 100, R: 90, T: 90, Y: 50, U: 60, I: 80, O: 70, P: 60,
+    A: 100, S: 90, D: 60, F: 50, G: 50, H: 50, J: 20, K: 40, L: 60,
+    Z: 30, X: 30, C: 60, V: 40, B: 50, N: 80, M: 50
   };
 
   const row1: string[] = ['Q','W','E','R','T','Y','U','I','O','P'];

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -59,10 +59,11 @@ import { track } from '$lib/analytics.js';
 
 // Letter purchase costs
 /** @type {Record<string, number>} */
+// Mirror of server public.letter_cost() (economy v3.2: −25%, cheapest $20).
 export const LETTER_COSTS = {
-  Q: 30, W: 50, E: 140, R: 120, T: 120, Y: 60, U: 80, I: 110, O: 90, P: 80,
-  A: 130, S: 120, D: 80, F: 60, G: 70, H: 70, J: 30, K: 50, L: 80,
-  Z: 40, X: 40, C: 80, V: 50, B: 60, N: 100, M: 70
+  Q: 20, W: 40, E: 100, R: 90, T: 90, Y: 50, U: 60, I: 80, O: 70, P: 60,
+  A: 100, S: 90, D: 60, F: 50, G: 50, H: 50, J: 20, K: 40, L: 60,
+  Z: 30, X: 30, C: 60, V: 40, B: 50, N: 80, M: 50
 };
 
 /** @type {import('svelte/store').Writable<GameState>} */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -314,7 +314,8 @@
   // ── Fold + broke-timer (Daily + Challenges) ──────────────────────────────
   // You're "broke" when you can't afford the cheapest still-buyable letter →
   // a 60s clock starts; guess it or you auto-Fold (lose the puzzle).
-  const LETTER_COSTS = { Q:30,W:50,E:140,R:120,T:120,Y:60,U:80,I:110,O:90,P:80,A:130,S:120,D:80,F:60,G:70,H:70,J:30,K:50,L:80,Z:40,X:40,C:80,V:50,B:60,N:100,M:70 };
+  // Mirror of the server-authoritative public.letter_cost() (economy v3.2: −25%, cheapest $20).
+  const LETTER_COSTS = { Q:20,W:40,E:100,R:90,T:90,Y:50,U:60,I:80,O:70,P:60,A:100,S:90,D:60,F:50,G:50,H:50,J:20,K:40,L:60,Z:30,X:30,C:60,V:40,B:50,N:80,M:50 };
   $: foldMode = ($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'match');
   $: gameActive = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
   $: isBroke = (() => {

--- a/supabase-climb.sql
+++ b/supabase-climb.sql
@@ -11,7 +11,7 @@
 --   state active|solved|stuck|complete).  RLS self-read.
 --
 -- _climb_puzzle_at(pos)  -- puzzle at a sequence position (null past the end).
--- _climb_bounty(pid)     -- round_to_$10( 0.65 × Σ distinct letter_cost ).
+-- _climb_bounty(pid)     -- round_to_$10( 0.85 × Σ distinct letter_cost ).  [v3.2; was 0.65]
 -- _climb_board(uid)      -- masked board (your real Cash IS the bankroll) +
 --   { climb:{bounty,heat,attempts,spent,position,stuck,last_gain,state} }.
 -- _climb_resolve(uid)    -- on solve: pay bounty × heat (once), state=solved,

--- a/supabase-daily-server-authoritative.sql
+++ b/supabase-daily-server-authoritative.sql
@@ -40,14 +40,15 @@ REVOKE INSERT, UPDATE, DELETE ON public.daily_sessions FROM anon, authenticated;
 -- ---- Letter costs live on the server (client can't be the pricing source) --
 CREATE OR REPLACE FUNCTION public.letter_cost(p_letter TEXT)
 RETURNS INT LANGUAGE sql IMMUTABLE AS $$
+  -- economy v3.2: −25%, cheapest $20 (see supabase-economy-v3-2-rebalance.sql)
   SELECT CASE upper(p_letter)
-    WHEN 'Q' THEN 30  WHEN 'W' THEN 50  WHEN 'E' THEN 140 WHEN 'R' THEN 120
-    WHEN 'T' THEN 120 WHEN 'Y' THEN 60  WHEN 'U' THEN 80  WHEN 'I' THEN 110
-    WHEN 'O' THEN 90  WHEN 'P' THEN 80  WHEN 'A' THEN 130 WHEN 'S' THEN 120
-    WHEN 'D' THEN 80  WHEN 'F' THEN 60  WHEN 'G' THEN 70  WHEN 'H' THEN 70
-    WHEN 'J' THEN 30  WHEN 'K' THEN 50  WHEN 'L' THEN 80  WHEN 'Z' THEN 40
-    WHEN 'X' THEN 40  WHEN 'C' THEN 80  WHEN 'V' THEN 50  WHEN 'B' THEN 60
-    WHEN 'N' THEN 100 WHEN 'M' THEN 70  ELSE NULL END;
+    WHEN 'Q' THEN 20  WHEN 'W' THEN 40  WHEN 'E' THEN 100 WHEN 'R' THEN 90
+    WHEN 'T' THEN 90  WHEN 'Y' THEN 50  WHEN 'U' THEN 60  WHEN 'I' THEN 80
+    WHEN 'O' THEN 70  WHEN 'P' THEN 60  WHEN 'A' THEN 100 WHEN 'S' THEN 90
+    WHEN 'D' THEN 60  WHEN 'F' THEN 50  WHEN 'G' THEN 50  WHEN 'H' THEN 50
+    WHEN 'J' THEN 20  WHEN 'K' THEN 40  WHEN 'L' THEN 60  WHEN 'Z' THEN 30
+    WHEN 'X' THEN 30  WHEN 'C' THEN 60  WHEN 'V' THEN 40  WHEN 'B' THEN 50
+    WHEN 'N' THEN 80  WHEN 'M' THEN 50  ELSE NULL END;
 $$;
 
 -- ---- Ensure today's puzzle is assigned and return its id ------------------
@@ -224,7 +225,7 @@ BEGIN
     WHERE substr(p_phrase, g.i + 1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions))
   );
   -- Loss = broke, or out of guesses and can't afford another ($150). Mirrors original game.
-  v_lost := (s.bankroll < 30);  -- broke: can't afford the cheapest letter
+  v_lost := (s.bankroll < 20);  -- broke: can't afford the cheapest letter (v3.2: was 30)
 
   IF v_won THEN
     s.state := 'won';

--- a/supabase-economy-v3-2-rebalance.sql
+++ b/supabase-economy-v3-2-rebalance.sql
@@ -1,0 +1,70 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Economy v3.2 — bigger bounties + cheaper letters (so money carries weight) ║
+-- ║  (migration: economy_v3_2_bounty_and_price_rebalance — applied via MCP)     ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Goal (owner): a solve should clearly pay; "spend less" should bite. The lever is
+-- the BOUNTY MULTIPLIER (k), not the price cut — under a derived bounty, halving
+-- letters shrinks bounty AND spend equally (same ratio). So we BUMP k and apply a
+-- light price trim for bankroll stretch / fewer broke-timers.
+--
+--   net = (k − f) × full_reveal      (f = fraction of letters skill made you buy)
+--
+-- Changes:
+--   • letter_cost(): −25%, rounded to clean $10s. Cheapest letter $30 → $20.
+--       Q20 W40 E100 R90 T90 Y50 U60 I80 O70 P60 A100 S90 D60 F50 G50 H50
+--       J20 K40 L60 Z30 X30 C60 V40 B50 N80 M50
+--   • _daily_reward(): k 0.70 → 1.20. Daily is the forgiving paycheck — bounty >
+--       full-reveal, so a solve ALWAYS nets positive (you still lose by NOT solving).
+--   • _climb_bounty(): k 0.65 → 0.85. Climb is the wealth engine — bounty <
+--       full-reveal, so brute-forcing a full reveal LOSES; efficiency is the skill.
+--       (Climb still multiplies by heat on top.)
+--   • Broke floor 30 → 20 in the two resolvers that hardcoded it
+--       (_freeplay_resolve, _makeup_resolve_and_return) — cheapest letter is now $20.
+--   • NOT touched (already dynamic via letter_cost / client isBroke, so auto-adapt):
+--       main Daily loss (client broke-timer → daily_fold), _arcade_resolve,
+--       arcade_buy_letter, climb broke check. Reveal stays a flat $150 premium.
+--       Arcade/Free Play start bankrolls unchanged → cheaper letters = the intended
+--       "bankroll stretches further" effect.
+--
+-- Client mirror (must stay in sync with letter_cost): LETTER_COSTS in
+--   src/lib/stores/GameStore.js, src/routes/+page.svelte, and letterCosts in
+--   src/lib/components/Keyboard.svelte.
+--
+-- Verified (live, new prices): "Let the Cat Out of the Bag" full-reveal $740 →
+--   Daily bounty $890 (>740: buy everything, still +$150) ·
+--   Climb bounty $630 (<740: full reveal loses −$110). Modes now feel distinct.
+
+CREATE OR REPLACE FUNCTION public.letter_cost(p_letter TEXT)
+RETURNS INT LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE upper(p_letter)
+    WHEN 'Q' THEN 20  WHEN 'W' THEN 40  WHEN 'E' THEN 100 WHEN 'R' THEN 90
+    WHEN 'T' THEN 90  WHEN 'Y' THEN 50  WHEN 'U' THEN 60  WHEN 'I' THEN 80
+    WHEN 'O' THEN 70  WHEN 'P' THEN 60  WHEN 'A' THEN 100 WHEN 'S' THEN 90
+    WHEN 'D' THEN 60  WHEN 'F' THEN 50  WHEN 'G' THEN 50  WHEN 'H' THEN 50
+    WHEN 'J' THEN 20  WHEN 'K' THEN 40  WHEN 'L' THEN 60  WHEN 'Z' THEN 30
+    WHEN 'X' THEN 30  WHEN 'C' THEN 60  WHEN 'V' THEN 40  WHEN 'B' THEN 50
+    WHEN 'N' THEN 80  WHEN 'M' THEN 50  ELSE NULL END;
+$$;
+
+CREATE OR REPLACE FUNCTION public._daily_reward(p_pid uuid)
+RETURNS integer LANGUAGE sql STABLE SECURITY DEFINER AS $function$
+  SELECT GREATEST(100, (round(1.20 * COALESCE(SUM(public.letter_cost(t.ch)), 0) / 10.0) * 10)::int)
+  FROM (
+    SELECT DISTINCT substr(upper(dp.phrase), g.i + 1, 1) AS ch
+    FROM public.daily_puzzles dp, generate_series(0, length(dp.phrase) - 1) g(i)
+    WHERE dp.id = p_pid AND substr(upper(dp.phrase), g.i + 1, 1) ~ '[A-Z]'
+  ) t;
+$function$;
+
+CREATE OR REPLACE FUNCTION public._climb_bounty(p_pid uuid)
+RETURNS integer LANGUAGE sql STABLE SECURITY DEFINER AS $function$
+  SELECT (round(0.85 * COALESCE(SUM(public.letter_cost(t.ch)), 0) / 10.0) * 10)::int
+  FROM (
+    SELECT DISTINCT substr(upper(dp.phrase), g.i + 1, 1) AS ch
+    FROM public.daily_puzzles dp, generate_series(0, length(dp.phrase) - 1) g(i)
+    WHERE dp.id = p_pid AND substr(upper(dp.phrase), g.i + 1, 1) ~ '[A-Z]'
+  ) t;
+$function$;
+
+-- _freeplay_resolve / _makeup_resolve_and_return: broke floor 30 → 20 (bodies otherwise
+-- unchanged from their prior definitions; see git history for the full functions).

--- a/supabase-v3-daily-fixed-reward.sql
+++ b/supabase-v3-daily-fixed-reward.sql
@@ -8,8 +8,10 @@
 -- redundant with spend anyway). Same shape as the Climb bounty → Daily & Climb now
 -- consistent ("a puzzle is worth a % of its full-reveal cost").
 --
--- _daily_reward(pid) = GREATEST(100, $10-rounded 0.70 × Σ distinct letter_cost).
---   0.70 (vs the Climb's 0.65) since the Daily has no heat multiplier. KNOB.
+-- _daily_reward(pid) = GREATEST(100, $10-rounded 1.20 × Σ distinct letter_cost).
+--   [v3.2; was 0.70] k=1.20 > 1.0 → Daily is the forgiving paycheck (a solve always
+--   nets +); Climb stays steep at 0.85 (full reveal loses). KNOB. See
+--   supabase-economy-v3-2-rebalance.sql.
 -- _daily_live(spent, reward) → { spent, reward, net=reward−spent }.
 -- daily_start / _daily_resolve_and_return feed the fixed reward into live.
 -- _finalize_daily: credits the gross reward; game_results.score = NET PROFIT


### PR DESCRIPTION
## What
Rebalances the economy so **money carries weight** — a solve clearly pays, and "spend less" actually bites. Applied live via MCP migration `economy_v3_2_bounty_and_price_rebalance`.

The insight: the lever for "money feels valuable" is the **bounty multiplier `k`**, not the price cut. Under a derived bounty, halving letters shrinks bounty *and* spend equally (same ratio, smaller numbers). So we bump `k` and apply a light price trim for **bankroll stretch** (afford more letters, fewer broke-timers).

```
net = (k − f) × full_reveal      // f = fraction of letters skill made you buy
```

## Per-mode
| Mode | Change | Result |
|---|---|---|
| **Daily** | k `0.70 → 1.20` | Forgiving paycheck — bounty > full-reveal, so a solve **always nets +** (you still lose by *not* solving) |
| **Climb / Cash Game** | k `0.65 → 0.85` (×heat) | Wealth engine — bounty < full-reveal, so **brute-forcing a full reveal loses**; efficiency is the skill |
| **All letters** | `−25%`, cheapest $30 → **$20** | Bankroll stretches further, fewer broke-timers |
| **Arcade / Free Play / Challenges** | inherit cheaper letters | Arcade/Climb broke checks are dynamic (`letter_cost`), so they auto-adapt; broke floor 30 → 20 in the two resolvers that hardcoded it |

## Verified (live, new prices)
"Let the Cat Out of the Bag" — full reveal **$740**:
- Daily bounty **$890** → buy every letter, still **+$150** ✅
- Climb bounty **$630** → full reveal **loses −$110** ✅

Modes now feel genuinely distinct (paycheck vs. wealth engine).

## Files
- Migration: `supabase-economy-v3-2-rebalance.sql` (canonical record) + synced comments in `supabase-daily-server-authoritative.sql`, `supabase-v3-daily-fixed-reward.sql`, `supabase-climb.sql`
- Client letter tables (kept in sync with server `letter_cost()`): `src/lib/stores/GameStore.js`, `src/routes/+page.svelte`, `src/lib/components/Keyboard.svelte`

🤖 Generated with [Claude Code](https://claude.com/claude-code)