### PR TITLE
docs: launch security lockdown (internal RPC EXECUTE + RLS)

### DIFF
--- a/supabase-security-lockdown.sql
+++ b/supabase-security-lockdown.sql
@@ -1,0 +1,22 @@
+-- Launch security hardening (2026-06-24). Applied to prod via MCP migration
+-- `security_lockdown_internal_funcs_and_rls`. Surfaced by get_advisors(security).
+--
+-- CRITICAL — Cash-minting exploit closed:
+--   All internal SECURITY DEFINER helpers (public._*) had the default EXECUTE-to-PUBLIC
+--   grant, so anon/authenticated could call them directly over PostgREST
+--   (/rest/v1/rpc/_*). e.g. _bank_credit(p_uid, p_delta, p_reason) would credit ANY
+--   account real Cash. Fix: loop pg_proc for public funcs starting with '_' and
+--   REVOKE EXECUTE FROM anon, authenticated, PUBLIC. Internal callers are SECURITY
+--   DEFINER and run as the owner, so chained calls (e.g. daily solve →
+--   _daily_reward → _bank_credit) are unaffected. Verified: QA 19/19 incl. daily-solve;
+--   has_function_privilege('authenticated','_bank_credit',...) = false; public RPCs
+--   (freeplay_start/get_bank/freeplay_cashout) still true.
+--
+-- RLS enabled (deny-all; app reads these only via definer RPCs, never direct .from()):
+--   networth_snapshots, puzzles, climb_sequence, challenge_pack, daily_stats.
+--
+-- STILL OPEN (advisor warnings, deliberately deferred — not launch-blocking):
+--   * function_search_path_mutable (~180 funcs) — set `SET search_path = ''` per func.
+--   * vulnerable_postgres_version — upgrade Postgres (dashboard).
+--   * auth_leaked_password_protection — enable HaveIBeenPwned check (Auth settings).
+--   * rls_enabled_no_policy (9 INFO) — tables with RLS on + no policy (deny-all is fine).


### PR DESCRIPTION
Documents the prod security migration `security_lockdown_internal_funcs_and_rls` (applied via MCP), surfaced by `get_advisors(security)` during a launch-readiness pass.

**Critical fix — Cash-minting exploit closed.** All internal `SECURITY DEFINER` helpers (`public._*`) had the default EXECUTE-to-PUBLIC grant, so `anon`/`authenticated` could call them directly via PostgREST (`/rest/v1/rpc/_*`). `_bank_credit(p_uid, p_delta, p_reason)` would credit **any** account real Cash. Revoked EXECUTE from `anon, authenticated, PUBLIC` on every `public._*` function. Internal callers run as the owner (SECURITY DEFINER), so chained calls are unaffected.

**RLS enabled** (deny-all) on 5 tables that were public with RLS off: `networth_snapshots`, `puzzles`, `climb_sequence`, `challenge_pack`, `daily_stats`. The app reads these only via definer RPCs (verified no direct `.from()`).

**Verification:** QA harness 19/19 incl. daily-solve (which chains `_daily_reward` → `_bank_credit` → `_log_game_result`); `_bank_credit` no longer executable by `authenticated`; public RPCs still work.

**Deferred (non-blocking) advisor warnings:** function search_path hardening (~180 funcs), Postgres version upgrade, leaked-password protection toggle, RLS-no-policy INFOs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)