### PR TITLE
Daily Twists: weekday helper rotation + Use/Pure leveler + honest losses

### DIFF
--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -18,10 +18,13 @@ export function powerupInfo(id) {
 // Keys match the server _daily_modifier() pool. `blurb` is the short "twist" line.
 /** @type {Record<string, { emoji: string, name: string, blurb: string }>} */
 export const MODIFIERS = {
-  discount:     { emoji: '🏷️', name: 'Discount Day', blurb: 'Every letter is 25% off' },
-  vowel_vision: { emoji: '👁️', name: 'Vowel Vision', blurb: 'Vowels cost half price' },
-  extra_bank:   { emoji: '💰', name: 'Big Bank',      blurb: 'Start with an extra $250' },
-  insurance:    { emoji: '🛡️', name: 'Insured',       blurb: 'Your first wrong guess is free' }
+  discount:       { emoji: '🏷️', name: 'Discount Day',  blurb: 'Every letter is 25% off' },
+  vowel_vision:   { emoji: '👁️', name: 'Vowel Vision',  blurb: 'Vowels cost half price' },
+  flat_rate:      { emoji: '⚖️', name: 'Flat Rate',     blurb: 'Every letter is a flat $50' },
+  free_vowel:     { emoji: '🎁', name: 'Free Vowel',    blurb: 'One vowel revealed free' },
+  consonant_sale: { emoji: '🔡', name: 'Consonant Sale', blurb: 'Consonants are 25% off' },
+  head_start:     { emoji: '🅰️', name: 'Head Start',    blurb: 'First letter of each word free' },
+  insured:        { emoji: '🛡️', name: 'Insured',       blurb: 'Your first wrong letter is free' }
 };
 
 /** @param {string} id */

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -86,7 +86,9 @@ export const gameStore = writable(/** @type {GameState} */ ({
   freeReveals: 0, // owned Free Reveal power-ups (daily)
   arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
   arcadeCashedOut: false, // true when the last arcade run ended via "Bank it" (vs bust)
-  modifier: null, // today's shared Daily Modifier id (daily only)
+  modifier: null, // active Daily Twist id (null when you went Pure)
+  twistActive: true, // did you Use today's Twist (true) or Go Pure (false)?
+  bountyMult: 1, // bounty multiplier (1.0 with Twist, 1.5 Pure)
   clue: null, // witty one-line hint for the current puzzle
   challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
@@ -203,7 +205,11 @@ function reconcileDailyBoard(board) {
     gameMode: 'daily',
     gameState: finished ? board.state : 'default',
     dailyResult: board.daily_result ?? prev.dailyResult ?? null,
-    dailyLive: board.live ?? prev.dailyLive ?? null
+    dailyLive: board.live ?? prev.dailyLive ?? null,
+    // Twist state: active modifier (null when Pure) + the bounty multiplier.
+    modifier: board.modifier !== undefined ? board.modifier : prev.modifier,
+    twistActive: board.twist_active !== undefined ? board.twist_active : (prev.twistActive ?? true),
+    bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1)
   }));
   // Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
   // not when re-opening an already-completed daily (which comes back 'won' with no result).
@@ -1119,25 +1125,21 @@ export function submitGuess() {
  * No localStorage: the server is the source of truth (and prevents replays).
  * The day's shared modifier is applied server-side at start (no client power-ups).
  */
-export async function fetchDailyGame() {
+export async function fetchDailyGame(useTwist = true) {
   try {
     track('daily_start');
-    const board = await dailyStart();
+    const board = await dailyStart([], useTwist);
     if (!board) {
       console.error('❌ daily_start returned no board');
       return false;
     }
-    reconcileDailyBoard(board);
+    reconcileDailyBoard(board); // sets modifier / twistActive / bountyMult from the board
     // Attendance reward (paid once on the first open of the day) → transient toast.
     const ab = /** @type {any} */ (board);
     if (ab.attendance != null && ab.attendance > 0) {
       gameStore.update(s => ({ ...s, cashToast: { amount: ab.attendance, label: `Day ${ab.attendance_day} streak · for showing up` } }));
     }
-    // Today's shared modifier (same for everyone) — drives the banner + key pricing.
-    try {
-      const [mod, clue] = await Promise.all([getDailyModifier(), getDailyClue()]);
-      gameStore.update(s => ({ ...s, modifier: mod, clue }));
-    } catch { /* non-fatal */ }
+    try { const clue = await getDailyClue(); gameStore.update(s => ({ ...s, clue })); } catch { /* non-fatal */ }
     console.log('✅ Daily session started/resumed');
     return true;
   } catch (err) {

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -414,8 +414,8 @@ export async function fetchArcadeLeaderboard(period = 'daily') {
  * @param {string[]} [powerups] - pre-game power-ups to activate (only applied on a fresh session)
  * @returns {Promise<object|null>} board
  */
-export async function dailyStart(powerups = []) {
-  const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups });
+export async function dailyStart(powerups = [], useTwist = true) {
+  const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups, p_use_twist: useTwist });
   if (error) { console.error('❌ daily_start error:', error); return null; }
   return data;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,7 @@
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getDailyGhost, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout, getDailyModifier } from '$lib/stores/statsStore.js';
   import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
@@ -755,13 +755,21 @@
       showStreakMessage = true;  // already solved today → come-back summary
       return;
     }
-    // Otherwise start fresh, or resume an in-progress daily (dailyStart resumes).
-    await startDaily();
+    if (inProgress) { await startDaily(true); return; } // resume — Twist choice already locked
+    // Fresh start → ask: Use today's Twist, or Go Pure for a ×1.5 bounty?
+    fx('tap');
+    try { dailyTwistMod = await getDailyModifier(); } catch { dailyTwistMod = null; }
+    showDailyTwist = true;
   }
 
-  async function startDaily() {
+  // Pre-game "Use the Twist or Go Pure" choice (locked once you start).
+  let showDailyTwist = false;
+  /** @type {string|null} */
+  let dailyTwistMod = null;
+  async function startDaily(useTwist = true) {
+    showDailyTwist = false;
     localStorage.setItem('gameMode', 'daily');
-    const ok = await fetchDailyGame();
+    const ok = await fetchDailyGame(useTwist);
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
@@ -1165,6 +1173,33 @@
           on:keydown={(e) => { if (e.key === 'Enter') sendMatchChat(); }} />
         <button class="chat-send" on:click={sendMatchChat} disabled={matchChatBusy || !matchChatInput.trim()}>Send</button>
       </div>
+    </div>
+  </div>
+{/if}
+
+<!-- 🎲 Daily: Use today's Twist or Go Pure (×1.5 bounty) — locked at start -->
+{#if showDailyTwist}
+  {@const m = dailyTwistMod ? modifierInfo(dailyTwistMod) : null}
+  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Today's Daily Twist">
+    <div class="modal-content twist-modal">
+      <h2 class="tw-title">Today’s Daily Twist</h2>
+      {#if m}
+        <div class="tw-mod">
+          <span class="tw-emoji">{m.emoji}</span>
+          <span class="tw-name">{m.name}</span>
+          <span class="tw-blurb">{m.blurb}</span>
+        </div>
+      {/if}
+      <p class="tw-q">Use the Twist, or go Pure for a bigger bounty?</p>
+      <div class="tw-actions">
+        <button class="tw-opt use" on:click={() => startDaily(true)}>
+          <strong>✅ Use it</strong><small>{m ? m.blurb : 'today’s help'}</small>
+        </button>
+        <button class="tw-opt pure" on:click={() => startDaily(false)}>
+          <strong>🎯 Go Pure</strong><small>no help · bounty <b>×1.5</b></small>
+        </button>
+      </div>
+      <p class="tw-hint">Locked in once you start.</p>
     </div>
   </div>
 {/if}
@@ -1755,7 +1790,8 @@
     <!-- 🌍 Category + today's modifier chip + witty clue -->
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
-      {#if dailyMod}<span class="mod-chip" title={dailyMod.name + ' — ' + dailyMod.blurb}>{dailyMod.emoji} {dailyMod.name}</span>{/if}
+      {#if dailyMod}<span class="mod-chip" title={dailyMod.name + ' — ' + dailyMod.blurb}>{dailyMod.emoji} {dailyMod.name}</span>
+      {:else if $gameStore.gameMode === 'daily' && $gameStore.twistActive === false}<span class="mod-chip pure" title="No Twist — bounty ×1.5">🎯 Pure · ×1.5</span>{/if}
     </div>
     {#if $gameStore.clue}
       <p class="puzzle-clue">{$gameStore.clue}</p>
@@ -2150,6 +2186,7 @@
     border-radius: var(--r-pill, 999px);
     white-space: nowrap;
   }
+  .mod-chip.pure { color: #6ee7b7; background: rgba(16, 185, 129, 0.12); border-color: rgba(110, 231, 183, 0.4); }
 
   .phrase-section {
     width: 100%;
@@ -2604,6 +2641,22 @@
   @keyframes chatPulse { 0%,100% { box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 0 rgba(244,63,94,0.5); } 50% { box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 6px rgba(244,63,94,0); } }
   .mcb-label { font-family: var(--font-display); font-size: 0.84rem; }
   .mc-dot { position: absolute; top: 3px; right: 3px; width: 10px; height: 10px; border-radius: 999px; background: #f43f5e; box-shadow: 0 0 0 2px var(--bg, #0a0e14); }
+  .twist-modal { max-width: 380px; text-align: center; }
+  .tw-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 0.7rem; }
+  .tw-mod { display: flex; flex-direction: column; align-items: center; gap: 2px; padding: 0.9rem; margin: 0 0 0.9rem;
+    border-radius: 14px; border: 1px solid rgba(253,224,71,0.4); background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.03)); }
+  .tw-emoji { font-size: 1.8rem; line-height: 1; }
+  .tw-name { font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--brand-2); }
+  .tw-blurb { font-size: 0.82rem; color: var(--text-muted); }
+  .tw-q { font-size: 0.9rem; color: var(--text); margin: 0 0 0.9rem; }
+  .tw-actions { display: flex; gap: 0.6rem; }
+  .tw-opt { flex: 1; display: flex; flex-direction: column; gap: 3px; padding: 0.85rem 0.6rem; border-radius: 13px; cursor: pointer; border: 1px solid var(--border-strong, var(--border)); background: var(--surface-2, rgba(255,255,255,0.05)); color: var(--text); }
+  .tw-opt strong { font-family: var(--font-display); font-size: 0.98rem; }
+  .tw-opt small { font-size: 0.72rem; color: var(--text-muted); line-height: 1.3; }
+  .tw-opt small b { color: #6ee7b7; }
+  .tw-opt.use { border-color: rgba(253,224,71,0.5); }
+  .tw-opt.pure { border-color: rgba(110,231,183,0.5); background: linear-gradient(135deg, rgba(16,185,129,0.12), rgba(16,185,129,0.03)); }
+  .tw-hint { font-size: 0.68rem; color: var(--text-faint); margin: 0.8rem 0 0; }
   .welcome-modal { max-width: 380px; text-align: center; }
   .wc-coin { display: block; margin: 0 auto 0.5rem; }
   .wc-title { font-family: var(--font-display); font-size: 1.4rem; margin: 0 0 0.35rem; }

--- a/supabase-daily-twists.sql
+++ b/supabase-daily-twists.sql
@@ -1,0 +1,31 @@
+-- Daily "Twists" + leveler + honest losses (2026-06-25).
+-- Migration: daily_twists_rotation_leveler_losses.
+--
+-- TWISTS (all helpers, one per weekday via _daily_modifier(), dow 0..6):
+--   Sun 🛡️ insured (first wrong letter free) · Mon 🏷️ discount (25% off all) ·
+--   Tue 👁️ vowel_vision (vowels 50% off) · Wed ⚖️ flat_rate (every letter $50) ·
+--   Thu 🎁 free_vowel (one vowel revealed free) · Fri 🔡 consonant_sale (consonants 25% off) ·
+--   Sat 🅰️ head_start (first letter of each word free).
+--   (Replaces old md5%4 pool incl. the 2 inert mods Big Bank / Insured-first-GUESS.)
+--   Effects live in daily_buy_letter (pricing/insured) + daily_start (free reveals).
+--
+-- LEVELER: daily_start(p_powerups, p_use_twist boolean default true). Choose BEFORE
+--   starting, locked on the session (daily_sessions.twist_active). Use Twist → bounty ×1.0;
+--   Go Pure (no twist) → bounty ×1.5 via _daily_reward_eff(pid, twist). Board responses now
+--   carry { modifier (null if Pure), twist_active, bounty_mult }.
+--
+-- LOSSES: daily_fold now calls _finalize_daily(p_won=false) → logs a game_results row
+--   (outcome='lost', earned 0, net=-spent, no bounty credit, no flawless). Win-rate /
+--   "played" / history are now honest. _finalize_daily guards the bounty _bank_credit to wins.
+--
+-- STREAK unchanged = ATTENDANCE (showing up), increments in daily_start; not solve-based
+--   (owner's call). See [[wordbank-economy-v3-1]].
+--
+-- Frontend: powerups.js MODIFIERS (the 7); dailyStart(powerups, useTwist) → p_use_twist;
+--   GameStore reconcileDailyBoard reads modifier/twist_active/bounty_mult (store fields
+--   twistActive/bountyMult); +page pre-game Twist-choice modal (Use it / Go Pure) shown on
+--   a FRESH daily (resume skips it); board shows the mod-chip or a "🎯 Pure · ×1.5" chip.
+--
+-- Verified (rolled back + live): rotation (Thu=free_vowel), Pure bounty ×1.5 ($780 board),
+--   discount E=75, flat=50, insured first-wrong=$0, free_vowel revealed both A's of FAJITAS,
+--   fold logs outcome='lost'.


### PR DESCRIPTION
Daily modifier redesign + leveler + stat fixes (backend migration already applied to prod). 7 weekday helper Twists; pre-game Use-it/Go-Pure (×1.5) choice; losses now logged. Verified rolled-back + live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)