### PR TITLE
Challenges → pot-of-spend economy + real challenge multiples

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1248,7 +1248,7 @@
                 </label>
               </div>
               <div class="ch-row">
-                <label class="ch-field"><span>Wager ($0 = friendly)</span>
+                <label class="ch-field"><span>Buy-in ($0 = friendly)</span>
                   <input class="ch-input" type="number" min="0" step="100" bind:value={mbWager} />
                 </label>
                 <label class="ch-field"><span>Respond within</span>
@@ -1259,7 +1259,7 @@
                 <span class="ch-tog-box">{mbItemsAllowed ? '✓' : ''}</span>
                 ⚡ Allow power-ups — players can bring & use items they own
               </button>
-              <p class="ch-objective">Your wager is your spending budget (min $500). Buy as few letters as you can — <strong>solve spending the least and you take the pot.</strong> Guesses are free.</p>
+              <p class="ch-objective">Your buy-in (min $500) is your spending cap. Buy as few letters as you can — <strong>unspent cash comes back, the pot is everyone’s spend, and the most efficient solver takes it.</strong> You only ever lose what you spend. Guesses are free.</p>
               <button class="ch-create" disabled={mbBusy} on:click={submitNewMatch} style="width:100%;">Send challenge ⚔️</button>
               {#if mbMsg}<p class="add-msg">{mbMsg}</p>{/if}
             </div>

--- a/supabase-challenge-pot-of-spend.sql
+++ b/supabase-challenge-pot-of-spend.sql
@@ -1,0 +1,26 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Challenges → Economy v3.1 "pot of spend"  (migration: match_settle_pot_of_spend) ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Challenges now express the core "spend less" mechanic with real money.
+--
+-- Escrow (unchanged, in accept_match/create_match): a wagered match debits `wager`
+-- ('wager_stake') and sets participant bankroll = budget = GREATEST(wager, 500).
+-- So spent = budget − bankroll, and buy-in == budget for wagered games.
+--
+-- _match_settle (rewritten):
+--   • No real contest (v_paid<2 OR nobody solved) → full buy-in refund ('wager_refund').
+--   • Otherwise: refund each player's UNSPENT buy-in (their leftover bankroll), and the
+--     POT = Σ everyone's spend. Distribute by rank (total_score = solved desc, spend asc):
+--       winner-take-all, or podium 60/(rest)/20% of the pot.
+--   • "You only ever lose what you spent." Zero-sum: winner's net = others' total spend.
+--   • Logs REAL spent/earned/net to the Play Log (game_results) for WAGERED settled games
+--     → challenge rows now have a true return multiple (earned/spent). Friendly (wager=0)
+--     and refunded games log null money (unchanged).
+--
+-- Verified (rolled-back 2-player sim, wager 500): edith spent 120 / test1 spent 300, both
+--   solved 3/3 → pot 420 → edith (rank 1) earned 420, net +300, multiple 3.5×; test1 net
+--   −300; settle-ledger edith +800 (380 refund + 420 pot), test1 +200 refund. With the −500
+--   escrow each: edith +300, test1 −300 → zero-sum.
+--
+-- Client copy: builder objective + "Buy-in" label updated (src/routes/+page.svelte).
+-- Full body applied via MCP; see git history.


### PR DESCRIPTION
## What
Makes challenges express the core **spend-less** mechanic with real money — the v3.1 "pot of spend" model — and **closes the long-deferred competitive-stats gap** (challenge rows now carry a true return multiple).

### `_match_settle` (migration `match_settle_pot_of_spend`)
- **Refund each player's UNSPENT buy-in** (their leftover bankroll).
- **The pot = the total everyone SPENT.** The most efficient solver (rank: solved desc, then spend asc) takes it (winner-take-all, or podium 60/—/20%).
- **"You only ever lose what you spent."** Zero-sum — the winner's net = everyone else's total spend.
- No real contest (nobody solved / <2 paid) → full buy-in refund.
- **Logs real `spent`/`earned`/`net` to the Play Log** for wagered settled games → challenge History/feed/H2H now show true multiples (friendly & refunded games log null, unchanged).

Escrow is unchanged (`accept_match` debits the buy-in; bankroll = budget, so spent = budget − bankroll).

## Verified (rolled-back 2-player sim, buy-in $500)
- edith spends **$120**, test1 spends **$300**, both solve 3/3
- pot = **$420** → edith (rank 1) earns $420, **net +$300, multiple 3.5×**; test1 **net −$300**
- settle-ledger: edith +$800 ($380 refund + $420 pot), test1 +$200 refund
- with the −$500 escrow each → edith **+$300**, test1 **−$300** → **zero-sum** ✅

## Client
- Builder objective rewritten: "unspent cash comes back, the pot is everyone's spend, and the most efficient solver takes it. You only ever lose what you spend."
- "Wager" → **"Buy-in"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)