### PR TITLE
Fix board overlap on phones + tighten vertical layout

### DIFF
--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -128,7 +128,7 @@
 
 .message-box {
   position: fixed;
-  bottom: 232px;
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 232px);
   left: 50%;
   transform: translateX(-50%);
   z-index: 1002;
@@ -150,7 +150,9 @@
 --------------------------- */
 .main-button-wrapper {
   position: fixed;
-  bottom: 188px; /* clears the futuristic keyboard (~172px) + gap */
+  /* Sit above the keyboard, which is lifted by the safe-area inset — match it so
+     the button never overlaps the top key row on phones with a home indicator. */
+  bottom: calc(env(safe-area-inset-bottom, 0px) + 188px);
   left: 50%;
   transform: translateX(-50%);
   display: flex;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1872,7 +1872,7 @@
     margin: 0 auto;
     text-align: center;
     font-family: var(--font-ui);
-    padding: 16px 12px 248px; /* space so content stays above fixed Solve + keyboard */
+    padding: 16px 12px calc(env(safe-area-inset-bottom, 0px) + 244px); /* space so content stays above fixed Solve + keyboard */
     min-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -2004,7 +2004,7 @@
     flex-wrap: wrap;
     gap: 8px;
     justify-content: center;
-    margin: 0 0 22px;
+    margin: 0 0 12px;
   }
   .category-chip {
     font-family: var(--font-display);
@@ -2043,7 +2043,7 @@
   .fold-bar.broke .fold-btn { color: #f87171; border-color: rgba(248,113,113,0.5); }
   .puzzle-clue {
     max-width: 340px;
-    margin: 10px auto 18px;
+    margin: 8px auto 12px;
     font-family: var(--font-ui);
     font-size: 0.98rem;
     font-style: italic;
@@ -2864,9 +2864,9 @@
 
   .game-logo {
     display: block;
-    width: min(64vw, 230px);
+    width: min(52vw, 180px);
     height: auto;
-    margin: 6px auto 16px;
+    margin: 2px auto 10px;
     filter: drop-shadow(0 2px 12px rgba(0, 0, 0, 0.5));
   }
 


### PR DESCRIPTION
## Problem
On a real iPhone the **SOLVE button overlapped the top keyboard row** (see report screenshot). Root cause: the keyboard is `fixed` at `bottom: calc(env(safe-area-inset-bottom) + 9px)`, but the SOLVE button was at a hardcoded `bottom: 188px` with **no** safe-area inset. On phones with a home indicator (~34px) the keyboard rises but the button doesn't → overlap. (Chromium reports `env()` insets as 0, which is why it never showed in our Playwright runs.)

## Fix
- SOLVE button + message box → `bottom: calc(env(safe-area-inset-bottom, 0px) + N)`, matching the keyboard. `main`'s bottom reserve gets the inset too. Consistent gap on every device.
- Tightened the upper stack so the whole board breathes: game logo 230→180px (less margin), `.puzzle-meta` 22→12px, clue bottom 18→12px.

## Test
- `npm run build` ✓
- Phone-width screenshot: clean gap between SOLVE and the keyboard, smaller logo, more breathing room (env=0 baseline unchanged; the inset only adds lift on real devices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)