### PR TITLE
Engraved buttons + sortable daily leaderboard + win streak in profile

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -23,6 +23,29 @@
   let loading = $state(true);
   let error = $state('');
 
+  // Sortable daily columns (client-side). Default: today's score, high → low.
+  /** @type {'name'|'net_worth'|'score'|'play_streak'|'win_streak'} */
+  let sortKey = $state('score');
+  /** @type {'asc'|'desc'} */
+  let sortDir = $state('desc');
+  /** @param {typeof sortKey} k */
+  function setSort(k) {
+    if (sortKey === k) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+    else { sortKey = k; sortDir = k === 'name' ? 'asc' : 'desc'; }
+  }
+  /** @param {typeof sortKey} k */
+  const arrow = (k) => sortKey === k ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+  let sortedRows = $derived.by(() => {
+    if (board !== 'daily') return rows;
+    const dir = sortDir === 'asc' ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      if (sortKey === 'name') return dir * String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' });
+      const av = sortKey === 'score' ? (a.score ?? -Infinity) : Number(a[sortKey] ?? 0);
+      const bv = sortKey === 'score' ? (b.score ?? -Infinity) : Number(b[sortKey] ?? 0);
+      return dir * (av - bv) || String(a.name || '').localeCompare(String(b.name || ''));
+    });
+  });
+
   const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
 
   async function load() {
@@ -85,20 +108,22 @@
     <table>
       <thead>
         <tr>
-          <th>#</th><th>Player</th>
-          {#if board === 'cash'}<th>{period === 'week' ? 'Gained' : 'Cash'}</th>
+          <th>#</th>
+          {#if board === 'cash'}<th>Player</th><th>{period === 'week' ? 'Gained' : 'Cash'}</th>
           {:else}
-            <th class="num" title="Cash on Hand">💰 Cash</th>
-            <th class="num" title="Today's Daily score">Score</th>
-            <th class="num" title="Play streak — days in a row played">🔥 Play</th>
-            <th class="num" title="Win streak — days in a row solved">🏆 Win</th>
+            <th><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}>Player{arrow('name')}</button></th>
+            <th class="num"><button class="sort" class:on={sortKey === 'net_worth'} onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button></th>
+            <th class="num"><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}>Score{arrow('score')}</button></th>
+            <th class="num"><button class="sort" class:on={sortKey === 'play_streak'} onclick={() => setSort('play_streak')}>🔥{arrow('play_streak')}</button></th>
+            <th class="num"><button class="sort" class:on={sortKey === 'win_streak'} onclick={() => setSort('win_streak')}>🏆{arrow('win_streak')}</button></th>
           {/if}
         </tr>
       </thead>
       <tbody>
-        {#each rows as r}
-          <tr class={r.is_me ? 'me' : (r.rank <= 3 ? 'top' : '')}>
-            <td class="rank">{medal(r.rank)}</td>
+        {#each sortedRows as r, i}
+          {@const pos = board === 'daily' ? i + 1 : r.rank}
+          <tr class={r.is_me ? 'me' : (pos <= 3 ? 'top' : '')}>
+            <td class="rank">{medal(pos)}</td>
             <td class="name">
               {#if r.is_me}
                 <button class="name-link" onclick={() => goto('/profile')} style={r.color ? `color:${r.color}` : ''}>You</button>
@@ -157,6 +182,10 @@
   td.metric.neg { color: #fb7185; }
   th.num { text-align: right; }
   th:last-child { text-align: right; }
+  th button.sort { background: none; border: none; padding: 0; margin: 0; cursor: pointer; font: inherit;
+    color: inherit; text-transform: inherit; letter-spacing: inherit; white-space: nowrap; }
+  th button.sort:hover { color: var(--text-muted); }
+  th button.sort.on { color: var(--brand-2); }
   /* tighter cells when the Daily board shows 6 columns */
   th, td { padding: 0.6rem 0.45rem; }
   td.rank { width: 30px; padding-left: 0.5rem; }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2449,20 +2449,23 @@
     justify-content: center;
     gap: 10px;
     text-align: center;
-    padding: 18px 20px;
-    border-radius: 10px;
+    padding: 19px 20px;
+    border-radius: 13px;
     /* silver bullion by default → turns gold on hover */
     background: linear-gradient(177deg, #ffffff 0%, #eef2f6 14%, #c2cbd5 52%, #94a0ad 82%, #76828f 100%);
-    border: 1px solid #828e9c;
+    border: 1px solid #6f7c8a;
     color: #2a3138;
     cursor: pointer;
     overflow: hidden;
     box-shadow:
-      inset 0 2px 1px rgba(255, 255, 255, 0.9),
+      inset 0 2px 1px rgba(255, 255, 255, 0.95),   /* top edge catch-light (raised) */
       inset 0 1px 0 rgba(255, 255, 255, 0.6),
-      inset 0 -3px 6px rgba(70, 85, 100, 0.45),
-      0 5px 12px rgba(0, 0, 0, 0.55),
-      0 0 18px rgba(205, 222, 240, 0.28);
+      inset 0 0 0 1.5px rgba(255, 255, 255, 0.4),   /* bright inner rim */
+      inset 0 0 0 3px rgba(74, 88, 104, 0.22),      /* recessed groove under the rim → engraved panel */
+      inset 0 -4px 7px rgba(64, 78, 94, 0.5),       /* bottom inner shadow (depth) */
+      0 1px 0 rgba(255, 255, 255, 0.28),            /* bottom outer edge highlight */
+      0 6px 13px rgba(0, 0, 0, 0.55),               /* drop shadow */
+      0 0 18px rgba(205, 222, 240, 0.26);           /* soft glow */
     transition: transform 0.16s var(--ease-spring), box-shadow 0.2s, filter 0.2s, color 0.2s, border-color 0.2s;
   }
   /* static polished-metal sheen: glossy top highlight + soft crown glow */
@@ -2529,8 +2532,10 @@
   .menu-card.disabled { opacity: 0.5; cursor: not-allowed; }
   .mc-title {
     position: relative; z-index: 1;
-    font-family: var(--font-display); font-weight: 800; font-size: 1.1rem; letter-spacing: 0.01em;
-    color: #4a3105; text-shadow: 0 1px 0 rgba(255, 248, 200, 0.5);
+    font-family: var(--font-display); font-weight: 800; font-size: 1.1rem; letter-spacing: 0.04em;
+    /* engraved/debossed: dark face, light catch-light on the lower lip, dark inner top */
+    color: #3a4654;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.72), 0 -1px 1px rgba(12, 20, 30, 0.32);
   }
   .mc-stat { position: relative; z-index: 1; font-family: var(--font-display); font-weight: 800; font-size: 0.9rem; color: #6b4a08; }
   /* notification badge — top-right corner of the bar */

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -79,8 +79,10 @@
 
       <div class="sec-title">📅 Daily</div>
       <div class="grid">
-        {@render chip('🔥 ' + (d.daily.current_streak ?? 0), 'Streak')}
-        {@render chip(d.daily.best_streak ?? 0, 'Best streak')}
+        {@render chip('🔥 ' + (d.daily.current_streak ?? 0), 'Play streak')}
+        {@render chip(d.daily.best_streak ?? 0, 'Best play')}
+        {@render chip('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak')}
+        {@render chip(d.daily.best_win_streak ?? 0, 'Best win')}
         {@render chip(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Win rate')}
         {@render chip(d.daily.won ?? 0, 'Dailies won')}
         {@render chip(mult(d.daily.best_multiple), 'Best ×')}


### PR DESCRIPTION
- **Engraved menu buttons**: debossed labels + more edge depth (inset bevel frame, stronger bevels, rounder corners) — captures the metal-button look without an image asset.
- **Sortable daily leaderboard**: tap any column header to sort — Cash / Score / 🔥 Play / 🏆 Win (asc+desc) and Player name both ways alphabetically; rank renumbers to the active sort.
- **Profile Daily stats**: now shows both 🔥 Play streak (+Best) and 🏆 Win streak (+Best).

Verified live. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)