### PR TITLE
Daily: Play streak + Win streak; redesigned daily leaderboard

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -12,8 +12,8 @@
     { k: 'daily', label: '📅 Daily' }
   ];
   const PERIOD_BOARDS = ['cash'];
-  /** scope: 'global' | 'friends' | a group id */
-  let scope = $state('friends');
+  /** scope: 'global' (Everyone) | 'friends' | a group id */
+  let scope = $state('global');
   /** @type {'week'|'all'} */
   let period = $state('all');
   /** @type {any[]} */
@@ -57,8 +57,8 @@
 <!-- Scope + period -->
 <div class="filters">
   <select class="filter-select" bind:value={scope}>
-    <option value="friends">Friends</option>
-    <option value="global">Global</option>
+    <option value="global">🌍 Everyone</option>
+    <option value="friends">👋 Friends</option>
     {#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
   </select>
   {#if PERIOD_BOARDS.includes(board)}
@@ -71,7 +71,7 @@
 
 <p class="caption">
   {#if board === 'cash'}{period === 'week' ? 'Cash gained this week' : 'Richest players — total Cash'}
-  {:else}Today's Daily score{/if}
+  {:else}Ranked by today's Daily score · {scope === 'global' ? 'everyone' : scope === 'friends' ? 'your friends' : 'this group'}{/if}
 </p>
 
 {#if loading}
@@ -87,7 +87,12 @@
         <tr>
           <th>#</th><th>Player</th>
           {#if board === 'cash'}<th>{period === 'week' ? 'Gained' : 'Cash'}</th>
-          {:else}<th>Score</th>{/if}
+          {:else}
+            <th class="num" title="Cash on Hand">💰 Cash</th>
+            <th class="num" title="Today's Daily score">Score</th>
+            <th class="num" title="Play streak — days in a row played">🔥 Play</th>
+            <th class="num" title="Win streak — days in a row solved">🏆 Win</th>
+          {/if}
         </tr>
       </thead>
       <tbody>
@@ -107,7 +112,10 @@
                 {period === 'week' ? (r.metric >= 0 ? '+' : '') + fmt(r.metric) : fmt(r.net_worth)}
               </td>
             {:else}
-              <td class="metric">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
+              <td class="metric">{fmt(r.net_worth)}</td>
+              <td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
+              <td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>
+              <td class="metric small">{r.win_streak > 0 ? '🏆' + r.win_streak : '—'}</td>
             {/if}
           </tr>
         {/each}
@@ -143,9 +151,15 @@
   td.name { font-weight: 600; }
   .name-link { background: none; border: none; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.2); text-underline-offset: 2px; }
   .name-link:hover { text-decoration-color: var(--gold); }
-  td.metric { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); text-align: right; }
+  td.metric { font-family: var(--font-display); font-weight: 700; color: var(--text); text-align: right; white-space: nowrap; }
+  td.metric.gold { color: var(--brand-2); }
+  td.metric.small { font-weight: 700; font-size: 0.82rem; color: var(--text-muted); }
   td.metric.neg { color: #fb7185; }
+  th.num { text-align: right; }
   th:last-child { text-align: right; }
+  /* tighter cells when the Daily board shows 6 columns */
+  th, td { padding: 0.6rem 0.45rem; }
+  td.rank { width: 30px; padding-left: 0.5rem; }
   tr.me { background: rgba(56,189,248,0.1); }
   tr.me td.name { color: #7dd3fc; }
   .title { font-size: 0.68rem; color: var(--text-faint); margin-left: 0.35rem; white-space: nowrap; }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -44,7 +44,7 @@ export async function getDailyStatus(userId) {
   });
   if (error) {
     console.error('❌ Error fetching daily status:', error);
-    return { has_played_today: false, last_daily_won: null, daily_bankroll: 0, arcade_bankroll: 1000, current_streak: 0, streak_freezes: 0, today_score: 0 };
+    return { has_played_today: false, last_daily_won: null, daily_bankroll: 0, arcade_bankroll: 1000, current_streak: 0, streak_freezes: 0, today_score: 0, win_streak: 0 };
   }
   const row = Array.isArray(data) ? data[0] : data;
   return {
@@ -52,9 +52,10 @@ export async function getDailyStatus(userId) {
     last_daily_won: row?.last_daily_won ?? null,
     daily_bankroll: row?.daily_bankroll ?? 0,
     arcade_bankroll: row?.arcade_bankroll ?? 1000,
-    current_streak: row?.current_streak ?? 0,
+    current_streak: row?.current_streak ?? 0, // PLAY streak (attendance / showing up)
     streak_freezes: row?.streak_freezes ?? 0,
-    today_score: row?.today_score ?? 0
+    today_score: row?.today_score ?? 0,
+    win_streak: row?.win_streak ?? 0 // WIN streak (consecutive solves)
   };
 }
 


### PR DESCRIPTION
Two distinct streaks + the daily leaderboard you asked for.

## Two streaks (both collected)
- **🔥 Play streak** — attendance (days in a row you *played*). The existing streak (drives the home fire); relabeled so it's clearly 'play'.
- **🏆 Win streak** — **new**: consecutive days *solved*. Maintained in `_finalize_daily` (extends on a consecutive-day solve, resets to 0 on a loss). New columns + returned by `get_daily_status`.

## Daily leaderboard redesign
`get_daily_board` now takes a scope — **Everyone / Friends / Group (default Everyone)** — and returns 4 metrics per player: **Cash on Hand** (net worth), **Today's Score**, **🔥 Play streak**, **🏆 Win streak** — ranked within the selected scope. `LeaderboardPanel` shows the 6-column table and defaults to Everyone.

## Verified
Rolled-back (win streak 4→5 on a consecutive solve, →0 on a loss; board returns all 4 metrics) and live (solved today's FAJITAS → ranked #1: Score 520 · 🔥1 · 🏆1 · Cash $2,570). `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)