### PR TITLE
Net Worth = Cash (no loans) + fix dead win-rate + stats doc

### DIFF
--- a/STATS_AND_LEADERBOARDS.md
+++ b/STATS_AND_LEADERBOARDS.md
@@ -1,0 +1,54 @@
+# WordBank — Stats & Leaderboards reference
+
+Canonical map of every stat + leaderboard, how each is computed, and how the game
+modes feed them. (No loans — Net Worth = your Cash balance = `profiles.bank`.)
+
+## Data sources
+1. **`game_results` (Play Log)** — one rich row per completed game, every mode. The spine.
+   Columns: outcome, game_mode, solved_count, spent, earned, net, multiple_x100, category,
+   match_id, opponent_id, group_id, rank, pot, wager.
+2. **`profiles`** — `bank` (your Cash / Net Worth), `current_win_streak`, `highest_win_streak`,
+   equipped_title/color. (`loan`, `total_games_*`, `total_cash_*`, `total_puzzles_correct` are
+   DEAD columns — not written; all live stats are computed from the Play Log.)
+3. **`climb_state`** — Cash Game position + heat.
+4. **`category_stats` / `user_badges`** — collection.
+
+## Profile stats (`get_profile_stats` / `get_public_profile`)
+| Stat | Calc | Source | Modes |
+|---|---|---|---|
+| Net Worth / Cash | `bank` | profiles | all |
+| Day / Best streak | consecutive daily wins | profiles | Daily |
+| Daily win rate | daily won ÷ daily played (Play Log) | Play Log | Daily |
+| Puzzles solved | `Σ solved_count` | Play Log | daily, cash game, challenge, makeup |
+| Furthest | `climb_state.position` | climb_state | Cash Game |
+| Challenge W-L-T | count by outcome (mode=challenge) | Play Log | Challenges |
+| Avg / Best multiple | avg/max `multiple_x100` | Play Log | daily, cash game, challenge |
+| Lifetime earned / spent | `Σ earned` / `Σ spent` | Play Log | all paid |
+| Badges / Category levels | user_badges / category_stats | — | all |
+
+## Leaderboards
+| Board | Ranks by | Source | Scope |
+|---|---|---|---|
+| **Daily** | today's daily score (= net) | Play Log (daily, today) | friends/global/group |
+| **Efficiency** | best multiple (week/all) | Play Log multiple_x100 | ↑ |
+| **Cash Game** | furthest position | climb_state | ↑ |
+| **Challenges** | wins + pot won (week/all) | Play Log challenge rows | ↑ |
+| **Wealth** | Cash (week = gain via networth_snapshots) | profiles.bank | ↑ |
+| Group → Compete | in-group challenge W / played | challenge_participants | one group |
+| Head-to-head | W-L-T vs an opponent | Play Log by opponent_id | per-player |
+
+Legacy/unused: `get_daily_leaderboard` (period/order-by) — superseded by `get_daily_board`.
+
+## How modes feed the system
+- **Daily** → Daily board, streak, puzzles_solved, reward→Wealth, multiple→Efficiency.
+- **Cash Game** → position→Cash Game board + "Furthest", bounty→Wealth, multiple→Efficiency. Forward-only, not farmable.
+- **Challenges** → W-L-T + pot→Challenges board + group Compete + H2H, net→Wealth, multiple→Efficiency.
+- **Make-up** → puzzles_solved + History + Efficiency; EXCLUDED from Daily board & streak.
+- **Arcade / Free Play** → arcade has its own board; Free Play = broke-safe trickle (self-contained).
+
+## Cash Game seeding
+- `climb_sequence(position, puzzle_id)` — a **fixed shuffle of 720 puzzles** (`ORDER BY md5(id)`),
+  **identical for everyone**, forward-only. `_climb_puzzle_at(position)` returns the rung.
+- Everyone starts at **position 1**; each puzzle solved once (income bounded).
+- Pool is now **1,200** puzzles but the ladder snapshot is **720** → ~480 unused; ladder ends at 720.
+  KNOB: re-seed to the full pool / loop for longer runs.

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -90,7 +90,7 @@
   </div>
 
   <p class="caption">
-    {#if board === 'wealth'}{period === 'week' ? 'Net Worth gained this week' : 'Net Worth — Cash minus Loans'}
+    {#if board === 'wealth'}{period === 'week' ? 'Cash gained this week' : 'Total Cash'}
     {:else if board === 'daily'}Today's Daily Score
     {:else if board === 'efficiency'}Best return multiple {period === 'week' ? 'this week' : 'all-time'} — spend the least
     {:else if board === 'challenges'}Challenge wins {period === 'week' ? 'this week' : 'all-time'}
@@ -109,7 +109,7 @@
         <thead>
           <tr>
             <th>#</th><th>Player</th>
-            {#if board === 'wealth'}<th>{period === 'week' ? 'Gained' : 'Net Worth'}</th><th>Cash</th>
+            {#if board === 'wealth'}<th>{period === 'week' ? 'Gained' : 'Cash'}</th>
             {:else if board === 'daily'}<th>Score</th>
             {:else if board === 'efficiency'}<th>Best ×</th><th>Category</th>
             {:else if board === 'challenges'}<th>Wins</th><th>Pot won</th>
@@ -127,13 +127,11 @@
                   <button class="name-link" onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))} style={r.color ? `color:${r.color}` : ''}>{r.name || 'Player'}</button>
                 {/if}
                 {#if r.title}<span class="title">{r.title}</span>{/if}
-                {#if board === 'wealth' && (r.net_worth ?? 0) < 0}<span class="red-flag">🔴</span>{/if}
               </td>
               {#if board === 'wealth'}
-                <td class="metric" class:neg={(period === 'week' ? r.metric : r.net_worth) < 0}>
+                <td class="metric" class:neg={period === 'week' && Number(r.metric) < 0}>
                   {period === 'week' ? (r.metric >= 0 ? '+' : '') + fmt(r.metric) : fmt(r.net_worth)}
                 </td>
-                <td class="dim">{fmt(r.cash)}</td>
               {:else if board === 'daily'}
                 <td class="metric">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
               {:else if board === 'efficiency'}
@@ -153,7 +151,7 @@
   {/if}
 
   <p class="hint">
-    {#if board === 'wealth'}Net Worth = Cash − Loans. 🔴 = in the red. Weekly resets Monday — fair for newcomers.
+    {#if board === 'wealth'}Your Cash balance — earn it across every mode. Weekly resets Monday, so newcomers can climb.
     {:else if board === 'daily'}Same puzzle for everyone today. Spend less, score more.
     {:else if board === 'efficiency'}Your best return multiple (bounty ÷ spend). The core flex — crack a puzzle spending next to nothing.
     {:else if board === 'challenges'}Head-to-head wins. Win challenges by solving on the least spend and taking the pot.


### PR DESCRIPTION
Two stat fixes (loans are gone) + a reference doc.

- **Net Worth = Cash** (`profiles.bank`) — the two profile RPCs were still doing `bank − loan`; now they don't. Every other RPC already used `bank`, so this makes Net Worth consistent everywhere. (Migration `profile_stats_no_loan_and_winrate`.)
- **Daily win rate was always 0%** — `total_games_played/won` are dead columns (never written). Now computed from the Play Log (daily won ÷ daily played). Verified: 8 played / 1 won → 13%.
- **Wealth leaderboard:** dropped the now-redundant "Cash" column (Net Worth = Cash) and the stale "Cash − Loans / 🔴 in the red" copy.
- **`STATS_AND_LEADERBOARDS.md`** — full reference of every stat + leaderboard (calc, source, per-mode) and the Cash Game seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)