### PR TITLE
Realtime notifications + clear-on-accept

### DIFF
--- a/LAUNCH_FOLLOWUPS.md
+++ b/LAUNCH_FOLLOWUPS.md
@@ -1,0 +1,22 @@
+# Launch follow-ups (come back to these)
+
+Deferred items from the 2026-06-24 launch security pass (`get_advisors`). None are
+launch-blocking; the critical Cash-minting exploit + RLS gaps were already fixed
+(see `supabase-security-lockdown.sql`).
+
+## Security hardening (deferred)
+- [ ] **Function `search_path` hardening** — ~180 `SECURITY DEFINER` functions have a
+      mutable `search_path` (`function_search_path_mutable`). Add `SET search_path = ''`
+      (and schema-qualify references) per function. Do as a careful, tested batch.
+- [ ] **Upgrade Postgres** — advisor flagged a vulnerable version. Dashboard →
+      Settings → Infrastructure → upgrade (has downtime; schedule it).
+- [ ] **Enable leaked-password protection** — Auth → Settings → turn on the
+      HaveIBeenPwned check (`auth_leaked_password_protection`).
+- [ ] Review the 9 `rls_enabled_no_policy` INFO tables — confirm deny-all is intended
+      (it is for definer-RPC-only tables); add read policies only where a table is read
+      directly by the client.
+
+## Reminder / rule
+Any NEW internal `SECURITY DEFINER` helper named `public._*` must
+`REVOKE EXECUTE ON FUNCTION ... FROM anon, authenticated, PUBLIC` or PostgREST exposes
+it directly (that was the Cash-minting hole).

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -2,6 +2,7 @@
 // and surfaces brand-new items as transient toasts (visible from any screen).
 import { writable } from 'svelte/store';
 import { getNotifications, markNotificationsRead } from '$lib/stores/statsStore.js';
+import { supabase } from '$lib/supabaseClient';
 
 /** @type {import('svelte/store').Writable<any[]>} */
 export const notifications = writable([]);
@@ -25,6 +26,8 @@ let started = false;
 let primed = false; // first poll seeds knownIds without toasting history
 /** @type {(() => void)|undefined} */
 let onVis;
+/** @type {any} */
+let channel;
 
 async function poll() {
   const res = await getNotifications();
@@ -50,13 +53,20 @@ export function dismissToast(id) {
   toasts.update((t) => t.filter((x) => x.id !== id));
 }
 
-export function startNotifications() {
+/** @param {string} [uid] subscribe to this user's notifications for instant updates */
+export function startNotifications(uid) {
   if (started || typeof window === 'undefined') return;
   started = true;
   poll();
   pollTimer = setInterval(poll, POLL_MS);
   onVis = () => { if (!document.hidden) poll(); };
   document.addEventListener('visibilitychange', onVis);
+  // Realtime: a new challenge / friend request shows up instantly (not just on poll).
+  if (uid) {
+    channel = supabase.channel(`notifs:${uid}`)
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${uid}` }, () => poll())
+      .subscribe();
+  }
 }
 
 export function stopNotifications() {
@@ -69,6 +79,7 @@ export function stopNotifications() {
   if (pollTimer) clearInterval(pollTimer);
   pollTimer = undefined;
   if (onVis && typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVis);
+  if (channel) { supabase.removeChannel(channel); channel = undefined; }
 }
 
 /** Force an immediate refresh (e.g. after acting on a challenge). */
@@ -80,4 +91,31 @@ export async function markAllNotificationsRead() {
   await markNotificationsRead();
   unreadCount.set(0);
   notifications.update((list) => list.map((n) => ({ ...n, read: true })));
+}
+
+/** Optimistically clear the badge for notifications matching a predicate, then sync. */
+function clearLocal(/** @type {(n:any)=>boolean} */ match) {
+  notifications.update((list) => {
+    let cleared = 0;
+    const next = list.map((n) => {
+      if (!n.read && match(n)) { cleared++; return { ...n, read: true }; }
+      return n;
+    });
+    if (cleared) unreadCount.update((c) => Math.max(0, c - cleared));
+    return next;
+  });
+}
+/** Clear the notification(s) for one challenge — e.g. after accepting it from the banner. */
+export async function markChallengeNotifRead(/** @type {string} */ matchId) {
+  if (!matchId) return;
+  clearLocal((n) => n?.data?.match_id === matchId);
+  await markNotificationsRead(matchId, null);
+  if (started) await poll();
+}
+/** Clear the friend-request notification from one person — e.g. accepting from the banner. */
+export async function markFriendNotifRead(/** @type {string} */ fromId) {
+  if (!fromId) return;
+  clearLocal((n) => n?.data?.from_id === fromId);
+  await markNotificationsRead(null, fromId);
+  if (started) await poll();
 }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -166,9 +166,10 @@ export async function getNotifications() {
   if (error || !data) { if (error) console.error('❌ get_notifications:', error); return { items: [], unread_count: 0 }; }
   return { items: Array.isArray(data.items) ? data.items : [], unread_count: data.unread_count ?? 0 };
 }
-/** Mark all my notifications read. */
-export async function markNotificationsRead() {
-  const { error } = await supabase.rpc('mark_notifications_read');
+/** Mark notifications read — all, one challenge (matchId), or one friend request (fromId).
+ *  @param {string|null} [matchId] @param {string|null} [fromId] */
+export async function markNotificationsRead(matchId = null, fromId = null) {
+  const { error } = await supabase.rpc('mark_notifications_read', { p_match_id: matchId, p_from_id: fromId });
   if (error) console.error('❌ mark_notifications_read:', error);
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,10 +41,10 @@
     // Start the global notification poller whenever a session is present,
     // and react to sign-in / sign-out across every route.
     supabase.auth.getSession().then(({ data }) => {
-      if (data.session) startNotifications();
+      if (data.session) startNotifications(data.session.user?.id);
     });
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session) startNotifications();
+      if (session) startNotifications(session.user?.id);
       else stopNotifications();
     });
     return () => sub.subscription.unsubscribe();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,7 +9,7 @@
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
   import { getDailyStatus, getDailyGhost, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout } from '$lib/stores/statsStore.js';
-  import { unreadCount, refreshNotifications, inboxRequest, inboxTarget } from '$lib/stores/notificationStore.js';
+  import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
   import {
@@ -222,6 +222,14 @@
   // ===== Home "act-now" banner: the single most-urgent thing needing me =====
   /** @type {any[]} incoming friend requests [{id,name,username}] */
   let friendRequests = [];
+  // When a new notification lands (badge ticks up), refresh the act-now banner's
+  // matches/requests too — so a fresh challenge shows up live, not just the count.
+  let _prevUnread = 0;
+  $: handleUnreadRise($unreadCount);
+  function handleUnreadRise(/** @type {number} */ n) {
+    if (browser && loggedIn && hasInitialized && n > _prevUnread) refreshChallengeCount();
+    _prevUnread = n;
+  }
   // Challenges where it's my turn, soonest-to-expire first.
   $: turnMatches = (myMatches ?? [])
     .filter((m) => m.status === 'open' && m.my_state !== 'done')
@@ -254,6 +262,7 @@
   async function acceptFriend(r) {
     fx('tap');
     await respondFriendRequest(r.id, true);
+    markFriendNotifRead(r.id);
     await refreshChallengeCount();
   }
   function onPinUnlocked() { markUnlocked(); pinLocked.set(false); }
@@ -943,7 +952,7 @@
     mbBusy = true;
     const ok = m.my_state === 'invited' ? await acceptAndPlayMatch(m.id) : await resumeMatch(m.id);
     mbBusy = false;
-    if (ok) launchMatchPlay();
+    if (ok) { markChallengeNotifRead(m.id); launchMatchPlay(); }
     else mbMsg = 'Could not open that challenge.';
   }
   /** Play a challenge with a budget capped at your current Cash. @param {any} m */

--- a/supabase-notifications-realtime.sql
+++ b/supabase-notifications-realtime.sql
@@ -1,0 +1,22 @@
+-- Notifications: instant delivery + targeted clearing (2026-06-24).
+-- Challenges (create_match) and friend requests (add_friend) already _notify the
+-- recipient; these changes make the top-right badge update live and let the
+-- act-now banner clear the right notification when you act on it.
+--
+-- Applied to prod via MCP:
+--   * ALTER PUBLICATION supabase_realtime ADD TABLE public.notifications;
+--     (notifications now broadcasts INSERTs; RLS notifications_self =
+--      user_id = auth.uid() scopes delivery to the recipient. The client subscribes
+--      in notificationStore.startNotifications(uid) → poll() on insert.)
+--   * mark_notifications_read migrations (by_match / by_match_or_from):
+--       mark_notifications_read(p_match_id uuid default null, p_from_id uuid default null)
+--       - no args  → mark ALL my unread read (unchanged behavior)
+--       - p_match_id → clear one challenge's notifs (banner-accept a challenge)
+--       - p_from_id  → clear one person's friend-request notif (banner-accept a friend)
+--     Front: notificationStore.markChallengeNotifRead(matchId) /
+--     markFriendNotifRead(fromId); +page respondToMatch + acceptFriend call them.
+--     +page also refreshes getMyMatches when unreadCount rises, so a new challenge
+--     shows in the banner live (not just the badge).
+--
+-- Verified live (2 accounts): A challenges B → B badge 0→1 within ~5s with no refresh;
+-- B accepts via the banner → badge → 0.


### PR DESCRIPTION
Makes challenge / friend-request notifications appear instantly and clear when you act on them.

## Changes
- **Realtime delivery** — `notifications` added to the `supabase_realtime` publication; the client subscribes per-user in `startNotifications(uid)`. The top-right badge now updates the moment someone challenges you or sends a friend request (previously poll-only, up to 45s). RLS `notifications_self` scopes delivery to the recipient.
- **Clear on banner-accept** — `mark_notifications_read(p_match_id, p_from_id)` can now target one challenge or one friend request. `respondToMatch` → `markChallengeNotifRead`, `acceptFriend` → `markFriendNotifRead`, with optimistic badge decrement.
- **Banner stays in sync** — when the unread count rises, refresh `getMyMatches` so a new challenge shows in the act-now banner live (not just the count).
- Adds `LAUNCH_FOLLOWUPS.md` documenting deferred security hardening (function search_path, Postgres upgrade, leaked-password toggle).

## Verification
Live 2-account run: A challenges B → **B's badge 0→1 in ~5s with no refresh**; B accepts via the banner → **badge → 0**. Both notifications already fired server-side (`create_match` / `add_friend`). `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)