### PR TITLE
Fix /history infinite-loop + E2E polish

### DIFF
--- a/scripts/shoot-stats.mjs
+++ b/scripts/shoot-stats.mjs
@@ -1,0 +1,62 @@
+// Screenshots for the stats/history/profile/group/activity UI (seeded pwtest account).
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5174';
+const EMAIL = process.env.PW_EMAIL || 'pwtest+wb@example.com';
+const PASS = process.env.PW_PASS || 'TestPass123!';
+mkdirSync('screenshots', { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const page = await ctx.newPage();
+page.on('console', (m) => { if (m.type() === 'error') console.log('  [err]', m.text().slice(0, 140)); });
+const shot = async (n) => { await page.screenshot({ path: `screenshots/stats-${n}.png` }); console.log('shot', n); };
+const wait = (ms) => page.waitForTimeout(ms);
+
+await page.goto(BASE, { waitUntil: 'networkidle' });
+await wait(1200);
+
+// login
+if (await page.locator('input[type=password]').count()) {
+  await page.fill('input[type=email]', EMAIL).catch(() => {});
+  await page.fill('input[type=password]', PASS).catch(() => {});
+  await page.getByRole('button', { name: /log in/i }).first().click().catch(() => {});
+  await wait(3000);
+}
+// skip PIN set if shown
+const skip = page.getByRole('button', { name: /skip for now/i });
+if (await skip.count()) { await skip.first().click().catch(() => {}); await wait(800); }
+await wait(1000);
+await shot('00-menu');
+
+// Progress submenu (to show new cards)
+const prog = page.getByRole('button', { name: /progress/i });
+if (await prog.count()) { await prog.first().click().catch(() => {}); await wait(600); await shot('01-progress-menu'); }
+
+// History
+await page.goto(`${BASE}/history`, { waitUntil: 'networkidle' }); await wait(1800); await shot('02-history');
+// expand a solo (daily) row
+await page.locator('.item-main').first().click().catch(() => {}); await wait(700); await shot('03-history-expanded');
+// filter to Versus
+const versus = page.getByRole('button', { name: /versus/i });
+if (await versus.count()) { await versus.first().click().catch(() => {}); await wait(1200); await shot('04-history-versus'); }
+
+// Activity
+await page.goto(`${BASE}/activity`, { waitUntil: 'networkidle' }); await wait(1800); await shot('05-activity');
+
+// Public profile + head-to-head
+await page.goto(`${BASE}/u/edithpink`, { waitUntil: 'networkidle' }); await wait(1800); await shot('06-profile-h2h');
+
+// Groups → open group → Compete tab
+await page.goto(`${BASE}/groups`, { waitUntil: 'networkidle' }); await wait(1600); await shot('07-groups-list');
+await page.locator('.g-card, .group-card, [class*=card]').first().click().catch(() => {});
+await wait(1400); await shot('08-group-wealth');
+const compete = page.getByRole('button', { name: /compete/i });
+if (await compete.count()) { await compete.first().click().catch(() => {}); await wait(1400); await shot('09-group-compete'); }
+
+// Leaderboard (clickable names)
+await page.goto(`${BASE}/leaderboard`, { waitUntil: 'networkidle' }); await wait(1800); await shot('10-leaderboard');
+
+await browser.close();
+console.log('done');

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -14,6 +14,7 @@
   const ICON = {
     daily_win: '📅', challenge: '⚔️', big_solve: '🎰', badge: '🏅', group_join: '👥'
   };
+  const pretty = (/** @type {string} */ s) => (s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
   const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
   const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
 
@@ -42,7 +43,7 @@
       case 'big_solve':
         return { verb: `pulled a ${mult(m.multiple_x100)} solve in the Cash Game`, tag: m.net != null ? money(m.net) : '' };
       case 'badge':
-        return { verb: `earned the “${m.badge}” badge`, tag: '' };
+        return { verb: `earned the “${pretty(m.badge)}” badge`, tag: '' };
       case 'group_join':
         return { verb: `joined ${r.group_name || 'a group'}`, tag: '' };
       default:

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -71,9 +71,10 @@
     }
   }
 
-  onMount(() => track('history_view'));
-  // initial load + reload whenever a filter changes
-  $effect(() => { mode; result; sort; load(true); });
+  onMount(() => { track('history_view'); load(true); });
+  // filters reload explicitly (an $effect here would self-invalidate: load() writes offset)
+  function setMode(/** @type {any} */ k) { mode = k; load(true); }
+  function setResult(/** @type {any} */ k) { result = k; load(true); }
 </script>
 
 <svelte:head><title>WordBank — History</title></svelte:head>
@@ -84,17 +85,17 @@
 
   <div class="chips">
     {#each MODES as m}
-      <button class="chip" class:active={mode === m.k} onclick={() => mode = /** @type {any} */ (m.k)}>{m.label}</button>
+      <button class="chip" class:active={mode === m.k} onclick={() => setMode(m.k)}>{m.label}</button>
     {/each}
   </div>
 
   <div class="row2">
     <div class="seg">
       {#each [['all','All'],['won','Won'],['lost','Lost'],['tie','Tie']] as [k, l]}
-        <button class="seg-btn" class:active={result === k} onclick={() => result = /** @type {any} */ (k)}>{l}</button>
+        <button class="seg-btn" class:active={result === k} onclick={() => setResult(k)}>{l}</button>
       {/each}
     </div>
-    <select class="sort" bind:value={sort}>
+    <select class="sort" bind:value={sort} onchange={() => load(true)}>
       <option value="recent">Newest</option>
       <option value="net">Biggest net</option>
       <option value="multiple">Highest ×</option>
@@ -127,8 +128,13 @@
               </span>
             </span>
             <span class="right">
-              {#if r.net != null}<span class="net" class:neg={Number(r.net) < 0}>{money(r.net)}</span>{/if}
-              {#if mult(r.multiple_x100)}<span class="mult">{mult(r.multiple_x100)}</span>{/if}
+              {#if r.game_mode === 'challenge' && r.net == null}
+                <span class="oc {r.outcome}">{r.outcome === 'won' ? 'WON' : r.outcome === 'tie' ? 'TIE' : 'LOST'}</span>
+                {#if Number(r.pot) > 0}<span class="mult">${Number(r.pot).toLocaleString()} pot</span>{/if}
+              {:else}
+                {#if r.net != null}<span class="net" class:neg={Number(r.net) < 0}>{money(r.net)}</span>{/if}
+                {#if mult(r.multiple_x100)}<span class="mult">{mult(r.multiple_x100)}</span>{/if}
+              {/if}
               <span class="date">{when(r.played_at)}</span>
             </span>
           </button>
@@ -187,6 +193,10 @@
   .net.neg, b.neg { color: #fb7185; }
   .mult { color: var(--gold); font-size: 0.74rem; font-weight: 700; }
   .date { color: var(--text-faint); font-size: 0.7rem; }
+  .oc { font-size: 0.68rem; font-weight: 800; letter-spacing: 0.04em; padding: 2px 7px; border-radius: 6px; }
+  .oc.won { background: rgba(126,224,168,0.18); color: #7ee0a8; }
+  .oc.lost { background: rgba(251,113,133,0.18); color: #fb7185; }
+  .oc.tie { background: var(--surface-2); color: var(--text-muted); }
 
   .detail-inline { padding: 0 13px 13px 49px; }
   .answer { color: var(--gold); font-weight: 700; margin: 0 0 8px; }

--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -108,7 +108,7 @@
     {#if (p.badges ?? []).length}
       <section class="badges">
         <div class="b-h">Badges · {p.badges.length}</div>
-        <div class="b-wrap">{#each p.badges as b}<span class="badge">🏅 {b}</span>{/each}</div>
+        <div class="b-wrap">{#each p.badges as b}<span class="badge">🏅 {(b || '').replace(/_/g, ' ').replace(/\b\w/g, (/** @type {string} */ c) => c.toUpperCase())}</span>{/each}</div>
       </section>
     {/if}
   {/if}


### PR DESCRIPTION
## What
Ran an end-to-end pass (seeded test account + Playwright screenshots of every new page). It caught one real bug and two rough edges.

### 🐛 Critical: /history infinite loop
The page's `$effect(() => { mode; result; sort; load(true) })` **read `offset`** (inside `load`) while `load` also **writes `offset`** — so the effect self-invalidated and spammed `get_history` forever (`ERR_INSUFFICIENT_RESOURCES`, page never settled). Replaced the effect with explicit filter handlers; `onMount` does the initial load. **This would have hit every user on the History page.**

### Polish (surfaced by the screenshots)
- **Challenge rows in History looked empty** (competitive net/multiple is deferred) → now show a colored **WON / LOST / TIE** chip + **pot** on the right.
- **Badge slugs** (`gold_bank`, `flawless`) → humanized to **"Gold Bank" / "Flawless"** in the activity feed and public profile.

Adds `scripts/shoot-stats.mjs` (reusable screenshot harness).

## Verified
Re-screenshotted after the fixes: History loads instantly with challenge chips + pots; activity badges read cleanly; silver→gold menu hover, public profile + head-to-head (1-1 vs @edithpink), and group Compete standings all render real data correctly. Build passes. Seeded test data fully cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)