### PR TITLE
Slow daily opening reveal; remove Winner banner + confetti

### DIFF
--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -9,7 +9,7 @@
   // 🎰 Daily opening reveal: each empty space lands one-by-one (shake + money signs
   // + green plus + a landing thunk), then +page counts the bounty up in green. Driven
   // by gameStore.dailyIntro, which bumps once on a fresh daily open.
-  const INTRO_STEP = 0.12; // seconds between box landings
+  const INTRO_STEP = 0.34; // seconds between box landings (slow, dramatic)
   let introActive = false;
   let introToken = 0;
   /** @type {ReturnType<typeof setTimeout>[]} */
@@ -40,8 +40,8 @@
       introTimers.push(setTimeout(() => fx('land'), d * 1000 + 30));
     }
     // Climax: the spaces "add up × the multiplier" into the green bounty.
-    introTimers.push(setTimeout(() => { fx('multiplier'); dispatch('introDone'); }, lastDelay * 1000 + 160));
-    introTimers.push(setTimeout(() => { introActive = false; }, lastDelay * 1000 + 950));
+    introTimers.push(setTimeout(() => { fx('multiplier'); dispatch('introDone'); }, lastDelay * 1000 + 420));
+    introTimers.push(setTimeout(() => { introActive = false; }, lastDelay * 1000 + 1900));
   }
 
   // 📤 Reactive State Setup
@@ -200,15 +200,17 @@
 
   /* 🎰 Daily opening reveal: each empty space drops in, rattles, and lands hard */
   .letter-box.intro {
-    animation: introPop 0.62s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    animation: introPop 0.92s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
     z-index: 1;
   }
   @keyframes introPop {
-    0%   { opacity: 0; transform: translateY(-34px) scale(0.35) rotate(-9deg); }
-    45%  { opacity: 1; transform: translateY(5px) scale(1.22) rotate(5deg);
-           border-color: #4ade80; box-shadow: 0 0 0 3px rgba(74,222,128,0.5), 0 0 22px rgba(74,222,128,0.6); }
-    60%  { transform: translateY(0) scale(0.94) rotate(-3deg); }
-    74%  { transform: translateY(0) scale(1.06) rotate(2deg); }
+    0%   { opacity: 0; transform: translateY(-40px) scale(0.3) rotate(-10deg); }
+    24%  { opacity: 1; transform: translateY(6px) scale(1.24) rotate(6deg);
+           border-color: #4ade80; box-shadow: 0 0 0 3px rgba(74,222,128,0.55), 0 0 24px rgba(74,222,128,0.65); }
+    40%  { transform: translateY(0) scale(0.92) rotate(-4deg); }
+    54%  { transform: translateY(0) scale(1.08) rotate(3deg); }
+    68%  { transform: translateY(0) scale(0.97) rotate(-1.5deg);
+           box-shadow: 0 0 0 2px rgba(74,222,128,0.4), 0 0 16px rgba(74,222,128,0.45); }
     100% { opacity: 1; transform: translateY(0) scale(1) rotate(0deg); }
   }
 

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -215,7 +215,7 @@ function reconcileDailyBoard(board) {
   }));
   // Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
   // not when re-opening an already-completed daily (which comes back 'won' with no result).
-  if (board.state === 'won') { if (board.daily_result) { setTimeout(() => launchConfetti(), 300); fx('win'); } }
+  if (board.state === 'won') { if (board.daily_result) { fx('win'); } } // no confetti — the slot-machine reveal is the celebration
   else if (finished) fx('bust');
   else playMoveCue(prev, board);
   // analytics: fire once, only on the actual solve transition

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -344,7 +344,7 @@
   // 🎰 Slot-machine money feel: count up/down the bankroll + the green "Solve to Earn",
   // and float a -$X by the number each time you spend.
   const tweenBank = tweened(0, { duration: 550, easing: cubicOut });
-  const tweenNet = tweened(0, { duration: 650, easing: cubicOut });
+  const tweenNet = tweened(0, { duration: 900, easing: cubicOut });
   $: tweenBank.set(Math.round($gameStore.bankroll ?? 0));
   // While the opening reveal is landing boxes, hold the bounty at $0 so it can
   // dramatically count up at the climax (introDone).
@@ -373,10 +373,10 @@
   function onDailyIntroDone() {
     introBuilding = false; // releases the reactive above → bounty counts 0 → net
     introCountPop = true;
-    setTimeout(() => { introCountPop = false; }, 800);
+    setTimeout(() => { introCountPop = false; }, 1200);
     if (($gameStore.bountyMult ?? 1) > 1) {
       showIntroMult = true;
-      setTimeout(() => { showIntroMult = false; }, 1500);
+      setTimeout(() => { showIntroMult = false; }, 2200);
     }
   }
   let _prevBank = /** @type {number|null} */ (null);
@@ -1928,11 +1928,8 @@
       <Keyboard />
     </section>
 
-    <!-- 🏆 Game Outcome Banner -->
-    {#if $gameStore.gameState === "won"}
-      <div class="win-burst" aria-hidden="true"></div>
-      <div class="banner win">Winner!</div>
-    {:else if $gameStore.gameState === "lost"}
+    <!-- 🏆 Game Outcome Banner (win celebration handled by the slot-machine reveal) -->
+    {#if $gameStore.gameState === "lost"}
       <div class="banner lose">Bankrupt!</div>
     {/if}
 
@@ -3153,8 +3150,8 @@
     text-shadow: 0 0 18px rgba(52,211,153,0.5); font-variant-numeric: tabular-nums; transition: color 0.2s; }
   .bounty-panel.loss .bp-amount { color: #fb7185; text-shadow: none; }
   /* 🎰 Opening-reveal climax: bounty number pops + glows as it counts up */
-  .bounty-panel.count-pop { animation: bountyGlow 0.8s ease-out; }
-  .bounty-panel.count-pop .bp-amount { animation: bountyCount 0.8s cubic-bezier(0.34, 1.56, 0.64, 1); }
+  .bounty-panel.count-pop { animation: bountyGlow 1.1s ease-out; }
+  .bounty-panel.count-pop .bp-amount { animation: bountyCount 1.1s cubic-bezier(0.34, 1.56, 0.64, 1); }
   @keyframes bountyGlow {
     0%   { box-shadow: 0 0 22px rgba(251,191,36,0.16); }
     35%  { box-shadow: 0 0 16px 4px rgba(74,222,128,0.6), 0 0 40px rgba(74,222,128,0.4); border-color: rgba(74,222,128,0.7); }
@@ -3168,11 +3165,12 @@
   /* the ×multiplier that flies in beside the bounty at the climax */
   .bp-mult { position: absolute; right: 14px; top: 50%; pointer-events: none;
     font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.5rem; color: #fde047;
-    text-shadow: 0 0 16px rgba(251,191,36,0.85); animation: bpMultIn 1.5s cubic-bezier(0.2,0.9,0.3,1) forwards; }
+    text-shadow: 0 0 16px rgba(251,191,36,0.85); animation: bpMultIn 2.2s cubic-bezier(0.2,0.9,0.3,1) forwards; }
   @keyframes bpMultIn {
     0%   { opacity: 0; transform: translate(28px, -50%) scale(2.2) rotate(12deg); }
-    20%  { opacity: 1; transform: translate(0, -50%) scale(1) rotate(0deg); }
-    78%  { opacity: 1; transform: translate(0, -50%) scale(1); }
+    14%  { opacity: 1; transform: translate(0, -50%) scale(1.15) rotate(0deg); }
+    24%  { transform: translate(0, -50%) scale(1); }
+    85%  { opacity: 1; transform: translate(0, -50%) scale(1); }
     100% { opacity: 0; transform: translate(0, -50%) scale(0.85); }
   }
   /* floating -$X spend feedback by the green number */


### PR DESCRIPTION
- Opening reveal slowed way down (stagger 0.12→0.34s, landing 0.62→0.92s, longer climax holds, count-up 650→900ms).
- Removed the redundant "Winner!" banner + burst and the daily-solve confetti — the slot-machine tile reveal is the celebration now.

Verified live: WIN_BANNER 0, CANVAS 0 (no confetti), reveal visibly slower.

🤖 Generated with [Claude Code](https://claude.com/claude-code)