### PR TITLE
Stat-heavy Profile (per-mode) + solve-time tracking

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -496,6 +496,12 @@ export async function getProfileStats() {
   if (error) { console.error('❌ get_profile_stats:', error); return null; }
   return data;
 }
+/** Stat-heavy profile: per-mode sections + records. @returns {Promise<any|null>} */
+export async function getProfileDetail() {
+  const { data, error } = await supabase.rpc('get_profile_detail');
+  if (error) { console.error('❌ get_profile_detail:', error); return null; }
+  return data;
+}
 
 /* ===== Play Log: history, head-to-head, challenge detail ===== */
 /**

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -2,8 +2,7 @@
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import { getProfileStats } from '$lib/stores/statsStore.js';
-  import { badgeInfo } from '$lib/badges.js';
+  import { getProfileDetail } from '$lib/stores/statsStore.js';
   import HistoryList from '$lib/components/HistoryList.svelte';
   import BadgesPanel from '$lib/components/BadgesPanel.svelte';
   import { track } from '$lib/analytics.js';
@@ -11,23 +10,27 @@
   /** @type {'stats'|'history'|'badges'} */
   let tab = $state('stats');
   /** @type {any|null} */
-  let s = $state(null);
+  let d = $state(null);
   let loading = $state(true);
 
   onMount(async () => {
     track('profile_view');
     const t = $page.url.searchParams.get('tab');
     if (t === 'history' || t === 'badges') tab = t;
-    try { s = await getProfileStats(); } finally { loading = false; }
+    try { d = await getProfileDetail(); } finally { loading = false; }
   });
 
   const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
   const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '—';
-  let winPct = $derived(s && s.games_played > 0 ? Math.round((s.games_won / s.games_played) * 100) : 0);
-  let record = $derived(s ? `${s.challenge_wins ?? 0}-${s.challenge_losses ?? 0}-${s.challenge_ties ?? 0}` : '—');
+  const time = (/** @type {any} */ ms) => !ms ? '—' : Number(ms) < 60000 ? Math.round(Number(ms) / 1000) + 's' : (Number(ms) / 60000).toFixed(1) + 'm';
+  const pct = (/** @type {number} */ w, /** @type {number} */ n) => n > 0 ? Math.round((w / n) * 100) + '%' : '—';
 </script>
 
-<svelte:head><title>WordBank — You</title></svelte:head>
+<svelte:head><title>WordBank — Profile</title></svelte:head>
+
+{#snippet chip(value, label)}
+  <div class="stat"><span class="sv">{value}</span><span class="sc">{label}</span></div>
+{/snippet}
 
 <main class="you-page">
   <div class="topbar">
@@ -38,12 +41,12 @@
 
   {#if loading}
     <p class="muted">Loading…</p>
-  {:else if s}
+  {:else if d}
     <header class="head">
-      <div class="coin" style={s.color ? `--c:${s.color}` : ''}>{(s.username || '?').slice(0, 1).toUpperCase()}</div>
-      <div class="uname">{s.username ? '@' + s.username : 'You'}</div>
-      <div class="nw" class:neg={Number(s.net_worth) < 0}>{fmt(s.net_worth)}</div>
-      <span class="nw-sub">Net Worth</span>
+      <div class="coin" style={d.color ? `--c:${d.color}` : ''}>{(d.username || '?').slice(0, 1).toUpperCase()}</div>
+      <div class="uname">{d.username ? '@' + d.username : 'You'}</div>
+      <div class="nw">{fmt(d.net_worth)}</div>
+      <span class="nw-sub">Cash</span>
     </header>
 
     <div class="tabs">
@@ -53,18 +56,60 @@
     </div>
 
     {#if tab === 'stats'}
+      <div class="sec-title">📊 Overall</div>
       <div class="grid">
-        <div class="stat"><span class="sv">🔥 {s.current_streak}</span><span class="sc">Day streak</span></div>
-        <div class="stat"><span class="sv">{s.longest_streak}</span><span class="sc">Best streak</span></div>
-        <div class="stat"><span class="sv">{winPct}%</span><span class="sc">Daily win rate</span></div>
-        <div class="stat"><span class="sv">{(s.puzzles_solved ?? 0).toLocaleString()}</span><span class="sc">Puzzles solved</span></div>
-        <div class="stat"><span class="sv">#{s.climb_position}</span><span class="sc">Furthest</span></div>
-        <div class="stat"><span class="sv">{record}</span><span class="sc">Challenge W-L-T</span></div>
-        <div class="stat"><span class="sv">{mult(s.avg_multiple_x100)}</span><span class="sc">Avg multiple</span></div>
-        <div class="stat"><span class="sv">{mult(s.best_multiple_x100)}</span><span class="sc">Best multiple</span></div>
-        <div class="stat"><span class="sv">{fmt(s.total_earned)}</span><span class="sc">Lifetime earned</span></div>
+        {@render chip((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles solved')}
+        {@render chip(d.overall.games_played ?? 0, 'Games played')}
+        {@render chip(d.overall.clean_solves ?? 0, 'Clean solves')}
+        {@render chip(mult(d.overall.avg_multiple), 'Avg multiple')}
+        {@render chip(mult(d.overall.best_multiple), 'Best multiple')}
+        {@render chip(fmt(d.overall.earned), 'Earned')}
       </div>
-      <p class="spent-line">Lifetime spent: <b>{fmt(s.total_spent)}</b></p>
+      <p class="spent-line">Lifetime spent: <b>{fmt(d.overall.spent)}</b></p>
+
+      <div class="sec-title">📅 Daily</div>
+      <div class="grid">
+        {@render chip('🔥 ' + (d.daily.current_streak ?? 0), 'Streak')}
+        {@render chip(d.daily.best_streak ?? 0, 'Best streak')}
+        {@render chip(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Win rate')}
+        {@render chip(d.daily.won ?? 0, 'Dailies won')}
+        {@render chip(mult(d.daily.best_multiple), 'Best ×')}
+        {@render chip(time(d.daily.fastest_ms), 'Fastest')}
+      </div>
+
+      <div class="sec-title">🎰 Cash Game</div>
+      <div class="grid">
+        {@render chip('#' + (d.cash_game.position ?? 0), 'Furthest')}
+        {@render chip(d.cash_game.solved ?? 0, 'Solved')}
+        {@render chip(fmt(d.cash_game.earned), 'Earned')}
+        {@render chip(mult(d.cash_game.best_multiple), 'Best ×')}
+        {@render chip(time(d.cash_game.fastest_ms), 'Fastest')}
+      </div>
+
+      <div class="sec-title">⚔️ Challenges</div>
+      <div class="grid">
+        {@render chip(`${d.challenges.wins ?? 0}-${d.challenges.losses ?? 0}-${d.challenges.ties ?? 0}`, 'W-L-T')}
+        {@render chip(pct(d.challenges.wins ?? 0, d.challenges.played ?? 0), 'Win rate')}
+        {@render chip(fmt(d.challenges.biggest_pot), 'Biggest pot')}
+      </div>
+
+      <div class="sec-title">🎲 Arcade</div>
+      <div class="grid">
+        {@render chip(fmt(d.arcade.best_bankroll), 'Best run')}
+        {@render chip(d.arcade.best_streak ?? 0, 'Best streak')}
+      </div>
+
+      {#if (d.categories ?? []).length}
+        <div class="sec-title">🗂️ Categories</div>
+        <div class="cats">
+          {#each d.categories as c}
+            <div class="cat-row">
+              <span class="cat-name">{c.category}</span>
+              <span class="cat-meta">{c.solves} solved{#if c.best_multiple} · best {mult(c.best_multiple)}{/if}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
     {:else if tab === 'history'}
       <HistoryList />
     {:else}
@@ -89,7 +134,6 @@
   .uname { font-family: var(--font-display); font-weight: 700; font-size: 1.3rem; }
   .nw { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.1rem; color: #fde047;
     margin-top: 10px; text-shadow: 0 0 18px rgba(251,191,36,0.5); }
-  .nw.neg { color: #fb7185; text-shadow: none; }
   .nw-sub { font-size: 0.72rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.1em; }
 
   .tabs { display: flex; gap: 8px; margin: 0 0 16px; }
@@ -97,10 +141,18 @@
     color: var(--text-muted); font-weight: 700; font-size: 0.88rem; cursor: pointer; }
   .tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
 
+  .sec-title { font-family: var(--font-display); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em;
+    text-transform: uppercase; color: var(--gold); text-align: left; margin: 18px 2px 8px; }
   .grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
-  .stat { display: flex; flex-direction: column; gap: 3px; padding: 0.9rem 0.4rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; text-align: center; }
-  .sv { font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--text); }
-  .sc { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-faint); }
-  .spent-line { text-align: center; color: var(--text-muted); font-size: 0.84rem; margin: 14px 0 0; }
+  .stat { display: flex; flex-direction: column; gap: 3px; padding: 0.85rem 0.4rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; text-align: center; }
+  .sv { font-family: var(--font-display); font-weight: 800; font-size: 1.02rem; color: var(--text); }
+  .sc { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-faint); }
+  .spent-line { text-align: center; color: var(--text-muted); font-size: 0.82rem; margin: 10px 0 0; }
   .spent-line b { color: var(--text); }
+
+  .cats { display: flex; flex-direction: column; gap: 6px; }
+  .cat-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 9px 11px;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 10px; }
+  .cat-name { font-weight: 600; color: var(--text); font-size: 0.86rem; }
+  .cat-meta { color: var(--text-faint); font-size: 0.74rem; }
 </style>


### PR DESCRIPTION
Makes the app stat-heavy where it belongs (Profile), and closes the one collection gap (solve time).

## Solve-time tracking (was 0/33 rows)
`game_results.time_ms` is now populated, capped at 30 min to exclude idle:
- **Daily / Make-up** — `now − session created_at`
- **Cash Game** — `now − climb_state.puzzle_started_at` (new column, stamped on start/advance)
- (Challenge/Arcade skipped — spend is their metric.)

Unlocks fastest-solve / speed records. Migrations `track_solve_time`, `track_solve_time_makeup`.

## Stat-heavy Profile
New `get_profile_detail()` RPC → per-mode breakdowns from the Play Log + profiles. The Profile **Stats tab** is now organized into sections with records:
- **Overall** — puzzles solved · games · clean solves · avg/best × · earned/spent
- **Daily** — streak · best streak · win% · dailies won · best × · **fastest**
- **Cash Game** — furthest · solved · earned · best × · fastest
- **Challenges** — W-L-T · win% · biggest pot
- **Arcade** — best run · best streak
- **Categories** — solves + best × per category

## Verified
`get_profile_detail` returns correct per-mode data; QA sweep **18/18, 0 console errors**; screenshot shows **"6s Fastest"** (solve time live). Group leaderboard (Group → Compete) and 1v1 head-to-head (public profile) both still intact — they were never on the leaderboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)