### PR TITLE
Consistent naming: Community · Profile (via avatar) · Store

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -579,9 +579,14 @@
       if (ch) {
         openChallenges().then(() => { mbTarget = 'friend'; mbOpponent = ch; });
         params.delete('challenge');
-        const qs = params.toString();
-        window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
       }
+      // Settings/account deep link from the Profile page's ⚙️ gear (/?account=1)
+      if (params.get('account')) {
+        handleMenuMyAccount();
+        params.delete('account');
+      }
+      const qs = params.toString();
+      window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
     } catch { /* non-fatal */ }
   }
   function dismissTutorial() {
@@ -1052,7 +1057,7 @@
           <button class="bank-chip" on:click={() => goto('/bank')} title="Your Cash">
             <span class="bc-coin">💰</span>{netWorth == null ? '—' : '$' + Math.round(netWorth).toLocaleString()}
           </button>
-          <button class="account-ic" on:click={handleMenuMyAccount} title="My Account">👤</button>
+          <button class="account-ic" on:click={() => goto('/profile')} title="Profile">👤</button>
         </div>
         <video class="menu-mark" src="/coin.mp4" poster="/coin-poster.jpg" autoplay loop muted playsinline disablepictureinpicture></video>
         <img class="menu-wordmark" src="/wordmark-slogan.png" alt="WordBank — Spend Less. Think More." />
@@ -1076,11 +1081,11 @@
             <span class="mc-title">Challenge Friends</span>
             {#if challengeCount + friendReqCount > 0}<span class="mc-badge" title="{challengeCount} match{challengeCount === 1 ? '' : 'es'}, {friendReqCount} friend request{friendReqCount === 1 ? '' : 's'}">{challengeCount + friendReqCount}</span>{/if}
           </button>
-          <button class="menu-card" style="--i: 2" on:click={() => { menuView = 'progress'; fx('tap'); }}>
-            <span class="mc-title">Progress</span>
+          <button class="menu-card" style="--i: 2" on:click={() => { menuView = 'community'; fx('tap'); }}>
+            <span class="mc-title">Community</span>
           </button>
           <button class="menu-card" style="--i: 3" on:click={() => goto('/shop')}>
-            <span class="mc-title">Shop</span>
+            <span class="mc-title">Store</span>
           </button>
         </div>
 
@@ -1129,20 +1134,17 @@
           </button>
         </div>
 
-      {:else if menuView === 'progress'}
+      {:else if menuView === 'community'}
         <div class="sub-head">
           <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
-          <h2 class="sub-title">Progress</h2>
+          <h2 class="sub-title">Community</h2>
         </div>
         <div class="main-menu-buttons stagger">
-          <button class="menu-card" style="--i: 0" on:click={() => goto('/profile')}>
-            <span class="mc-title">You</span>
+          <button class="menu-card" style="--i: 0" on:click={handleMenuLeaderboard}>
+            <span class="mc-title">Leaderboard</span>
           </button>
-          <button class="menu-card" style="--i: 1" on:click={handleMenuLeaderboard}>
-            <span class="mc-title">Ranks</span>
-          </button>
-          <button class="menu-card" style="--i: 2" on:click={() => goto('/activity')}>
-            <span class="mc-title">Feed</span>
+          <button class="menu-card" style="--i: 1" on:click={() => goto('/activity')}>
+            <span class="mc-title">Activity</span>
           </button>
         </div>
       {/if}
@@ -1361,7 +1363,6 @@
             </div>
           </div>
 
-          <button class="main-menu-btn ghost-btn" on:click={() => goto('/profile')}>📊 Profile &amp; Stats</button>
           <button class="main-menu-btn ghost-btn" on:click={() => goto('/groups')}>👥 Groups</button>
 
           <div class="ma-section-label">Settings</div>
@@ -1456,7 +1457,7 @@
         </div>
       </div>
       {#if climb.state === 'active' && selfPups.length}
-        <p class="cp-hint">Your power-ups · tap to use · stock up in the Shop</p>
+        <p class="cp-hint">Your power-ups · tap to use · stock up in the Store</p>
         <div class="climb-pups">
           {#each selfPups as item}
             {@const used = (climb.equipped ?? []).includes(item.id)}

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -30,14 +30,18 @@
 <svelte:head><title>WordBank — You</title></svelte:head>
 
 <main class="you-page">
-  <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
+  <div class="topbar">
+    <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
+    <h1 class="page-title">Profile</h1>
+    <button class="gear" onclick={() => goto('/?account=1')} title="Settings" aria-label="Settings">⚙️</button>
+  </div>
 
   {#if loading}
     <p class="muted">Loading…</p>
   {:else if s}
     <header class="head">
       <div class="coin" style={s.color ? `--c:${s.color}` : ''}>{(s.username || '?').slice(0, 1).toUpperCase()}</div>
-      <h1>{s.username ? '@' + s.username : 'You'}</h1>
+      <div class="uname">{s.username ? '@' + s.username : 'You'}</div>
       <div class="nw" class:neg={Number(s.net_worth) < 0}>{fmt(s.net_worth)}</div>
       <span class="nw-sub">Net Worth</span>
     </header>
@@ -71,14 +75,18 @@
 
 <style>
   .you-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
+  .topbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
   .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
+  .page-title { font-family: var(--font-display); font-size: 1.2rem; margin: 0; }
+  .gear { background: none; border: none; font-size: 1.1rem; cursor: pointer; padding: 6px; opacity: 0.85; }
+  .gear:hover { opacity: 1; }
   .muted { color: var(--text-muted); text-align: center; padding: 2rem 0; }
 
   .head { text-align: center; margin: 8px 0 18px; }
   .coin { width: 64px; height: 64px; margin: 0 auto 8px; border-radius: 50%; display: grid; place-items: center;
     font-family: var(--font-display); font-weight: 800; font-size: 1.6rem; color: #3a2a00;
     background: linear-gradient(135deg, var(--c, #fde047), #f59e0b); box-shadow: 0 0 24px rgba(251,191,36,0.4); }
-  h1 { font-family: var(--font-display); font-size: 1.4rem; margin: 0; }
+  .uname { font-family: var(--font-display); font-weight: 700; font-size: 1.3rem; }
   .nw { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.1rem; color: #fde047;
     margin-top: 10px; text-shadow: 0 0 18px rgba(251,191,36,0.5); }
   .nw.neg { color: #fb7185; text-shadow: none; }

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -79,13 +79,13 @@
   }
 </script>
 
-<svelte:head><title>WordBank — Shop</title></svelte:head>
+<svelte:head><title>WordBank — Store</title></svelte:head>
 
 <main class="shop-page">
   <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
 
   <div class="head">
-    <h1>🛍️ Shop</h1>
+    <h1>🛍️ Store</h1>
     <span class="bank-chip">💰 ${bank.toLocaleString()}</span>
   </div>
   <p class="sub">Stock up on power-ups to bring into the Cash Game &amp; challenges, and spend on flair. Cosmetics are pure show — no pay-to-win.</p>


### PR DESCRIPTION
Aligns menu cards, page titles, and entry points (your review caught the mismatch where cards said You/Ranks/Feed but pages said Leaderboard/Activity).

- **Progress → Community** (holds Leaderboard + Activity); **Shop → Store**.
- **Profile moved behind the top-right avatar** — the universal 'tap your head = profile' pattern. 👤 now opens /profile directly.
- /profile gets a **Profile** title + a ⚙️ settings gear (opens the account/settings modal via /?account=1). Removed the redundant 'Profile & Stats' button from that modal.

Verified: QA sweep 18/18, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)