### PR TITLE
Activity feed (stats step 6 — system complete)

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -553,6 +553,13 @@ export async function getGroupStandings(groupId) {
   if (error) { console.error('❌ get_group_standings:', error); return null; }
   return data;
 }
+/** Activity feed — you + friends + your groups (games, badges, joins).
+ * @param {number} [limit] @param {number} [offset] @returns {Promise<any[]>} */
+export async function getActivityFeed(limit = 30, offset = 0) {
+  const { data, error } = await supabase.rpc('get_activity_feed', { p_limit: limit, p_offset: offset });
+  if (error) { console.error('❌ get_activity_feed:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
 
 /* ===== Power-ups (catalog + buy + use-in-Climb) ===== */
 /** @returns {Promise<{cash:number, items:any[]}>} */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1162,6 +1162,9 @@
           <button class="menu-card" style="--i: 4" on:click={() => goto('/history')}>
             <span class="mc-title">History</span>
           </button>
+          <button class="menu-card" style="--i: 5" on:click={() => goto('/activity')}>
+            <span class="mc-title">Activity</span>
+          </button>
         </div>
       {/if}
     </div>

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -1,0 +1,118 @@
+<script>
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getActivityFeed } from '$lib/stores/statsStore.js';
+  import { track } from '$lib/analytics.js';
+
+  /** @type {any[]} */
+  let rows = $state([]);
+  let loading = $state(true);
+  let done = $state(false);
+  let offset = $state(0);
+  const PAGE = 30;
+
+  const ICON = {
+    daily_win: '📅', challenge: '⚔️', big_solve: '🎰', badge: '🏅', group_join: '👥'
+  };
+  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
+  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
+
+  /** relative time */
+  function ago(/** @type {string} */ t) {
+    const s = Math.max(1, Math.floor((Date.now() - new Date(t).getTime()) / 1000));
+    if (s < 60) return s + 's';
+    if (s < 3600) return Math.floor(s / 60) + 'm';
+    if (s < 86400) return Math.floor(s / 3600) + 'h';
+    if (s < 604800) return Math.floor(s / 86400) + 'd';
+    return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  /** @param {any} r */
+  function line(r) {
+    const m = r.meta || {};
+    switch (r.type) {
+      case 'daily_win': {
+        const extra = m.multiple_x100 ? ` (${mult(m.multiple_x100)})` : '';
+        return { verb: `won the Daily${extra}`, tag: m.net != null ? money(m.net) : '' };
+      }
+      case 'challenge':
+        return m.opponent_name
+          ? { verb: `beat @${m.opponent_name} in a challenge`, tag: '' }
+          : { verb: `won a group challenge${m.rank ? ` · #${m.rank}` : ''}`, tag: '' };
+      case 'big_solve':
+        return { verb: `pulled a ${mult(m.multiple_x100)} solve in the Cash Game`, tag: m.net != null ? money(m.net) : '' };
+      case 'badge':
+        return { verb: `earned the “${m.badge}” badge`, tag: '' };
+      case 'group_join':
+        return { verb: `joined ${r.group_name || 'a group'}`, tag: '' };
+      default:
+        return { verb: 'did something', tag: '' };
+    }
+  }
+
+  async function load(reset = false) {
+    if (reset) { offset = 0; done = false; rows = []; }
+    loading = true;
+    const page = await getActivityFeed(PAGE, offset);
+    rows = reset ? page : [...rows, ...page];
+    offset += page.length;
+    if (page.length < PAGE) done = true;
+    loading = false;
+  }
+
+  onMount(() => { track('activity_view'); load(true); });
+</script>
+
+<svelte:head><title>WordBank — Activity</title></svelte:head>
+
+<main class="a-page">
+  <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
+  <h1>📣 Activity</h1>
+  <p class="sub">You, your friends, and your groups.</p>
+
+  {#if loading && rows.length === 0}
+    <p class="msg">Loading…</p>
+  {:else if rows.length === 0}
+    <p class="msg">Nothing yet. Add friends and play — wins, badges and challenges show up here.</p>
+  {:else}
+    <ul class="feed">
+      {#each rows as r, i (r.type + r.actor_id + r.ts + i)}
+        {@const l = line(r)}
+        <li class="ev">
+          <span class="ev-ic">{ICON[r.type] || '•'}</span>
+          <span class="ev-body">
+            <button class="ev-actor" onclick={() => goto('/u/' + encodeURIComponent(r.actor_name || ''))}>@{r.actor_name || 'player'}</button>
+            <span class="ev-verb">{l.verb}</span>
+          </span>
+          {#if l.tag}<span class="ev-tag" class:neg={l.tag.startsWith('−')}>{l.tag}</span>{/if}
+          <span class="ev-time">{ago(r.ts)}</span>
+        </li>
+      {/each}
+    </ul>
+    {#if !done}
+      <button class="more" onclick={() => load(false)} disabled={loading}>{loading ? 'Loading…' : 'Load more'}</button>
+    {/if}
+  {/if}
+</main>
+
+<style>
+  .a-page { max-width: 560px; margin: 0 auto; padding: 16px 14px 60px; }
+  .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
+  h1 { font-family: var(--font-display); font-size: 1.5rem; margin: 4px 0 2px; }
+  .sub { color: var(--text-faint); font-size: 0.84rem; margin: 0 0 16px; }
+  .msg { color: var(--text-muted); text-align: center; padding: 28px 10px; }
+
+  .feed { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 7px; }
+  .ev { display: flex; align-items: center; gap: 11px; padding: 11px 13px; border: 1px solid var(--border);
+    border-radius: var(--r-md); background: var(--surface); }
+  .ev-ic { font-size: 1.2rem; flex: 0 0 auto; }
+  .ev-body { flex: 1; min-width: 0; font-size: 0.9rem; line-height: 1.35; }
+  .ev-actor { background: none; border: none; padding: 0; font: inherit; font-weight: 800; color: var(--gold); cursor: pointer; }
+  .ev-verb { color: var(--text); }
+  .ev-tag { flex: 0 0 auto; font-weight: 800; color: #7ee0a8; font-size: 0.85rem; font-variant-numeric: tabular-nums; }
+  .ev-tag.neg { color: #fb7185; }
+  .ev-time { flex: 0 0 auto; color: var(--text-faint); font-size: 0.72rem; }
+
+  .more { display: block; margin: 14px auto 0; padding: 9px 22px; border-radius: var(--r-pill);
+    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; cursor: pointer; }
+</style>

--- a/supabase-play-log-read-rpcs.sql
+++ b/supabase-play-log-read-rpcs.sql
@@ -43,5 +43,11 @@
 --   settled group challenge_matches (topscore>0). (migration get_group_standings.)
 --   Client: getGroupStandings(groupId) → /groups "Compete" tab.
 --
--- NEXT (STATS_AND_HISTORY_DESIGN.md §8): activity feed (last). Competitive spent/earned
---   still deferred (matches rank by total_score, not the v3.1 pot-of-spend model).
+-- get_activity_feed(p_limit, p_offset) → TABLE(ts, type, actor_id, actor_name, group_id,
+--   group_name, meta jsonb). Read-only UNION over game_results (daily wins, challenge WINS
+--   [winner-centric → 1 row/match], climb solves ≥4×), user_badges(earned_at), and
+--   group_members(joined_at), scoped to viewer + friends + their groups. No events table,
+--   no write hooks. (migration get_activity_feed.) Client: getActivityFeed → /activity page.
+--
+-- STATS/HISTORY SYSTEM COMPLETE (design §8 steps 1–6). Remaining/deferred: competitive
+--   spent/earned/net (matches rank by total_score, not the v3.1 pot-of-spend model).


### PR DESCRIPTION
## What
The final step of the stats system: a **read-only social activity feed** — you + friends + your groups.

Designed deliberately as a **UNION over existing tables** (no new events table, no write hooks across settle functions), so the feed can never drift from reality and there was zero risk to gameplay paths.

Server (migration `get_activity_feed`):
- **`get_activity_feed(limit, offset)`** → `ts, type, actor, group, meta`. Sources: `game_results` (daily wins · challenge **wins**, winner-centric so 1 row/match · climb solves ≥4×), `user_badges(earned_at)`, `group_members(joined_at)`. Scoped to viewer + friends + their groups. **Verified at runtime** (group joins + badges surfacing; daily/challenge rows fill in as new enriched games accrue).

Client:
- `statsStore.getActivityFeed` wrapper.
- **`/activity` page** — relative-time feed with per-type copy ("won the Daily 4.2× · beat @X · pulled a 5.3× solve · earned a badge · joined a group"); actor names link to their public profile; Load-more paging.
- Progress submenu → **Activity** card.

Build passes.

## 🎉 Stats/history system complete
All 6 steps from `STATS_AND_HISTORY_DESIGN.md` are now shipped: Play Log → `/history` → shared challenge detail → public profile + head-to-head → group Compete tab → activity feed.

Deferred (noted): competitive `spent/earned/net` (challenges still rank by `total_score`, not the v3.1 pot-of-spend model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)