### PR TITLE
Notifications: drop chat from inbox; auto-clear handled friend requests

### DIFF
--- a/supabase-notifications-realtime.sql
+++ b/supabase-notifications-realtime.sql
@@ -20,3 +20,15 @@
 --
 -- Verified live (2 accounts): A challenges B → B badge 0→1 within ~5s with no refresh;
 -- B accepts via the banner → badge → 0.
+--
+-- Follow-up (migration notifications_drop_chat_and_clear_friend_requests):
+--   * Chat lives in the in-game 💬 icon only — send_match_message NO LONGER posts a
+--     'challenge_chat' notification, and get_notifications excludes type='challenge_chat'
+--     from both items + unread_count. Existing challenge_chat rows deleted.
+--   * Friend-request notifications now auto-clear: respond_friend_request (and the
+--     add_friend auto-accept branch) DELETE the recipient's friend_request notification
+--     for that requester. respond_friend_request returns ok:true even when the request
+--     was already handled (status 'friends'/'gone'), so a stale Accept resolves the UI
+--     instead of doing nothing. Existing already-handled friend_request notifs deleted.
+--   Verified (rolled back): accept → friends + notif deleted; accept again → 'friends';
+--   live: @Chefcharles inbox left with only the legit challenge (chat + stale request gone).


### PR DESCRIPTION
Fixes three reported notification issues (all at the DB layer — the panel reads `get_notifications` and the accept response).

1. **Chat messages cluttering the inbox** → `send_match_message` no longer posts a `challenge_chat` notification, and `get_notifications` excludes them from items + unread count. Chat unread stays in the in-game 💬 icon. Existing chat notifs deleted.
2. **Accepting a friend request did nothing when already accepted** → `respond_friend_request` now returns `ok:true` (status `friends`/`gone`) even when the request was already handled, so the UI resolves instead of silently failing.
3. **Stale friend-request notification wouldn't go away** → `respond_friend_request` and `add_friend`'s auto-accept now delete the recipient's `friend_request` notification for that requester. Existing already-handled ones cleaned up.

Verified rolled-back (accept → friends + notif deleted; accept-again → friends) and live (@Chefcharles inbox left with only the legit challenge; 0 chat / 0 stale friend-request notifs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)