### PR TITLE
Challenge results: show the money outcome + walkthrough fixes

### DIFF
--- a/scripts/vs-walkthrough.mjs
+++ b/scripts/vs-walkthrough.mjs
@@ -1,0 +1,125 @@
+// 1v1 challenge walkthrough. Phases via env PHASE: setup | create | play | results.
+// Fixed creds so phases coordinate; clean up vsa@/vsb@ after.
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+mkdirSync('screenshots', { recursive: true });
+
+const BASE = process.env.BASE || 'http://localhost:5173';
+const PHASE = process.env.PHASE || 'setup';
+const ANSWER = (process.env.ANSWER || '').toUpperCase().replace(/[^A-Z]/g, '');
+const A = { email: 'vsa@example.com', pass: 'TestPass123!', user: 'vsalice' };
+const B = { email: 'vsb@example.com', pass: 'TestPass123!', user: 'vsbob' };
+const log = (...a) => console.log('  ', ...a);
+
+const browser = await chromium.launch();
+const ctx = () => browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const wait = (p, ms) => p.waitForTimeout(ms);
+
+async function dismissGates(p) {
+  const sk = p.getByRole('button', { name: /skip for now/i });
+  if (await sk.count()) { await sk.first().click().catch(() => {}); await wait(p, 600); }
+  const st = p.getByRole('button', { name: /^skip$/i });
+  if (await st.count()) { await st.first().click().catch(() => {}); await wait(p, 500); }
+}
+async function signup(p, acc) {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(p, 1000);
+  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); await wait(p, 300);
+  await p.locator('input').first().fill(acc.email);
+  await p.fill('input[type=password]', acc.pass);
+  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); await wait(p, 3500);
+  const claim = p.locator('input.claim-input');
+  if (await claim.count()) { await claim.fill(acc.user); await p.locator('button.claim-btn').click().catch(() => {}); await wait(p, 1800); }
+  await dismissGates(p);
+}
+async function login(p, acc) {
+  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(p, 1000);
+  if (await p.locator('input[type=password]').count()) {
+    await p.locator('input').first().fill(acc.user);
+    await p.fill('input[type=password]', acc.pass);
+    await p.getByRole('button', { name: /log in/i }).first().click(); await wait(p, 3000);
+  }
+  await dismissGates(p);
+}
+// buy `wrong` letters (not in the answer → pure spend, keeps all tiles editable), then solve.
+async function playSolve(p, answer, wrong) {
+  for (const L of wrong) { await p.keyboard.press(L); await wait(p, 250); await p.keyboard.press('Enter'); await wait(p, 900); }
+  // enter guess mode
+  await p.getByRole('button', { name: /^solve$/i }).first().click().catch(async () => { await p.keyboard.press(' '); });
+  await wait(p, 700);
+  for (const ch of answer) { await p.keyboard.press(ch); await wait(p, 60); }
+  await wait(p, 400);
+  await p.getByRole('button', { name: /^submit$/i }).first().click().catch(async () => { await p.keyboard.press('Enter'); });
+  await wait(p, 2500);
+}
+async function openChallengeInbox(p) {
+  await p.getByRole('button', { name: /challenge friends/i }).first().click().catch(() => {}); await wait(p, 600);
+  await p.getByRole('button', { name: /start challenge/i }).first().click().catch(() => {}); await wait(p, 1200);
+}
+
+// ──────────────────────────────────────────────────────────────
+if (PHASE === 'setup') {
+  const ca = await ctx(); const pa = await ca.newPage(); await signup(pa, A); log('A signed up', A.user);
+  const cb = await ctx(); const pb = await cb.newPage(); await signup(pb, B); log('B signed up', B.user);
+  console.log('SETUP_DONE');
+}
+
+if (PHASE === 'create') {
+  const c = await ctx(); const p = await c.newPage(); await login(p, A);
+  await openChallengeInbox(p);
+  await p.locator('input.ch-input').first().fill(B.user); await wait(p, 800);
+  // pack size 1
+  await p.locator('select.ch-input').first().selectOption('1').catch(() => {});
+  // wager 500
+  await p.locator('input[type=number].ch-input').first().fill('500').catch(() => {});
+  await wait(p, 400);
+  await p.getByRole('button', { name: /send challenge/i }).first().click().catch(() => {});
+  await wait(p, 2500);
+  await p.screenshot({ path: 'screenshots/vs-01-created.png' });
+  console.log('CREATE_DONE');
+}
+
+if (PHASE === 'play') {
+  // wrong letters not in the answer
+  const pool = 'QZXJKVWBYG'.split('').filter((L) => !ANSWER.includes(L));
+  // B accepts + plays (spends more → loses)
+  const cb = await ctx(); const pb = await cb.newPage(); await login(pb, B);
+  await openChallengeInbox(pb);
+  await pb.getByRole('button', { name: /^play$/i }).first().click().catch(() => {}); await wait(pb, 2600);
+  await pb.screenshot({ path: 'screenshots/vs-02-B-board.png' });
+  await playSolve(pb, ANSWER, pool.slice(0, 4)); // B buys 4 wrong letters
+  await pb.screenshot({ path: 'screenshots/vs-03-B-after.png' });
+  log('B played');
+  // A plays (spends less → wins)
+  const ca = await ctx(); const pa = await ca.newPage(); await login(pa, A);
+  await openChallengeInbox(pa);
+  await pa.getByRole('button', { name: /^(play|resume)$/i }).first().click().catch(() => {}); await wait(pa, 2600);
+  await playSolve(pa, ANSWER, pool.slice(0, 1)); // A buys 1 wrong letter
+  await pa.screenshot({ path: 'screenshots/vs-04-A-result.png' });
+  log('A played');
+  console.log('PLAY_DONE');
+}
+
+if (PHASE === 'results') {
+  const c = await ctx(); const p = await c.newPage(); await login(p, A);
+  // 1) view results from the challenge inbox
+  await openChallengeInbox(p);
+  await p.screenshot({ path: 'screenshots/vs-05-inbox.png' });
+  await p.getByRole('button', { name: /results/i }).first().click().catch(() => {}); await wait(p, 1800);
+  await p.screenshot({ path: 'screenshots/vs-06-results-modal.png' });
+  // 2) History (Profile → History tab)
+  await p.goto(`${BASE}/history`, { waitUntil: 'networkidle' }); await wait(p, 1600);
+  await p.screenshot({ path: 'screenshots/vs-07-history.png' });
+  // 3) Profile stats
+  await p.goto(`${BASE}/profile`, { waitUntil: 'networkidle' }); await wait(p, 1500);
+  await p.screenshot({ path: 'screenshots/vs-08-profile.png' });
+  // 4) Leaderboard challenges
+  await p.goto(`${BASE}/leaderboard?board=challenges`, { waitUntil: 'networkidle' }); await wait(p, 1600);
+  await p.getByRole('button', { name: /challenges/i }).first().click().catch(() => {}); await wait(p, 1200);
+  await p.screenshot({ path: 'screenshots/vs-09-leaderboard.png' });
+  // 5) Activity
+  await p.goto(`${BASE}/activity`, { waitUntil: 'networkidle' }); await wait(p, 1600);
+  await p.screenshot({ path: 'screenshots/vs-10-activity.png' });
+  console.log('RESULTS_DONE');
+}
+
+await browser.close();

--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -10,9 +10,13 @@
   $: parts = detail?.participants ?? [];
   $: m = detail?.match;
   $: opp = parts.find((/** @type {any} */ p) => !p.is_me);
+  $: me = parts.find((/** @type {any} */ p) => p.is_me);
   $: noSolve = parts.length > 0 && parts.every((/** @type {any} */ p) => (p.solved ?? 0) === 0);
   $: title = detail?.group_name || (opp ? '@' + (opp.name || 'player') : 'Challenge');
+  $: wagered = Number(m?.wager) > 0;
   const rankIcon = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
+  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
+  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
 </script>
 
 {#if detail}
@@ -27,10 +31,19 @@
         <p class="md-sub">
           {m?.pack_size} puzzle{m?.pack_size === 1 ? '' : 's'}
           · {m?.payout === 'podium' ? 'podium 3·2·1' : 'winner-take-all'}
-          {#if Number(m?.wager) > 0}· ${Number(m.wager).toLocaleString()} buy-in{:else}· friendly{/if}
+          {#if wagered}· ${Number(m.wager).toLocaleString()} buy-in{:else}· friendly{/if}
           {#if m?.status !== 'settled'}· <em>in progress</em>{/if}
-          {#if noSolve && Number(m?.wager) > 0}· wager refunded{/if}
+          {#if noSolve && wagered}· buy-in refunded{/if}
         </p>
+
+        {#if wagered && m?.status === 'settled' && me && me.net != null && !noSolve}
+          <div class="md-outcome {Number(me.net) >= 0 ? 'win' : 'loss'}">
+            <span class="md-out-net">{money(me.net)}</span>
+            <span class="md-out-lbl">
+              {#if Number(me.net) >= 0}you took the pot{#if mult(me.multiple_x100)} · {mult(me.multiple_x100)}{/if}{:else}you spent ${me.spent}{/if}
+            </span>
+          </div>
+        {/if}
 
         <div class="md-standings">
           {#each parts as p}
@@ -38,7 +51,7 @@
               <span class="md-rank">{noSolve ? '🤝' : rankIcon(p.rank)}</span>
               <span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
               <span class="md-meta">
-                {#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null} · ${Number(p.spent).toLocaleString()} spent{/if}
+                {#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null} · ${Number(p.spent).toLocaleString()} spent{/if}{#if wagered && p.net != null} · <span class:pos={Number(p.net) >= 0} class:neg={Number(p.net) < 0}>{money(p.net)}</span>{/if}
                 {:else}{p.state}{/if}
               </span>
             </div>
@@ -50,7 +63,7 @@
             <div class="md-pack-h">Puzzles</div>
             {#each detail.pack as pk}
               <div class="md-pk">
-                <span class="md-pos">{pk.position + 1}</span>
+                <span class="md-pos">{pk.position}</span>
                 <span class="md-cat">{pk.category}</span>
                 <span class="md-ans">{pk.phrase ? '“' + pk.phrase + '”' : '🔒 hidden until settled'}</span>
               </div>
@@ -71,6 +84,15 @@
   .md-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 4px; }
   .md-sub { color: var(--text-faint); font-size: 0.8rem; margin: 0 0 16px; }
   .md-msg { color: var(--text-muted); text-align: center; padding: 24px 0; }
+
+  .md-outcome { display: flex; align-items: baseline; gap: 10px; justify-content: center; padding: 12px; margin: 0 0 16px;
+    border-radius: var(--r-md); border: 1px solid var(--border); }
+  .md-outcome.win { background: rgba(126,224,168,0.1); border-color: rgba(126,224,168,0.3); }
+  .md-outcome.loss { background: rgba(251,113,133,0.08); border-color: rgba(251,113,133,0.25); }
+  .md-out-net { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.6rem; }
+  .md-outcome.win .md-out-net { color: #7ee0a8; } .md-outcome.loss .md-out-net { color: #fb7185; }
+  .md-out-lbl { color: var(--text-muted); font-size: 0.82rem; }
+  .md-meta .pos { color: #7ee0a8; } .md-meta .neg { color: #fb7185; }
 
   .md-standings { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
   .md-row { display: flex; align-items: center; gap: 10px; padding: 9px 11px; border-radius: var(--r-sm); background: var(--surface); }

--- a/src/routes/badges/+page.svelte
+++ b/src/routes/badges/+page.svelte
@@ -6,7 +6,7 @@
 <svelte:head><title>WordBank — Badges</title></svelte:head>
 
 <main class="badges-page">
-  <button class="back-btn" onclick={() => goto('/profile')}>← You</button>
+  <button class="back-btn" onclick={() => goto('/profile')}>← Profile</button>
   <h1>🏅 Badges</h1>
   <BadgesPanel />
 </main>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -6,7 +6,7 @@
 <svelte:head><title>WordBank — History</title></svelte:head>
 
 <main class="h-page">
-  <button class="back-btn" onclick={() => goto('/profile')}>← You</button>
+  <button class="back-btn" onclick={() => goto('/profile')}>← Profile</button>
   <h1>📜 History</h1>
   <HistoryList />
 </main>


### PR DESCRIPTION
## What
Ran a full **2-account 1v1 walkthrough** (create → accept → play → auto-settle → results) and fixed what it surfaced.

**Pot-of-spend confirmed live:** vsalice spent **\$20**, took the **\$120 pot** → **net +\$100, 6.0×, rank 1**; vsbob spent \$100 → −\$100. Zero-sum, in the real UI.

### Fixes
- **Results modal showed spend but not winnings.** `get_match_detail` now returns per-participant `net`/`earned`/`multiple_x100` (migration `match_detail_add_money`); `MatchDetailModal` shows a green/red **outcome banner** ("+\$100 — you took the pot · 6.0×") + each player's net in standings.
- **Puzzle position off-by-one** — showed "2" for the only puzzle in a 1-pack (`position` is already 1-indexed; dropped the `+1`).
- **Back buttons** "← You" → "← Profile" on /history + /badges (post-rename consistency).

Adds `scripts/vs-walkthrough.mjs` (phased 1v1 E2E harness).

See the next message for the full walkthrough report + remaining recommendations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)