### PR TITLE
Clearer challenge money: budget bar + tap-to-explain

### DIFF
--- a/src/lib/components/StandingStrip.svelte
+++ b/src/lib/components/StandingStrip.svelte
@@ -1,16 +1,16 @@
 <script>
-  // Live challenge HUD. Shows your own money clearly (Spent · Stake left · Wallet)
-  // plus a directional rank vs FINISHED rivals — never the exact spend to beat
-  // (the server only sends a direction). The lead-flip is the reward moment.
-  // "First to play / set the bar" is intentionally dropped: when no one has
-  // finished yet we just show your own numbers and the objective.
+  // Live challenge HUD. Frames your buy-in as one budget being consumed:
+  //   Spent (filled) + Left to spend (rest) = your buy-in.
+  // 💰 Cash is shown separately as your account. Tap any value for a plain
+  // explanation. Rank vs FINISHED rivals is directional only (never the exact
+  // spend to beat); the lead-flip is the reward moment.
   import { fx } from '$lib/sound.js';
 
   /** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play', provisional?:boolean } | null} */
   export let standing = null;
   /** @type {number} */ export let spent = 0;
-  /** @type {number} in-game stake you have left to spend this match */ export let bankroll = 0;
-  /** @type {number|null} your total Cash wallet (separate from the match stake) */ export let netWorth = null;
+  /** @type {number} in-game budget you have left to spend this match */ export let bankroll = 0;
+  /** @type {number|null} your total Cash account (separate from the match budget) */ export let netWorth = null;
 
   // Chime when you flip INTO the lead. prevState lives outside the reactive
   // dependency graph (read/written inside a fn) so it can't self-invalidate.
@@ -24,85 +24,99 @@
   const ord = (/** @type {number} */ n) => { const s = ['th','st','nd','rd'], v = n % 100; return n + (s[(v - 20) % 10] || s[v] || s[0]); };
   const medal = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
   const money = (/** @type {number|null} */ n) => n == null ? '—' : '$' + Math.round(n).toLocaleString();
+
   $: ranked = !!standing && standing.state !== 'first_to_play';
-  // Only celebrate the lead on the board — the "how to win" objective lives in the ? help.
-  $: msg = standing && standing.state === 'lead' ? "✓ In the lead" : '';
+  $: budget = Math.max(0, (spent ?? 0) + (bankroll ?? 0)); // spent + left = your buy-in
+  $: spentPct = budget > 0 ? Math.min(100, Math.max(0, (spent / budget) * 100)) : 0;
+  $: lead = standing && standing.state === 'lead';
+
+  // Tap a value → explain it. Tapping the same one (or the note) closes it.
+  let info = /** @type {null | 'spent' | 'left' | 'budget' | 'cash'} */ (null);
+  function toggle(/** @type {any} */ k) { fx('tap'); info = info === k ? null : k; }
+  const EXPLAIN = {
+    spent: 'What you’ve spent on letters this match. The lowest spend to solve wins the whole pot — so keep it small.',
+    left: 'Your budget that’s still unspent. Anything you don’t use is refunded to your Cash at the end.',
+    budget: 'Your buy-in — the most you can spend this match (Spent + Left). Unspent money comes back to you.',
+    cash: 'Your account balance, outside this match. Your buy-in already moved out of here into the match budget — that’s why it can be less than your budget.'
+  };
 </script>
 
-{#if standing}
-  {#key standing.state}
-    <div class="standing {standing.state}">
-      <div class="top">
-        {#if ranked}
-          <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar">so far</span>{/if}</span>
-        {/if}
-        <span class="spent" class:solo={!ranked}>Spent <b>{money(spent)}</b></span>
+{#if standing || budget > 0}
+  <div class="standing {standing?.state ?? 'first_to_play'}" class:lead>
+    {#if ranked && standing}
+      <div class="rank-row">
+        <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar">so far</span>{/if}</span>
+        {#if lead}<span class="lead-badge">✓ In the lead</span>{/if}
       </div>
-      <div class="money">
-        <span class="m">Left to spend <b>{money(bankroll)}</b></span>
-        <span class="dot">·</span>
-        <span class="m wallet">💰 Cash {money(netWorth)}</span>
-      </div>
-      {#if msg}<div class="msg">{msg}</div>{/if}
+    {/if}
+
+    <div class="bud-labels">
+      <button class="chip" class:on={info === 'spent'} on:click={() => toggle('spent')}>Spent <b>{money(spent)}</b></button>
+      <button class="chip right" class:on={info === 'left'} on:click={() => toggle('left')}><b>{money(bankroll)}</b> left to spend</button>
     </div>
-  {/key}
+    <button class="bar" class:on={info === 'budget'} on:click={() => toggle('budget')} aria-label="Your buy-in budget">
+      <span class="bar-fill" style="width:{spentPct}%"></span>
+    </button>
+    <div class="bud-foot">
+      <button class="foot" class:on={info === 'budget'} on:click={() => toggle('budget')}>{money(budget)} buy-in</button>
+      <button class="foot cash" class:on={info === 'cash'} on:click={() => toggle('cash')}>💰 Cash {money(netWorth)}</button>
+    </div>
+
+    {#if info}
+      <button class="explain" on:click={() => (info = null)}>
+        <span class="ex-ic">ⓘ</span><span class="ex-tx">{EXPLAIN[info]}</span>
+      </button>
+    {:else}
+      <div class="hint">Tap any value to see what it means</div>
+    {/if}
+  </div>
 {/if}
 
 <style>
   .standing {
-    max-width: 360px;
-    margin: 0 auto 6px;
-    padding: 9px 14px;
+    max-width: 360px; margin: 0 auto 6px; padding: 9px 13px 8px;
     border-radius: 13px;
     border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
     background: var(--surface, rgba(255, 255, 255, 0.05));
     animation: stPop 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
-  @keyframes stPop {
-    from { transform: scale(0.96); opacity: 0.4; }
-    to { transform: scale(1); opacity: 1; }
-  }
-  .top {
-    display: flex; align-items: center; justify-content: space-between; gap: 10px;
-    font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.92rem;
-    color: var(--text, #fff);
-  }
+  @keyframes stPop { from { transform: scale(0.96); opacity: 0.4; } to { transform: scale(1); opacity: 1; } }
+
+  .rank-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 7px;
+    font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.92rem; color: var(--text, #fff); }
   .sofar { margin-left: 6px; font-family: var(--font-ui, sans-serif); font-weight: 600; font-size: 0.62rem;
     text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint, #8090a0); }
-  .spent { font-weight: 700; color: var(--text, #fff); font-size: 0.92rem; }
-  .spent.solo { margin-left: 0; }
-  .spent b { font-variant-numeric: tabular-nums; }
-  .money {
-    display: flex; align-items: center; gap: 7px; margin-top: 4px;
-    font-family: var(--font-ui, sans-serif); font-size: 0.78rem; color: var(--text-muted, #c2cbd8);
-  }
-  .money b { color: var(--text, #fff); font-variant-numeric: tabular-nums; }
-  .money .dot { color: var(--text-faint, #6b7686); }
-  .money .wallet { color: var(--text-faint, #8090a0); }
-  .msg {
-    margin-top: 4px; text-align: left;
-    font-family: var(--font-ui, sans-serif); font-size: 0.76rem; font-weight: 600;
-  }
+  .lead-badge { font-size: 0.78rem; font-weight: 700; color: #7ee0a8; }
 
-  .standing.lead {
-    border-color: rgba(126, 224, 168, 0.55);
-    background: linear-gradient(135deg, rgba(126, 224, 168, 0.16), rgba(126, 224, 168, 0.05));
-    box-shadow: 0 0 18px rgba(126, 224, 168, 0.25);
-  }
-  .standing.lead .msg { color: #7ee0a8; }
+  /* tappable values */
+  button { font-family: inherit; cursor: pointer; background: none; border: none; color: inherit; padding: 0; }
+  .bud-labels { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .chip { font-size: 0.82rem; color: var(--text-muted, #c2cbd8); border-bottom: 1px dotted var(--text-faint, #6b7686); line-height: 1.5; }
+  .chip.right { text-align: right; }
+  .chip b { color: var(--text, #fff); font-variant-numeric: tabular-nums; }
+  .chip.on { color: var(--brand-2, #fde047); border-bottom-color: var(--brand-2, #fde047); }
 
-  .standing.behind {
-    border-color: rgba(251, 191, 36, 0.5);
-    background: linear-gradient(135deg, rgba(251, 191, 36, 0.13), rgba(251, 191, 36, 0.04));
-  }
-  .standing.behind .msg { color: #fbbf24; }
+  .bar { display: block; width: 100%; height: 9px; margin: 5px 0 6px; border-radius: 999px;
+    background: rgba(255, 255, 255, 0.10); overflow: hidden; }
+  .bar-fill { display: block; height: 100%; border-radius: 999px;
+    background: linear-gradient(90deg, #fbbf24, #fde047); transition: width 0.35s ease; }
+  .bar.on { box-shadow: 0 0 0 2px rgba(253, 224, 71, 0.4); }
 
-  .standing.tied { border-color: var(--border-strong, rgba(255, 255, 255, 0.18)); }
-  .standing.tied .msg { color: var(--text-muted, #c2cbd8); }
+  .bud-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .foot { font-size: 0.72rem; color: var(--text-faint, #8090a0); border-bottom: 1px dotted transparent; }
+  .foot.cash { color: var(--text-muted, #c2cbd8); border-bottom-color: var(--text-faint, #6b7686); }
+  .foot.on { color: var(--brand-2, #fde047); border-bottom-color: var(--brand-2, #fde047); }
 
-  .standing.first_to_play {
-    border-color: rgba(125, 188, 255, 0.5);
-    background: linear-gradient(135deg, rgba(125, 188, 255, 0.12), rgba(125, 188, 255, 0.04));
-  }
-  .standing.first_to_play .msg { color: #93c5fd; }
+  .hint { margin-top: 6px; font-size: 0.63rem; color: var(--text-faint, #6b7686); text-align: center; }
+  .explain { display: flex; gap: 6px; align-items: flex-start; text-align: left; width: 100%;
+    margin-top: 7px; padding: 7px 9px; border-radius: 9px;
+    background: rgba(125, 188, 255, 0.10); border: 1px solid rgba(125, 188, 255, 0.28); }
+  .ex-ic { color: #93c5fd; font-size: 0.8rem; line-height: 1.35; }
+  .ex-tx { font-size: 0.74rem; line-height: 1.35; color: var(--text, #fff); }
+
+  .standing.lead { border-color: rgba(126, 224, 168, 0.5);
+    background: linear-gradient(135deg, rgba(126, 224, 168, 0.13), rgba(126, 224, 168, 0.04));
+    box-shadow: 0 0 16px rgba(126, 224, 168, 0.22); }
+  .standing.behind { border-color: rgba(251, 191, 36, 0.45); }
+  .standing.first_to_play { border-color: rgba(125, 188, 255, 0.4); }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1592,16 +1592,8 @@
         </div>
       {:else}
         {#if matchInfo.pack_size > 1}<p class="match-pos">Puzzle {matchInfo.position}/{matchInfo.pack_size}</p>{/if}
-        {#if matchInfo.standing}
-          <StandingStrip standing={matchInfo.standing} spent={matchInfo.spent ?? 0}
-            bankroll={Math.max(0, (matchInfo.budget ?? 0) - (matchInfo.spent ?? 0))} {netWorth} />
-        {:else}
-          <div class="match-money">
-            <span class="mm-cell">Spent <b>${(matchInfo.spent ?? 0).toLocaleString()}</b></span>
-            <span class="mm-cell">Left to spend <b>${Math.max(0, (matchInfo.budget ?? 0) - (matchInfo.spent ?? 0)).toLocaleString()}</b></span>
-            <span class="mm-cell wallet">💰 Cash {netWorth == null ? '—' : '$' + Math.round(netWorth).toLocaleString()}</span>
-          </div>
-        {/if}
+        <StandingStrip standing={matchInfo.standing ?? null} spent={matchInfo.spent ?? 0}
+          bankroll={Math.max(0, (matchInfo.budget ?? 0) - (matchInfo.spent ?? 0))} {netWorth} />
       {/if}
       {#if (matchInfo.my_debuffs ?? []).length}
         <p class="debuff-banner">{(matchInfo.my_debuffs ?? []).map((/** @type {string} */ d) => DEBUFF_LABEL[d] ?? d).join(' · ')}</p>
@@ -2904,12 +2896,6 @@
   .cr-note { margin-top: 2px; font-size: 0.68rem; color: var(--text-faint); }
   .cr-ready { margin-top: 2px; font-size: 0.68rem; font-weight: 700; color: #6ee7b7; }
   .cr-wallet { margin-top: 3px; font-size: 0.66rem; color: var(--text-faint); }
-  /* Challenge money fallback (no finished rivals yet) */
-  .match-money { display: flex; align-items: center; justify-content: center; flex-wrap: wrap; gap: 4px 12px;
-    max-width: 360px; margin: 0 auto 4px; font-size: 0.84rem; color: var(--text-muted); }
-  .match-money .mm-cell b { color: var(--text); font-variant-numeric: tabular-nums; }
-  .match-money .wallet { color: var(--text-faint); font-size: 0.78rem; }
-
   /* Cash Game (Climb) gamified HUD */
   .climb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; max-width: 360px; margin: 0 auto 14px; }
   .climb-level {


### PR DESCRIPTION
Makes the challenge money read clearly by showing the *relationship* visually and letting players tap any value for a plain-English explanation.

## The problem
Three dollar figures (Spent, Left to spend, Cash) with no visual link — players couldn't tell how they related, and "Left to spend > Cash" looked like a bug.

## The fix
- **Budget bar** — your buy-in is shown as one budget being consumed: the filled part is **Spent**, the rest is **Left to spend**. So `Spent + Left = your buy-in` is obvious at a glance.
- **💰 Cash separate** — sits below the bar as your account balance, clearly a different thing.
- **Tap to explain** — Spent / Left / buy-in / Cash are each tappable and explain themselves inline. The Cash note specifically says *why* it can be less than your budget ("your buy-in already moved out of here into the match budget"). A "Tap any value to see what it means" hint points players to it.
- StandingStrip now renders the budget block even before any rival finishes, so the old text-only fallback path is gone (one code path).

## Verification
Live Playwright on a $1,000 buy-in challenge: bar shows `Spent $20 / $980 left to spend` over `$1,000 buy-in · 💰 Cash $1,000`; tapping Cash and Spent shows the right explanations. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)