### PR TITLE
Phase 3: multi-pack standing + results spend tie-back banner

### DIFF
--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -17,6 +17,27 @@
   const rankIcon = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
   const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
   const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
+  const ordinal = (/** @type {number} */ n) => { const s = ['th', 'st', 'nd', 'rd'], v = n % 100; return n + (s[(v - 20) % 10] || s[v] || s[0]); };
+  const dollars = (/** @type {any} */ n) => '$' + Number(n ?? 0).toLocaleString();
+
+  // The spend "tie-back": frame the outcome in the universal metric — who solved
+  // for the least. Works for 1v1 and groups, wagered or friendly.
+  $: field = parts.length;
+  $: winner = parts.find((/** @type {any} */ p) => Number(p.rank) === 1);
+  $: iWon = me && Number(me.rank) === 1;
+  $: tieback = (() => {
+    if (!me || noSolve || m?.status !== 'settled') return '';
+    const myS = dollars(me.spent);
+    if (field === 2 && opp) {
+      const oS = dollars(opp.spent), on = '@' + (opp.name || 'opponent');
+      if (iWon) return me.solved ? `You solved for ${myS} — beat ${on}'s ${oS}.` : `You took it — ${on} didn't solve.`;
+      if (Number(opp.rank) === 1) return opp.solved ? `${on} solved for ${oS} — you spent ${myS}.` : `You spent ${myS}.`;
+      return `You spent ${myS}.`;
+    }
+    if (iWon) return `You solved for ${myS} — cheapest of ${field}.`;
+    if (winner) return `Winner @${winner.name || 'player'} solved for ${dollars(winner.spent)} — you placed ${ordinal(Number(me.rank))} (${myS}).`;
+    return `You placed ${ordinal(Number(me.rank))} — you spent ${myS}.`;
+  })();
 </script>
 
 {#if detail}
@@ -43,6 +64,10 @@
               {#if Number(me.net) >= 0}you took the pot{#if mult(me.multiple_x100)} · {mult(me.multiple_x100)}{/if}{:else}you spent ${me.spent}{/if}
             </span>
           </div>
+        {/if}
+
+        {#if tieback}
+          <p class="md-tieback">🎯 {tieback}</p>
         {/if}
 
         <div class="md-standings">
@@ -92,6 +117,8 @@
   .md-out-net { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.6rem; }
   .md-outcome.win .md-out-net { color: #7ee0a8; } .md-outcome.loss .md-out-net { color: #fb7185; }
   .md-out-lbl { color: var(--text-muted); font-size: 0.82rem; }
+  .md-tieback { text-align: center; font-size: 0.9rem; font-weight: 600; color: var(--text); margin: 0 0 16px;
+    padding: 10px 12px; border-radius: var(--r-md); background: rgba(251,191,36,0.08); border: 1px solid rgba(251,191,36,0.25); }
   .md-meta .pos { color: #7ee0a8; } .md-meta .neg { color: #fb7185; }
 
   .md-standings { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }

--- a/src/lib/components/StandingStrip.svelte
+++ b/src/lib/components/StandingStrip.svelte
@@ -4,7 +4,7 @@
   // (the server only sends a direction). The lead-flip is the reward moment.
   import { fx } from '$lib/sound.js';
 
-  /** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play' } | null} */
+  /** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play', provisional?:boolean } | null} */
   export let standing = null;
   /** @type {number} */ export let spent = 0;
 
@@ -33,7 +33,7 @@
         {#if standing.state === 'first_to_play'}
           <span class="rank">🚩 First to play</span>
         {:else}
-          <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}</span>
+          <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar">so far</span>{/if}</span>
         {/if}
         <span class="spent">Spent <b>${spent.toLocaleString()}</b></span>
       </div>
@@ -61,6 +61,8 @@
     font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.92rem;
     color: var(--text, #fff);
   }
+  .sofar { margin-left: 6px; font-family: var(--font-ui, sans-serif); font-weight: 600; font-size: 0.62rem;
+    text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint, #8090a0); }
   .spent { font-weight: 600; color: var(--text-muted, #c2cbd8); font-size: 0.84rem; }
   .spent b { color: var(--text, #fff); font-variant-numeric: tabular-nums; }
   .msg {

--- a/supabase-match-standing.sql
+++ b/supabase-match-standing.sql
@@ -1,15 +1,17 @@
--- Phase 2 of OBJECTIVE_HUD_SPEC: live DIRECTIONAL standing for 1v1 / single-puzzle
--- group challenges. Applied to prod via MCP migration `match_board_directional_standing`.
+-- OBJECTIVE_HUD_SPEC live DIRECTIONAL standing. Applied to prod via MCP migrations
+-- `match_board_directional_standing` (Phase 2) + `match_board_standing_multipack` (Phase 3).
 --
--- _match_board now returns a `standing` object alongside `match` while you're playing
--- a single-puzzle (pack_size=1), non-blitz, open match:
---   { field_size, finished, rank, state }
+-- _match_board returns a `standing` object alongside `match` while playing a non-blitz,
+-- open match:
+--   { field_size, finished, rank, state, provisional? }
 --   state ∈ 'lead' | 'behind' | 'tied' | 'first_to_play'
 --
--- Spoiler-safe by design: the server compares your spend-so-far to FINISHED rivals'
--- locked spend and returns only a DIRECTION + rank — never the exact spend-to-beat.
--- Lower spend wins (a finished non-solver isn't a bar; you just need to solve).
--- Verified (rolled back): lead {rank1}, behind {rank2}, tied {rank1}, first_to_play {finished0}.
+-- Spoiler-safe by design: the server compares you to FINISHED rivals and returns only a
+-- DIRECTION + rank — never the exact number to beat.
+--   • pack_size = 1 → compare SPEND (predicts "if you solve now, do you win?"). Lower wins;
+--     a finished non-solver isn't a bar (you just need to solve).
+--   • pack_size > 1 → compare TOTAL_SCORE so far, flagged provisional=true (it climbs as you solve).
+-- Verified (rolled back): single lead/behind/tied/first_to_play; multipack lead/behind provisional.
 
 CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
  RETURNS jsonb
@@ -17,7 +19,7 @@ CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
  SECURITY DEFINER
 AS $function$
 DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT;
-  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
 BEGIN
   SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
   IF NOT FOUND THEN RETURN NULL; END IF;
@@ -35,25 +37,39 @@ BEGIN
   END IF;
   IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
 
-  -- Directional standing (single-puzzle, non-blitz): my projected rank vs FINISHED
-  -- rivals, computed here so the exact spend-to-beat never reaches the client.
-  -- Lower spend wins (ties broken by who solved); show direction, never the number.
-  IF m.pack_size = 1 AND m.status = 'open' AND m.mode <> 'blitz' THEN
-    v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+  -- Directional standing vs FINISHED rivals, computed here so the exact number to
+  -- beat never reaches the client — only a direction. Lower spend / higher score wins.
+  IF m.status = 'open' AND m.mode <> 'blitz' THEN
     SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
     SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
-    SELECT min(GREATEST(0, v_budget - o.bankroll)) INTO v_best_spent
-      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
-    SELECT count(*) INTO v_ahead
-      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
-        AND GREATEST(0, v_budget - o.bankroll) < v_my_spent;
-    IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
-    ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
-    ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
-    ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
-    ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+    IF m.pack_size = 1 THEN
+      -- Single puzzle: compare SPEND (predicts "if you solve now, do you win?").
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, v_budget - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, v_budget - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      -- Multi-puzzle pack: compare TOTAL_SCORE so far (provisional — it climbs as you solve).
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
     END IF;
-    v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
   END IF;
 
   v_pid := public._match_pid(p_id, cp.position);


### PR DESCRIPTION
Final piece of `OBJECTIVE_HUD_SPEC.md`.

## What
**1. Multi-puzzle pack standing.** `_match_board` now computes the directional standing for `pack_size > 1` too, comparing **total_score so far** vs finished rivals and flagging it `provisional: true` (it climbs as you solve). Single-puzzle keeps the sharper spend-based comparison. `StandingStrip` shows a muted **"so far"** tag when provisional.

**2. Results spend tie-back banner.** `MatchDetailModal` gains a banner that frames every settled result in the universal metric:
- 1v1 win: `🎯 You solved for $20 — beat @vsbob's $100.`
- 1v1 loss: `🎯 @vsbob solved for $40 — you spent $100.`
- group: `🎯 Winner @x solved for $30 — you placed 3rd ($90).`

Works for 1v1 and groups, wagered or friendly.

## Spoiler-safe
Multi-pack standing still sends only a direction + rank, never raw opponent numbers. Exact figures appear only on the settled results screen.

## Test
- `npm run build` ✓
- Rolled-back SQL: multipack `lead`/`behind` provisional verified.
- Full 2-player run to settlement: tie-back banner renders correctly on the live results modal (screenshot).
- Synced to `supabase-match-standing.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)