### PR TITLE
Free Play credits economy: persistent play-money + Store cash-out

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -576,6 +576,19 @@ export async function buyPowerup(id) {
   if (error || !data) { if (error) console.error('❌ buy_powerup:', error); return { ok: false }; }
   return data;
 }
+/* ===== Free Play cash-out (credits → real Cash, 40:1, $50/day cap) ===== */
+/** @returns {Promise<{credits:number,cashable_credits:number,max_cash:number,rate:number,floor:number,daily_cap:number,cap_remaining:number}|null>} */
+export async function getFreeplayCashoutStatus() {
+  const { data, error } = await supabase.rpc('freeplay_cashout_status');
+  if (error || !data) { if (error) console.error('❌ freeplay_cashout_status:', error); return null; }
+  return data;
+}
+/** Cash out credits (null = the max allowed). @param {number|null} amount @returns {Promise<any>} */
+export async function freeplayCashout(amount = null) {
+  const { data, error } = await supabase.rpc('freeplay_cashout', { p_amount: amount });
+  if (error || !data) { if (error) console.error('❌ freeplay_cashout:', error); return { ok: false }; }
+  return data;
+}
 /** Use a power-up in the Climb. @param {string} id @returns {Promise<any>} */
 export async function climbUsePowerup(id) {
   const { data, error } = await supabase.rpc('climb_use_powerup', { p_id: id });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1651,10 +1651,14 @@
         <div class="credits-panel">
           <span class="cr-label">🎟️ Credits</span>
           <span class="cr-amount">{Math.round($gameStore.bankroll ?? 0).toLocaleString()}</span>
-          <span class="cr-note">Play money · doesn't touch your Cash</span>
+          {#if (($gameStore.bankroll ?? 0) - 2000) >= 40}
+            <span class="cr-ready">💵 ${Math.floor((($gameStore.bankroll ?? 0) - 2000) / 40)} ready — cash out in Store</span>
+          {:else}
+            <span class="cr-note">Play money · cash out at 40:1 in the Store</span>
+          {/if}
         </div>
         {#if freeLive}
-          <p class="live-line">Solve {freeLive.clean ? 'clean ' : ''}to bank <b>+${freeLive.clean ? 50 : 25}</b> real Cash</p>
+          <p class="live-line">Solve {freeLive.clean ? 'clean ' : ''}for <b>+{freeLive.clean ? 250 : 120}</b> credits</p>
         {/if}
       {/if}
     </section>
@@ -2853,6 +2857,7 @@
   .cr-label { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: #c4b5fd; }
   .cr-amount { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.1rem; line-height: 1.1; color: #c4b5fd; font-variant-numeric: tabular-nums; }
   .cr-note { margin-top: 2px; font-size: 0.68rem; color: var(--text-faint); }
+  .cr-ready { margin-top: 2px; font-size: 0.68rem; font-weight: 700; color: #6ee7b7; }
 
   /* Cash Game (Climb) gamified HUD */
   .climb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; max-width: 360px; margin: 0 auto 14px; }

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic, getPowerups, buyPowerup } from '$lib/stores/statsStore.js';
+  import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic, getPowerups, buyPowerup, getFreeplayCashoutStatus, freeplayCashout } from '$lib/stores/statsStore.js';
   import { requirePin } from '$lib/pinConfirm.js';
   import { track } from '$lib/analytics.js';
   import { fx } from '$lib/sound.js';
@@ -33,12 +33,31 @@
   /** @type {any[]} */
   let sabs = $state([]);
 
+  /** @type {any|null} */
+  let cashout = $state(null);
+
   async function load() {
-    const [shop, pu] = await Promise.all([getShop(), getPowerups()]);
+    const [shop, pu, co] = await Promise.all([getShop(), getPowerups(), getFreeplayCashoutStatus()]);
     bank = shop.bank;
     items = shop.items;
     pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
     sabs = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'sabotage');
+    cashout = co;
+  }
+
+  async function doCashout() {
+    if (busy || !cashout) return;
+    const amt = Math.min(cashout.max_cash, cashout.cap_remaining);
+    if (amt <= 0) return;
+    try { await requirePin(`Cash out ${(amt * 40).toLocaleString()} credits → $${amt}`, [
+      { label: 'Credits', value: (amt * 40).toLocaleString() },
+      { label: 'You receive', value: '$' + amt }
+    ]); } catch { return; }
+    busy = 'cashout'; msg = '';
+    const res = await freeplayCashout(amt);
+    busy = '';
+    if (res?.ok) { fx('win'); track('freeplay_cashout', { cash: res.cashed }); await load(); }
+    else { msg = res?.reason === 'daily_cap' ? "You've hit today's $50 cash-out cap — come back tomorrow." : 'Could not cash out right now.'; }
   }
 
   /** @param {any} item */
@@ -94,6 +113,27 @@
     <p class="loading">Loading…</p>
   {:else}
     {#if msg}<p class="msg">{msg}</p>{/if}
+
+    {#if cashout && cashout.credits > 0}
+      <div class="cashout-card">
+        <div class="co-top">
+          <div>
+            <span class="co-label">🎟️ Free Play credits</span>
+            <span class="co-credits">{cashout.credits.toLocaleString()}</span>
+          </div>
+          {#if cashout.max_cash > 0 && cashout.cap_remaining > 0}
+            <button class="co-btn" disabled={busy === 'cashout'} onclick={doCashout}>
+              💵 Cash out ${Math.min(cashout.max_cash, cashout.cap_remaining)}
+            </button>
+          {:else if cashout.cap_remaining <= 0}
+            <span class="co-pending">Daily $50 cap reached</span>
+          {:else}
+            <span class="co-pending">Earn {(2040 - cashout.credits).toLocaleString()} more to cash out</span>
+          {/if}
+        </div>
+        <p class="co-note">First 2,000 credits are your stake. Cash out the rest at 40 credits = $1 (up to $50/day).</p>
+      </div>
+    {/if}
 
     <h2 class="section">⚡ Power-ups</h2>
     <p class="section-note">Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like — the Daily stays power-up-free.</p>
@@ -186,6 +226,20 @@
   .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1.4rem; }
   .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
   .msg { text-align: center; color: #f87171; font-size: 0.88rem; margin: 0 0 1rem; }
+  .cashout-card {
+    border: 1px solid rgba(110, 231, 183, 0.35); border-radius: 16px; padding: 0.9rem 1rem; margin: 0 0 1.2rem;
+    background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(20, 26, 38, 0.6));
+  }
+  .co-top { display: flex; align-items: center; justify-content: space-between; gap: 0.7rem; }
+  .co-label { display: block; font-size: 0.74rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.05em; }
+  .co-credits { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.6rem; color: #6ee7b7; }
+  .co-btn {
+    padding: 0.6rem 0.95rem; border-radius: 11px; border: none; cursor: pointer; font-weight: 800; font-size: 0.9rem;
+    color: #04240f; background: linear-gradient(135deg, #6ee7b7, #34d399); white-space: nowrap;
+  }
+  .co-btn:disabled { opacity: 0.5; cursor: default; }
+  .co-pending { font-size: 0.78rem; color: var(--text-muted); text-align: right; }
+  .co-note { font-size: 0.72rem; color: var(--text-faint); margin: 0.6rem 0 0; line-height: 1.35; }
   .section { font-family: var(--font-display); font-size: 1.05rem; margin: 1.4rem 0 0.4rem; }
   .section-note { font-size: 0.76rem; color: var(--text-faint); margin: 0 0 0.8rem; }
   .card.pup { align-items: center; text-align: center; gap: 0.3rem; }

--- a/supabase-freeplay-credits.sql
+++ b/supabase-freeplay-credits.sql
@@ -1,0 +1,35 @@
+-- Free Play "Credits" economy (Phases 3–4). Free Play is a persistent play-money
+-- sandbox that is fully separate from real Cash until you choose to cash out.
+--
+-- Applied to prod via MCP migrations:
+--   freeplay_persistent_credits   (Phase 3: persistent credits + earn-on-solve)
+--   freeplay_cashout              (Phase 4: cash-out RPCs)
+--
+-- MODEL
+--   * Credits live in freeplay_sessions.bankroll and now PERSIST across puzzles and
+--     sessions (previously reset to 1000 each puzzle).
+--   * New players start at 2000 credits. Existing sessions were backfilled to
+--     GREATEST(bankroll, 2000).
+--   * You spend credits on letters and EARN credits on solve: +250 clean / +120
+--     otherwise (added to bankroll — no more direct real-Cash payout from Free Play).
+--   * Go broke (bankroll < 50 at the start of the next puzzle / a new session) and you
+--     reset to 2000. freeplay_start and freeplay_next both apply the reset.
+--
+-- CASH-OUT (in the Store)
+--   * freeplay_cashout_status() → { credits, cashable_credits, max_cash, rate:40,
+--     floor:2000, daily_cap:50, cap_remaining }.
+--   * freeplay_cashout(p_amount int default null) converts credits → real Cash at
+--     40 credits = $1 (so 2000 cashable credits = $50). The first 2000 credits are a
+--     non-cashable stake floor (cashable = bankroll - 2000). Whole dollars only.
+--     Capped at $50/day (summed from bank_ledger reason 'freeplay_cashout'). Passing
+--     null cashes out the max allowed. Real Cash is added via _bank_credit.
+--
+-- Verified (rolled back): new=2000, carry-over=3400, broke->2000, restart keeps 2750;
+-- clean solve bank 1800->2050 with real Cash UNCHANGED; 4200 credits → cashable 2200,
+-- max $55 capped to $50 (2000 credits spent, bank->2200), 2nd same-day attempt =
+-- daily_cap, 1500 credits = $0 cashable.
+--
+-- Frontend: src/routes/shop/+page.svelte cash-out card (getFreeplayCashoutStatus /
+-- freeplayCashout in statsStore.js, PIN-confirmed). Free Play board shows a
+-- "💵 $X ready — cash out in Store" hint once cashable ≥ $1, and the solve line reads
+-- "Solve clean for +250 credits".


### PR DESCRIPTION
Finishes the Free Play redesign (Phases 3–4). Free Play becomes a persistent play-money "Credits" sandbox, fully separate from real Cash until you choose to cash out in the Store. (Phase 2 — Arcade removal — already shipped in #273.)

## Phase 3 — persistent credits economy
- Credits live in `freeplay_sessions.bankroll` and now **persist** across puzzles and sessions (previously reset to 1,000 every puzzle).
- New players start at **2,000** credits; existing sessions backfilled to `GREATEST(bankroll, 2000)`.
- You **earn credits on solve** (+250 clean / +120 otherwise) instead of a direct real-Cash payout.
- Go broke (`bankroll < 50` at the next puzzle / new session) → **reset to 2,000**.

## Phase 4 — Store cash-out
- `freeplay_cashout_status()` and `freeplay_cashout(p_amount)` RPCs.
- Rate **40 credits = $1** (2,000 cashable credits = $50). The first 2,000 credits are a non-cashable stake floor. Whole dollars only, **$50/day cap**.
- Store cash-out card (PIN-confirmed) + Free Play board "💵 \$X ready — cash out in Store" hint once cashable ≥ \$1.

## Verification
Backend verified via rolled-back SQL: new=2000, carry-over=3400, broke→2000, restart keeps 2750; clean solve bank 1800→2050 with real Cash **unchanged**; 4,200 credits → cashable 2,200, max \$55 capped to \$50 (2,000 credits spent), 2nd same-day attempt = `daily_cap`, 1,500 credits = \$0 cashable. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)