### PR TITLE
Phase 1: pre-game "How to win" objective card (all modes)

### DIFF
--- a/scripts/qa-e2e.mjs
+++ b/scripts/qa-e2e.mjs
@@ -97,7 +97,11 @@ try {
   await page.getByRole('button', { name: /play now/i }).first().click().catch(() => {});
   await wait(700);
   await page.getByRole('button', { name: /daily/i }).first().click().catch(() => {});
-  await wait(2800); await shot('02-daily-board');
+  await wait(2800);
+  // Pre-game "How to win" objective card (first entry per mode) — dismiss to reach the board.
+  const objGo = page.getByRole('button', { name: /let’s go|let's go/i });
+  if (await objGo.count()) { await objGo.first().click().catch(() => {}); await wait(600); ok('objective-card', 'shown + dismissed'); }
+  await shot('02-daily-board');
   if (!(await page.getByRole('button', { name: /^solve$/i }).count())) { bad('daily-open', 'no Solve button — board did not load'); }
   else {
     ok('daily-open');

--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -1,0 +1,145 @@
+<script>
+  // Pre-game "How to win" card. Shown the moment a mode starts so a first-time
+  // player always knows the objective. Solo modes show it once (the parent gates
+  // on localStorage); challenges show it every entry (they carry the stakes).
+  import { createEventDispatcher } from 'svelte';
+  const dispatch = createEventDispatcher();
+
+  /** @type {string} */ export let mode;
+  /** @type {{ opponent?: string, wager?: number, packSize?: number, fieldSize?: number }} */
+  export let ctx = {};
+
+  /** @param {string} m @param {any} c */
+  function content(m, c) {
+    const pk = (c.packSize ?? 1) > 1 ? `${c.packSize} puzzles` : 'the puzzle';
+    const w = c.wager ? `$${Number(c.wager).toLocaleString()}` : null;
+    switch (m) {
+      case 'daily': return { icon: '📅', title: "Today's Daily",
+        goal: 'Solve the hidden phrase.',
+        win: 'Spend as little Cash as you can — your leftover is your score.',
+        bar: 'Just showing up pays a streak reward.' };
+      case 'climb': return { icon: '🧗', title: 'Cash Game',
+        goal: 'Climb an endless ladder of puzzles.',
+        win: 'Solve each one cheaply to grow your bankroll.',
+        bar: "Don't go broke." };
+      case 'arcade': return { icon: '🎲', title: 'Arcade Run',
+        goal: 'Survival mode — keep your streak alive.',
+        win: 'The bigger your streak, the bigger the payout.',
+        bar: 'One slip ends the run.' };
+      case 'freeplay': return { icon: '🎯', title: 'Free Play',
+        goal: 'Practice with zero stakes.',
+        win: 'Every solve pays a little Cash.',
+        bar: 'Grind back anytime.' };
+      case 'makeup': return { icon: '🗓️', title: 'Make-up Daily',
+        goal: 'Play a daily you missed.',
+        win: 'Same rules — solve it as cheaply as you can.',
+        bar: 'Counts toward your stats.' };
+      case 'match': {
+        if ((c.fieldSize ?? 2) > 2) return { icon: '👥', title: 'Group Challenge',
+          goal: `Solve ${pk} spending as little as possible.`,
+          win: 'Least spent to solve ranks 1st — the pot is everyone’s spend.',
+          bar: w ? `Your ${w} buy-in is your cap. Unspent Cash comes back.`
+                 : 'Unspent Cash comes back — you only lose what you spend.' };
+        return { icon: '⚔️', title: c.opponent ? `Duel vs @${c.opponent}` : 'Challenge',
+          goal: `Solve ${pk} — then it comes down to who spent less.`,
+          win: 'Whoever solves spending the LEAST wins the pot.',
+          bar: w ? `Your ${w} buy-in is your cap. Unspent Cash comes back — you only lose what you spend.`
+                 : 'Unspent Cash comes back — you only lose what you spend.' };
+      }
+      default: return { icon: '🎯', title: 'WordBank',
+        goal: 'Solve the hidden phrase.', win: 'Spend as little as you can.', bar: '' };
+    }
+  }
+
+  $: c = content(mode, ctx);
+  function go() { dispatch('close'); }
+</script>
+
+<div class="obj-overlay" role="dialog" aria-modal="true" aria-label="How to win">
+  <div class="obj-card">
+    <span class="obj-pill">🎯 How to win</span>
+    <div class="obj-icon">{c.icon}</div>
+    <h2 class="obj-title">{c.title}</h2>
+
+    <p class="obj-goal">{c.goal}</p>
+    <div class="obj-win"><span class="obj-win-key">WIN</span>{c.win}</div>
+    {#if c.bar}<p class="obj-bar">{c.bar}</p>{/if}
+
+    <button class="obj-btn" on:click={go}>Let’s go →</button>
+  </div>
+</div>
+
+<style>
+  .obj-overlay {
+    position: fixed; inset: 0; z-index: 3100;
+    display: grid; place-items: center; padding: 20px;
+    background: rgba(4, 8, 14, 0.72); backdrop-filter: blur(8px);
+    animation: objFade 0.22s ease;
+  }
+  @keyframes objFade { from { opacity: 0; } to { opacity: 1; } }
+
+  .obj-card {
+    position: relative; width: 100%; max-width: 380px;
+    padding: 26px 24px 22px; border-radius: var(--r-lg, 20px);
+    background: var(--surface-strong, rgba(20, 26, 38, 0.92));
+    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+    box-shadow: var(--shadow-lg, 0 24px 60px rgba(0, 0, 0, 0.5)), var(--glow-brand, 0 0 30px rgba(251, 191, 36, 0.25));
+    text-align: center;
+    animation: objPop 0.3s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+  }
+  @keyframes objPop {
+    from { transform: translateY(14px) scale(0.96); opacity: 0; }
+    to { transform: translateY(0) scale(1); opacity: 1; }
+  }
+
+  .obj-pill {
+    display: inline-block; margin-bottom: 10px; padding: 4px 12px; border-radius: 999px;
+    font-family: var(--font-display, sans-serif); font-size: 0.68rem; font-weight: 800;
+    letter-spacing: 0.08em; color: #3a2a00;
+    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+  }
+  .obj-icon {
+    font-size: 2.8rem; line-height: 1; margin: 2px 0 10px;
+    animation: objIcon 0.4s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+  }
+  @keyframes objIcon {
+    from { transform: scale(0.4) rotate(-12deg); opacity: 0; }
+    to { transform: scale(1) rotate(0); opacity: 1; }
+  }
+  .obj-title {
+    font-family: var(--font-display, sans-serif); font-size: 1.35rem; font-weight: 700;
+    margin: 0 0 12px; color: var(--text, #fff);
+  }
+  .obj-goal {
+    font-family: var(--font-ui, sans-serif); font-size: 0.96rem; line-height: 1.45;
+    color: var(--text, #f3f6fb); margin: 0 auto 12px; max-width: 320px;
+  }
+  .obj-win {
+    display: flex; align-items: center; gap: 10px; text-align: left;
+    margin: 0 auto 12px; max-width: 320px; padding: 11px 13px;
+    border-radius: 13px; border: 1px solid rgba(253, 224, 71, 0.45);
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.05));
+    font-family: var(--font-ui, sans-serif); font-size: 0.92rem; line-height: 1.4;
+    color: var(--text, #fff); font-weight: 600;
+  }
+  .obj-win-key {
+    flex: none; font-family: var(--font-display, sans-serif); font-size: 0.6rem; font-weight: 800;
+    letter-spacing: 0.1em; color: #3a2a00; padding: 3px 7px; border-radius: 7px;
+    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+  }
+  .obj-bar {
+    font-family: var(--font-ui, sans-serif); font-size: 0.82rem; line-height: 1.4;
+    color: var(--text-muted, #aeb8c6); margin: 0 auto 18px; max-width: 320px;
+  }
+
+  .obj-btn {
+    width: 100%; max-width: 220px; height: 48px; border: none; border-radius: 14px;
+    font-family: var(--font-display, sans-serif); font-size: 1.05rem; font-weight: 700;
+    color: #3a2a00; cursor: pointer;
+    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+    box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36, 0.35));
+    transition: transform 0.16s var(--ease-spring, ease), filter 0.2s;
+  }
+  .obj-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
+  .obj-btn:active { transform: scale(0.97); }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,6 +32,7 @@
   import FlipDigit from '$lib/components/FlipDigit.svelte';
   import Auth from '$lib/components/Auth.svelte';
   import Tutorial from '$lib/components/Tutorial.svelte';
+  import ObjectiveCard from '$lib/components/ObjectiveCard.svelte';
   import PowerupTray from '$lib/components/PowerupTray.svelte';
   import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
 
@@ -600,6 +601,42 @@
     if (browser) localStorage.setItem(TUTORIAL_KEY, 'true');
   }
 
+  // ===== Pre-game "How to win" objective card =====
+  // Shows the objective the moment a mode starts. Solo modes show once (per mode,
+  // localStorage); challenges show every entry. One reactive latch detects the
+  // menu→game transition so we don't have to wire every scattered start site.
+  /** @type {{ mode: string, ctx: any } | null} */
+  let objective = null;
+  let _wasMenu = true;
+  const SOLO_MODES = ['daily', 'climb', 'arcade', 'freeplay', 'makeup'];
+
+  function buildObjectiveCtx(/** @type {string} */ mode) {
+    if (mode !== 'match') return {};
+    const mi = get(gameStore).matchInfo || {};
+    const opps = mi.opponents ?? [];
+    return { opponent: opps.length === 1 ? opps[0]?.name : undefined,
+      wager: mi.wager, packSize: mi.pack_size, fieldSize: opps.length + 1 };
+  }
+  /** @param {boolean} [forced] re-opened via the board ⓘ button — bypass the once-seen gate */
+  function showObjectiveFor(/** @type {string} */ mode, forced = false) {
+    if (!mode || showTutorial) return;
+    if (!forced && SOLO_MODES.includes(mode) && browser && localStorage.getItem('wb_obj_' + mode) === '1') return;
+    objective = { mode, ctx: buildObjectiveCtx(mode) };
+  }
+  function dismissObjective() {
+    if (objective && browser && SOLO_MODES.includes(objective.mode)) localStorage.setItem('wb_obj_' + objective.mode, '1');
+    objective = null;
+  }
+
+  // Detect entering a game from the menu (latch flips once per entry).
+  $: if (browser && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup) {
+    if (showMainMenu) { _wasMenu = true; }
+    else if (_wasMenu && $gameStore.gameMode && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost') {
+      _wasMenu = false;
+      showObjectiveFor($gameStore.gameMode);
+    }
+  }
+
   /** @param {Event} e */
   const removeButtonFocus = (e) => {
     if (e.target && /** @type {HTMLElement} */ (e.target).tagName === 'BUTTON') /** @type {HTMLButtonElement} */ (e.target).blur();
@@ -1005,6 +1042,10 @@
 <!-- 📜 Guided tutorial (first run + replayable from ❓) -->
 {#if showTutorial}
   <Tutorial on:close={dismissTutorial} />
+{/if}
+
+{#if objective && !showTutorial}
+  <ObjectiveCard mode={objective.mode} ctx={objective.ctx} on:close={dismissObjective} />
 {/if}
 
 {#if $gameStore.cashToast}
@@ -1545,6 +1586,7 @@
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
       {#if dailyMod}<span class="mod-chip" title={dailyMod.name + ' — ' + dailyMod.blurb}>{dailyMod.emoji} {dailyMod.name}</span>{/if}
+      <button class="obj-chip" title="How to win" aria-label="How to win" on:click={() => showObjectiveFor($gameStore.gameMode, true)}>🎯</button>
     </div>
     {#if $gameStore.clue}
       <p class="puzzle-clue">{$gameStore.clue}</p>
@@ -1944,6 +1986,17 @@
     border: 1px solid rgba(253, 224, 71, 0.28);
     padding: 6px 13px;
     border-radius: var(--r-pill);
+  }
+  /* ⓘ re-open the "How to win" card */
+  .obj-chip {
+    font-size: 0.82rem;
+    line-height: 1;
+    color: var(--brand-2);
+    background: rgba(253, 224, 71, 0.10);
+    border: 1px solid rgba(253, 224, 71, 0.28);
+    padding: 6px 10px;
+    border-radius: var(--r-pill);
+    cursor: pointer;
   }
   .fold-bar { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin: 6px auto 2px; }
   .fold-bar.broke {


### PR DESCRIPTION
First step of `OBJECTIVE_HUD_SPEC.md` — make the objective unmistakable for a first-time player.

## What
`ObjectiveCard.svelte` shows a short **Goal · WIN · context** card the moment a mode starts:
- **Solo** (daily / cash game / arcade / free play / makeup): shown **once per mode** (`localStorage wb_obj_<mode>`).
- **Challenges**: shown **every entry**, with opponent / wager / field size baked in — distinct **1v1** ("whoever solves spending the LEAST wins the pot") vs **group** copy.
- A **🎯 chip** on the board re-opens it anytime (forced; bypasses the once-seen gate).

One reactive **latch** in `+page.svelte` detects the menu→game transition, so we didn't have to wire each scattered start site.

## Not in this PR
Phase 2 — the live **directional standing** strip (rank + ahead/behind) — is separate, and needs the `_match_board` `standing` field.

## Test
- `npm run build` ✓
- QA sweep **19/19** (new `objective-card` assertion + daily-solve still passes), **0 console errors**.
- Screenshot verified on a 430×932 phone viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)