### PR TITLE
Shared challenge detail view (stats step 3) + fix get_match_detail crash

### DIFF
--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -1,0 +1,88 @@
+<script>
+  import { createEventDispatcher } from 'svelte';
+
+  /** @type {any} */
+  export let detail = null; // get_match_detail() result, or { loading:true }
+
+  const dispatch = createEventDispatcher();
+  const close = () => dispatch('close');
+
+  $: parts = detail?.participants ?? [];
+  $: m = detail?.match;
+  $: opp = parts.find((/** @type {any} */ p) => !p.is_me);
+  $: noSolve = parts.length > 0 && parts.every((/** @type {any} */ p) => (p.solved ?? 0) === 0);
+  $: title = detail?.group_name || (opp ? '@' + (opp.name || 'player') : 'Challenge');
+  const rankIcon = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
+</script>
+
+{#if detail}
+  <div class="md-overlay" role="button" tabindex="0"
+       on:click={close} on:keydown={(e) => { if (e.key === 'Escape') close(); }}>
+    <div class="md" role="dialog" tabindex="0" on:click|stopPropagation on:keydown={() => {}}>
+      <button class="md-x" on:click={close}>✕</button>
+      {#if detail.loading}
+        <p class="md-msg">Loading…</p>
+      {:else}
+        <h2 class="md-title">{noSolve ? '🤝' : '⚔️'} {title}</h2>
+        <p class="md-sub">
+          {m?.pack_size} puzzle{m?.pack_size === 1 ? '' : 's'}
+          · {m?.payout === 'podium' ? 'podium 3·2·1' : 'winner-take-all'}
+          {#if Number(m?.wager) > 0}· ${Number(m.wager).toLocaleString()} buy-in{:else}· friendly{/if}
+          {#if m?.status !== 'settled'}· <em>in progress</em>{/if}
+          {#if noSolve && Number(m?.wager) > 0}· wager refunded{/if}
+        </p>
+
+        <div class="md-standings">
+          {#each parts as p}
+            <div class="md-row" class:me={p.is_me}>
+              <span class="md-rank">{noSolve ? '🤝' : rankIcon(p.rank)}</span>
+              <span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
+              <span class="md-meta">
+                {#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null} · ${Number(p.spent).toLocaleString()} spent{/if}
+                {:else}{p.state}{/if}
+              </span>
+            </div>
+          {/each}
+        </div>
+
+        {#if detail.pack?.length}
+          <div class="md-pack">
+            <div class="md-pack-h">Puzzles</div>
+            {#each detail.pack as pk}
+              <div class="md-pk">
+                <span class="md-pos">{pk.position + 1}</span>
+                <span class="md-cat">{pk.category}</span>
+                <span class="md-ans">{pk.phrase ? '“' + pk.phrase + '”' : '🔒 hidden until settled'}</span>
+              </div>
+            {/each}
+          </div>
+        {/if}
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .md-overlay { position: fixed; inset: 0; z-index: 10000; display: grid; place-items: center; padding: 18px;
+    background: rgba(5,5,5,0.8); backdrop-filter: blur(4px); }
+  .md { width: 100%; max-width: 440px; max-height: 86vh; overflow-y: auto; position: relative;
+    background: var(--surface-strong); border: 1px solid var(--border-strong); border-radius: var(--r-lg); padding: 20px; }
+  .md-x { position: absolute; top: 12px; right: 14px; background: none; border: none; color: var(--text-muted); font-size: 1rem; cursor: pointer; }
+  .md-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 4px; }
+  .md-sub { color: var(--text-faint); font-size: 0.8rem; margin: 0 0 16px; }
+  .md-msg { color: var(--text-muted); text-align: center; padding: 24px 0; }
+
+  .md-standings { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+  .md-row { display: flex; align-items: center; gap: 10px; padding: 9px 11px; border-radius: var(--r-sm); background: var(--surface); }
+  .md-row.me { background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.3); }
+  .md-rank { flex: 0 0 28px; font-weight: 700; }
+  .md-name { flex: 1; font-weight: 700; color: var(--text); }
+  .md-meta { color: var(--text-faint); font-size: 0.76rem; text-align: right; }
+
+  .md-pack { border-top: 1px solid var(--border); padding-top: 12px; }
+  .md-pack-h { color: var(--text-faint); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .md-pk { display: flex; align-items: center; gap: 10px; padding: 5px 0; font-size: 0.84rem; }
+  .md-pos { flex: 0 0 20px; color: var(--text-faint); }
+  .md-cat { flex: 0 0 auto; color: var(--text-muted); font-size: 0.74rem; }
+  .md-ans { color: var(--gold); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,7 @@
   import { get } from 'svelte/store';
 
   import { gameStore, fetchDailyGame, fetchArcadeGame, arcadeContinue, fetchFreeplayGame, freeplayContinue, arcadeCashOut, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
-  import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch } from '$lib/stores/statsStore.js';
+  import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch, getMatchDetail } from '$lib/stores/statsStore.js';
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -33,6 +33,7 @@
   import Auth from '$lib/components/Auth.svelte';
   import Tutorial from '$lib/components/Tutorial.svelte';
   import PowerupTray from '$lib/components/PowerupTray.svelte';
+  import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
 
   export let data;
 
@@ -784,7 +785,7 @@
   /** @param {any} m */
   async function respondToMatch(m) {
     if (mbBusy) return;
-    if (m.status === 'settled') { matchResults = await getMatch(m.id); return; }
+    if (m.status === 'settled') { matchResults = { loading: true }; matchResults = await getMatchDetail(m.id); return; }
     // Accepting an invite commits your wager → confirm with PIN (resuming doesn't).
     if (m.my_state === 'invited') {
       try { await requirePin(m.wager > 0 ? `Enter challenge · $${Number(m.wager).toLocaleString()} wager` : 'Enter challenge'); } catch { return; }
@@ -1174,26 +1175,9 @@
       <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Challenge Friends">
         <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showChallenges = false}></button>
         <div class="modal-content main-menu-modal ch-modal">
-          <button class="close-btn" on:click={() => { if (matchResults) matchResults = null; else showChallenges = false; }}>❌</button>
+          <button class="close-btn" on:click={() => showChallenges = false}>❌</button>
 
-          {#if matchResults}
-            <!-- Results card -->
-            {@const noSolve = (matchResults.participants ?? []).every((x) => (x.solved ?? 0) === 0)}
-            <h2>{noSolve ? '🤝 Tie' : '🏆 Results'}</h2>
-            <p class="cat-sub">{matchResults.pack_size} puzzle{matchResults.pack_size === 1 ? '' : 's'}{#if matchResults.wager > 0} · ${matchResults.wager?.toLocaleString()} · {matchResults.payout === 'podium' ? 'podium 3·2·1' : 'winner-take-all'}{/if}{#if noSolve && matchResults.wager > 0} · wager refunded{/if}</p>
-            <div class="ch-list">
-              {#each matchResults.participants as p, i}
-                <div class="ch-item">
-                  <div class="ch-info">
-                    <span class="ch-vs">{noSolve ? '🤝' : i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '#' + (i + 1)} {p.is_me ? 'You' : p.name}</span>
-                    <span class="ch-meta">{p.state === 'done' ? `solved ${p.solved ?? 0}/${matchResults.pack_size}` : p.state}</span>
-                  </div>
-                  <span class="ch-result">{p.spent != null ? '$' + p.spent.toLocaleString() + ' spent' : '—'}</span>
-                </div>
-              {/each}
-            </div>
-            <button class="ch-create" on:click={() => matchResults = null} style="width:100%;margin-top:0.8rem;">Back</button>
-          {:else}
+          {#if true}
             <h2>⚔️ Challenge Friends</h2>
             <p class="cat-sub">Build a match — a pack of puzzles vs a friend or a group. Same puzzles for everyone.</p>
 
@@ -1284,6 +1268,9 @@
         </div>
       </div>
     {/if}
+
+    <!-- Settled-challenge results (shared with /history) -->
+    <MatchDetailModal detail={matchResults} on:close={() => matchResults = null} />
 
     <!-- 🔔 Notifications panel -->
     {#if showNotifications}

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { getHistory, getMatchDetail } from '$lib/stores/statsStore.js';
+  import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
   import { track } from '$lib/analytics.js';
 
   /** @type {'all'|'daily'|'climb'|'arcade'|'challenge'} */
@@ -21,9 +22,8 @@
 
   /** which solo row is expanded (id) */
   let openRow = $state('');
-  /** challenge detail modal */
+  /** challenge detail modal (shared MatchDetailModal) */
   let detail = $state(/** @type {any} */ (null));
-  let detailLoading = $state(false);
 
   const MODES = [
     { k: 'all', label: 'All' }, { k: 'daily', label: '📅 Daily' },
@@ -62,10 +62,9 @@
   /** @param {any} r */
   async function openDetail(r) {
     if (r.game_mode === 'challenge' && r.match_id) {
-      detailLoading = true; detail = { loading: true, row: r };
+      detail = { loading: true };
       const d = await getMatchDetail(r.match_id);
-      detail = d ? { ...d, row: r } : null;
-      detailLoading = false;
+      detail = d || null;
       if (!d) error = 'Could not load that challenge.';
     } else {
       openRow = openRow === r.id ? '' : r.id;
@@ -156,49 +155,8 @@
   {/if}
 </main>
 
-<!-- Challenge detail -->
-{#if detail}
-  <div class="modal-overlay" role="button" tabindex="0"
-       onclick={() => detail = null} onkeydown={(e) => { if (e.key === 'Escape') detail = null; }}>
-    <div class="modal" role="dialog" tabindex="0" onclick={(e) => e.stopPropagation()} onkeydown={() => {}}>
-      <button class="x" onclick={() => detail = null}>✕</button>
-      {#if detail.loading}
-        <p class="msg">Loading…</p>
-      {:else}
-        <h2 class="m-title">⚔️ {detail.group_name || (detail.row?.opponent_name ? '@' + detail.row.opponent_name : 'Challenge')}</h2>
-        <p class="m-sub">
-          {detail.match?.pack_size} puzzle{detail.match?.pack_size === 1 ? '' : 's'}
-          · {detail.match?.payout === 'podium' ? 'podium' : 'winner-take-all'}
-          {#if Number(detail.match?.wager) > 0}· ${detail.match.wager} buy-in{:else}· friendly{/if}
-          {#if detail.match?.status !== 'settled'}· <em>in progress</em>{/if}
-        </p>
-
-        <div class="standings">
-          {#each (detail.participants || []) as p}
-            <div class="st-row" class:me={p.is_me}>
-              <span class="st-rank">{p.rank === 1 ? '🥇' : p.rank === 2 ? '🥈' : p.rank === 3 ? '🥉' : '#' + p.rank}</span>
-              <span class="st-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
-              <span class="st-meta">solved {p.solved ?? 0}/{detail.match?.pack_size} · {p.score ?? 0} pts</span>
-            </div>
-          {/each}
-        </div>
-
-        {#if detail.pack?.length}
-          <div class="pack">
-            <div class="pack-h">Puzzles</div>
-            {#each detail.pack as pk}
-              <div class="pk-row">
-                <span class="pk-pos">{pk.position + 1}</span>
-                <span class="pk-cat">{pk.category}</span>
-                <span class="pk-ans">{pk.phrase ? '“' + pk.phrase + '”' : '🔒'}</span>
-              </div>
-            {/each}
-          </div>
-        {/if}
-      {/if}
-    </div>
-  </div>
-{/if}
+<!-- Challenge detail (shared with the challenge inbox) -->
+<MatchDetailModal {detail} on:close={() => detail = null} />
 
 <style>
   .h-page { max-width: 560px; margin: 0 auto; padding: 16px 14px 60px; }
@@ -240,26 +198,4 @@
 
   .msg { color: var(--text-muted); text-align: center; padding: 24px 0; }
   .msg.err { color: #fb7185; }
-
-  .modal-overlay { position: fixed; inset: 0; z-index: 9999; display: grid; place-items: center; padding: 18px;
-    background: rgba(5,5,5,0.78); backdrop-filter: blur(4px); }
-  .modal { width: 100%; max-width: 440px; max-height: 86vh; overflow-y: auto; position: relative;
-    background: var(--surface-strong); border: 1px solid var(--border-strong); border-radius: var(--r-lg); padding: 20px; }
-  .x { position: absolute; top: 12px; right: 14px; background: none; border: none; color: var(--text-muted); font-size: 1rem; cursor: pointer; }
-  .m-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 4px; }
-  .m-sub { color: var(--text-faint); font-size: 0.8rem; margin: 0 0 16px; }
-
-  .standings { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
-  .st-row { display: flex; align-items: center; gap: 10px; padding: 9px 11px; border-radius: var(--r-sm); background: var(--surface); }
-  .st-row.me { background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.3); }
-  .st-rank { flex: 0 0 28px; font-weight: 700; }
-  .st-name { flex: 1; font-weight: 700; color: var(--text); }
-  .st-meta { color: var(--text-faint); font-size: 0.76rem; }
-
-  .pack { border-top: 1px solid var(--border); padding-top: 12px; }
-  .pack-h { color: var(--text-faint); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
-  .pk-row { display: flex; align-items: center; gap: 10px; padding: 5px 0; font-size: 0.84rem; }
-  .pk-pos { flex: 0 0 20px; color: var(--text-faint); }
-  .pk-cat { flex: 0 0 auto; color: var(--text-muted); font-size: 0.74rem; }
-  .pk-ans { color: var(--gold); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/supabase-play-log-read-rpcs.sql
+++ b/supabase-play-log-read-rpcs.sql
@@ -16,11 +16,15 @@
 --   where opponent_id = p_opponent. No new table — pure query over the Play Log.
 --   Client: getHeadToHead(opponentId).
 --
--- get_match_detail(p_match_id) → jsonb { match{...}, group_name, participants[
---   {user_id,name,is_me,solved,score,state,rank} ordered by score], pack[
+-- get_match_detail(p_match_id) → jsonb { match{...,budget}, group_name, participants[
+--   {user_id,name,is_me,solved,score,spent,state,rank} ordered by score], pack[
 --   {position,category,phrase}] }. Participants-only (returns NULL otherwise).
+--   spent = GREATEST(0, budget − bankroll), budget = max(wager,500) (matches get_match).
 --   Spoiler-safe: pack phrases are NULL until the match status='settled'.
---   Client: getMatchDetail(matchId) → opened from a challenge row in /history.
+--   Client: getMatchDetail(matchId) → shared MatchDetailModal.svelte, opened from a
+--   challenge row in /history AND the challenge inbox "Results" button.
+--   (migrations: match_detail_add_spent, fix_match_detail_window_in_agg — the latter
+--    moves rank() into a subquery; window fns can't nest inside jsonb_agg, a runtime bug.)
 --
 -- All three GRANT EXECUTE TO authenticated. Full bodies applied via MCP; see git
 -- history / live definitions. Verified: get_history returns rows under jwt-impersonation.


### PR DESCRIPTION
## What
Step 3 of the stats system: the challenge inbox **Results** button now opens the **same rich detail view** as `/history` — final standings (rank · solved · spent) plus the puzzle pack (answers revealed once settled). Revisitable forever from both places.

- **New `MatchDetailModal.svelte`** — one shared detail view used by `/history` *and* the challenge inbox. Derives the title (group name or `@opponent`), tie/win medals, and is spoiler-safe (pack answers hidden until settled). `/history` now renders it instead of its own inline modal.
- **`+page.svelte`:** the settled-match "Results" button now calls `getMatchDetail(id)` into the shared modal, replacing the thin inline card (and the old `getMatch` path for viewing results).
- **`get_match_detail`:** adds per-participant `spent` (`budget − bankroll`, `budget = max(wager, 500)`) so the shared view shows spend like the old card did.

## Bug fixed 🐛
The original `get_match_detail` (PR #227) nested `rank() OVER (...)` **inside `jsonb_agg`**, which Postgres rejects at *runtime* — so the detail modal would have crashed for every user the first time it was opened. Moved `rank()` into a subquery. **Verified on a real settled match** (3-puzzle Food & Drink pack, `@edithpink` #1 vs You #2 with solved/spent).

Migrations: `match_detail_add_spent`, `fix_match_detail_window_in_agg`. Build passes.

## Next (design §8)
Public profile `/u/[username]` + head-to-head · group Compete tab · activity feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)