### PR TITLE
Rename Climb → Cash Game in the UI

### DIFF
--- a/src/lib/components/HistoryList.svelte
+++ b/src/lib/components/HistoryList.svelte
@@ -25,7 +25,7 @@
 
   const MODES = [
     { k: 'all', label: 'All' }, { k: 'daily', label: '📅 Daily' },
-    { k: 'climb', label: '🎰 Climb' }, { k: 'arcade', label: '🎲 Arcade' },
+    { k: 'climb', label: '🎰 Cash Game' }, { k: 'arcade', label: '🎲 Arcade' },
     { k: 'challenge', label: '⚔️ Versus' }
   ];
   const icon = (/** @type {string} */ m) =>

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -29,9 +29,9 @@
     },
     {
       icon: '🧗',
-      title: 'Climb & Challenges',
+      title: 'Cash Game & Challenges',
       isNew: true,
-      body: 'Climb an endless ladder of puzzles for Cash bounties, or wager friends: your wager is your budget, and whoever solves spending the least takes the pot.'
+      body: 'Take on an endless ladder of puzzles for Cash bounties, or wager friends: your wager is your budget, and whoever solves spending the least takes the pot.'
     },
     {
       icon: '🎲',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1450,7 +1450,7 @@
     <!-- 🎰 Cash Game (Climb) HUD -->
     {#if isClimb && climb}
       <div class="climb-top">
-        <span class="climb-level">🧗 Climb&nbsp;#{climb.position}</span>
+        <span class="climb-level">🎰 Cash&nbsp;Game&nbsp;#{climb.position}</span>
         <div class="heat-meter" class:hot={(climb.heat ?? 100) > 100}>
           <span class="heat-fill" style="width:{Math.min(100, Math.max(0, (climb.heat ?? 100) - 100))}%"></span>
           <span class="heat-x">🔥 ×{climbHeat}</span>
@@ -1665,7 +1665,7 @@
             <div class="result-medal">🎰</div>
             <h2>Solved! +${(climb?.last_gain ?? 0).toLocaleString()}</h2>
             <p class="result-sub">{$gameStore.currentPhrase}</p>
-            <p class="arcade-gain">Climb #{climb?.position} · Heat ×{climbHeat}{#if (climb?.heat ?? 100) >= 200} 🔥 maxed{/if}</p>
+            <p class="arcade-gain">Cash Game #{climb?.position} · Heat ×{climbHeat}{#if (climb?.heat ?? 100) >= 200} 🔥 maxed{/if}</p>
             <div class="result-actions">
               <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Leave</button>
               <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance(); }}>Next →</button>

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -10,7 +10,7 @@
   const TABS = [
     { k: 'daily', label: '📅 Daily' },
     { k: 'efficiency', label: '⚡ Efficiency' },
-    { k: 'climb', label: '🎰 Climb' },
+    { k: 'climb', label: '🎰 Cash Game' },
     { k: 'challenges', label: '⚔️ Challenges' },
     { k: 'wealth', label: '💰 Wealth' }
   ];
@@ -113,7 +113,7 @@
             {:else if board === 'daily'}<th>Score</th>
             {:else if board === 'efficiency'}<th>Best ×</th><th>Category</th>
             {:else if board === 'challenges'}<th>Wins</th><th>Pot won</th>
-            {:else}<th>Climb</th>{/if}
+            {:else}<th>Furthest</th>{/if}
           </tr>
         </thead>
         <tbody>
@@ -157,7 +157,7 @@
     {:else if board === 'daily'}Same puzzle for everyone today. Spend less, score more.
     {:else if board === 'efficiency'}Your best return multiple (bounty ÷ spend). The core flex — crack a puzzle spending next to nothing.
     {:else if board === 'challenges'}Head-to-head wins. Win challenges by solving on the least spend and taking the pot.
-    {:else}How far you've climbed the Cash Game ladder. Everyone faces the same puzzles, in order.{/if}
+    {:else}How far you got in the Cash Game. Everyone faces the same puzzles, in order.{/if}
   </p>
 </main>
 

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -58,7 +58,7 @@
         <div class="stat"><span class="sv">{s.longest_streak}</span><span class="sc">Best streak</span></div>
         <div class="stat"><span class="sv">{winPct}%</span><span class="sc">Daily win rate</span></div>
         <div class="stat"><span class="sv">{(s.puzzles_solved ?? 0).toLocaleString()}</span><span class="sc">Puzzles solved</span></div>
-        <div class="stat"><span class="sv">#{s.climb_position}</span><span class="sc">Climb position</span></div>
+        <div class="stat"><span class="sv">#{s.climb_position}</span><span class="sc">Furthest</span></div>
         <div class="stat"><span class="sv">{record}</span><span class="sc">Challenge W-L-T</span></div>
         <div class="stat"><span class="sv">{mult(s.avg_multiple_x100)}</span><span class="sc">Avg multiple</span></div>
         <div class="stat"><span class="sv">{mult(s.best_multiple_x100)}</span><span class="sc">Best multiple</span></div>

--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -100,7 +100,7 @@
       <div class="stat"><span class="s-n">{winPct(p)}</span><span class="s-l">Daily win %</span></div>
       <div class="stat"><span class="s-n">{p.puzzles_solved}</span><span class="s-l">Puzzles solved</span></div>
       <div class="stat"><span class="s-n">{p.challenge_wins}</span><span class="s-l">Challenge wins</span></div>
-      <div class="stat"><span class="s-n">#{p.climb_position}</span><span class="s-l">Climb position</span></div>
+      <div class="stat"><span class="s-n">#{p.climb_position}</span><span class="s-l">Furthest</span></div>
       <div class="stat"><span class="s-n">{mult(p.avg_multiple_x100)}</span><span class="s-l">Avg multiple</span></div>
       <div class="stat"><span class="s-n">{mult(p.best_multiple_x100)}</span><span class="s-l">Best multiple</span></div>
     </section>


### PR DESCRIPTION
Standardizes on **Cash Game** (already used in the Play menu) and drops the off-theme word **Climb** everywhere user-facing. The position metric becomes **Furthest**.

- Leaderboard tab + column + hint, History mode chip, Profile/public-profile stat, in-game HUD + solve result, and the Tutorial copy.
- Internal identifiers (gameMode `'climb'`, `climb_state`, `get_climb_*` RPCs, function names) untouched — purely labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)