### PR TITLE
IA Phase 4: Activity browse-inbox + unread dot; route toasts; kill dead bell

### DIFF
--- a/scripts/vs-walkthrough.mjs
+++ b/scripts/vs-walkthrough.mjs
@@ -54,9 +54,14 @@ async function playSolve(p, answer, wrong) {
   await p.getByRole('button', { name: /^submit$/i }).first().click().catch(async () => { await p.keyboard.press('Enter'); });
   await wait(p, 2500);
 }
+// Community hub → Challenges tab (the inbox of your matches).
 async function openChallengeInbox(p) {
-  await p.getByRole('button', { name: /challenge friends/i }).first().click().catch(() => {}); await wait(p, 600);
-  await p.getByRole('button', { name: /start challenge/i }).first().click().catch(() => {}); await wait(p, 1200);
+  await p.locator('.menu-card').filter({ hasText: 'Community' }).first().click().catch(() => {}); await wait(p, 1200);
+}
+// Community → Challenges → the New-Challenge builder modal.
+async function openNewChallenge(p) {
+  await openChallengeInbox(p);
+  await p.getByRole('button', { name: /New Challenge/i }).first().click().catch(() => {}); await wait(p, 1000);
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -68,7 +73,7 @@ if (PHASE === 'setup') {
 
 if (PHASE === 'create') {
   const c = await ctx(); const p = await c.newPage(); await login(p, A);
-  await openChallengeInbox(p);
+  await openNewChallenge(p);
   await p.locator('input.ch-input').first().fill(B.user); await wait(p, 800);
   // pack size 1
   await p.locator('select.ch-input').first().selectOption('1').catch(() => {});

--- a/src/lib/components/NotificationsPanel.svelte
+++ b/src/lib/components/NotificationsPanel.svelte
@@ -1,0 +1,68 @@
+<script>
+  // Your personal notifications inbox (results, sabotages, friend requests,
+  // incoming challenges). Shown in Community ▸ Activity. Friend requests can be
+  // accepted/declined inline; tapping a row routes via onNavigate.
+  import { notifications, refreshNotifications } from '$lib/stores/notificationStore.js';
+  import { respondFriendRequest } from '$lib/stores/statsStore.js';
+  import { fx } from '$lib/sound.js';
+
+  /** @type {{ onNavigate?: ((n:any)=>void)|null, onChange?: (()=>void)|null }} */
+  let { onNavigate = null, onChange = null } = $props();
+
+  let responded = $state(/** @type {Record<string,'accepted'|'declined'>} */ ({}));
+
+  /** @param {any} n @param {boolean} accept */
+  async function respond(n, accept) {
+    const fromId = n?.data?.from_id;
+    if (!fromId || responded[n.id]) return;
+    const res = await respondFriendRequest(fromId, accept);
+    if (res?.ok) {
+      responded = { ...responded, [n.id]: accept ? 'accepted' : 'declined' };
+      fx(accept ? 'win' : 'tap');
+      refreshNotifications();
+      onChange?.();
+    }
+  }
+</script>
+
+{#if $notifications.length === 0}
+  <p class="empty">No notifications yet — challenge results, sabotages and requests land here.</p>
+{:else}
+  <div class="notif-list">
+    {#each $notifications as n (n.id)}
+      <div class="notif-item" class:fresh={!n.read}>
+        <button class="ni-main" onclick={() => onNavigate?.(n)}>
+          <span class="ni-title">{n.title}</span>
+          <span class="ni-body">{n.body}</span>
+        </button>
+        {#if n.type === 'friend_request' && n.data?.from_id}
+          {#if responded[n.id]}
+            <span class="ni-done {responded[n.id]}">{responded[n.id] === 'accepted' ? '✓ Friends' : 'Declined'}</span>
+          {:else}
+            <div class="ni-actions">
+              <button class="ni-act accept" onclick={() => respond(n, true)}>Accept</button>
+              <button class="ni-act decline" onclick={() => respond(n, false)}>Decline</button>
+            </div>
+          {/if}
+        {/if}
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .empty { color: var(--text-muted); font-size: 0.88rem; text-align: center; padding: 1rem 0.4rem; }
+  .notif-list { display: flex; flex-direction: column; gap: 0.5rem; }
+  .notif-item { padding: 0.7rem 0.85rem; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); }
+  .notif-item.fresh { border-color: rgba(253, 224, 71,0.45); background: linear-gradient(135deg, rgba(251, 191, 36,0.08), rgba(253, 224, 71,0.03)); }
+  .ni-main { text-align: left; display: flex; flex-direction: column; gap: 2px; width: 100%; background: none; border: none; color: inherit; cursor: pointer; padding: 0; }
+  .ni-title { font-family: var(--font-display); font-weight: 700; font-size: 0.92rem; }
+  .ni-body { font-size: 0.82rem; color: var(--text-muted); }
+  .ni-actions { display: flex; gap: 0.5rem; margin-top: 0.55rem; }
+  .ni-act { flex: 1; padding: 0.45rem 0.7rem; border-radius: 9px; font-weight: 800; font-size: 0.82rem; cursor: pointer; border: 1px solid var(--border); }
+  .ni-act.accept { color: #3a2a00; border: none; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
+  .ni-act.decline { color: #f87171; background: transparent; border-color: rgba(248,113,113,0.4); }
+  .ni-done { display: inline-block; margin-top: 0.5rem; font-size: 0.8rem; font-weight: 800; }
+  .ni-done.accepted { color: var(--brand-2); }
+  .ni-done.declined { color: var(--text-faint); }
+</style>

--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -7,9 +7,14 @@
   function open(t) {
     fx('select');
     dismissToast(t.id);
-    // Challenge toasts (incoming, result, sabotage, chat) all open the home Challenges inbox.
+    // Route to the right Community tab: requests → People, your-turn challenge →
+    // Challenges, everything ambient (result, sabotage, chat) → Activity.
+    const target =
+      (t.type === 'friend_request' || t.data?.route === 'friends') ? 'people'
+      : t.type === 'challenge_incoming' ? 'challenges'
+      : 'activity';
     goto('/');
-    requestInbox();
+    requestInbox(target);
   }
 </script>
 

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -9,9 +9,12 @@ export const unreadCount = writable(0);
 /** @type {import('svelte/store').Writable<{id:string,title:string,body:string,data:any}[]>} */
 export const toasts = writable([]);
 
-/** Bumped when something (e.g. a tapped challenge toast) wants the home Challenges inbox opened. */
+/** Bumped when something (e.g. a tapped toast) wants a Community tab opened. */
 export const inboxRequest = writable(0);
-export function requestInbox() { inboxRequest.update((n) => n + 1); }
+/** Which Community tab the next inboxRequest should land on. */
+export const inboxTarget = writable(/** @type {'challenges'|'activity'|'people'} */ ('challenges'));
+/** @param {'challenges'|'activity'|'people'} [target] */
+export function requestInbox(target = 'challenges') { inboxTarget.set(target); inboxRequest.update((n) => n + 1); }
 
 const POLL_MS = 45000;
 /** @type {ReturnType<typeof setInterval>|undefined} */
@@ -39,7 +42,7 @@ async function poll() {
 
 /** @param {any} n */
 function pushToast(n) {
-  toasts.update((t) => [...t, { id: n.id, title: n.title, body: n.body, data: n.data }]);
+  toasts.update((t) => [...t, { id: n.id, title: n.title, body: n.body, data: n.data, type: n.type }]);
   setTimeout(() => dismissToast(n.id), 6000);
 }
 /** @param {string} id */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
   import { getDailyStatus, getDailyGhost, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getPersonalBests } from '$lib/stores/statsStore.js';
-  import { unreadCount, notifications, markAllNotificationsRead, refreshNotifications, inboxRequest } from '$lib/stores/notificationStore.js';
+  import { unreadCount, markAllNotificationsRead, refreshNotifications, inboxRequest, inboxTarget } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -40,6 +40,7 @@
   import ActivityPanel from '$lib/components/ActivityPanel.svelte';
   import FriendsPanel from '$lib/components/FriendsPanel.svelte';
   import GroupsPanel from '$lib/components/GroupsPanel.svelte';
+  import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
 
   export let data;
 
@@ -660,11 +661,14 @@
       window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
     } catch { /* non-fatal */ }
   }
-  // A tapped challenge toast (incoming / result / sabotage / chat) opens the inbox.
+  // A tapped toast opens the Community tab it routed to (challenges / activity / people).
   let _inboxSeen = 0;
   $: if (browser && $inboxRequest > _inboxSeen && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup) {
     _inboxSeen = $inboxRequest;
-    openChallenges();
+    const t = $inboxTarget;
+    if (t === 'people') { openCommunity('people'); peopleTab = 'friends'; }
+    else if (t === 'activity') openCommunityActivity();
+    else openCommunity('challenges');
   }
   function dismissTutorial() {
     showTutorial = false;
@@ -819,20 +823,6 @@
   let myGroups = [];
   let challengeCount = 0; // matches awaiting my play (badge on the Challenges card)
   let friendReqCount = 0; // incoming friend requests (badge on Friends)
-  /** @type {Record<string, 'accepted'|'declined'>} responded friend-request notifications (by id) */
-  let notifResponded = {};
-  /** Accept/decline a friend request straight from the bell panel. @param {any} n @param {boolean} accept */
-  async function respondNotif(n, accept) {
-    const fromId = n?.data?.from_id;
-    if (!fromId || notifResponded[n.id]) return;
-    const res = await respondFriendRequest(fromId, accept);
-    if (res?.ok) {
-      notifResponded = { ...notifResponded, [n.id]: accept ? 'accepted' : 'declined' };
-      fx(accept ? 'win' : 'tap');
-      refreshNotifications();
-      refreshChallengeCount();
-    }
-  }
   /** @type {any|null} */
   let matchResults = null; // a settled match's results being viewed
   // Builder form
@@ -883,18 +873,22 @@
     [myMatches, myGroups] = await Promise.all([getMyMatches(), getMyGroups()]);
     challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
   }
+  /** Open Community ▸ Activity and clear the unread dot. */
+  async function openCommunityActivity() {
+    await openCommunity('activity');
+    markAllNotificationsRead();
+  }
+  /** Tapping a notification routes to where you'd act on it. @param {any} n */
+  function notifNavigate(n) {
+    if (n.type === 'friend_request' || n.data?.route === 'friends') { openCommunity('people'); peopleTab = 'friends'; }
+    else if (n.type === 'challenge_incoming' || n.data?.challenge_id || n.data?.match_id) openCommunity('challenges');
+  }
   /** Back-compat shim for existing callers (banner "+N more", toasts, result modal). */
   async function openChallenges(forceTab) {
     if (forceTab === 'new') return newChallenge();
     return openCommunity('challenges');
   }
 
-  // ===== Notifications panel (bell) =====
-  let showNotifications = false;
-  async function openNotifications() {
-    showNotifications = true;
-    await markAllNotificationsRead();
-  }
   function onMbOppInput() {
     clearTimeout(mbSearchTimer);
     const q = mbOpponent.trim();
@@ -1225,6 +1219,7 @@
           </button>
           <button class="menu-card" style="--i: 1" on:click={() => { fx('tap'); openCommunity('challenges'); }}>
             <span class="mc-title">Community</span>
+            {#if $unreadCount > 0}<span class="mc-dot" title="New activity"></span>{/if}
           </button>
           <button class="menu-card" style="--i: 2" on:click={() => goto('/shop')}>
             <span class="mc-title">Store</span>
@@ -1277,7 +1272,7 @@
           <div class="comm-tabs">
             <button class="comm-tab" class:active={communityTab === 'challenges'} on:click={() => { communityTab = 'challenges'; fx('tap'); }}>Challenges</button>
             <button class="comm-tab" class:active={communityTab === 'leaderboard'} on:click={() => { communityTab = 'leaderboard'; fx('tap'); }}>Leaderboard</button>
-            <button class="comm-tab" class:active={communityTab === 'activity'} on:click={() => { communityTab = 'activity'; fx('tap'); }}>Activity</button>
+            <button class="comm-tab" class:active={communityTab === 'activity'} on:click={() => { communityTab = 'activity'; fx('tap'); markAllNotificationsRead(); }}>Activity{#if $unreadCount > 0}<span class="comm-dot"></span>{/if}</button>
           </div>
         {/if}
 
@@ -1309,7 +1304,12 @@
         {:else if communityTab === 'leaderboard'}
           <div class="comm-body"><LeaderboardPanel /></div>
         {:else if communityTab === 'activity'}
-          <div class="comm-body"><ActivityPanel /></div>
+          <div class="comm-body">
+            <div class="act-sec">📥 For you</div>
+            <NotificationsPanel onNavigate={notifNavigate} onChange={refreshChallengeCount} />
+            <div class="act-sec">📣 Feed</div>
+            <ActivityPanel />
+          </div>
         {:else}
           <div class="comm-body">
             {#if peopleTab === 'friends'}
@@ -1421,42 +1421,6 @@
 
     <!-- Settled-challenge results (shared with /history) -->
     <MatchDetailModal detail={matchResults} on:close={() => matchResults = null} />
-
-    <!-- 🔔 Notifications panel -->
-    {#if showNotifications}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Notifications">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showNotifications = false}></button>
-        <div class="modal-content main-menu-modal ch-modal">
-          <button class="close-btn" on:click={() => showNotifications = false}>❌</button>
-          <h2>🔔 Notifications</h2>
-          {#if $notifications.length === 0}
-            <p class="cat-sub">No notifications yet. Challenge a friend to get started!</p>
-          {:else}
-            <div class="notif-list">
-              {#each $notifications as n (n.id)}
-                <div class="notif-item" class:fresh={!n.read}>
-                  <button class="ni-main"
-                    on:click={() => { showNotifications = false; if (n.data?.route === 'friends') goto('/friends'); else if (n.data?.challenge_id || n.data?.match_id || n.data?.route === 'challenge') openChallenges(); }}>
-                    <span class="ni-title">{n.title}</span>
-                    <span class="ni-body">{n.body}</span>
-                  </button>
-                  {#if n.type === 'friend_request' && n.data?.from_id}
-                    {#if notifResponded[n.id]}
-                      <span class="ni-done {notifResponded[n.id]}">{notifResponded[n.id] === 'accepted' ? '✓ Friends' : 'Declined'}</span>
-                    {:else}
-                      <div class="ni-actions">
-                        <button class="ni-act accept" on:click={() => respondNotif(n, true)}>Accept</button>
-                        <button class="ni-act decline" on:click={() => respondNotif(n, false)}>Decline</button>
-                      </div>
-                    {/if}
-                  {/if}
-                </div>
-              {/each}
-            </div>
-          {/if}
-        </div>
-      </div>
-    {/if}
 
     <!-- Streak message (when Daily is disabled and user taps it) -->
     {#if showStreakMessage}
@@ -2251,6 +2215,10 @@
   .comm-tab { flex: 1; padding: 9px 0; border-radius: 12px; border: 1px solid var(--border); background: var(--surface);
     color: var(--text-muted); font-family: var(--font-display); font-weight: 700; font-size: 0.86rem; cursor: pointer; }
   .comm-tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
+  .comm-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: #f43f5e; margin-left: 6px; vertical-align: middle; }
+  .menu-card .mc-dot { top: 12px; right: 14px; }
+  .act-sec { font-family: var(--font-display); font-size: 0.72rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--gold); text-align: left; margin: 6px 2px 8px; }
+  .act-sec:not(:first-child) { margin-top: 20px; }
   .comm-body { width: 100%; }
   .comm-body.people { display: flex; flex-direction: column; gap: 0.6rem; }
   .ch-new-btn {


### PR DESCRIPTION
Completes the notification model from `MENU_IA_PLAN.md` — the last notification piece.

## What
- **Community ▸ Activity is now the browse inbox**: a **📥 For you** notifications section (challenge results, sabotages, friend requests — accept/decline inline) above the **📣 Feed** social stream. Extracted `NotificationsPanel` from the (dead, unreachable) bell panel.
- **Unread dot** on the home **Community** card *and* the **Activity** tab, driven by `unreadCount`. Opening Activity calls `markAllNotificationsRead()` and clears it.
- **Toasts route by type**: `friend_request` → People · `challenge_incoming` → Challenges · everything ambient (result/sabotage/chat) → Activity. (Added `inboxTarget` to the store; the toast payload now carries its `type`.)
- **Removed** the dead `showNotifications` bell panel + `openNotifications`/`respondNotif` helpers.
- Fixed `vs-walkthrough.mjs` for the Phase 2 Community navigation.

## Notification model (now fully built)
| | Banner | Activity + dot | Toast |
|---|:--:|:--:|:--:|
| Challenge invite / your turn | ✅ | ✅ | ✅ |
| Friend request | ✅ | ✅ | — |
| Result / sabotage / chat | ❌ | ✅ | ✅ |

## Test
- `npm run build` ✓
- Live: inserted a `challenge_result` notification → the **Community card shows the red dot**; Community ▸ Activity renders it under **📥 For you** + the social feed under **📣 Feed**; viewing Activity clears the dot. Screenshots captured.

Last one: Phase 5 (Play → "challenge a friend" subtle link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)