### PR TITLE
Daily opening reveal: box-by-box landing → bounty count-up ×1.5

### DIFF
--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -2,8 +2,47 @@
   import { gameStore } from '$lib/stores/GameStore.js';
   import { onDestroy, createEventDispatcher } from 'svelte';
   import { getGlobalIndex } from '$lib/helpers/gameUtils.js';
+  import { fx } from '$lib/sound.js';
 
   const dispatch = createEventDispatcher();
+
+  // 🎰 Daily opening reveal: each empty space lands one-by-one (shake + money signs
+  // + green plus + a landing thunk), then +page counts the bounty up in green. Driven
+  // by gameStore.dailyIntro, which bumps once on a fresh daily open.
+  const INTRO_STEP = 0.12; // seconds between box landings
+  let introActive = false;
+  let introToken = 0;
+  /** @type {ReturnType<typeof setTimeout>[]} */
+  let introTimers = [];
+  /** @param {number} gi */
+  const introDelay = (gi) => Math.min(gi, 16) * INTRO_STEP;
+
+  $: maybeStartIntro($gameStore.dailyIntroGo);
+  /** @param {number|undefined} tok */
+  function maybeStartIntro(tok) {
+    if (!tok || tok === introToken) return;
+    introToken = tok;
+    runIntro();
+  }
+  function runIntro() {
+    const phrase = $gameStore.currentPhrase || '';
+    /** @type {number[]} */
+    const idxs = [];
+    for (let i = 0; i < phrase.length; i++) if (phrase[i] !== ' ') idxs.push(i);
+    if (!idxs.length) return;
+    introTimers.forEach(clearTimeout);
+    introTimers = [];
+    introActive = true;
+    let lastDelay = 0;
+    for (const gi of idxs) {
+      const d = introDelay(gi);
+      lastDelay = Math.max(lastDelay, d);
+      introTimers.push(setTimeout(() => fx('land'), d * 1000 + 30));
+    }
+    // Climax: the spaces "add up × the multiplier" into the green bounty.
+    introTimers.push(setTimeout(() => { fx('multiplier'); dispatch('introDone'); }, lastDelay * 1000 + 160));
+    introTimers.push(setTimeout(() => { introActive = false; }, lastDelay * 1000 + 950));
+  }
 
   // 📤 Reactive State Setup
 
@@ -65,7 +104,7 @@
     wonFired = false;
   }
 
-  onDestroy(() => clearInterval(revealInterval));
+  onDestroy(() => { clearInterval(revealInterval); introTimers.forEach(clearTimeout); });
 
   // 🎯 Active Guess Slot Logic
   $: activeGuessIndex = $gameStore.gameState === 'guess_mode'
@@ -116,14 +155,20 @@
           {:else}
             {@const gi = getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)}
             {@const won = $gameStore.gameState === 'won'}
-            <span class="letter-box {shakeIndexes.has(gi) ? 'shake' : ''} {won ? 'win' : ''}"
-              style={won ? `animation-delay:${Math.min(gi, 14) * 0.095}s` : ''}>
+            {@const intro = introActive && !won}
+            <span class="letter-box {shakeIndexes.has(gi) ? 'shake' : ''} {won ? 'win' : ''} {intro ? 'intro' : ''}"
+              style={won ? `animation-delay:${Math.min(gi, 14) * 0.095}s` : intro ? `animation-delay:${introDelay(gi)}s` : ''}>
               {$gameStore.purchasedLetters[gi] || ""}
               {#if won}
                 <span class="coin c1" style="animation-delay:{Math.min(gi, 14) * 0.095}s">$</span>
                 <span class="coin c2" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.07}s">$</span>
                 <span class="coin c3" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.04}s">$</span>
                 <span class="plus" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.13}s">+</span>
+              {:else if intro}
+                <span class="coin c1" style="animation-delay:{introDelay(gi) + 0.18}s">$</span>
+                <span class="coin c2" style="animation-delay:{introDelay(gi) + 0.25}s">$</span>
+                <span class="coin c3" style="animation-delay:{introDelay(gi) + 0.22}s">$</span>
+                <span class="plus" style="animation-delay:{introDelay(gi) + 0.28}s">+</span>
               {/if}
             </span>
           {/if}
@@ -151,6 +196,20 @@
   }
   .shake {
     animation: shake 2s ease-in-out;
+  }
+
+  /* 🎰 Daily opening reveal: each empty space drops in, rattles, and lands hard */
+  .letter-box.intro {
+    animation: introPop 0.62s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    z-index: 1;
+  }
+  @keyframes introPop {
+    0%   { opacity: 0; transform: translateY(-34px) scale(0.35) rotate(-9deg); }
+    45%  { opacity: 1; transform: translateY(5px) scale(1.22) rotate(5deg);
+           border-color: #4ade80; box-shadow: 0 0 0 3px rgba(74,222,128,0.5), 0 0 22px rgba(74,222,128,0.6); }
+    60%  { transform: translateY(0) scale(0.94) rotate(-3deg); }
+    74%  { transform: translateY(0) scale(1.06) rotate(2deg); }
+    100% { opacity: 1; transform: translateY(0) scale(1) rotate(0deg); }
   }
 
   /* 🎰 Win reveal: each tile pops with green money, staggered left→right */

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -86,6 +86,11 @@ const SOUNDS = {
   },
   wrong: () => tone(150, 0.2, 'sawtooth', 0.11),
   reveal: () => sweep(420, 1150, 0.24, 'triangle', 0.13),
+  // Box landing thunk for the daily opening reveal: a low knock + a bright coin ping.
+  land: () => {
+    tone(180, 0.08, 'square', 0.13);
+    tone(1180, 0.09, 'sine', 0.09, 0.03);
+  },
   win: () => [523, 659, 784, 1047].forEach((f, i) => tone(f, 0.2, 'sine', 0.16, i * 0.09)),
   bust: () => sweep(440, 80, 0.55, 'sawtooth', 0.16),
   multiplier: () => {
@@ -114,6 +119,7 @@ const HAPTICS = {
   correct: [14],
   wrong: [22, 36, 22],
   reveal: [12],
+  land: [10],
   win: [18, 40, 18, 40, 36],
   bust: [60, 30, 60],
   multiplier: [10, 24, 10],

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -95,7 +95,9 @@ export const gameStore = writable(/** @type {GameState} */ ({
   climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
   matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
   cashToast: null, // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
-  dailyLive: null // { spent, clean, no_vowels, first_try, reward, net } — live Daily HUD metrics
+  dailyLive: null, // { spent, clean, no_vowels, first_try, reward, net } — live Daily HUD metrics
+  dailyIntro: 0, // bumps on a FRESH daily open → ARMS the opening reveal (pending)
+  dailyIntroGo: 0 // bumps once the board is actually visible → PLAYS the opening reveal
 }));
 
 /* ================================
@@ -1150,6 +1152,10 @@ export async function fetchDailyGame() {
     const ab = /** @type {any} */ (board);
     if (ab.attendance != null && ab.attendance > 0) {
       gameStore.update(s => ({ ...s, cashToast: { amount: ab.attendance, label: `Day ${ab.attendance_day} streak · for showing up` } }));
+    }
+    // 🎰 Fresh open (first time today, board still active) → play the opening reveal.
+    if (ab.state === 'active' && ab.attendance != null && ab.attendance > 0) {
+      gameStore.update(s => ({ ...s, dailyIntro: (s.dailyIntro || 0) + 1 }));
     }
     try { const clue = await getDailyClue(); gameStore.update(s => ({ ...s, clue })); } catch { /* non-fatal */ }
     console.log('✅ Daily session started/resumed');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -346,7 +346,39 @@
   const tweenBank = tweened(0, { duration: 550, easing: cubicOut });
   const tweenNet = tweened(0, { duration: 650, easing: cubicOut });
   $: tweenBank.set(Math.round($gameStore.bankroll ?? 0));
-  $: tweenNet.set(soloHero ? Math.round(soloHero.net) : 0);
+  // While the opening reveal is landing boxes, hold the bounty at $0 so it can
+  // dramatically count up at the climax (introDone).
+  $: tweenNet.set(introBuilding ? 0 : (soloHero ? Math.round(soloHero.net) : 0));
+
+  // 🎰 Daily opening reveal coordination (boxes land → bounty counts up × multiplier).
+  // fetchDailyGame ARMS it (dailyIntro token); we only PLAY it once the board is
+  // actually on screen — i.e. the "How to win" card is dismissed — by bumping
+  // dailyIntroGo, which PhraseDisplay watches.
+  let introBuilding = false;
+  let _introFired = 0;
+  let introCountPop = false;
+  let showIntroMult = false;
+  // Play the armed opening reveal — but only when the board is truly on screen
+  // (no objective card up, not on the menu). Called from dismissObjective and,
+  // when the card is suppressed, right after the board renders.
+  function playDailyIntroIfArmed() {
+    const tok = get(gameStore).dailyIntro;
+    if (!browser || !tok || tok === _introFired) return;
+    if (objective || showMainMenu) return;
+    _introFired = tok;
+    introBuilding = true;
+    tweenNet.set(0, { duration: 0 });
+    gameStore.update((s) => ({ ...s, dailyIntroGo: (s.dailyIntroGo || 0) + 1 }));
+  }
+  function onDailyIntroDone() {
+    introBuilding = false; // releases the reactive above → bounty counts 0 → net
+    introCountPop = true;
+    setTimeout(() => { introCountPop = false; }, 800);
+    if (($gameStore.bountyMult ?? 1) > 1) {
+      showIntroMult = true;
+      setTimeout(() => { showIntroMult = false; }, 1500);
+    }
+  }
   let _prevBank = /** @type {number|null} */ (null);
   let _floatId = 0;
   /** @type {{id:number,text:string}[]} */
@@ -758,6 +790,7 @@
   function dismissObjective() {
     if (objective && browser && SOLO_MODES.includes(objective.mode)) localStorage.setItem('wb_obj_' + objective.mode, '1');
     objective = null;
+    tick().then(playDailyIntroIfArmed); // board is now visible → play the opening reveal
   }
 
   // Detect entering a game from the menu (latch flips once per entry).
@@ -820,6 +853,11 @@
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
+      // If the "How to win" card is suppressed (already seen), the board is now
+      // visible — play the opening reveal once reactives settle. If the card DOES
+      // show, this no-ops (objective set) and the reveal fires on its dismiss.
+      await tick();
+      playDailyIntroIfArmed();
     } else {
       initError = "Daily puzzle failed to load.";
     }
@@ -1828,7 +1866,7 @@
 
     <!-- 🔤 Phrase Display -->
     <section class="phrase-section">
-      <PhraseDisplay on:revealComplete={onPhraseRevealComplete} />
+      <PhraseDisplay on:revealComplete={onPhraseRevealComplete} on:introDone={onDailyIntroDone} />
     </section>
 
     <!-- 🏳️ Give up (Daily + Challenges + Free Play) · broke-timer is Daily/Challenge only -->
@@ -1846,9 +1884,10 @@
     <section class="stats-section">
       {#if soloHero}
         <!-- Daily · Makeup · Cash Game: the number you keep if you solve now (bankroll is up top) -->
-        <div class="bounty-panel" class:loss={soloHero.net < 0}>
+        <div class="bounty-panel" class:loss={soloHero.net < 0} class:count-pop={introCountPop}>
           <span class="bp-label">{soloHero.net >= 0 ? 'Solve to Earn' : '⚠️ You’re losing money'}</span>
           <span class="bp-amount">{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</span>
+          {#if showIntroMult}<span class="bp-mult">×{$gameStore.bountyMult}</span>{/if}
           {#each spendFloaters as f (f.id)}<span class="spend-float">{f.text}</span>{/each}
         </div>
       {:else if isFreeplay}
@@ -3113,6 +3152,29 @@
   .bp-amount { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.3rem; line-height: 1.05; color: #4ade80;
     text-shadow: 0 0 18px rgba(52,211,153,0.5); font-variant-numeric: tabular-nums; transition: color 0.2s; }
   .bounty-panel.loss .bp-amount { color: #fb7185; text-shadow: none; }
+  /* 🎰 Opening-reveal climax: bounty number pops + glows as it counts up */
+  .bounty-panel.count-pop { animation: bountyGlow 0.8s ease-out; }
+  .bounty-panel.count-pop .bp-amount { animation: bountyCount 0.8s cubic-bezier(0.34, 1.56, 0.64, 1); }
+  @keyframes bountyGlow {
+    0%   { box-shadow: 0 0 22px rgba(251,191,36,0.16); }
+    35%  { box-shadow: 0 0 16px 4px rgba(74,222,128,0.6), 0 0 40px rgba(74,222,128,0.4); border-color: rgba(74,222,128,0.7); }
+    100% { box-shadow: 0 0 22px rgba(251,191,36,0.16); }
+  }
+  @keyframes bountyCount {
+    0%   { transform: scale(0.7); opacity: 0.5; }
+    45%  { transform: scale(1.32); text-shadow: 0 0 30px rgba(74,222,128,0.95); }
+    100% { transform: scale(1); }
+  }
+  /* the ×multiplier that flies in beside the bounty at the climax */
+  .bp-mult { position: absolute; right: 14px; top: 50%; pointer-events: none;
+    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.5rem; color: #fde047;
+    text-shadow: 0 0 16px rgba(251,191,36,0.85); animation: bpMultIn 1.5s cubic-bezier(0.2,0.9,0.3,1) forwards; }
+  @keyframes bpMultIn {
+    0%   { opacity: 0; transform: translate(28px, -50%) scale(2.2) rotate(12deg); }
+    20%  { opacity: 1; transform: translate(0, -50%) scale(1) rotate(0deg); }
+    78%  { opacity: 1; transform: translate(0, -50%) scale(1); }
+    100% { opacity: 0; transform: translate(0, -50%) scale(0.85); }
+  }
   /* floating -$X spend feedback by the green number */
   .spend-float { position: absolute; right: 16px; top: 8px; pointer-events: none;
     font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.05rem; color: #fb7185;


### PR DESCRIPTION
When the Daily starts, each empty space lands one-by-one (shake + green money signs + green plus + a landing thunk), then the spaces "add up × the multiplier" as the green Solve-to-Earn bounty counts up from \$0 and the ×1.5 flies in beside it.

The reveal fires only once the board is actually visible — after the "How to win" card is dismissed, or right after the board renders when that card is suppressed — never behind the card. Verified live frame-by-frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)