### PR TITLE
All buttons beep on press + turn gold on touch

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -104,18 +104,28 @@ h1, h2, h3, h4 {
 
 button { font-family: inherit; }
 
-/* Super-dramatic gold glow on any button press / selection (keyboard, menu,
-   chips — everything). Component rules (.menu-card, .key) layer a stronger
-   version on top. */
-button:active,
-button:focus-visible {
+/* Press = the button turns GOLD (fill + glow), app-wide. Works on touch (phones)
+   too — the layout adds a touchstart listener so iOS applies :active.
+   Component rules (.menu-card, .key) layer a stronger version on top. */
+button:active {
   outline: none;
   border-color: #fde047;
+  background: linear-gradient(135deg, #fde047, #f59e0b);
+  color: #3a2a00;
   box-shadow:
     0 0 0 2px rgba(253, 224, 71, 1),
     0 0 16px rgba(251, 191, 36, 0.95),
     0 0 34px rgba(251, 191, 36, 0.7),
     0 0 66px rgba(251, 191, 36, 0.42);
+}
+/* Keyboard focus = the gold glow ring only (don't fill on tab-focus). */
+button:focus-visible {
+  outline: none;
+  border-color: #fde047;
+  box-shadow:
+    0 0 0 2px rgba(253, 224, 71, 0.9),
+    0 0 16px rgba(251, 191, 36, 0.7),
+    0 0 34px rgba(251, 191, 36, 0.45);
 }
 
 /* Numbers that should feel like a readout (money, counters) */

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -141,8 +141,16 @@ export function vibrate(name) {
   }
 }
 
+/** @type {Record<string, number>} */
+const _lastFx = {};
 /** Combined sound + haptic feedback for a named event. @param {string} name */
 export function fx(name) {
+  // Collapse rapid duplicate cues (e.g. the global button beep + a handler's own fx('tap')).
+  if (browser) {
+    const now = typeof performance !== 'undefined' ? performance.now() : 0;
+    if (_lastFx[name] && now - _lastFx[name] < 60) return;
+    _lastFx[name] = now;
+  }
   playSound(name);
   vibrate(name);
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,10 +3,25 @@
   import { onMount } from 'svelte';
   import { supabase } from '$lib/supabaseClient';
   import { startNotifications, stopNotifications } from '$lib/stores/notificationStore.js';
+  import { fx } from '$lib/sound.js';
   import Toaster from '$lib/components/Toaster.svelte';
   import PinConfirm from '$lib/components/PinConfirm.svelte';
 
   let { children } = $props();
+
+  // Every button beeps on press, app-wide. touchstart no-op also enables :active on iOS.
+  /** @param {Event} e */
+  function buttonBeep(e) {
+    const el = /** @type {HTMLElement} */ (e.target)?.closest?.('button, [role="button"]');
+    // .key = keyboard letters (their own 'select' cue); skip so they don't double-beep.
+    if (el && !(/** @type {HTMLButtonElement} */ (el).disabled) && !el.classList.contains('key')) fx('tap');
+  }
+  onMount(() => {
+    document.addEventListener('pointerdown', buttonBeep, true);
+    const noop = () => {};
+    document.addEventListener('touchstart', noop, { passive: true });
+    return () => { document.removeEventListener('pointerdown', buttonBeep, true); document.removeEventListener('touchstart', noop); };
+  });
 
   onMount(() => {
     // "Keep me logged in" = off → end the session on a cold open (new browser


### PR DESCRIPTION
## What
Two app-wide button polish items:

1. **Every button beeps on press.** A global `pointerdown` listener in `+layout.svelte` plays `fx('tap')` for any `<button>`/`[role=button]` (skips `.key`, the keyboard letters, which already play their own `select` cue). Buttons that previously had no sound on click now beep.
2. **Buttons turn gold when pressed — including on phones.** `button:active` now fills the button with the gold gradient (+ glow), split out from `:focus-visible` (which keeps just the glow ring for keyboard nav). A `touchstart` no-op listener makes iOS apply `:active` so the gold press is visible on touch.

`fx()` now collapses duplicate same-name cues within 60ms, so the global beep doesn't double with buttons that already call `fx('tap')`.

## Test
- `npm run build` ✓
- Playwright smoke: home loads with **0 console errors**; one button click creates exactly **1** oscillator (one beep, no double).

🤖 Generated with [Claude Code](https://claude.com/claude-code)