### PR TITLE
Challenge polish: win celebration, View Results, real career stats

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -704,7 +704,8 @@ function reconcileMatchBoard(board) {
     matchInfo: { ...match, id: activeMatchId }
   }));
   if (done) { setTimeout(() => launchConfetti(), 250); fx('win'); }
-  else if ((match.last_score ?? 0) > 0 && (match.position ?? 1) > (prev.matchInfo?.position ?? 0)) { fx('win'); }
+  // Celebrate EACH solved puzzle in the pack (not just finishing the whole pack).
+  else if ((match.last_score ?? 0) > 0 && (match.position ?? 1) > (prev.matchInfo?.position ?? 0)) { setTimeout(() => launchConfetti(), 250); fx('win'); }
   else playMoveCue(prev, board);
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1677,7 +1677,11 @@
             <p class="result-sub">{#if matchInfo?.mode === 'blitz'}You scored {(matchInfo?.total_score ?? 0).toLocaleString()} across {matchInfo?.pack_size} puzzle{matchInfo?.pack_size === 1 ? '' : 's'}{:else}You solved {matchInfo?.solved ?? 0}/{matchInfo?.pack_size} spending ${(matchInfo?.spent ?? 0).toLocaleString()}{/if}</p>
             <p class="arcade-gain">{matchInfo?.status === 'settled' ? 'Settled — check the results.' : "Lowest spend wins — we'll settle once everyone plays."}</p>
             <div class="result-actions">
-              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); openChallenges(); }}>Challenge Friends</button>
+              {#if matchInfo?.status === 'settled'}
+                <button class="share-btn" on:click={async () => { const id = matchInfo?.id; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); matchResults = { loading: true }; matchResults = await getMatchDetail(id); }}>View Results</button>
+              {:else}
+                <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); openChallenges(); }}>Challenge Friends</button>
+              {/if}
               <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
             </div>
           {:else if isFreeplay}


### PR DESCRIPTION
All the 1v1-walkthrough recs + a dead-column bug it exposed.

- **Win celebration on every challenge solve** — confetti now fires for each puzzle solved in a pack (was only on finishing the whole pack; per-puzzle solves just beeped).
- **Direct "View Results"** on the settled match modal — opens the detail modal in one tap instead of "Challenge Friends" → inbox → Results. Also gives the **loser** a clear path to their outcome.
- **Real career stats (bug fix).** `total_puzzles_correct` / `total_cash_accrued` / `total_cash_spent` were **dead columns** — only read, never written — so "Puzzles solved" and "Lifetime earned/spent" were `0` for *everyone, every mode*. Now computed from the Play Log in `get_profile_stats` + `get_public_profile` (uniform across daily/climb/arcade/challenge). Verified: daily + challenge → **puzzles 4, earned \$950, spent \$160**.

Migration `profile_stats_from_play_log`. QA sweep 18/18, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)