### PR TITLE
Fix make-up daily: clue + real Cash + correct stats

### DIFF
--- a/scripts/makeup-test.mjs
+++ b/scripts/makeup-test.mjs
@@ -1,0 +1,54 @@
+import { chromium } from 'playwright';
+import { mkdirSync } from 'node:fs';
+mkdirSync('screenshots', { recursive: true });
+const BASE = process.env.BASE || 'http://localhost:5173';
+const PHASE = process.env.PHASE || 'setup';
+const ACC = { email: 'mka@example.com', pass: 'TestPass123!', user: 'mkalice' };
+const ANSWER = 'THEICEAGE';
+const b = await chromium.launch();
+const c = await b.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const p = await c.newPage();
+const w = (ms) => p.waitForTimeout(ms);
+async function gates() {
+  const sk = p.getByRole('button', { name: /skip for now/i }); if (await sk.count()) { await sk.first().click().catch(()=>{}); await w(500); }
+  const st = p.getByRole('button', { name: /^skip$/i }); if (await st.count()) { await st.first().click().catch(()=>{}); await w(400); }
+}
+await p.goto(BASE, { waitUntil: 'networkidle' }); await w(1000);
+if (PHASE === 'setup') {
+  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await w(300);
+  await p.locator('input').first().fill(ACC.email); await p.fill('input[type=password]', ACC.pass);
+  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await w(3500);
+  const claim = p.locator('input.claim-input');
+  if (await claim.count()) { await claim.fill(ACC.user); await p.locator('button.claim-btn').click().catch(()=>{}); await w(1800); }
+  await gates(); console.log('SETUP_DONE');
+}
+if (PHASE === 'play') {
+  if (await p.locator('input[type=password]').count()) {
+    await p.locator('input').first().fill(ACC.user); await p.fill('input[type=password]', ACC.pass);
+    await p.getByRole('button', { name: /log in/i }).first().click(); await w(3000);
+  }
+  await gates();
+  // bankroll shown on the menu top chip
+  const menuBank = await p.locator('text=/\\$[0-9,]+/').first().innerText().catch(()=>'?');
+  console.log('menu bankroll:', menuBank);
+  await p.goto(`${BASE}/streak`, { waitUntil: 'networkidle' }); await w(1500);
+  await p.screenshot({ path: 'screenshots/mk-01-calendar.png' });
+  // tap day 22 (a makeable past day → "The Ice Age")
+  await p.locator('.cell.playable', { has: p.locator('.cell-day', { hasText: /^22$/ }) }).first().click().catch(async () => {
+    await p.locator('.cell.playable').first().click().catch(()=>{});
+  });
+  await w(2800);
+  await p.screenshot({ path: 'screenshots/mk-02-board.png' });
+  const clue = await p.locator('.puzzle-clue').innerText().catch(()=>'(no clue)');
+  const boardBank = await p.locator('text=/\\$[0-9,]+/').first().innerText().catch(()=>'?');
+  console.log('makeup clue:', clue);
+  console.log('makeup board bankroll:', boardBank);
+  // solve
+  await p.getByRole('button', { name: /^solve$/i }).first().click().catch(async()=>{await p.keyboard.press(' ');}); await w(700);
+  for (const ch of ANSWER) { await p.keyboard.press(ch); await w(70); }
+  await w(400);
+  await p.getByRole('button', { name: /^submit$/i }).first().click().catch(async()=>{await p.keyboard.press('Enter');}); await w(2600);
+  await p.screenshot({ path: 'screenshots/mk-03-result.png' });
+  console.log('PLAY_DONE');
+}
+await b.close();

--- a/src/lib/components/HistoryList.svelte
+++ b/src/lib/components/HistoryList.svelte
@@ -29,7 +29,7 @@
     { k: 'challenge', label: '⚔️ Versus' }
   ];
   const icon = (/** @type {string} */ m) =>
-    m === 'daily' ? '📅' : m === 'climb' ? '🎰' : m === 'arcade' ? '🎲' : m === 'challenge' ? '⚔️' : '🎮';
+    m === 'daily' ? '📅' : m === 'makeup' ? '🗓️' : m === 'climb' ? '🎰' : m === 'arcade' ? '🎲' : m === 'challenge' ? '⚔️' : '🎮';
   const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
   const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
   const when = (/** @type {string} */ t) => new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -509,6 +509,7 @@ function reconcileMakeupBoard(board) {
     gameMode: 'makeup',
     gameState: finished ? board.state : 'default',
     modifier: null, arcadeRun: null,
+    clue: board.clue ?? prev.clue ?? null,
     makeupDate: board.makeup?.date ?? prev.makeupDate ?? activeMakeupDate
   }));
   if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -273,7 +273,7 @@
   $: resultWon = $gameStore.gameState === 'won';
   $: isDailyResult = $gameStore.gameMode === 'daily';
   // Live Daily HUD metrics (only while actively playing the daily).
-  $: dLive = ($gameStore.gameMode === 'daily' && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
+  $: dLive = (($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'makeup') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
     ? $gameStore.dailyLive : null;
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
@@ -1443,7 +1443,7 @@
     {#if isMakeup}
       <div class="makeup-banner">
         <span class="mb-tag">🗓️ Make-up</span>
-        <span class="mb-text">Playing {makeupLabel} · fills your calendar (no streak/Bank)</span>
+        <span class="mb-text">Playing {makeupLabel} · fills your calendar · earns the puzzle's Cash (no streak)</span>
       </div>
     {/if}
 

--- a/supabase-makeup-mirror-daily.sql
+++ b/supabase-makeup-mirror-daily.sql
@@ -1,0 +1,24 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Make-up daily now mirrors the regular daily (migration: makeup_mirror_daily_real_cash) ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Bugs reported: make-up (play a past day from the streak calendar) showed no clue and
+-- started with a sandboxed $1000 instead of the player's real Cash.
+--
+-- Fix — make-up = playing that day's daily for real:
+--   • makeup_start: session bankroll seeded 0 (was 1000); board returns the player's REAL
+--     bank (like daily_start), plus the puzzle `clue` and a `live` {spent,reward,net} HUD.
+--   • makeup_buy_letter / makeup_reveal: spend REAL Cash (profiles.bank), track s.spent
+--     (was the fabricated s.bankroll).
+--   • _makeup_resolve_and_return: on the first transition to won, pays the puzzle reward
+--     ('makeup_reward') + records the category solve + writes a Play Log row with
+--     game_mode='makeup'. Loss = real bank < 20. Returns real bank + live + clue.
+--
+-- Stats impact (verified): a solved make-up writes ONE game_results row, game_mode='makeup' →
+--   counts in puzzles_solved / History / efficiency, but is EXCLUDED from today's daily
+--   leaderboard (which filters game_mode='daily') and does NOT touch the daily streak.
+--   Verified live (mka, bank 2500): solve "The Ice Age" → bank 3140 (+640 reward, $0 spent),
+--   play_log [{makeup, won, earned 640, solved 1}], puzzles_solved 1, daily_rows 0.
+--
+-- Client: reconcileMakeupBoard sets `clue` (GameStore.js); dLive HUD extended to make-up;
+--   make-up banner copy updated ("earns the puzzle's Cash"); History icon 🗓️ for makeup.
+-- Full bodies applied via MCP; see git history.


### PR DESCRIPTION
Playwright-tested the streak-calendar make-up flow and fixed the two reported bugs.

**Before:** playing a past day showed **no clue/hint** and started with a sandboxed **\$1000** (not your Cash), with no stats impact.

**After — make-up = playing that day's daily for real** (migration `makeup_mirror_daily_real_cash`):
- `makeup_start`: real-Cash bankroll + the puzzle **clue** + a live worth HUD.
- `makeup_buy_letter` / `makeup_reveal`: spend real Cash, track spend.
- `_makeup_resolve_and_return`: pays the puzzle reward on solve + writes a Play Log row tagged `makeup`.

**Stats — the right way:** a make-up solve counts in **puzzles solved / History / efficiency** (mode `makeup`) but is **excluded from today's daily leaderboard** and **doesn't touch the streak** (it just fills the calendar for Perfect Week/Month).

### Verified live (Playwright + DB)
Tapped Jun 22 in the calendar → board showed **"Glaciers covered Earth."** + **BALANCE \$2500** (real). Solved "The Ice Age" → **bank +\$640**, Play Log `[{makeup, won, earned 640, solved 1}]`, **puzzles_solved 1**, **daily_rows 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)