### PR TITLE
Cleaner challenge banner; show stakes at the PIN confirm

### DIFF
--- a/src/lib/components/PinConfirm.svelte
+++ b/src/lib/components/PinConfirm.svelte
@@ -38,6 +38,13 @@
     <div class="pc-card">
       <h2 class="pc-title">Enter your PIN</h2>
       <p class="pc-reason">{$pinConfirm.reason}</p>
+      {#if $pinConfirm.details?.length}
+        <div class="pc-stakes">
+          {#each $pinConfirm.details as d}
+            <div class="pc-stake"><span class="pc-sk-label">{d.label}</span><span class="pc-sk-value">{d.value}</span></div>
+          {/each}
+        </div>
+      {/if}
       <PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
       {#if msg}<p class="pc-msg">{msg}</p>{/if}
       <button class="pc-cancel" on:click={cancel}>Cancel</button>
@@ -55,7 +62,12 @@
   }
   .pc-card { width: 100%; max-width: 360px; text-align: center; }
   .pc-title { font-family: var(--font-display); font-size: 1.35rem; margin: 0 0 0.2rem; }
-  .pc-reason { color: #fbbf24; font-weight: 700; font-size: 0.95rem; margin: 0 0 1.4rem; }
+  .pc-reason { color: #fbbf24; font-weight: 700; font-size: 0.95rem; margin: 0 0 1rem; }
+  .pc-stakes { width: 100%; max-width: 280px; margin: 0 auto 1.3rem; display: flex; flex-direction: column; gap: 6px;
+    padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(253,224,71,0.3); background: rgba(251,191,36,0.06); }
+  .pc-stake { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 0.86rem; }
+  .pc-sk-label { color: var(--text-muted, #aeb8c6); }
+  .pc-sk-value { font-family: var(--font-display); font-weight: 700; color: var(--text, #fff); }
   .pc-msg { margin-top: 0.9rem; font-size: 0.86rem; color: #f87171; }
   .pc-cancel { margin-top: 1.4rem; background: none; border: none; color: var(--text-faint); font-size: 0.85rem; text-decoration: underline; cursor: pointer; }
 </style>

--- a/src/lib/pinConfirm.js
+++ b/src/lib/pinConfirm.js
@@ -7,16 +7,16 @@ import { hasPinFor } from '$lib/pin.js';
 import { user } from '$lib/stores/userStore.js';
 import { supabase } from '$lib/supabaseClient';
 
-/** @type {import('svelte/store').Writable<null | {reason:string, uid:string, resolve:(v:boolean)=>void, reject:(e:any)=>void}>} */
+/** @type {import('svelte/store').Writable<null | {reason:string, details?:{label:string,value:string}[], uid:string, resolve:(v:boolean)=>void, reject:(e:any)=>void}>} */
 export const pinConfirm = writable(null);
 
-/** @param {string} reason @returns {Promise<boolean>} */
-export async function requirePin(reason = 'Confirm') {
+/** @param {string} reason @param {{label:string,value:string}[]} [details] line items (e.g. challenge stakes) shown above the pad @returns {Promise<boolean>} */
+export async function requirePin(reason = 'Confirm', details) {
   // Resolve the uid from the store, or the session (so it works on any route).
   let uid = get(user)?.id;
   if (!uid) { try { const { data } = await supabase.auth.getSession(); uid = data?.session?.user?.id; } catch { /* ignore */ } }
   if (!uid || !hasPinFor(uid)) return true; // nothing to confirm
   return await new Promise((resolve, reject) => {
-    pinConfirm.set({ reason, uid, resolve, reject });
+    pinConfirm.set({ reason, details, uid, resolve, reject });
   });
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -250,7 +250,7 @@
       const exp = expiryLabel(m);
       return { kind: 'match', icon: '⚔️',
         title: invited ? `${m.host} challenged you` : `Your turn vs ${m.host}`,
-        sub: `${m.pack_size} puzzle${m.pack_size === 1 ? '' : 's'}${m.wager > 0 ? ' · $' + m.wager.toLocaleString() : ''}${exp ? ' · ' + exp : ''}`,
+        sub: exp || '', // keep it clean — stakes (puzzles/buy-in) show at the PIN confirm
         cta: (invited ? 'Play' : 'Resume') + ' →',
         more: (turnMatches.length - 1) + friendRequests.length,
         primary: () => respondToMatch(m), moreAction: () => openChallenges() };
@@ -905,7 +905,13 @@
     if (mbTarget === 'friend' && !mbOpponent.trim()) { mbMsg = 'Pick an opponent.'; return; }
     if (mbTarget === 'group' && !mbGroupId) { mbMsg = 'Pick a group.'; return; }
     const w = Math.floor(Number(mbWager) || 0);
-    try { await requirePin(w > 0 ? `Enter challenge · $${w.toLocaleString()} wager` : 'Enter challenge'); } catch { return; }
+    const createStakes = [
+      { label: mbTarget === 'group' ? 'Group' : 'Opponent', value: mbTarget === 'group' ? (myGroups.find((g) => g.id === mbGroupId)?.name || 'Group') : '@' + mbOpponent.trim() },
+      { label: 'Puzzles', value: String(mbPackSize) },
+      { label: 'Buy-in', value: w > 0 ? '$' + w.toLocaleString() : 'Friendly' },
+      { label: 'Payout', value: mbPayout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
+    ];
+    try { await requirePin(w > 0 ? 'Send & stake your buy-in' : 'Send this challenge', createStakes); } catch { return; }
     mbBusy = true; mbMsg = 'Creating…';
     const res = await startMatch({
       opponent: mbTarget === 'friend' ? mbOpponent.trim() : null,
@@ -926,13 +932,24 @@
         : 'Could not create the challenge.';
     }
   }
+  /** Stakes shown on the PIN confirm. @param {any} m */
+  function matchStakes(m) {
+    const s = [
+      { label: m.is_host ? 'Players' : 'Opponent', value: m.is_host ? `${m.players}` : '@' + m.host },
+      { label: 'Puzzles', value: String(m.pack_size) },
+      { label: 'Buy-in', value: Number(m.wager) > 0 ? '$' + Number(m.wager).toLocaleString() : 'Friendly' },
+      { label: 'Payout', value: m.payout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
+    ];
+    if (Number(m.wager) > 0 && netWorth != null) s.push({ label: 'Your Cash', value: '$' + Math.round(netWorth).toLocaleString() });
+    return s;
+  }
   /** @param {any} m */
   async function respondToMatch(m) {
     if (mbBusy) return;
     if (m.status === 'settled') { matchResults = { loading: true }; matchResults = await getMatchDetail(m.id); return; }
-    // Accepting an invite commits your wager → confirm with PIN (resuming doesn't).
+    // Accepting an invite commits your buy-in → confirm with PIN (resuming doesn't).
     if (m.my_state === 'invited') {
-      try { await requirePin(m.wager > 0 ? `Enter challenge · $${Number(m.wager).toLocaleString()} wager` : 'Enter challenge'); } catch { return; }
+      try { await requirePin(`Accept @${m.host}'s challenge`, matchStakes(m)); } catch { return; }
     }
     mbBusy = true;
     const ok = m.my_state === 'invited' ? await acceptAndPlayMatch(m.id) : await resumeMatch(m.id);


### PR DESCRIPTION
## What
- **Cleaner banner** — the act-now challenge banner drops the game description (puzzles · buy-in). It's now just `⚔️ @host challenged you · expires in Xd · Play →`.
- **Stakes at the PIN confirm** — those details move to where you actually commit. `requirePin()` now takes an optional `details` list rendered as a stakes panel above the pad: **Opponent · Puzzles · Buy-in · Payout · Your Cash**. Wired into both accepting an invite and creating a challenge.

## Test
- `npm run build` ✓
- Live: banner reads `⚔️ vsalice challenged you · expires in 2d · Play →`; tapping Play shows the PIN confirm with the full stakes panel (incl. "Your Cash $2,000"). 0 page errors. Screenshots captured.

> Note: the "Your Cash" line lets you see at confirm time whether you can afford the buy-in. The full insufficient-funds behavior (play-with-what-you-have vs decline) is a separate decision — discussing next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)