### PR TITLE
Phase 2: live directional standing strip for challenges

### DIFF
--- a/scripts/vs-walkthrough.mjs
+++ b/scripts/vs-walkthrough.mjs
@@ -42,6 +42,9 @@ async function login(p, acc) {
 }
 // buy `wrong` letters (not in the answer → pure spend, keeps all tiles editable), then solve.
 async function playSolve(p, answer, wrong) {
+  // Dismiss the pre-game "How to win" objective card (shown on every match entry).
+  const objGo = p.getByRole('button', { name: /let’s go|let's go/i });
+  if (await objGo.count()) { await objGo.first().click().catch(() => {}); await wait(p, 500); }
   for (const L of wrong) { await p.keyboard.press(L); await wait(p, 250); await p.keyboard.press('Enter'); await wait(p, 900); }
   // enter guess mode
   await p.getByRole('button', { name: /^solve$/i }).first().click().catch(async () => { await p.keyboard.press(' '); });

--- a/src/lib/components/StandingStrip.svelte
+++ b/src/lib/components/StandingStrip.svelte
@@ -1,0 +1,92 @@
+<script>
+  // Live directional standing for a challenge (Phase 2 of OBJECTIVE_HUD_SPEC).
+  // Shows rank + ahead/behind vs FINISHED rivals — never the exact spend to beat
+  // (the server only sends a direction). The lead-flip is the reward moment.
+  import { fx } from '$lib/sound.js';
+
+  /** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play' } | null} */
+  export let standing = null;
+  /** @type {number} */ export let spent = 0;
+
+  // Chime when you flip INTO the lead. prevState lives outside the reactive
+  // dependency graph (read/written inside a fn) so it can't self-invalidate.
+  let prevState;
+  function onStanding(/** @type {any} */ s) {
+    if (s && s.state === 'lead' && prevState && prevState !== 'lead') fx('lead');
+    prevState = s?.state;
+  }
+  $: onStanding(standing);
+
+  const ord = (/** @type {number} */ n) => { const s = ['th','st','nd','rd'], v = n % 100; return n + (s[(v - 20) % 10] || s[v] || s[0]); };
+  const medal = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
+  $: msg = !standing ? '' :
+    standing.state === 'lead' ? "✓ You're in the lead" :
+    standing.state === 'behind' ? '▲ Spend less to take the lead' :
+    standing.state === 'tied' ? 'Dead even — spend less to pull ahead' :
+    '🚩 Set the bar — spend as little as you can';
+</script>
+
+{#if standing}
+  {#key standing.state}
+    <div class="standing {standing.state}">
+      <div class="top">
+        {#if standing.state === 'first_to_play'}
+          <span class="rank">🚩 First to play</span>
+        {:else}
+          <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}</span>
+        {/if}
+        <span class="spent">Spent <b>${spent.toLocaleString()}</b></span>
+      </div>
+      <div class="msg">{msg}</div>
+    </div>
+  {/key}
+{/if}
+
+<style>
+  .standing {
+    max-width: 360px;
+    margin: 0 auto 6px;
+    padding: 9px 14px;
+    border-radius: 13px;
+    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+    background: var(--surface, rgba(255, 255, 255, 0.05));
+    animation: stPop 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  @keyframes stPop {
+    from { transform: scale(0.96); opacity: 0.4; }
+    to { transform: scale(1); opacity: 1; }
+  }
+  .top {
+    display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.92rem;
+    color: var(--text, #fff);
+  }
+  .spent { font-weight: 600; color: var(--text-muted, #c2cbd8); font-size: 0.84rem; }
+  .spent b { color: var(--text, #fff); font-variant-numeric: tabular-nums; }
+  .msg {
+    margin-top: 3px; text-align: left;
+    font-family: var(--font-ui, sans-serif); font-size: 0.76rem; font-weight: 600;
+  }
+
+  .standing.lead {
+    border-color: rgba(126, 224, 168, 0.55);
+    background: linear-gradient(135deg, rgba(126, 224, 168, 0.16), rgba(126, 224, 168, 0.05));
+    box-shadow: 0 0 18px rgba(126, 224, 168, 0.25);
+  }
+  .standing.lead .msg { color: #7ee0a8; }
+
+  .standing.behind {
+    border-color: rgba(251, 191, 36, 0.5);
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.13), rgba(251, 191, 36, 0.04));
+  }
+  .standing.behind .msg { color: #fbbf24; }
+
+  .standing.tied { border-color: var(--border-strong, rgba(255, 255, 255, 0.18)); }
+  .standing.tied .msg { color: var(--text-muted, #c2cbd8); }
+
+  .standing.first_to_play {
+    border-color: rgba(125, 188, 255, 0.5);
+    background: linear-gradient(135deg, rgba(125, 188, 255, 0.12), rgba(125, 188, 255, 0.04));
+  }
+  .standing.first_to_play .msg { color: #93c5fd; }
+</style>

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -92,6 +92,11 @@ const SOUNDS = {
     tone(880, 0.09, 'sine', 0.13);
     tone(1320, 0.13, 'sine', 0.12, 0.08);
   },
+  // Bright rising blip — you just took the lead in a challenge.
+  lead: () => {
+    tone(784, 0.08, 'sine', 0.12);
+    tone(1175, 0.12, 'sine', 0.11, 0.07);
+  },
   // Heavy metallic vault CLUNK: mechanism click → deep thunk → metal overtone.
   vault: () => {
     tone(140, 0.05, 'square', 0.16);            // latch click
@@ -112,6 +117,7 @@ const HAPTICS = {
   win: [18, 40, 18, 40, 36],
   bust: [60, 30, 60],
   multiplier: [10, 24, 10],
+  lead: [12, 20, 16],
   vault: [50, 30, 90]
 };
 

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -702,7 +702,7 @@ function reconcileMatchBoard(board) {
     gameState: done ? 'won' : 'default',
     modifier: null, arcadeRun: null,
     clue: done ? prev.clue : (board.clue ?? null),
-    matchInfo: { ...match, id: activeMatchId }
+    matchInfo: { ...match, id: activeMatchId, standing: board.standing ?? null }
   }));
   if (done) { setTimeout(() => launchConfetti(), 250); fx('win'); }
   // Celebrate EACH solved puzzle in the pack (not just finishing the whole pack).

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -33,6 +33,7 @@
   import Auth from '$lib/components/Auth.svelte';
   import Tutorial from '$lib/components/Tutorial.svelte';
   import ObjectiveCard from '$lib/components/ObjectiveCard.svelte';
+  import StandingStrip from '$lib/components/StandingStrip.svelte';
   import PowerupTray from '$lib/components/PowerupTray.svelte';
   import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
 
@@ -1542,6 +1543,9 @@
           <div class="ch-cell" class:hot={matchRemaining <= 10}><span class="ch-val">⏱️{matchRemaining}</span><span class="ch-label">Time</span></div>
         {/if}
       </div>
+      {#if matchInfo.standing}
+        <StandingStrip standing={matchInfo.standing} spent={matchInfo.spent ?? 0} />
+      {/if}
       {#if (matchInfo.my_debuffs ?? []).length}
         <p class="debuff-banner">{(matchInfo.my_debuffs ?? []).map((/** @type {string} */ d) => DEBUFF_LABEL[d] ?? d).join(' · ')}</p>
       {/if}

--- a/supabase-match-standing.sql
+++ b/supabase-match-standing.sql
@@ -1,0 +1,64 @@
+-- Phase 2 of OBJECTIVE_HUD_SPEC: live DIRECTIONAL standing for 1v1 / single-puzzle
+-- group challenges. Applied to prod via MCP migration `match_board_directional_standing`.
+--
+-- _match_board now returns a `standing` object alongside `match` while you're playing
+-- a single-puzzle (pack_size=1), non-blitz, open match:
+--   { field_size, finished, rank, state }
+--   state ∈ 'lead' | 'behind' | 'tied' | 'first_to_play'
+--
+-- Spoiler-safe by design: the server compares your spend-so-far to FINISHED rivals'
+-- locked spend and returns only a DIRECTION + rank — never the exact spend-to-beat.
+-- Lower spend wins (a finished non-solver isn't a bar; you just need to solve).
+-- Verified (rolled back): lead {rank1}, behind {rank2}, tied {rank1}, first_to_play {finished0}.
+
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')),
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id)) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF m.mode = 'blitz' THEN
+    v_minfo := v_minfo || jsonb_build_object('started_at', cp.started_at, 'clock_seconds', m.pack_size * 30, 'combo', cp.combo_x100);
+  END IF;
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  -- Directional standing (single-puzzle, non-blitz): my projected rank vs FINISHED
+  -- rivals, computed here so the exact spend-to-beat never reaches the client.
+  -- Lower spend wins (ties broken by who solved); show direction, never the number.
+  IF m.pack_size = 1 AND m.status = 'open' AND m.mode <> 'blitz' THEN
+    v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    SELECT min(GREATEST(0, v_budget - o.bankroll)) INTO v_best_spent
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+    SELECT count(*) INTO v_ahead
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+        AND GREATEST(0, v_budget - o.bankroll) < v_my_spent;
+    IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+    ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+    ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+    ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+    ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+    END IF;
+    v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN 'fog' = ANY(COALESCE(cp.debuffs,'{}')) THEN NULL ELSE v_clue END);
+END; $function$;


### PR DESCRIPTION
The headline feature from `OBJECTIVE_HUD_SPEC.md`: while playing a 1v1 / single-puzzle group challenge, you now see **how you're doing** — without the exact number to grind toward.

## What
A `StandingStrip` under the match HUD shows your live **rank + ahead/behind**:
- `🥇 1st of 2 · Spent $0 · ✓ You're in the lead`
- flips to `🥈 2nd of 2 · Spent $100 · ▲ Spend less to take the lead` as you spend past a rival.

## Spoiler-safe by design
`_match_board` computes a `standing` `{field_size, finished, rank, state}` **server-side**, comparing your spend-so-far to *finished* rivals' locked spend and sending only a **direction** (`lead`/`behind`/`tied`/`first_to_play`). The exact spend-to-beat never reaches the client — so there's nothing to grind to, and the lead-flip only reveals you passed someone *after* you've already spent past them.

- Color-coded (green lead / amber behind / blue first-to-play), re-pops on each state change, plays a new `lead` chime when you take the lead.
- Only for `pack_size = 1`, non-blitz, open matches. Multi-puzzle packs = Phase 3.

## Test
- `npm run build` ✓
- Rolled-back SQL verifies all 4 branches: lead `{rank1}`, behind `{rank2}`, tied `{rank1}`, first_to_play `{finished0}`.
- Live 2-player run: rival finishes, second player's strip shows **lead**, then flips to **behind** after spending past them.
- Synced to `supabase-match-standing.sql`; `vs-walkthrough.mjs` updated to dismiss the objective card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)