### PR TITLE
Bankroll on top for every mode; challenge = one number + one bar

### DIFF
--- a/src/lib/components/StandingStrip.svelte
+++ b/src/lib/components/StandingStrip.svelte
@@ -1,19 +1,12 @@
 <script>
-  // Live challenge HUD. Frames your buy-in as one budget being consumed:
-  //   Spent (filled) + Left to spend (rest) = your buy-in.
-  // 💰 Cash is shown separately as your account. Tap any value for a plain
-  // explanation. Rank vs FINISHED rivals is directional only (never the exact
-  // spend to beat); the lead-flip is the reward moment.
+  // Compact challenge standing: just your rank vs FINISHED rivals (never the exact
+  // spend to beat) + a lead celebration. The money (left to spend + bar) lives in the
+  // top bankroll bar now. Hidden until at least one rival has finished.
   import { fx } from '$lib/sound.js';
 
   /** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play', provisional?:boolean } | null} */
   export let standing = null;
-  /** @type {number} */ export let spent = 0;
-  /** @type {number} in-game budget you have left to spend this match */ export let bankroll = 0;
-  /** @type {number|null} your total Cash account (separate from the match budget) */ export let netWorth = null;
 
-  // Chime when you flip INTO the lead. prevState lives outside the reactive
-  // dependency graph (read/written inside a fn) so it can't self-invalidate.
   let prevState;
   function onStanding(/** @type {any} */ s) {
     if (s && s.state === 'lead' && prevState && prevState !== 'lead') fx('lead');
@@ -23,100 +16,32 @@
 
   const ord = (/** @type {number} */ n) => { const s = ['th','st','nd','rd'], v = n % 100; return n + (s[(v - 20) % 10] || s[v] || s[0]); };
   const medal = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
-  const money = (/** @type {number|null} */ n) => n == null ? '—' : '$' + Math.round(n).toLocaleString();
-
   $: ranked = !!standing && standing.state !== 'first_to_play';
-  $: budget = Math.max(0, (spent ?? 0) + (bankroll ?? 0)); // spent + left = your buy-in
-  $: spentPct = budget > 0 ? Math.min(100, Math.max(0, (spent / budget) * 100)) : 0;
-  $: lead = standing && standing.state === 'lead';
-
-  // Tap a value → explain it. Tapping the same one (or the note) closes it.
-  let info = /** @type {null | 'spent' | 'left' | 'budget' | 'cash'} */ (null);
-  function toggle(/** @type {any} */ k) { fx('tap'); info = info === k ? null : k; }
-  const EXPLAIN = {
-    spent: 'What you’ve spent on letters this match. The lowest spend to solve wins the whole pot — so keep it small.',
-    left: 'Your budget that’s still unspent. Anything you don’t use is refunded to your Cash at the end.',
-    budget: 'Your buy-in — the most you can spend this match (Spent + Left). Unspent money comes back to you.',
-    cash: 'Your account balance, outside this match. Your buy-in already moved out of here into the match budget — that’s why it can be less than your budget.'
-  };
 </script>
 
-{#if standing || budget > 0}
-  <div class="standing {standing?.state ?? 'first_to_play'}" class:lead>
-    {#if ranked && standing}
-      <div class="rank-row">
-        <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar">so far</span>{/if}</span>
-        {#if lead}<span class="lead-badge">✓ In the lead</span>{/if}
-      </div>
-    {/if}
-
-    <div class="bud-labels">
-      <button class="chip" class:on={info === 'spent'} on:click={() => toggle('spent')}>Spent <b>{money(spent)}</b></button>
-      <button class="chip right" class:on={info === 'left'} on:click={() => toggle('left')}><b>{money(bankroll)}</b> left to spend</button>
+{#if ranked && standing}
+  {#key standing.state}
+    <div class="standing {standing.state}">
+      <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar">so far</span>{/if}</span>
+      {#if standing.state === 'lead'}<span class="lead-badge">✓ In the lead</span>{/if}
     </div>
-    <button class="bar" class:on={info === 'budget'} on:click={() => toggle('budget')} aria-label="Your buy-in budget">
-      <span class="bar-fill" style="width:{spentPct}%"></span>
-    </button>
-    <div class="bud-foot">
-      <button class="foot" class:on={info === 'budget'} on:click={() => toggle('budget')}>{money(budget)} buy-in</button>
-      <button class="foot cash" class:on={info === 'cash'} on:click={() => toggle('cash')}>💰 Cash {money(netWorth)}</button>
-    </div>
-
-    {#if info}
-      <button class="explain" on:click={() => (info = null)}>
-        <span class="ex-ic">ⓘ</span><span class="ex-tx">{EXPLAIN[info]}</span>
-      </button>
-    {:else}
-      <div class="hint">Tap any value to see what it means</div>
-    {/if}
-  </div>
+  {/key}
 {/if}
 
 <style>
   .standing {
-    max-width: 360px; margin: 0 auto 6px; padding: 9px 13px 8px;
-    border-radius: 13px;
+    display: flex; align-items: center; justify-content: center; gap: 10px;
+    max-width: 360px; margin: 0 auto 6px; padding: 6px 14px; border-radius: 11px;
     border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
     background: var(--surface, rgba(255, 255, 255, 0.05));
-    animation: stPop 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+    font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.9rem; color: var(--text, #fff);
+    animation: stPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
-  @keyframes stPop { from { transform: scale(0.96); opacity: 0.4; } to { transform: scale(1); opacity: 1; } }
-
-  .rank-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 7px;
-    font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.92rem; color: var(--text, #fff); }
+  @keyframes stPop { from { transform: scale(0.96); opacity: 0.5; } to { transform: scale(1); opacity: 1; } }
   .sofar { margin-left: 6px; font-family: var(--font-ui, sans-serif); font-weight: 600; font-size: 0.62rem;
     text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint, #8090a0); }
   .lead-badge { font-size: 0.78rem; font-weight: 700; color: #7ee0a8; }
-
-  /* tappable values */
-  button { font-family: inherit; cursor: pointer; background: none; border: none; color: inherit; padding: 0; }
-  .bud-labels { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
-  .chip { font-size: 0.82rem; color: var(--text-muted, #c2cbd8); border-bottom: 1px dotted var(--text-faint, #6b7686); line-height: 1.5; }
-  .chip.right { text-align: right; }
-  .chip b { color: var(--text, #fff); font-variant-numeric: tabular-nums; }
-  .chip.on { color: var(--brand-2, #fde047); border-bottom-color: var(--brand-2, #fde047); }
-
-  .bar { display: block; width: 100%; height: 9px; margin: 5px 0 6px; border-radius: 999px;
-    background: rgba(255, 255, 255, 0.10); overflow: hidden; }
-  .bar-fill { display: block; height: 100%; border-radius: 999px;
-    background: linear-gradient(90deg, #fbbf24, #fde047); transition: width 0.35s ease; }
-  .bar.on { box-shadow: 0 0 0 2px rgba(253, 224, 71, 0.4); }
-
-  .bud-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
-  .foot { font-size: 0.72rem; color: var(--text-faint, #8090a0); border-bottom: 1px dotted transparent; }
-  .foot.cash { color: var(--text-muted, #c2cbd8); border-bottom-color: var(--text-faint, #6b7686); }
-  .foot.on { color: var(--brand-2, #fde047); border-bottom-color: var(--brand-2, #fde047); }
-
-  .hint { margin-top: 6px; font-size: 0.63rem; color: var(--text-faint, #6b7686); text-align: center; }
-  .explain { display: flex; gap: 6px; align-items: flex-start; text-align: left; width: 100%;
-    margin-top: 7px; padding: 7px 9px; border-radius: 9px;
-    background: rgba(125, 188, 255, 0.10); border: 1px solid rgba(125, 188, 255, 0.28); }
-  .ex-ic { color: #93c5fd; font-size: 0.8rem; line-height: 1.35; }
-  .ex-tx { font-size: 0.74rem; line-height: 1.35; color: var(--text, #fff); }
-
   .standing.lead { border-color: rgba(126, 224, 168, 0.5);
-    background: linear-gradient(135deg, rgba(126, 224, 168, 0.13), rgba(126, 224, 168, 0.04));
-    box-shadow: 0 0 16px rgba(126, 224, 168, 0.22); }
+    background: linear-gradient(135deg, rgba(126, 224, 168, 0.13), rgba(126, 224, 168, 0.04)); }
   .standing.behind { border-color: rgba(251, 191, 36, 0.45); }
-  .standing.first_to_play { border-color: rgba(125, 188, 255, 0.4); }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1603,6 +1603,28 @@
     <!-- 🧠 Game Logo -->
     <img class="game-logo" src="/wordmark.png" alt="WordBank" />
 
+    <!-- 💰 Bankroll — top of every mode. Challenge/1v1 = one number (left to spend) + one depleting bar. -->
+    {#if $gameStore.currentPhrase && $gameStore.gameMode}
+      {#if isMatch && matchInfo && !matchBlitz && !matchInfo.done}
+        {@const buyin = matchInfo.budget ?? 0}
+        {@const left = Math.max(0, buyin - (matchInfo.spent ?? 0))}
+        <div class="top-bank">
+          <div class="tb-row"><span class="tb-cap">💰 Left to spend</span><span class="tb-amt">${left.toLocaleString()}</span></div>
+          <div class="tb-bar"><span class="tb-fill" style="width:{buyin > 0 ? Math.max(0, Math.min(100, (left / buyin) * 100)) : 100}%"></span></div>
+          <div class="tb-sub">of your ${buyin.toLocaleString()} buy-in</div>
+        </div>
+      {:else if isFreeplay}
+        <button class="top-bank tap" disabled={fpCashBusy} on:click={tapCredits}>
+          <div class="tb-row"><span class="tb-cap">🎟️ Credits</span><span class="tb-amt cr">{Math.round($gameStore.bankroll ?? 0).toLocaleString()}</span></div>
+          <div class="tb-sub">tap to cash out at 40:1</div>
+        </button>
+      {:else if !matchBlitz}
+        <div class="top-bank">
+          <div class="tb-row"><span class="tb-cap">💰 Bankroll</span><span class="tb-amt">${Math.round($gameStore.bankroll ?? 0).toLocaleString()}</span></div>
+        </div>
+      {/if}
+    {/if}
+
     <!-- 🔍 Diagnostic banner (shows when init failed) -->
     {#if initError}
       <div class="diagnostic-banner">
@@ -1681,8 +1703,7 @@
         </div>
       {:else}
         {#if matchInfo.pack_size > 1}<p class="match-pos">Puzzle {matchInfo.position}/{matchInfo.pack_size}</p>{/if}
-        <StandingStrip standing={matchInfo.standing ?? null} spent={matchInfo.spent ?? 0}
-          bankroll={Math.max(0, (matchInfo.budget ?? 0) - (matchInfo.spent ?? 0))} {netWorth} />
+        <StandingStrip standing={matchInfo.standing ?? null} />
       {/if}
       {#if (matchInfo.my_debuffs ?? []).length}
         <p class="debuff-banner">{(matchInfo.my_debuffs ?? []).map((/** @type {string} */ d) => DEBUFF_LABEL[d] ?? d).join(' · ')}</p>
@@ -1758,25 +1779,20 @@
     <!-- 💰 Money hero -->
     <section class="stats-section">
       {#if soloHero}
-        <!-- Daily · Makeup · Cash Game: one number = what you keep, ticking down as you spend -->
+        <!-- Daily · Makeup · Cash Game: the number you keep if you solve now (bankroll is up top) -->
         <div class="bounty-panel" class:loss={soloHero.net < 0}>
           <span class="bp-label">{soloHero.net >= 0 ? '🏆 Solve now to keep' : '⚠️ You’re losing money'}</span>
           <span class="bp-amount">{soloHero.net >= 0 ? '$' : '−$'}{Math.abs(soloHero.net).toLocaleString()}</span>
-          <span class="bp-balance">Balance ${Math.round($gameStore.bankroll ?? 0).toLocaleString()}</span>
         </div>
       {:else if isFreeplay}
-        <!-- Free Play: play-money "Credits" (separate pool, never touches real Cash) -->
+        <!-- Free Play: credits are up top; here just the cash-out + your Cash + reward -->
         <div class="credits-panel">
-          <button class="cr-tap" on:click={tapCredits} disabled={fpCashBusy} title="Tap to cash out credits for Cash">
-            <span class="cr-label">🎟️ Credits</span>
-            <span class="cr-amount">{Math.round($gameStore.bankroll ?? 0).toLocaleString()}</span>
-          </button>
           {#if (($gameStore.bankroll ?? 0) - 2000) >= 40}
             <button class="cr-cashout" disabled={fpCashBusy} on:click={doFreeplayCashout}>
               💵 Cash out ${Math.min(50, Math.floor((($gameStore.bankroll ?? 0) - 2000) / 40))}
             </button>
           {:else}
-            <span class="cr-note">Play money · tap credits to cash out at 40:1</span>
+            <span class="cr-note">Play money · cash out at 40:1</span>
           {/if}
           <span class="cr-wallet">💰 Cash {netWorth == null ? '—' : '$' + Math.round(netWorth).toLocaleString()}</span>
         </div>
@@ -2990,16 +3006,25 @@
   .bp-amount { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.3rem; line-height: 1.05; color: #fcd34d;
     text-shadow: 0 0 18px rgba(251,191,36,0.45); font-variant-numeric: tabular-nums; transition: color 0.2s; }
   .bounty-panel.loss .bp-amount { color: #fb7185; text-shadow: none; }
-  .bp-balance { margin-top: 3px; font-size: 0.74rem; color: var(--text-faint); }
+  /* 💰 Top bankroll bar (very top, all modes) */
+  .top-bank { width: 100%; max-width: 340px; margin: 0 auto 12px; padding: 9px 16px; border-radius: 14px;
+    border: 1px solid rgba(253, 224, 71, 0.4); background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.03)); }
+  .top-bank.tap { cursor: pointer; display: block; text-align: left;
+    border-color: rgba(167, 139, 250, 0.55); border-style: dashed;
+    background: linear-gradient(135deg, rgba(167, 139, 250, 0.13), rgba(167, 139, 250, 0.03)); }
+  .top-bank.tap:disabled { cursor: default; opacity: 0.6; }
+  .tb-row { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .tb-cap { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--brand-2); }
+  .tb-amt { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.7rem; line-height: 1; color: #fcd34d; font-variant-numeric: tabular-nums; }
+  .tb-amt.cr { color: #c4b5fd; }
+  .top-bank.tap .tb-cap { color: #c4b5fd; }
+  .tb-bar { margin-top: 7px; height: 9px; border-radius: 999px; background: rgba(255,255,255,0.10); overflow: hidden; }
+  .tb-fill { display: block; height: 100%; border-radius: 999px; background: linear-gradient(90deg, #fbbf24, #fde047); transition: width 0.35s ease; }
+  .tb-sub { margin-top: 5px; font-size: 0.66rem; color: var(--text-faint); }
   /* Free Play play-money "Credits" — violet + dashed so it reads as not-real-Cash */
   .credits-panel { display: flex; flex-direction: column; align-items: center; gap: 1px;
     width: 100%; max-width: 320px; margin: 0 auto; padding: 13px 18px; border-radius: var(--r-lg, 18px);
     border: 1px dashed rgba(167, 139, 250, 0.55); background: linear-gradient(135deg, rgba(167, 139, 250, 0.13), rgba(167, 139, 250, 0.03)); }
-  .cr-tap { display: flex; flex-direction: column; align-items: center; gap: 1px; background: none; border: none; cursor: pointer; padding: 2px 6px; border-radius: 12px; }
-  .cr-tap:hover:not(:disabled) { background: rgba(196, 181, 253, 0.08); }
-  .cr-tap:disabled { cursor: default; }
-  .cr-label { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: #c4b5fd; }
-  .cr-amount { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.1rem; line-height: 1.1; color: #c4b5fd; font-variant-numeric: tabular-nums; }
   .cr-note { margin-top: 2px; font-size: 0.68rem; color: var(--text-faint); }
   .cr-cashout { margin-top: 5px; padding: 0.4rem 0.9rem; border-radius: 999px; cursor: pointer; font-weight: 800; font-size: 0.8rem;
     color: #04240f; background: linear-gradient(135deg, #6ee7b7, #34d399); border: none; }


### PR DESCRIPTION
Puts your bankroll at the very top of the board in every mode and simplifies the challenge money to a single depleting bar.

## Changes
- **Top bankroll bar** (new, very top of the board, all modes):
  - Daily / Makeup / Cash Game → `💰 Bankroll $X`
  - Free Play → `🎟️ Credits N` (tap to cash out at 40:1)
  - Challenge / 1v1 / group → `Left to spend $X` + **one bar that depletes from your buy-in** as you spend (one number, one bar)
- **Removed** the multi-value standing strip (Spent · Left · Cash) and the "tap any value to see what it means" hint. `StandingStrip` is now just a small rank chip ("🥈 2nd of 4" + lead badge) shown once a rival finishes.
- **Solo hero** keeps `🏆 Solve now to keep $X` but drops the redundant `Balance` line (bankroll moved up top). **Free Play** panel drops the duplicate credits number, keeping the cash-out button + your Cash.

## Verification
Live screenshots across all four modes: Daily `💰 BANKROLL $2,030` + `SOLVE NOW TO KEEP $450`; Cash Game `💰 BANKROLL $2,010` + `SOLVE NOW TO KEEP $580`; Free Play `🎟️ CREDITS 2,000` (tap to cash out); Challenge `💰 LEFT TO SPEND $980` over a single bar of the `$1,000 buy-in`. `npm run build` passes (no unused-selector warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)