### PR TITLE
Phase 4: solo "beat your best" goal line

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -68,6 +68,14 @@ export async function getBank() {
     ledger: Array.isArray(data.ledger) ? data.ledger : [] };
 }
 
+/** Lowest winning spend per mode (e.g. { daily: 20, climb: 60 }) — powers the
+ *  solo "beat your best" goal line. @returns {Promise<Record<string, number>>} */
+export async function getPersonalBests() {
+  const { data, error } = await supabase.rpc('get_personal_bests');
+  if (error) { console.error('❌ get_personal_bests:', error); return {}; }
+  return data && typeof data === 'object' ? data : {};
+}
+
 /** My chosen username (null until claimed). @returns {Promise<string|null>} */
 export async function getMyUsername() {
   const { data, error } = await supabase.rpc('get_my_username');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   import { powerupInfo } from '$lib/powerups.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, getPersonalBests } from '$lib/stores/statsStore.js';
   import { unreadCount, notifications, markAllNotificationsRead, refreshNotifications, inboxRequest } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
@@ -304,6 +304,26 @@
   // Free Play live: clean status + the trickle you'd earn.
   $: freeLive = ($gameStore.gameMode === 'freeplay' && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
     ? { clean: ($gameStore.incorrectLetters?.length ?? 0) === 0 } : null;
+
+  // Solo "beat your best" goal line: your lowest winning spend for this mode.
+  /** @type {Record<string, number>|null} */
+  let personalBests = null;
+  $: if (browser && loggedIn && hasInitialized && personalBests === null) {
+    personalBests = {}; // guard against refetch while the promise resolves
+    getPersonalBests().then((b) => personalBests = b);
+  }
+  $: soloBest = (() => { const v = personalBests?.[$gameStore.gameMode]; return typeof v === 'number' ? v : null; })();
+  $: soloSpent = isClimb ? (climbLive?.spent ?? null) : (dLive ? dLive.spent : null);
+  $: showGoalLine = soloBest !== null && soloSpent !== null
+    && ($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'makeup' || isClimb);
+  // Refresh the best after each solo win (e.g. a Cash Game run improves it mid-session).
+  let _prevSoloGS = '';
+  function refreshBestOnWin(/** @type {string} */ gs, /** @type {string} */ mode) {
+    const solo = mode === 'daily' || mode === 'makeup' || mode === 'climb';
+    if (gs === 'won' && _prevSoloGS !== 'won' && solo && personalBests) getPersonalBests().then((b) => personalBests = b);
+    _prevSoloGS = gs;
+  }
+  $: refreshBestOnWin($gameStore.gameState, $gameStore.gameMode);
 
   // ── Fold + broke-timer (Daily + Challenges) ──────────────────────────────
   // You're "broke" when you can't afford the cheapest still-buyable letter →
@@ -1644,6 +1664,11 @@
       {:else if freeLive}
         <p class="live-line">Solve {freeLive.clean ? 'clean ' : ''}to win <b>+${freeLive.clean ? 50 : 25}</b></p>
       {/if}
+      {#if showGoalLine}
+        <p class="goal-line" class:beating={soloSpent <= soloBest}>
+          {#if soloSpent <= soloBest}🔥 Under your best{:else}🎯 Beat your best{/if}: <b>{soloBest === 0 ? 'free' : '$' + soloBest.toLocaleString()}</b>
+        </p>
+      {/if}
     </section>
 
     <!-- 💎 Arcade power-up tray (earned this run) -->
@@ -2789,6 +2814,9 @@
   .live-line { margin: 9px auto 0; text-align: center; font-size: 0.82rem; color: var(--text-muted); }
   .live-line b { display: inline-block; font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--brand-2); }
   .live-line b.lose { color: #fb7185; }
+  .goal-line { margin: 6px auto 0; text-align: center; font-size: 0.76rem; font-weight: 600; color: var(--text-faint); }
+  .goal-line b { font-family: var(--font-display); font-weight: 800; color: var(--brand-2); font-variant-numeric: tabular-nums; }
+  .goal-line.beating, .goal-line.beating b { color: #7ee0a8; }
 
   /* Cash Game (Climb) gamified HUD */
   .climb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; max-width: 360px; margin: 0 auto 14px; }

--- a/supabase-personal-bests.sql
+++ b/supabase-personal-bests.sql
@@ -1,0 +1,21 @@
+-- Phase 4 of OBJECTIVE_HUD_SPEC: solo "beat your best" goal line.
+-- Applied to prod via MCP migration `get_personal_bests`.
+--
+-- Returns the current user's lowest WINNING spend per mode, e.g. { "daily": 20, "climb": 60 }.
+-- Derived from the Play Log (game_results). The client shows it as a goal line on the
+-- solo spend HUD ("🎯 Beat your best: $X" / "🔥 Under your best") for daily / makeup / climb.
+-- Modes with no prior win are simply absent → no goal line shown.
+
+CREATE OR REPLACE FUNCTION public.get_personal_bests()
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT COALESCE(jsonb_object_agg(game_mode, min_spent), '{}'::jsonb)
+  FROM (
+    SELECT game_mode, MIN(spent)::int AS min_spent
+    FROM public.game_results
+    WHERE user_id = auth.uid() AND outcome = 'won' AND spent IS NOT NULL
+    GROUP BY game_mode
+  ) t;
+$function$;


### PR DESCRIPTION
Final phase of `OBJECTIVE_HUD_SPEC.md` — gives single-player a target.

## What
Solo modes now show a personal-best goal line on the spend HUD:
- `get_personal_bests()` RPC returns the lowest **winning** spend per mode from the Play Log (e.g. `{ daily: 20, climb: 60 }`).
- `+page` renders it for daily / makeup / cash game: `🎯 Beat your best: $X`, flipping to green `🔥 Under your best` while you're below it. Modes with no prior win show nothing.
- Refetches after each solo win, so a Cash Game run's best stays current mid-session.

## Test
- `npm run build` ✓
- Rolled-back SQL returns `{climb:60, daily:20}`.
- Live Cash Game with an injected $50 best renders **🔥 Under your best: $50** (screenshot).
- Synced to `supabase-personal-bests.sql`.

## Completes the system
| Phase | What | PR |
|---|---|---|
| 1 | Objective cards | #252 |
| 2 | Live directional standing | #253 |
| 3 | Multi-pack standing + results tie-back | #254 |
| 4 | Solo goal line | this |

🤖 Generated with [Claude Code](https://claude.com/claude-code)