### PR TITLE
Make reduced-budget play work end to end

### DIFF
--- a/supabase-challenge-short-cash.sql
+++ b/supabase-challenge-short-cash.sql
@@ -27,3 +27,12 @@
 -- _match_settle: spend/refund/spent now use coalesce(start_budget, greatest(wager,500))
 -- per participant instead of one match-level budget.
 -- (body applied via migration match_settle_per_participant_budget)
+
+-- End-to-end fix (migrations match_board_per_participant_budget +
+-- getmatch_detail_per_participant_budget): _match_board, get_match and
+-- get_match_detail also computed the budget/spent against the match wager, so a
+-- reduced player's board showed "Spent $200 of $500" and standings compared the
+-- wrong budgets. All three now use each participant's start_budget. match_buy_letter
+-- already caps spending at the live bankroll, so the reduced budget is enforced.
+-- Verified live: a $300 player accepts a $500 challenge → board shows "$0 of $300",
+-- stakes $300 (bank→0), bankroll=start_budget=300.


### PR DESCRIPTION
Follow-up to #266: the "play with what you have" sheet accepted a reduced stake, but the **board** still showed the wrong budget — so it only half-worked.

## The bug
`_match_board`, `get_match`, and `get_match_detail` computed budget/spent against the match wager (`greatest(wager,500)`), not the player's actual stake. A $300 player saw **"Spent $200 of $500"** the instant they entered, and the live standing compared everyone against the wrong budget.

## The fix
All three now use each participant's `start_budget`. `match_buy_letter` already caps spending at the live `bankroll`, so the smaller budget is properly enforced. (Settle was already per-participant from #266.)

## Test
- `npm run build` ✓
- **Live, full flow**: a $300 player taps Play on a $500 challenge → "Play with $300" → lands on a board showing **BALANCE $300** / "Spent $0 of $300". DB confirms staked $300 (bank → $0), `bankroll = start_budget = 300`, active.
- Settle correctness verified earlier (rolled back). 0 console errors. Screenshot captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)