### PR TITLE
IA Phase 2: Community hub — challenges live here now

### DIFF
--- a/src/lib/components/ActivityPanel.svelte
+++ b/src/lib/components/ActivityPanel.svelte
@@ -1,0 +1,106 @@
+<script>
+  // Activity feed — you, your friends, your groups. Reused by the /activity route
+  // and the Community ▸ Activity tab.
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getActivityFeed } from '$lib/stores/statsStore.js';
+
+  /** @type {any[]} */
+  let rows = $state([]);
+  let loading = $state(true);
+  let done = $state(false);
+  let offset = $state(0);
+  const PAGE = 30;
+
+  const ICON = {
+    daily_win: '📅', challenge: '⚔️', big_solve: '🎰', badge: '🏅', group_join: '👥'
+  };
+  const pretty = (/** @type {string} */ s) => (s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
+  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
+
+  /** relative time */
+  function ago(/** @type {string} */ t) {
+    const s = Math.max(1, Math.floor((Date.now() - new Date(t).getTime()) / 1000));
+    if (s < 60) return s + 's';
+    if (s < 3600) return Math.floor(s / 60) + 'm';
+    if (s < 86400) return Math.floor(s / 3600) + 'h';
+    if (s < 604800) return Math.floor(s / 86400) + 'd';
+    return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  /** @param {any} r */
+  function line(r) {
+    const m = r.meta || {};
+    switch (r.type) {
+      case 'daily_win': {
+        const extra = m.multiple_x100 ? ` (${mult(m.multiple_x100)})` : '';
+        return { verb: `won the Daily${extra}`, tag: m.net != null ? money(m.net) : '' };
+      }
+      case 'challenge':
+        return m.opponent_name
+          ? { verb: `beat @${m.opponent_name} in a challenge`, tag: '' }
+          : { verb: `won a group challenge${m.rank ? ` · #${m.rank}` : ''}`, tag: '' };
+      case 'big_solve':
+        return { verb: `pulled a ${mult(m.multiple_x100)} solve in the Cash Game`, tag: m.net != null ? money(m.net) : '' };
+      case 'badge':
+        return { verb: `earned the “${pretty(m.badge)}” badge`, tag: '' };
+      case 'group_join':
+        return { verb: `joined ${r.group_name || 'a group'}`, tag: '' };
+      default:
+        return { verb: 'did something', tag: '' };
+    }
+  }
+
+  async function load(reset = false) {
+    if (reset) { offset = 0; done = false; rows = []; }
+    loading = true;
+    const page = await getActivityFeed(PAGE, offset);
+    rows = reset ? page : [...rows, ...page];
+    offset += page.length;
+    if (page.length < PAGE) done = true;
+    loading = false;
+  }
+
+  onMount(() => load(true));
+</script>
+
+{#if loading && rows.length === 0}
+  <p class="msg">Loading…</p>
+{:else if rows.length === 0}
+  <p class="msg">Nothing yet. Add friends and play — wins, badges and challenges show up here.</p>
+{:else}
+  <ul class="feed">
+    {#each rows as r, i (r.type + r.actor_id + r.ts + i)}
+      {@const l = line(r)}
+      <li class="ev">
+        <span class="ev-ic">{ICON[r.type] || '•'}</span>
+        <span class="ev-body">
+          <button class="ev-actor" onclick={() => goto('/u/' + encodeURIComponent(r.actor_name || ''))}>@{r.actor_name || 'player'}</button>
+          <span class="ev-verb">{l.verb}</span>
+        </span>
+        {#if l.tag}<span class="ev-tag" class:neg={l.tag.startsWith('−')}>{l.tag}</span>{/if}
+        <span class="ev-time">{ago(r.ts)}</span>
+      </li>
+    {/each}
+  </ul>
+  {#if !done}
+    <button class="more" onclick={() => load(false)} disabled={loading}>{loading ? 'Loading…' : 'Load more'}</button>
+  {/if}
+{/if}
+
+<style>
+  .msg { color: var(--text-muted); text-align: center; padding: 28px 10px; }
+  .feed { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 7px; }
+  .ev { display: flex; align-items: center; gap: 11px; padding: 11px 13px; border: 1px solid var(--border);
+    border-radius: var(--r-md); background: var(--surface); }
+  .ev-ic { font-size: 1.2rem; flex: 0 0 auto; }
+  .ev-body { flex: 1; min-width: 0; font-size: 0.9rem; line-height: 1.35; text-align: left; }
+  .ev-actor { background: none; border: none; padding: 0; font: inherit; font-weight: 800; color: var(--gold); cursor: pointer; }
+  .ev-verb { color: var(--text); }
+  .ev-tag { flex: 0 0 auto; font-weight: 800; color: #7ee0a8; font-size: 0.85rem; font-variant-numeric: tabular-nums; }
+  .ev-tag.neg { color: #fb7185; }
+  .ev-time { flex: 0 0 auto; color: var(--text-faint); font-size: 0.72rem; }
+  .more { display: block; margin: 14px auto 0; padding: 9px 22px; border-radius: var(--r-pill);
+    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; cursor: pointer; }
+</style>

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -1,0 +1,153 @@
+<script>
+  // Leaderboard content (Cash · Daily). Reused by the /leaderboard route and the
+  // Community ▸ Leaderboard tab. The page/hub provides its own title + back.
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import { getWealthLeaderboard, getDailyBoard, getMyGroups } from '$lib/stores/statsStore.js';
+
+  /** @type {'cash'|'daily'} */
+  let board = $state('cash');
+  const TABS = [
+    { k: 'cash', label: '💰 Cash' },
+    { k: 'daily', label: '📅 Daily' }
+  ];
+  const PERIOD_BOARDS = ['cash'];
+  /** scope: 'global' | 'friends' | a group id */
+  let scope = $state('friends');
+  /** @type {'week'|'all'} */
+  let period = $state('all');
+  /** @type {any[]} */
+  let rows = $state([]);
+  /** @type {any[]} */
+  let groups = $state([]);
+  let loading = $state(true);
+  let error = $state('');
+
+  const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
+
+  async function load() {
+    loading = true; error = '';
+    try {
+      const isGroup = scope !== 'global' && scope !== 'friends';
+      const sc = isGroup ? 'group' : scope;
+      const grp = isGroup ? scope : null;
+      if (board === 'cash') rows = await getWealthLeaderboard(sc, period, grp);
+      else rows = await getDailyBoard(sc, grp);
+    } catch (e) {
+      error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
+    } finally { loading = false; }
+  }
+
+  onMount(async () => { groups = await getMyGroups(); await load(); });
+
+  // reload whenever the board / scope / period changes
+  $effect(() => { board; scope; period; load(); });
+
+  /** @param {number} rank */
+  const medal = (rank) => rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : String(rank);
+</script>
+
+<!-- Board selector -->
+<div class="tabs">
+  {#each TABS as t}
+    <button class="tab" class:active={board === t.k} onclick={() => board = /** @type {any} */ (t.k)}>{t.label}</button>
+  {/each}
+</div>
+
+<!-- Scope + period -->
+<div class="filters">
+  <select class="filter-select" bind:value={scope}>
+    <option value="friends">Friends</option>
+    <option value="global">Global</option>
+    {#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
+  </select>
+  {#if PERIOD_BOARDS.includes(board)}
+    <div class="seg">
+      <button class="seg-btn" class:on={period === 'week'} onclick={() => period = 'week'}>This Week</button>
+      <button class="seg-btn" class:on={period === 'all'} onclick={() => period = 'all'}>All-Time</button>
+    </div>
+  {/if}
+</div>
+
+<p class="caption">
+  {#if board === 'cash'}{period === 'week' ? 'Cash gained this week' : 'Richest players — total Cash'}
+  {:else}Today's Daily score{/if}
+</p>
+
+{#if loading}
+  <p class="muted">Loading…</p>
+{:else if error}
+  <p class="error">{error}</p>
+{:else if rows.length === 0}
+  <p class="muted">Nobody here yet — add friends or play!</p>
+{:else}
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>#</th><th>Player</th>
+          {#if board === 'cash'}<th>{period === 'week' ? 'Gained' : 'Cash'}</th>
+          {:else}<th>Score</th>{/if}
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as r}
+          <tr class={r.is_me ? 'me' : (r.rank <= 3 ? 'top' : '')}>
+            <td class="rank">{medal(r.rank)}</td>
+            <td class="name">
+              {#if r.is_me}
+                <button class="name-link" onclick={() => goto('/profile')} style={r.color ? `color:${r.color}` : ''}>You</button>
+              {:else}
+                <button class="name-link" onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))} style={r.color ? `color:${r.color}` : ''}>{r.name || 'Player'}</button>
+              {/if}
+              {#if r.title}<span class="title">{r.title}</span>{/if}
+            </td>
+            {#if board === 'cash'}
+              <td class="metric" class:neg={period === 'week' && Number(r.metric) < 0}>
+                {period === 'week' ? (r.metric >= 0 ? '+' : '') + fmt(r.metric) : fmt(r.net_worth)}
+              </td>
+            {:else}
+              <td class="metric">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
+            {/if}
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+{/if}
+
+<p class="hint">
+  {#if board === 'cash'}Your total Cash, earned across every mode. The weekly view resets Monday — fair for newcomers.
+  {:else}Same puzzle for everyone today. Spend less, score more.{/if}
+</p>
+
+<style>
+  .tabs { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; overflow-x: auto; padding-bottom: 4px; -webkit-overflow-scrolling: touch; justify-content: center; }
+  .tabs::-webkit-scrollbar { display: none; }
+  .tab { flex: 0 0 auto; padding: 0.5rem 0.8rem; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.82rem; white-space: nowrap; border: 1px solid var(--border); background: var(--surface); color: var(--text-muted); }
+  .tab.active { color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border-color: transparent; }
+  .filters { display: flex; gap: 0.5rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 0.5rem; }
+  .filter-select { padding: 0.5rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.9rem; }
+  .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; overflow: hidden; }
+  .seg-btn { padding: 0.45rem 0.9rem; cursor: pointer; font-size: 0.82rem; font-weight: 600; background: transparent; color: var(--text-muted); border: none; }
+  .seg-btn.on { background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); color: #3a2a00; }
+  .caption { color: var(--text-faint); font-size: 0.8rem; margin: 0.2rem 0 1rem; text-align: center; }
+  .muted { color: var(--text-muted); padding: 2rem 0; text-align: center; }
+  .error { color: #fb7185; text-align: center; }
+  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; }
+  table { width: 100%; border-collapse: collapse; }
+  th { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-faint); padding: 0.7rem 0.6rem; text-align: left; border-bottom: 1px solid var(--border); }
+  td { padding: 0.7rem 0.6rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; text-align: left; }
+  tr:last-child td { border-bottom: none; }
+  td.rank { width: 34px; }
+  td.name { font-weight: 600; }
+  .name-link { background: none; border: none; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.2); text-underline-offset: 2px; }
+  .name-link:hover { text-decoration-color: var(--gold); }
+  td.metric { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); text-align: right; }
+  td.metric.neg { color: #fb7185; }
+  th:last-child { text-align: right; }
+  tr.me { background: rgba(56,189,248,0.1); }
+  tr.me td.name { color: #7dd3fc; }
+  .title { font-size: 0.68rem; color: var(--text-faint); margin-left: 0.35rem; white-space: nowrap; }
+  .hint { margin-top: 1.2rem; font-size: 0.76rem; color: var(--text-faint); line-height: 1.5; text-align: center; }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -36,6 +36,8 @@
   import StandingStrip from '$lib/components/StandingStrip.svelte';
   import PowerupTray from '$lib/components/PowerupTray.svelte';
   import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
+  import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
+  import ActivityPanel from '$lib/components/ActivityPanel.svelte';
 
   export let data;
 
@@ -644,7 +646,7 @@
       const params = new URLSearchParams(window.location.search);
       const ch = params.get('challenge');
       if (ch) {
-        openChallenges().then(() => { mbTarget = 'friend'; mbOpponent = ch; });
+        newChallenge().then(() => { mbTarget = 'friend'; mbOpponent = ch; });
         params.delete('challenge');
       }
       // Settings/account deep link from the Profile page's ⚙️ gear (/?account=1)
@@ -800,9 +802,9 @@
     }
   }
   // ===== Challenge Builder (configurable packs vs friends/groups) =====
-  let showChallenges = false;
-  /** Which view of the Challenges modal: the inbox list vs the new-match builder. */
-  let chTab = /** @type {'inbox'|'new'} */ ('inbox');
+  let showChallenges = false; // the New-Challenge builder modal
+  /** Which Community hub tab is showing. */
+  let communityTab = /** @type {'challenges'|'leaderboard'|'activity'|'people'} */ ('challenges');
   /** @type {any[]} */
   let myMatches = [];
   /** @type {any[]} */
@@ -856,14 +858,27 @@
       friendReqCount = friendRequests.length;
     } catch { /* non-fatal */ }
   }
-  /** @param {'inbox'|'new'} [forceTab] */
-  async function openChallenges(forceTab) {
+  /** Open the New-Challenge builder modal. */
+  async function newChallenge() {
     if (!get(user)?.id) return;
-    mbMsg = ''; matchResults = null;
+    mbMsg = '';
+    myGroups = await getMyGroups();
     showChallenges = true;
+  }
+  /** Go to the Community hub. @param {'challenges'|'leaderboard'|'activity'|'people'} [tab] */
+  async function openCommunity(tab) {
+    if (!get(user)?.id) return;
+    matchResults = null;
+    communityTab = tab ?? 'challenges';
+    menuView = 'community';
+    showMainMenu = true;
     [myMatches, myGroups] = await Promise.all([getMyMatches(), getMyGroups()]);
     challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
-    chTab = forceTab ?? (myMatches.length ? 'inbox' : 'new'); // land on the list if you have any
+  }
+  /** Back-compat shim for existing callers (banner "+N more", toasts, result modal). */
+  async function openChallenges(forceTab) {
+    if (forceTab === 'new') return newChallenge();
+    return openCommunity('challenges');
   }
 
   // ===== Notifications panel (bell) =====
@@ -1200,13 +1215,10 @@
           <button class="menu-card primary" style="--i: 0" on:click={() => { menuView = 'play'; fx('tap'); }}>
             <span class="mc-title">Play Now</span>
           </button>
-          <button class="menu-card" style="--i: 1" on:click={() => { menuView = 'challenge'; fx('tap'); }}>
-            <span class="mc-title">Challenge Friends</span>
-          </button>
-          <button class="menu-card" style="--i: 2" on:click={() => { menuView = 'community'; fx('tap'); }}>
+          <button class="menu-card" style="--i: 1" on:click={() => { fx('tap'); openCommunity('challenges'); }}>
             <span class="mc-title">Community</span>
           </button>
-          <button class="menu-card" style="--i: 3" on:click={() => goto('/shop')}>
+          <button class="menu-card" style="--i: 2" on:click={() => goto('/shop')}>
             <span class="mc-title">Store</span>
           </button>
         </div>
@@ -1237,38 +1249,58 @@
           {#if blitzSoon}<p class="pm-soon-note">⚡ Solo Blitz is coming soon!</p>{/if}
         </div>
 
-      {:else if menuView === 'challenge'}
-        <div class="sub-head">
-          <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
-          <h2 class="sub-title">Challenge Friends</h2>
-        </div>
-        <div class="main-menu-buttons stagger">
-          <button class="menu-card primary" style="--i: 0" on:click={openChallenges}>
-            <span class="mc-title">Start Challenge</span>
-            {#if challengeCount > 0}<span class="mc-badge" title="{challengeCount} waiting">{challengeCount}</span>{/if}
-          </button>
-          <button class="menu-card" style="--i: 1" on:click={() => goto('/friends')}>
-            <span class="mc-title">Friends</span>
-            {#if friendReqCount > 0}<span class="mc-badge" title="{friendReqCount} friend request{friendReqCount === 1 ? '' : 's'}">{friendReqCount}</span>{/if}
-          </button>
-          <button class="menu-card" style="--i: 2" on:click={() => goto('/groups')}>
-            <span class="mc-title">Groups</span>
-          </button>
-        </div>
-
       {:else if menuView === 'community'}
         <div class="sub-head">
           <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
           <h2 class="sub-title">Community</h2>
+          <button class="sub-people" title="Friends & Groups" aria-label="Friends & Groups" on:click={() => { communityTab = 'people'; fx('tap'); }}>👥</button>
         </div>
-        <div class="main-menu-buttons stagger">
-          <button class="menu-card" style="--i: 0" on:click={handleMenuLeaderboard}>
-            <span class="mc-title">Leaderboard</span>
-          </button>
-          <button class="menu-card" style="--i: 1" on:click={() => goto('/activity')}>
-            <span class="mc-title">Activity</span>
-          </button>
+        <div class="comm-tabs">
+          <button class="comm-tab" class:active={communityTab === 'challenges'} on:click={() => { communityTab = 'challenges'; fx('tap'); }}>Challenges</button>
+          <button class="comm-tab" class:active={communityTab === 'leaderboard'} on:click={() => { communityTab = 'leaderboard'; fx('tap'); }}>Leaderboard</button>
+          <button class="comm-tab" class:active={communityTab === 'activity'} on:click={() => { communityTab = 'activity'; fx('tap'); }}>Activity</button>
         </div>
+
+        {#if communityTab === 'challenges'}
+          <div class="comm-body">
+            <button class="ch-new-btn" on:click={newChallenge}>＋ New Challenge</button>
+            {#if myMatches.length}
+              <div class="ch-list">
+                {#each myMatches as m}
+                  <div class="ch-item">
+                    <div class="ch-info">
+                      <span class="ch-vs">{m.is_host ? 'You hosted' : m.host + ' invited you'}</span>
+                      <span class="ch-meta">{m.pack_size} puzzle{m.pack_size === 1 ? '' : 's'} · {m.players} players{#if m.wager > 0} · ${m.wager?.toLocaleString()}{/if}</span>
+                    </div>
+                    {#if m.status === 'settled'}
+                      <button class="ch-play ghost" disabled={mbBusy} on:click={() => respondToMatch(m)}>Results</button>
+                    {:else if m.my_state !== 'done'}
+                      <button class="ch-play" disabled={mbBusy} on:click={() => respondToMatch(m)}>{m.my_state === 'invited' ? 'Play' : 'Resume'}</button>
+                    {:else}
+                      <span class="ch-waiting">Waiting…</span>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            {:else}
+              <p class="ch-empty">No challenges yet. Tap <b>＋ New Challenge</b> to start one.</p>
+            {/if}
+          </div>
+        {:else if communityTab === 'leaderboard'}
+          <div class="comm-body"><LeaderboardPanel /></div>
+        {:else if communityTab === 'activity'}
+          <div class="comm-body"><ActivityPanel /></div>
+        {:else}
+          <div class="comm-body people">
+            <button class="menu-card" on:click={() => goto('/friends')}>
+              <span class="mc-title">Friends</span>
+              {#if friendReqCount > 0}<span class="mc-badge" title="{friendReqCount} request{friendReqCount === 1 ? '' : 's'}">{friendReqCount}</span>{/if}
+            </button>
+            <button class="menu-card" on:click={() => goto('/groups')}>
+              <span class="mc-title">Groups</span>
+            </button>
+          </div>
+        {/if}
       {/if}
     </div>
 
@@ -1299,38 +1331,10 @@
         <div class="modal-content main-menu-modal ch-modal">
           <button class="close-btn" on:click={() => showChallenges = false}>❌</button>
 
-          <h2>⚔️ Challenges</h2>
-          <div class="ch-tabs">
-            <button type="button" class="ch-tab" class:active={chTab === 'inbox'} on:click={() => chTab = 'inbox'}>📥 Inbox{#if myMatches.length} · {myMatches.length}{/if}</button>
-            <button type="button" class="ch-tab" class:active={chTab === 'new'} on:click={() => chTab = 'new'}>⚔️ New</button>
-          </div>
+          <h2>⚔️ New Challenge</h2>
+          <p class="cat-sub">Build a match — a pack of puzzles vs a friend or a group. Same puzzles for everyone.</p>
 
-          {#if chTab === 'inbox'}
-            {#if myMatches.length}
-              <div class="ch-list">
-                {#each myMatches as m}
-                  <div class="ch-item">
-                    <div class="ch-info">
-                      <span class="ch-vs">{m.is_host ? 'You hosted' : m.host + ' invited you'}</span>
-                      <span class="ch-meta">{m.pack_size} puzzle{m.pack_size === 1 ? '' : 's'} · {m.players} players{#if m.wager > 0} · ${m.wager?.toLocaleString()}{/if}</span>
-                    </div>
-                    {#if m.status === 'settled'}
-                      <button class="ch-play ghost" disabled={mbBusy} on:click={() => respondToMatch(m)}>Results</button>
-                    {:else if m.my_state !== 'done'}
-                      <button class="ch-play" disabled={mbBusy} on:click={() => respondToMatch(m)}>{m.my_state === 'invited' ? 'Play' : 'Resume'}</button>
-                    {:else}
-                      <span class="ch-waiting">Waiting…</span>
-                    {/if}
-                  </div>
-                {/each}
-              </div>
-            {:else}
-              <p class="ch-empty">No challenges yet. Tap <b>⚔️ New</b> to start one.</p>
-            {/if}
-          {:else}
-            <p class="cat-sub">Build a match — a pack of puzzles vs a friend or a group. Same puzzles for everyone.</p>
-
-            <div class="ch-new">
+          <div class="ch-new">
               <!-- Opponent: friend or group -->
               <div class="ch-modes">
                 <button type="button" class="ch-mode" class:active={mbTarget === 'friend'} on:click={() => mbTarget = 'friend'}>👤 A friend<small>by username</small></button>
@@ -1393,7 +1397,6 @@
               <button class="ch-create" disabled={mbBusy} on:click={submitNewMatch} style="width:100%;">Send challenge ⚔️</button>
               {#if mbMsg}<p class="add-msg">{mbMsg}</p>{/if}
             </div>
-          {/if}
         </div>
       </div>
     {/if}
@@ -1823,7 +1826,7 @@
               {#if matchInfo?.status === 'settled'}
                 <button class="share-btn" on:click={async () => { const id = matchInfo?.id; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); matchResults = { loading: true }; matchResults = await getMatchDetail(id); }}>View Results</button>
               {:else}
-                <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); openChallenges(); }}>Challenge Friends</button>
+                <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); newChallenge(); }}>Challenge Friends</button>
               {/if}
               <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
             </div>
@@ -1870,7 +1873,7 @@
             {/if}
             <p class="arcade-gain">We'll settle the pot once your friend plays.</p>
             <div class="result-actions">
-              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; openChallenges(); }}>Challenge Friends</button>
+              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); newChallenge(); }}>Challenge Friends</button>
               <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
             </div>
           {:else}
@@ -2220,6 +2223,25 @@
   }
   .sub-back:hover { transform: translateX(-2px); border-color: var(--border-strong); background: var(--surface-2); }
   .sub-title { font-family: var(--font-display); font-size: 1.15rem; font-weight: 800; }
+  .sub-people {
+    margin-left: auto; width: 40px; height: 40px; display: grid; place-items: center; font-size: 1.1rem;
+    background: var(--surface); border: 1px solid var(--border); border-radius: 12px; cursor: pointer;
+  }
+  .sub-people:hover { border-color: var(--brand-2); }
+  /* Community hub tabs + body */
+  .comm-tabs { display: flex; gap: 8px; width: 100%; margin: 12px 0 14px; }
+  .comm-tab { flex: 1; padding: 9px 0; border-radius: 12px; border: 1px solid var(--border); background: var(--surface);
+    color: var(--text-muted); font-family: var(--font-display); font-weight: 700; font-size: 0.86rem; cursor: pointer; }
+  .comm-tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
+  .comm-body { width: 100%; }
+  .comm-body.people { display: flex; flex-direction: column; gap: 0.6rem; }
+  .ch-new-btn {
+    width: 100%; margin-bottom: 12px; padding: 12px; border-radius: 14px; border: none; cursor: pointer;
+    font-family: var(--font-display); font-weight: 800; font-size: 0.95rem; color: #3a2a00;
+    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+    box-shadow: 0 6px 18px rgba(251, 191, 36, 0.25);
+  }
+  .ch-new-btn:hover { filter: brightness(1.05); }
   .menu-hero {
     display: flex;
     flex-direction: column;

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -1,67 +1,9 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getActivityFeed } from '$lib/stores/statsStore.js';
+  import ActivityPanel from '$lib/components/ActivityPanel.svelte';
   import { track } from '$lib/analytics.js';
-
-  /** @type {any[]} */
-  let rows = $state([]);
-  let loading = $state(true);
-  let done = $state(false);
-  let offset = $state(0);
-  const PAGE = 30;
-
-  const ICON = {
-    daily_win: '📅', challenge: '⚔️', big_solve: '🎰', badge: '🏅', group_join: '👥'
-  };
-  const pretty = (/** @type {string} */ s) => (s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
-  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
-
-  /** relative time */
-  function ago(/** @type {string} */ t) {
-    const s = Math.max(1, Math.floor((Date.now() - new Date(t).getTime()) / 1000));
-    if (s < 60) return s + 's';
-    if (s < 3600) return Math.floor(s / 60) + 'm';
-    if (s < 86400) return Math.floor(s / 3600) + 'h';
-    if (s < 604800) return Math.floor(s / 86400) + 'd';
-    return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  }
-
-  /** @param {any} r */
-  function line(r) {
-    const m = r.meta || {};
-    switch (r.type) {
-      case 'daily_win': {
-        const extra = m.multiple_x100 ? ` (${mult(m.multiple_x100)})` : '';
-        return { verb: `won the Daily${extra}`, tag: m.net != null ? money(m.net) : '' };
-      }
-      case 'challenge':
-        return m.opponent_name
-          ? { verb: `beat @${m.opponent_name} in a challenge`, tag: '' }
-          : { verb: `won a group challenge${m.rank ? ` · #${m.rank}` : ''}`, tag: '' };
-      case 'big_solve':
-        return { verb: `pulled a ${mult(m.multiple_x100)} solve in the Cash Game`, tag: m.net != null ? money(m.net) : '' };
-      case 'badge':
-        return { verb: `earned the “${pretty(m.badge)}” badge`, tag: '' };
-      case 'group_join':
-        return { verb: `joined ${r.group_name || 'a group'}`, tag: '' };
-      default:
-        return { verb: 'did something', tag: '' };
-    }
-  }
-
-  async function load(reset = false) {
-    if (reset) { offset = 0; done = false; rows = []; }
-    loading = true;
-    const page = await getActivityFeed(PAGE, offset);
-    rows = reset ? page : [...rows, ...page];
-    offset += page.length;
-    if (page.length < PAGE) done = true;
-    loading = false;
-  }
-
-  onMount(() => { track('activity_view'); load(true); });
+  onMount(() => track('activity_view'));
 </script>
 
 <svelte:head><title>WordBank — Activity</title></svelte:head>
@@ -70,30 +12,7 @@
   <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
   <h1>📣 Activity</h1>
   <p class="sub">You, your friends, and your groups.</p>
-
-  {#if loading && rows.length === 0}
-    <p class="msg">Loading…</p>
-  {:else if rows.length === 0}
-    <p class="msg">Nothing yet. Add friends and play — wins, badges and challenges show up here.</p>
-  {:else}
-    <ul class="feed">
-      {#each rows as r, i (r.type + r.actor_id + r.ts + i)}
-        {@const l = line(r)}
-        <li class="ev">
-          <span class="ev-ic">{ICON[r.type] || '•'}</span>
-          <span class="ev-body">
-            <button class="ev-actor" onclick={() => goto('/u/' + encodeURIComponent(r.actor_name || ''))}>@{r.actor_name || 'player'}</button>
-            <span class="ev-verb">{l.verb}</span>
-          </span>
-          {#if l.tag}<span class="ev-tag" class:neg={l.tag.startsWith('−')}>{l.tag}</span>{/if}
-          <span class="ev-time">{ago(r.ts)}</span>
-        </li>
-      {/each}
-    </ul>
-    {#if !done}
-      <button class="more" onclick={() => load(false)} disabled={loading}>{loading ? 'Loading…' : 'Load more'}</button>
-    {/if}
-  {/if}
+  <ActivityPanel />
 </main>
 
 <style>
@@ -101,19 +20,4 @@
   .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
   h1 { font-family: var(--font-display); font-size: 1.5rem; margin: 4px 0 2px; }
   .sub { color: var(--text-faint); font-size: 0.84rem; margin: 0 0 16px; }
-  .msg { color: var(--text-muted); text-align: center; padding: 28px 10px; }
-
-  .feed { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 7px; }
-  .ev { display: flex; align-items: center; gap: 11px; padding: 11px 13px; border: 1px solid var(--border);
-    border-radius: var(--r-md); background: var(--surface); }
-  .ev-ic { font-size: 1.2rem; flex: 0 0 auto; }
-  .ev-body { flex: 1; min-width: 0; font-size: 0.9rem; line-height: 1.35; }
-  .ev-actor { background: none; border: none; padding: 0; font: inherit; font-weight: 800; color: var(--gold); cursor: pointer; }
-  .ev-verb { color: var(--text); }
-  .ev-tag { flex: 0 0 auto; font-weight: 800; color: #7ee0a8; font-size: 0.85rem; font-variant-numeric: tabular-nums; }
-  .ev-tag.neg { color: #fb7185; }
-  .ev-time { flex: 0 0 auto; color: var(--text-faint); font-size: 0.72rem; }
-
-  .more { display: block; margin: 14px auto 0; padding: 9px 22px; border-radius: var(--r-pill);
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; cursor: pointer; }
 </style>

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -1,57 +1,9 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
-  import { getWealthLeaderboard, getDailyBoard, getMyGroups } from '$lib/stores/statsStore.js';
+  import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
   import { track } from '$lib/analytics.js';
-
-  /** @type {'cash'|'daily'} */
-  let board = $state('cash');
-  const TABS = [
-    { k: 'cash', label: '💰 Cash' },
-    { k: 'daily', label: '📅 Daily' }
-  ];
-  // boards that support a week/all period toggle
-  const PERIOD_BOARDS = ['cash'];
-  /** scope: 'global' | 'friends' | a group id */
-  let scope = $state('friends');
-  /** @type {'week'|'all'} */
-  let period = $state('all');
-  /** @type {any[]} */
-  let rows = $state([]);
-  /** @type {any[]} */
-  let groups = $state([]);
-  let loading = $state(true);
-  let error = $state('');
-
-  const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
-
-  async function load() {
-    loading = true; error = '';
-    try {
-      const isGroup = scope !== 'global' && scope !== 'friends';
-      const sc = isGroup ? 'group' : scope;
-      const grp = isGroup ? scope : null;
-      if (board === 'cash') rows = await getWealthLeaderboard(sc, period, grp);
-      else rows = await getDailyBoard(sc, grp);
-    } catch (e) {
-      error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
-    } finally { loading = false; }
-  }
-
-  onMount(async () => {
-    track('leaderboard_view');
-    groups = await getMyGroups();
-    const b = $page.url.searchParams.get('board');
-    if (b && TABS.some((t) => t.k === b)) board = /** @type {any} */ (b);
-    await load();
-  });
-
-  // reload whenever the board / scope / period changes
-  $effect(() => { board; scope; period; load(); });
-
-  /** @param {number} rank */
-  const medal = (rank) => rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : String(rank);
+  onMount(() => track('leaderboard_view'));
 </script>
 
 <svelte:head><title>WordBank — Leaderboard</title></svelte:head>
@@ -59,112 +11,11 @@
 <main class="lb-page">
   <button class="back-btn" onclick={() => goto('/')}>← Menu</button>
   <h1>🏆 Leaderboard</h1>
-
-  <!-- Board selector -->
-  <div class="tabs">
-    {#each TABS as t}
-      <button class="tab" class:active={board === t.k} onclick={() => board = /** @type {any} */ (t.k)}>{t.label}</button>
-    {/each}
-  </div>
-
-  <!-- Scope + period -->
-  <div class="filters">
-    <select class="filter-select" bind:value={scope}>
-      <option value="friends">Friends</option>
-      <option value="global">Global</option>
-      {#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
-    </select>
-    {#if PERIOD_BOARDS.includes(board)}
-      <div class="seg">
-        <button class="seg-btn" class:on={period === 'week'} onclick={() => period = 'week'}>This Week</button>
-        <button class="seg-btn" class:on={period === 'all'} onclick={() => period = 'all'}>All-Time</button>
-      </div>
-    {/if}
-  </div>
-
-  <p class="caption">
-    {#if board === 'cash'}{period === 'week' ? 'Cash gained this week' : 'Richest players — total Cash'}
-    {:else}Today's Daily score{/if}
-  </p>
-
-  {#if loading}
-    <p class="muted">Loading…</p>
-  {:else if error}
-    <p class="error">{error}</p>
-  {:else if rows.length === 0}
-    <p class="muted">Nobody here yet — add friends or play!</p>
-  {:else}
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>#</th><th>Player</th>
-            {#if board === 'cash'}<th>{period === 'week' ? 'Gained' : 'Cash'}</th>
-            {:else}<th>Score</th>{/if}
-          </tr>
-        </thead>
-        <tbody>
-          {#each rows as r}
-            <tr class={r.is_me ? 'me' : (r.rank <= 3 ? 'top' : '')}>
-              <td class="rank">{medal(r.rank)}</td>
-              <td class="name">
-                {#if r.is_me}
-                  <button class="name-link" onclick={() => goto('/profile')} style={r.color ? `color:${r.color}` : ''}>You</button>
-                {:else}
-                  <button class="name-link" onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))} style={r.color ? `color:${r.color}` : ''}>{r.name || 'Player'}</button>
-                {/if}
-                {#if r.title}<span class="title">{r.title}</span>{/if}
-              </td>
-              {#if board === 'cash'}
-                <td class="metric" class:neg={period === 'week' && Number(r.metric) < 0}>
-                  {period === 'week' ? (r.metric >= 0 ? '+' : '') + fmt(r.metric) : fmt(r.net_worth)}
-                </td>
-              {:else}
-                <td class="metric">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
-              {/if}
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
-  {/if}
-
-  <p class="hint">
-    {#if board === 'cash'}Your total Cash, earned across every mode. The weekly view resets Monday — fair for newcomers.
-    {:else}Same puzzle for everyone today. Spend less, score more.{/if}
-  </p>
+  <LeaderboardPanel />
 </main>
 
 <style>
   .lb-page { max-width: 640px; margin: 0 auto; padding: 2rem 1rem 3rem; text-align: center; }
   .back-btn { display: inline-block; margin-bottom: 1rem; padding: 0.55rem 1.1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
   h1 { font-family: var(--font-display); font-size: 1.9rem; margin: 0 0 1rem; }
-  .tabs { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; overflow-x: auto; padding-bottom: 4px; -webkit-overflow-scrolling: touch; }
-  .tabs::-webkit-scrollbar { display: none; }
-  .tab { flex: 0 0 auto; padding: 0.5rem 0.8rem; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.82rem; white-space: nowrap; border: 1px solid var(--border); background: var(--surface); color: var(--text-muted); }
-  .tab.active { color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border-color: transparent; }
-  .filters { display: flex; gap: 0.5rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 0.5rem; }
-  .filter-select { padding: 0.5rem 0.8rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.9rem; }
-  .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; overflow: hidden; }
-  .seg-btn { padding: 0.45rem 0.9rem; cursor: pointer; font-size: 0.82rem; font-weight: 600; background: transparent; color: var(--text-muted); border: none; }
-  .seg-btn.on { background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); color: #3a2a00; }
-  .caption { color: var(--text-faint); font-size: 0.8rem; margin: 0.2rem 0 1rem; }
-  .muted { color: var(--text-muted); padding: 2rem 0; }
-  .error { color: #fb7185; }
-  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; }
-  table { width: 100%; border-collapse: collapse; }
-  th { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-faint); padding: 0.7rem 0.6rem; text-align: left; border-bottom: 1px solid var(--border); }
-  td { padding: 0.7rem 0.6rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; text-align: left; }
-  tr:last-child td { border-bottom: none; }
-  td.rank { width: 34px; }
-  td.name { font-weight: 600; }
-  .name-link { background: none; border: none; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.2); text-underline-offset: 2px; }
-  .name-link:hover { text-decoration-color: var(--gold); }
-  td.metric { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); text-align: right; }
-  td.metric.neg { color: #fb7185; }
-  th:last-child { text-align: right; }
-  tr.me { background: rgba(56,189,248,0.1); }
-  tr.me td.name { color: #7dd3fc; }
-  .title { font-size: 0.68rem; color: var(--text-faint); margin-left: 0.35rem; white-space: nowrap; }
-  .hint { margin-top: 1.2rem; font-size: 0.76rem; color: var(--text-faint); line-height: 1.5; }
 </style>


### PR DESCRIPTION
Per `MENU_IA_PLAN.md`: Community becomes the "with people" hub, and the standalone **Challenge Friends** card is gone.

## What
- **Home cards** are now **Play · Community · Store** (4 → 3).
- **Community is a tabbed hub** (opens on Challenges): **Challenges · Leaderboard · Activity**, with a **👥 People** button (Friends + Groups) in the header.
- The **challenge inbox moved inline** into the Challenges tab; the heavy builder stays as a focused **"＋ New Challenge"** modal (stripped of its old inbox tab).
- **Extracted `LeaderboardPanel` + `ActivityPanel`** so the `/leaderboard` and `/activity` routes *and* the Community tabs share one implementation (same pattern as the profile panels).
- **Repointed callers:** `openChallenges()` → Community ▸ Challenges; post-game "Challenge Friends" + the `/?challenge=` deep-link → the New-Challenge builder.

## Test
- `npm run build` ✓
- QA sweep **19/19, 0 console errors** (the refactored /leaderboard + /activity routes sweep clean).
- Live hub verified: home cards correct, all three tabs render (leaderboard table + activity feed embedded), 👥 People shows Friends/Groups, ＋ New Challenge opens the builder. Screenshots captured.

Next: Phase 3 (unified People screen), Phase 4 (Activity dot + toast routing), Phase 5 (Play → challenge-a-friend link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)