### PR TITLE
Daily Twist as a tappable power-up (no popup, ×1.5 if unused)

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,7 +3,7 @@
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
-import { dailyStart, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyUseTwist, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayResume, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
@@ -86,9 +86,9 @@ export const gameStore = writable(/** @type {GameState} */ ({
   freeReveals: 0, // owned Free Reveal power-ups (daily)
   arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
   arcadeCashedOut: false, // true when the last arcade run ended via "Bank it" (vs bust)
-  modifier: null, // active Daily Twist id (null when you went Pure)
-  twistActive: true, // did you Use today's Twist (true) or Go Pure (false)?
-  bountyMult: 1, // bounty multiplier (1.0 with Twist, 1.5 Pure)
+  modifier: null, // today's Daily Twist power-up id (daily only)
+  twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
+  bountyMult: 1, // bounty multiplier (1.0 once Twist used, else 1.5)
   clue: null, // witty one-line hint for the current puzzle
   challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
@@ -206,9 +206,9 @@ function reconcileDailyBoard(board) {
     gameState: finished ? board.state : 'default',
     dailyResult: board.daily_result ?? prev.dailyResult ?? null,
     dailyLive: board.live ?? prev.dailyLive ?? null,
-    // Twist state: active modifier (null when Pure) + the bounty multiplier.
+    // Daily Twist: the available modifier id + whether you've used it + bounty multiplier.
     modifier: board.modifier !== undefined ? board.modifier : prev.modifier,
-    twistActive: board.twist_active !== undefined ? board.twist_active : (prev.twistActive ?? true),
+    twistUsed: board.twist_used !== undefined ? board.twist_used : (prev.twistUsed ?? false),
     bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1)
   }));
   // Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
@@ -1125,10 +1125,22 @@ export function submitGuess() {
  * No localStorage: the server is the source of truth (and prevents replays).
  * The day's shared modifier is applied server-side at start (no client power-ups).
  */
-export async function fetchDailyGame(useTwist = true) {
+/** Use today's Daily Twist power-up (applies effect, bounty → ×1.0). */
+export async function useDailyTwist() {
+  try {
+    const board = await dailyUseTwist();
+    if (board) { reconcileDailyBoard(board); return true; }
+    return false;
+  } catch (err) {
+    console.error('❌ Error using daily twist:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+export async function fetchDailyGame() {
   try {
     track('daily_start');
-    const board = await dailyStart([], useTwist);
+    const board = await dailyStart([]);
     if (!board) {
       console.error('❌ daily_start returned no board');
       return false;

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -415,9 +415,15 @@ export async function fetchArcadeLeaderboard(period = 'daily') {
  * @param {string[]} [powerups] - pre-game power-ups to activate (only applied on a fresh session)
  * @returns {Promise<object|null>} board
  */
-export async function dailyStart(powerups = [], useTwist = true) {
-  const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups, p_use_twist: useTwist });
+export async function dailyStart(powerups = []) {
+  const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups });
   if (error) { console.error('❌ daily_start error:', error); return null; }
+  return data;
+}
+/** Use today's Daily Twist power-up (applies its effect; bounty drops to ×1.0). */
+export async function dailyUseTwist() {
+  const { data, error } = await supabase.rpc('daily_use_twist');
+  if (error) { console.error('❌ daily_use_twist error:', error); return null; }
   return data;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
   import { supabase } from '$lib/supabaseClient';
   import { get } from 'svelte/store';
 
-  import { gameStore, fetchDailyGame, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -755,21 +755,22 @@
       showStreakMessage = true;  // already solved today → come-back summary
       return;
     }
-    if (inProgress) { await startDaily(true); return; } // resume — Twist choice already locked
-    // Fresh start → ask: Use today's Twist, or Go Pure for a ×1.5 bounty?
-    fx('tap');
-    try { dailyTwistMod = await getDailyModifier(); } catch { dailyTwistMod = null; }
-    showDailyTwist = true;
+    // Today's Twist is auto-given on the board — no pre-game popup. Just play.
+    await startDaily();
   }
 
-  // Pre-game "Use the Twist or Go Pure" choice (locked once you start).
-  let showDailyTwist = false;
-  /** @type {string|null} */
-  let dailyTwistMod = null;
-  async function startDaily(useTwist = true) {
-    showDailyTwist = false;
+  // Use today's Daily Twist power-up (tap the tray slot).
+  let dailyTwistBusy = false;
+  async function useTwist() {
+    if (dailyTwistBusy || $gameStore.twistUsed) return;
+    dailyTwistBusy = true;
+    fx('select');
+    await useDailyTwist();
+    dailyTwistBusy = false;
+  }
+  async function startDaily() {
     localStorage.setItem('gameMode', 'daily');
-    const ok = await fetchDailyGame(useTwist);
+    const ok = await fetchDailyGame();
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
@@ -1173,33 +1174,6 @@
           on:keydown={(e) => { if (e.key === 'Enter') sendMatchChat(); }} />
         <button class="chat-send" on:click={sendMatchChat} disabled={matchChatBusy || !matchChatInput.trim()}>Send</button>
       </div>
-    </div>
-  </div>
-{/if}
-
-<!-- 🎲 Daily: Use today's Twist or Go Pure (×1.5 bounty) — locked at start -->
-{#if showDailyTwist}
-  {@const m = dailyTwistMod ? modifierInfo(dailyTwistMod) : null}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Today's Daily Twist">
-    <div class="modal-content twist-modal">
-      <h2 class="tw-title">Today’s Daily Twist</h2>
-      {#if m}
-        <div class="tw-mod">
-          <span class="tw-emoji">{m.emoji}</span>
-          <span class="tw-name">{m.name}</span>
-          <span class="tw-blurb">{m.blurb}</span>
-        </div>
-      {/if}
-      <p class="tw-q">Use the Twist, or go Pure for a bigger bounty?</p>
-      <div class="tw-actions">
-        <button class="tw-opt use" on:click={() => startDaily(true)}>
-          <strong>✅ Use it</strong><small>{m ? m.blurb : 'today’s help'}</small>
-        </button>
-        <button class="tw-opt pure" on:click={() => startDaily(false)}>
-          <strong>🎯 Go Pure</strong><small>no help · bounty <b>×1.5</b></small>
-        </button>
-      </div>
-      <p class="tw-hint">Locked in once you start.</p>
     </div>
   </div>
 {/if}
@@ -1790,8 +1764,6 @@
     <!-- 🌍 Category + today's modifier chip + witty clue -->
     <div class="puzzle-meta">
       {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
-      {#if dailyMod}<span class="mod-chip" title={dailyMod.name + ' — ' + dailyMod.blurb}>{dailyMod.emoji} {dailyMod.name}</span>
-      {:else if $gameStore.gameMode === 'daily' && $gameStore.twistActive === false}<span class="mod-chip pure" title="No Twist — bounty ×1.5">🎯 Pure · ×1.5</span>{/if}
     </div>
     {#if $gameStore.clue}
       <p class="puzzle-clue">{$gameStore.clue}</p>
@@ -1844,6 +1816,16 @@
     <section class="buttons-section">
       <GameButtons />
     </section>
+
+    <!-- ⚡ Power-up tray (Daily: today's Twist — tap to use, or keep it for ×1.5) -->
+    {#if $gameStore.gameMode === 'daily' && dailyMod && !$gameStore.twistUsed && gameActive}
+      <section class="pu-tray">
+        <button class="pu-slot" disabled={dailyTwistBusy} on:click={useTwist} title={dailyMod.name + ' — ' + dailyMod.blurb}>
+          <span class="pu-emoji">{dailyMod.emoji}</span>
+        </button>
+        <span class="pu-hint">{dailyMod.name} · tap to use, or keep it for <b>×1.5</b></span>
+      </section>
+    {/if}
 
     <!-- ⌨️ Keyboard Section (keyboard disables itself via gameStore state) -->
     <section class="keyboard-section">
@@ -2218,6 +2200,16 @@
     width: 100%;
     padding: 0;
   }
+  /* ⚡ Power-up tray (above the keyboard) */
+  .pu-tray { display: flex; align-items: center; justify-content: center; gap: 10px; margin: 8px auto 6px; max-width: 360px; }
+  .pu-slot { position: relative; width: 50px; height: 50px; border-radius: 12px; display: grid; place-items: center; cursor: pointer;
+    border: 1px solid rgba(253, 224, 71, 0.55); background: linear-gradient(135deg, rgba(251, 191, 36, 0.2), rgba(251, 191, 36, 0.05));
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2); animation: puPulse 1.8s ease-in-out infinite; }
+  .pu-slot:disabled { opacity: 0.5; cursor: default; animation: none; }
+  @keyframes puPulse { 0%,100% { box-shadow: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 0 rgba(251,191,36,0.5); } 50% { box-shadow: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 5px rgba(251,191,36,0); } }
+  .pu-emoji { font-size: 1.5rem; line-height: 1; }
+  .pu-hint { font-size: 0.72rem; color: var(--text-muted); max-width: 200px; }
+  .pu-hint b { color: #6ee7b7; }
 
   .diagnostic-banner {
     background: #ffebee;
@@ -2634,22 +2626,6 @@
   @keyframes chatPulse { 0%,100% { box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 0 rgba(244,63,94,0.5); } 50% { box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 6px rgba(244,63,94,0); } }
   .mcb-label { font-family: var(--font-display); font-size: 0.84rem; }
   .mc-dot { position: absolute; top: 3px; right: 3px; width: 10px; height: 10px; border-radius: 999px; background: #f43f5e; box-shadow: 0 0 0 2px var(--bg, #0a0e14); }
-  .twist-modal { max-width: 380px; text-align: center; }
-  .tw-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 0.7rem; }
-  .tw-mod { display: flex; flex-direction: column; align-items: center; gap: 2px; padding: 0.9rem; margin: 0 0 0.9rem;
-    border-radius: 14px; border: 1px solid rgba(253,224,71,0.4); background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.03)); }
-  .tw-emoji { font-size: 1.8rem; line-height: 1; }
-  .tw-name { font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--brand-2); }
-  .tw-blurb { font-size: 0.82rem; color: var(--text-muted); }
-  .tw-q { font-size: 0.9rem; color: var(--text); margin: 0 0 0.9rem; }
-  .tw-actions { display: flex; gap: 0.6rem; }
-  .tw-opt { flex: 1; display: flex; flex-direction: column; gap: 3px; padding: 0.85rem 0.6rem; border-radius: 13px; cursor: pointer; border: 1px solid var(--border-strong, var(--border)); background: var(--surface-2, rgba(255,255,255,0.05)); color: var(--text); }
-  .tw-opt strong { font-family: var(--font-display); font-size: 0.98rem; }
-  .tw-opt small { font-size: 0.72rem; color: var(--text-muted); line-height: 1.3; }
-  .tw-opt small b { color: #6ee7b7; }
-  .tw-opt.use { border-color: rgba(253,224,71,0.5); }
-  .tw-opt.pure { border-color: rgba(110,231,183,0.5); background: linear-gradient(135deg, rgba(16,185,129,0.12), rgba(16,185,129,0.03)); }
-  .tw-hint { font-size: 0.68rem; color: var(--text-faint); margin: 0.8rem 0 0; }
   .welcome-modal { max-width: 380px; text-align: center; }
   .wc-coin { display: block; margin: 0 auto 0.5rem; }
   .wc-title { font-family: var(--font-display); font-size: 1.4rem; margin: 0 0 0.35rem; }


### PR DESCRIPTION
Phase 2a of the Daily redesign.

- **No more pre-game popup** — the day's Twist is auto-given and shown as a **power-up slot above the keyboard** (emoji + pulse + hint).
- **Bounty is ×1.5 until you use it.** Tap the Twist → applies its effect (instant reveals, or turns on the pricing modifier) and drops to **×1.0**; the slot disappears. Keep it → ×1.5.
- Backend: `twist_used` on daily_sessions, new `daily_use_twist()` RPC, buy_letter pricing + reward gated on `twist_used`, dropped a stale `daily_start` overload that caused an ambiguity error.
- Plus the prior layout pass: centered bankroll chip, green 'Solve to Earn' (no 🏆), category centered with the modifier chip removed.

**Still to come:** carry-the-unused-Twist into your cross-mode inventory (2b), the full 3-left/3-right-of-Solve tray geometry, and the slot-machine animations (Phase 3).

Verified live: no popup; tap reveals + bounty $780→$520 (×1.5→×1.0). `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)