### PR TITLE
Daily: fix "Missed" after navigating away + correct won/lost label

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -149,7 +149,9 @@
 
       // Into the menu immediately — the loading screen only gates on auth + profile.
       showMainMenu = true;
-      savedGameInfo = null;
+      // Load any in-progress game so the menu shows "Resume" (not "Missed") after
+      // returning from another route (e.g. the Store).
+      savedGameInfo = getSavedGameInfo(session.user.id);
       hasInitialized = true;
 
       // Secondary menu data: must NOT block the loading screen or each other.
@@ -1307,7 +1309,7 @@
           <button class="menu-card" class:done={dailyDone} style="--i: 0" on:click={handleMenuDaily}>
             <span class="mc-title">{dailyInProgress ? 'Resume Daily' : 'Daily'}</span>
             {#if dailyDone}
-              <span class="daily-chip {dailyStatus?.last_daily_won ? 'won' : 'lost'}">{dailyStatus?.last_daily_won ? `✅ Solved${dailyStatus?.today_score ? ' · +' + dailyStatus.today_score.toLocaleString() : ''}` : '❌ Missed'}</span>
+              <span class="daily-chip {dailyStatus?.last_daily_won ? 'won' : 'lost'}">{dailyStatus?.last_daily_won ? `✅ Solved${dailyStatus?.today_score ? ' · +' + dailyStatus.today_score.toLocaleString() : ''}` : '❌ Didn’t solve'}</span>
             {:else if dailyInProgress}
               <span class="daily-chip prog">⏳ Resume</span>
             {/if}


### PR DESCRIPTION
Two Daily bugs:

1. **Starting the Daily then navigating away (e.g. to the Store) marked it "❌ Missed."** The menu init reset `savedGameInfo = null`, so on return it no longer saw the in-progress Daily (`has_played_today` true + no in-progress save → 'done/missed'). Now it loads the saved game on init → shows **"Resume Daily"**. Verified live.
2. **A *lost* Daily showed "✅ Solved."** `get_daily_status.last_daily_won` was `EXISTS(any daily result today)`, not the actual outcome. Now checks `outcome='won'`; menu copy for a played loss is **"Didn't solve"**.

Also confirmed: **Daily is not timed** — the only clock is the 60s 'out of Cash' countdown that auto-folds you if you can't afford a letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)