### PR TITLE
Play Log v2: unified rich game_results (stats/history foundation)

### DIFF
--- a/STATS_AND_HISTORY_DESIGN.md
+++ b/STATS_AND_HISTORY_DESIGN.md
@@ -1,0 +1,193 @@
+# WordBank — Stats, Results, History & Leaderboards (design)
+
+> Status: design draft for review. Goal: decide WHAT we track, HOW results are
+> shown + revisited, and WHAT pages/flows we need — across the whole app and per
+> game mode. Builds on what already exists (don't rebuild settled gameplay).
+
+---
+
+## 0. The one foundational decision
+
+Almost everything below hinges on **one change**: turn the thin `game_results`
+table (today: `won, bankroll_left, game_mode, score`) into a **rich, unified Play
+Log** — one row per completed game, any mode, with the same columns everywhere.
+
+That single table becomes the engine for: career stats, the History page + all its
+filters, 1v1 records, and most leaderboards. Get this right and the rest is UI.
+
+### Proposed `game_results` (v2) columns
+| Column | Meaning |
+|---|---|
+| `id, user_id, mode, played_at, finished_at` | who/when. mode ∈ daily/climb/arcade/freeplay/challenge |
+| `puzzle_id, category` | what was played (null/array for multi-puzzle packs) |
+| `outcome` | won / lost / tie |
+| `solved_count, puzzle_count` | 1/1 for solo; e.g. 3/5 for a pack |
+| `spent` | total Cash spent (letters + reveals + power-ups) |
+| `earned` | bounty/reward/pot-share paid out |
+| `net` | earned − spent (the Cash result) |
+| **`multiple_x100`** | **return multiple = earned ÷ spent ×100 — the headline flex stat** |
+| `time_ms` | solve time (for tiebreaks + "fastest" stats) |
+| `clean, first_try, no_reveals, no_vowels` | quality flags (already computed for Daily) |
+| `match_id, opponent_id, group_id, rank, field_size, pot, wager` | competitive context (null for solo) |
+
+> Today the per-mode session tables (`daily_sessions`, `arcade_runs`,
+> `challenge_participants`, etc.) already hold most of these numbers at settlement
+> — we just need each mode's `_finalize/_settle` to write one enriched row here
+> instead of the current 4-field stub.
+
+---
+
+## 1. Overall (career / player-level) stats
+
+Surfaced on **your profile** + the new **History** page. Pulled from the Play Log
+aggregate + `profiles`.
+
+- **Identity/wealth:** Net Worth (Cash − loan), lifetime Cash earned, lifetime spent.
+- **Volume:** games played, puzzles solved, win %, days active.
+- **Efficiency (the brand):** **average return multiple**, best-ever multiple,
+  lifetime "cleanest solve" (lowest spend on a hard puzzle).
+- **Streaks:** current/longest daily streak (have), current/longest arcade streak (have).
+- **Competitive:** challenge W-L-T, win %, biggest pot won, current rival (most-played opponent).
+- **Collection:** badges earned / total, categories mastered, titles unlocked.
+- **Per-category:** solves + win% + best multiple per category (have `category_stats`, extend it).
+
+---
+
+## 2. Per-game-type stats
+
+### Daily (the paycheck)
+- Per play: bounty, spent, **net (profit)**, multiple, time, quality flags, streak day #.
+- Aggregate: streak, perfect weeks/months (have calendar), avg daily profit, daily win %,
+  "ghost" percentile vs field (have), best daily multiple.
+- **Archive:** every past daily — date, answer, your result — revisitable (gap today).
+
+### Climb / Cash Game (the wealth engine)
+- Per session: furthest position, bounty earned, spent, net, peak heat, power-ups used.
+- Aggregate: best position ever, total Climb earnings, longest heat streak, avg multiple.
+- **Climb log:** position-by-position history of a run (gap today).
+
+### Arcade / Gauntlet (survival)
+- Per run: peak bankroll (banked), furthest rung, puzzles solved, multiplier reached, power-ups earned.
+- Aggregate: best run ever, total banked, avg furthest. (Leaderboard exists; **run archive is a gap**.)
+
+### Free Play (broke-safe grind)
+- Light: puzzles solved, trickle earned today (capped $300), categories practiced.
+- Mostly excluded from competitive stats by design — keep it that way.
+
+### Challenges / Matches (PvP)
+- Per match: opponent/group, pack size, your solved/spent/rank, pot, payout, **per-puzzle breakdown**.
+- Aggregate: W-L-T overall, by opponent (H2H), by group, win %, avg finish rank, biggest pot.
+- **Per-challenge detail must persist and be revisitable** (data persists; UI is the gap).
+
+### Groups
+- Member standings (have: Net Worth) **+ group-scoped competitive stats** (gap):
+  group challenges played, per-member W-L within the group, "group MVP," group activity feed.
+
+---
+
+## 3. Results display + tracking
+
+### Daily result
+- **Immediately:** keep the current result modal (medal, profit, ghost-vs-yesterday, friend placement).
+- **Add:** "Saved to History" affordance; one-line "today's multiple Nx" headline; share card.
+- **Later:** appears in History → Daily, tappable to re-see the answer + your breakdown.
+
+### Challenge result — the big one
+- **Right when it finishes (you're done):** immediate "you're in — settling when everyone
+  plays" card (have) → once settled, a **rich result card**: final standings, your rank,
+  pot won, per-puzzle head-to-head (you vs them: spent/solved/time per puzzle).
+- **Revisit later:** two doors —
+  1. **Challenge inbox** "Results" button (have the button → upgrade to the rich detail view).
+  2. **History → Challenges** → tap any past match → same detail view, forever.
+- **Notification:** "Your challenge vs @X settled — you won $Y" (new notification type).
+
+---
+
+## 4. History + filters (the missing hub)
+
+New page **`/history`** — the unified Play Log, reverse-chronological, infinite scroll.
+
+**Each row:** mode icon · title (puzzle/opponent/group) · result chip (won/lost/tie) ·
+net ±$ · multiple · date. Tap → detail view (solo breakdown or challenge head-to-head).
+
+**Filters (stackable):**
+- **Mode:** Daily / Climb / Arcade / Challenges / (Free Play hidden by default)
+- **Result:** Won / Lost / Tie
+- **Category:** any category
+- **Opponent / Group:** specific friend or group (this is also how you reach a H2H view)
+- **Date range:** this week / month / all-time / custom
+- **Sort:** newest · biggest net · highest multiple · fastest
+
+Backed by `get_history(filters, cursor)` over the enriched `game_results`.
+
+---
+
+## 5. Leaderboards / personal / group / 1v1 — tracking, storage, management
+
+| Scope | Source | Where shown | Status |
+|---|---|---|---|
+| **Global / Friends / Group leaderboards** (Wealth, Daily, Climb, Arcade) | existing leaderboard RPCs over profiles + game_results | `/leaderboard` (3 tabs + scope) | ✅ exists |
+| **Personal stats** | Play Log aggregate + profiles | `/profile` | ✅ exists, enrich with multiple + H2H summary |
+| **1v1 head-to-head** | `get_head_to_head(opponent_id)` over competitive Play Log rows | friend's public profile + History filter | ❌ new |
+| **Group competition** | `get_group_standings(id)` + group challenge rows | `/groups/[id]` new "Compete" tab | ❌ new (only net-worth standings today) |
+| **Challenge leaderboard** | aggregate challenge W/pot from Play Log | new `/leaderboard` "Challenges" tab | ❌ optional |
+
+**1v1 (head-to-head):** derive from competitive Play Log rows filtered by `opponent_id`.
+`get_head_to_head(uid, opponent)` → `{ wins, losses, ties, win_pct, avg_multiple_each,
+biggest_pot, last5[] }`. No new table needed — it's a query over the Play Log.
+
+**Group:** add a `/groups/[id]` **Compete tab**: in-group challenge standings (W-L per
+member vs the group), recent group matches, group MVP. Net-worth standings stay as the
+"Wealth" tab.
+
+**Management/storage notes:** Play Log is append-only (never mutated post-settlement) →
+clean audit + cheap history. Leaderboards stay as aggregate RPCs (no materialized tables
+yet; revisit if slow). `bank_ledger` remains the money audit trail (separate concern).
+
+---
+
+## 6. Activity feed (optional, high-engagement)
+
+New `activity` events table + `/` feed strip or `/activity` page: "@friend won the Daily
+(4.2x)", "your challenge vs @X settled", "@Y joined the group", "you unlocked a badge",
+"@Z beat your daily score." Powers richer notifications too (today only friend-req +
+challenge-invite exist). Lower priority than History + Challenge detail.
+
+---
+
+## 7. Pages / components — what we need
+
+**New pages**
+- `/history` — unified Play Log + filters (§4). **Highest value.**
+- `/history/[id]` (or modal) — game/challenge detail; challenge = per-puzzle head-to-head. **Highest value.**
+- `/u/[username]` — public profile (others' stats + your H2H vs them + challenge button).
+- `/activity` (optional) — feed.
+
+**Upgrades to existing**
+- `/profile` — add avg/best multiple, challenge W-L-T, "rivals" row.
+- `/groups/[id]` — add **Compete tab** (challenge standings, group history, MVP).
+- `/leaderboard` — optional Challenges tab; link rows → public profiles.
+- Challenge inbox "Results" → open the new rich detail view.
+- Result modals — "Saved to History" + multiple headline + better share card.
+
+**New RPCs**
+- `get_history(filters, cursor)`, `get_game_detail(id)`, `get_match_detail(id)`,
+  `get_head_to_head(opponent)`, `get_group_standings(id)`, `get_public_profile(username)`.
+
+**Schema work**
+- Enrich `game_results` (§0) + make every `_finalize/_settle` write one row.
+- Extend `category_stats` with best multiple + win%.
+- (Optional) `activity` events table.
+
+---
+
+## 8. Suggested build order
+
+1. **Enrich the Play Log** (§0) + backfill writers — unlocks everything. *(foundation)*
+2. **`/history` + filters** (§4) — the hub players will ask for first.
+3. **Challenge detail view** (§3) revisitable from inbox + History — closes the most-felt gap.
+4. **Head-to-head** (§5) + **public profile** (§7).
+5. **Group Compete tab** (§5).
+6. **Activity feed** (§6) — last, highest-engagement polish.
+
+*Draft — react/redline and I'll turn the approved slice into migrations + pages.*

--- a/supabase-play-log-v2.sql
+++ b/supabase-play-log-v2.sql
@@ -1,0 +1,76 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Play Log v2 — game_results becomes the unified rich record (foundation)    ║
+-- ║  migrations: play_log_v2_schema_helper_solo_writers                         ║
+-- ║              play_log_v2_climb_challenge_match_writers   (both via MCP)     ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Foundation for STATS_AND_HISTORY_DESIGN.md. One enriched row per completed game,
+-- EVERY mode (daily, arcade, climb, challenge). Powers: career stats, /history +
+-- filters, per-challenge detail, 1v1 head-to-head (query by opponent_id).
+--
+-- ADDITIVE & SAFE: legacy columns (won, bankroll_left, game_mode, score) keep their
+-- EXACT prior meaning, so existing leaderboards (which filter by game_mode) are
+-- untouched. New climb/challenge rows don't hit daily/arcade boards.
+--
+-- New columns on game_results (all nullable):
+--   outcome (won|lost|tie), puzzle_id, category, solved_count, puzzle_count,
+--   spent, earned, net, multiple_x100 (return multiple ×100), time_ms,
+--   clean, first_try, no_reveals, no_vowels,
+--   match_id, opponent_id, group_id, rank, field_size, pot, wager
+-- Indexes: (user_id, opponent_id) [H2H], (match_id) [detail], (user_id, game_mode, played_at desc).
+--
+-- Writers:
+--   • _finalize_daily   — own INSERT, extended (legacy bankroll_left=spent, score=net kept).
+--                         Adds puzzle/category/solved/spent/earned/net/multiple/clean.
+--   • record_arcade_result — own INSERT, extended with outcome + earned(=banked).
+--   • _climb_resolve    — NEW: logs on solve (won, earned=payout, spent) AND on stuck (lost).
+--   • _match_settle     — NEW: logs one row per done participant (rank, solved/pack, pot,
+--                         wager, group_id, opponent_id for 1v1). spent/earned deferred.
+--   • _challenge_settle — NEW (legacy 1v1): logs both players (outcome, pot, opponent).
+--   All three settlers reproduced verbatim with ONLY _log_game_result() calls added.
+--
+-- Helper: _log_game_result(p_user, p_mode, p_outcome, p_puzzle_id, p_category,
+--   p_solved, p_total, p_spent, p_earned, p_time_ms, p_clean, p_first_try,
+--   p_no_reveals, p_no_vowels, p_match_id, p_opponent_id, p_group_id, p_rank,
+--   p_field_size, p_pot, p_wager). Derives net + multiple_x100; sets legacy cols via
+--   COALESCE(spent, earned, 0) → bankroll_left, COALESCE(net,0) → score.
+--
+-- Verified (rolled-back sims):
+--   climb: spent 120 / earned 630 → net 510, multiple 525, solved 1/1.
+--   daily (k=1.2): spent 140 / earned 830 → net 690, multiple 593, clean, category captured;
+--          legacy bankroll_left=140, score=690 preserved.
+--   get_daily_leaderboard still returns rows.
+
+ALTER TABLE public.game_results
+  ADD COLUMN IF NOT EXISTS outcome       TEXT,
+  ADD COLUMN IF NOT EXISTS puzzle_id     UUID,
+  ADD COLUMN IF NOT EXISTS category      TEXT,
+  ADD COLUMN IF NOT EXISTS solved_count  INT,
+  ADD COLUMN IF NOT EXISTS puzzle_count  INT,
+  ADD COLUMN IF NOT EXISTS spent         INT,
+  ADD COLUMN IF NOT EXISTS earned        INT,
+  ADD COLUMN IF NOT EXISTS net           INT,
+  ADD COLUMN IF NOT EXISTS multiple_x100 INT,
+  ADD COLUMN IF NOT EXISTS time_ms       INT,
+  ADD COLUMN IF NOT EXISTS clean         BOOLEAN,
+  ADD COLUMN IF NOT EXISTS first_try     BOOLEAN,
+  ADD COLUMN IF NOT EXISTS no_reveals    BOOLEAN,
+  ADD COLUMN IF NOT EXISTS no_vowels     BOOLEAN,
+  ADD COLUMN IF NOT EXISTS match_id      UUID,
+  ADD COLUMN IF NOT EXISTS opponent_id   UUID,
+  ADD COLUMN IF NOT EXISTS group_id      UUID,
+  ADD COLUMN IF NOT EXISTS rank          INT,
+  ADD COLUMN IF NOT EXISTS field_size    INT,
+  ADD COLUMN IF NOT EXISTS pot           BIGINT,
+  ADD COLUMN IF NOT EXISTS wager         BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_game_results_opponent ON public.game_results (user_id, opponent_id) WHERE opponent_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_game_results_match    ON public.game_results (match_id)            WHERE match_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_game_results_mode     ON public.game_results (user_id, game_mode, played_at DESC);
+
+-- Full body of _log_game_result + the rewritten writers were applied via MCP; see the
+-- two named migrations above and git history. Helper signature (canonical):
+--   public._log_game_result(uuid, text, text, uuid, text, int, int, int, int, int,
+--     boolean, boolean, boolean, boolean, uuid, uuid, uuid, int, int, bigint, bigint)
+
+-- NEXT (per STATS_AND_HISTORY_DESIGN.md §8): get_history(filters,cursor),
+--   get_game_detail(id), get_match_detail(id), get_head_to_head(opponent) → then /history UI.


### PR DESCRIPTION
## What
Foundation step for the stats/history system (per `STATS_AND_HISTORY_DESIGN.md`). Turns the 4-field `game_results` stub into a **unified Play Log** — one enriched row per completed game, **every mode**. This one table will power `/history` + filters, per-challenge detail, and 1v1 head-to-head records.

Applied live via two MCP migrations: `play_log_v2_schema_helper_solo_writers`, `play_log_v2_climb_challenge_match_writers`.

## Why it's safe
Purely **additive**. Legacy columns (`won, bankroll_left, game_mode, score`) keep their exact prior meaning, so existing leaderboards (which filter by `game_mode`) are untouched. The new `climb`/`challenge` rows never reach the daily/arcade boards.

## Changes
- **+21 nullable columns:** `outcome, puzzle_id, category, solved_count, puzzle_count, spent, earned, net, multiple_x100, time_ms, clean, first_try, no_reveals, no_vowels, match_id, opponent_id, group_id, rank, field_size, pot, wager`
- **+3 indexes:** head-to-head `(user_id, opponent_id)`, detail `(match_id)`, history `(user_id, game_mode, played_at desc)`
- **`_log_game_result()` helper** — derives `net` + `multiple_x100`, preserves legacy columns
- **Writers wired to log:**
  - `_finalize_daily`, `record_arcade_result` — own INSERTs extended (legacy semantics preserved)
  - `_climb_resolve` — **new**: logs on solve *and* on stuck
  - `_match_settle` — **new**: one row per finisher (rank, solved/pack, pot, wager, opponent for 1v1)
  - `_challenge_settle` — **new** (legacy 1v1): both players
  - All three settlers reproduced verbatim with *only* the log calls added.

## Verified (rolled-back sims)
- **Daily** (k=1.2): spent 140 / earned 830 → **net 690, multiple 593**, clean, category captured; legacy `bankroll_left=140, score=690` preserved.
- **Climb:** spent 120 / earned 630 → **net 510, multiple 525**, solved 1/1.
- `get_daily_leaderboard` still returns rows.

## Next (per design §8)
`get_history(filters, cursor)`, `get_game_detail(id)`, `get_match_detail(id)`, `get_head_to_head(opponent)` → then the `/history` page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)