### PR TITLE
Cash Game ladder: sequential + looping over all puzzles

### DIFF
--- a/STATS_AND_LEADERBOARDS.md
+++ b/STATS_AND_LEADERBOARDS.md
@@ -47,8 +47,11 @@ Legacy/unused: `get_daily_leaderboard` (period/order-by) — superseded by `get_
 - **Arcade / Free Play** → arcade has its own board; Free Play = broke-safe trickle (self-contained).
 
 ## Cash Game seeding
-- `climb_sequence(position, puzzle_id)` — a **fixed shuffle of 720 puzzles** (`ORDER BY md5(id)`),
-  **identical for everyone**, forward-only. `_climb_puzzle_at(position)` returns the rung.
-- Everyone starts at **position 1**; each puzzle solved once (income bounded).
-- Pool is now **1,200** puzzles but the ladder snapshot is **720** → ~480 unused; ladder ends at 720.
-  KNOB: re-seed to the full pool / loop for longer runs.
+- Every puzzle has a stable number **`daily_puzzles.seq`** (1..N). New puzzles auto-get the
+  next number (sequence default) and extend the ladder.
+- `_climb_puzzle_at(position)` = the **Nth puzzle by `seq`, wrapping around the whole pool**:
+  `rn = ((position-1) mod count) + 1`. So the Cash Game runs through ALL puzzles in order
+  and **loops back to #1** at the end — never dead-ends. Same order for everyone, forward-only.
+- Everyone starts at position 1; badges at 50 / 100 / 500.
+- (The old fixed-720 `climb_sequence` table is deprecated/unused; seq 1..720 was backfilled
+  from it to preserve continuity for in-progress players.)

--- a/supabase-cash-game-ladder.sql
+++ b/supabase-cash-game-ladder.sql
@@ -1,0 +1,17 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Cash Game ladder: sequential, looping over ALL puzzles                     ║
+-- ║  (migration: cash_game_sequential_looping_ladder)                           ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Replaces the fixed 720-puzzle `climb_sequence` snapshot. Every puzzle gets a stable
+-- number `daily_puzzles.seq` (1..N); new puzzles auto-get the next number via a sequence
+-- default and extend the ladder. The Cash Game runs through them in seq order and LOOPS
+-- back to #1 at the end — never dead-ends ("complete" branch in climb_next is now unreachable).
+--
+-- _climb_puzzle_at(position) = Nth puzzle by seq, wrapping:
+--   rn = ((position-1) mod count(daily_puzzles)) + 1   (row_number → robust to deleted seqs)
+--
+-- Backfill preserved continuity: seq 1..720 = the old climb_sequence positions, the rest
+-- appended (721+). Verified: pos 1 "Pride and Prejudice", pos 1200 "No Mans Sky",
+-- pos 1201 loops to "Pride and Prejudice", pos 1202 → #2. 1200 puzzles, seq 1..1200 unique.
+--
+-- climb_sequence is now deprecated/unused (kept for backfill provenance; safe to drop later).


### PR DESCRIPTION
## What
Reworks Cash Game seeding to the simpler design: **number every puzzle, run through them in order, loop at the end.**

**Before:** a separate `climb_sequence` table — a fixed shuffle of only **720** of the 1,200 puzzles that **dead-ended** at position 721 ("complete") and never grew.

**After** (migration `cash_game_sequential_looping_ladder`):
- Every puzzle gets a stable number **`daily_puzzles.seq`** (1..N). New puzzles **auto-get the next number** (sequence default) and extend the ladder.
- `_climb_puzzle_at(position)` = the Nth puzzle by `seq`, **wrapping**: `((position-1) mod count)+1` → **loops back to #1** at the end. Never dead-ends. Same order for everyone, forward-only.
- Backfilled `seq 1..720` from the old `climb_sequence` so in-progress players continue seamlessly; the rest appended. `climb_sequence` is now deprecated/unused.

## Verified
1,200 puzzles, `seq 1..1200` unique. pos 1200 = "No Mans Sky" (last) → **pos 1201 loops to "Pride and Prejudice" (#1)** → pos 1202 → #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)