### PR TITLE
Daily Twist carry-over: keep it → cross-mode power-up

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1961,6 +1961,9 @@
               {#if dailyPlacement && dailyPlacement.rank > 0 && dailyPlacement.total > 1}
                 <p class="daily-placement">{dailyPlacement.rank === 1 ? '🥇' : dailyPlacement.rank === 2 ? '🥈' : dailyPlacement.rank === 3 ? '🥉' : '🏅'} #{dailyPlacement.rank} of {dailyPlacement.total} among friends today</p>
               {/if}
+              {#if !$gameStore.twistUsed && dailyMod}
+                <p class="twist-kept">🎟️ You kept your <b>{dailyMod.name}</b> Twist — it's now a power-up for Cash Game &amp; Challenges</p>
+              {/if}
             {:else}
               <div class="result-bankroll">
                 <span class="rb-label">Banked</span>
@@ -3493,6 +3496,9 @@
   .ds-amount.lose { color: #fb7185; text-shadow: 0 0 18px rgba(251,113,133,0.35); }
   .ds-cash { font-size: 0.8rem; color: var(--text-muted); }
   .daily-placement { font-family: var(--font-display); font-weight: 700; font-size: 0.9rem; color: #fcd34d; margin: 0 0 14px; }
+  .twist-kept { font-size: 0.82rem; line-height: 1.35; color: #6ee7b7; margin: 0 0 14px; padding: 8px 12px;
+    background: rgba(110,231,183,0.1); border: 1px solid rgba(110,231,183,0.32); border-radius: 12px; }
+  .twist-kept b { color: #a7f3d0; }
   .ghost-compare {
     margin: 2px auto 16px;
     padding: 10px 14px;

--- a/supabase-daily-twist-carryover.sql
+++ b/supabase-daily-twist-carryover.sql
@@ -1,0 +1,45 @@
+-- 🎟️ Daily Twist cross-mode carry-over  (applied via MCP migration `daily_twist_carryover`)
+--
+-- Solving the Daily WITHOUT using the Twist already pays a ×1.5 bounty. Now it also
+-- BANKS the Twist as a usable power-up in Cash Game & Challenges.
+--
+-- Design (low-risk): map each Daily Twist (the weekday modifier from _daily_modifier())
+-- to an existing ACTIVE cross-mode power-up id, then grant it into the v2 'cash' pool
+-- via _award_powerup(uid, id, 'cash'). The client already surfaces 'cash'-pool power-ups
+-- in Cash Game (ownedClimb) and Challenges (ownedSelf) through get_powerups(), so no
+-- money-handling RPCs change and the grant is usable immediately.
+--
+-- Grant fires only on WIN + Twist-not-used (ties it to the same reward as ×1.5, and
+-- avoids fold-farming). Hooked inside _finalize_daily's p_won branch, reusing the
+-- v_used (daily_sessions.twist_used) it already reads for _daily_reward_eff.
+--
+-- Twist → power-up map:
+--   free_vowel     -> free_vowel     (exact)
+--   vowel_vision   -> vowel_vision   (exact)
+--   discount       -> half_off
+--   consonant_sale -> half_off
+--   flat_rate      -> extra_hint
+--   head_start     -> free_reveal
+--   insured        -> last_letters
+--
+-- See the migration for the full _finalize_daily body; the mapping helper:
+CREATE OR REPLACE FUNCTION public._twist_powerup(p_mod text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT CASE p_mod
+    WHEN 'free_vowel'     THEN 'free_vowel'
+    WHEN 'vowel_vision'   THEN 'vowel_vision'
+    WHEN 'discount'       THEN 'half_off'
+    WHEN 'consonant_sale' THEN 'half_off'
+    WHEN 'flat_rate'      THEN 'extra_hint'
+    WHEN 'head_start'     THEN 'free_reveal'
+    WHEN 'insured'        THEN 'last_letters'
+    ELSE NULL
+  END;
+$$;
+REVOKE EXECUTE ON FUNCTION public._twist_powerup(text) FROM anon, authenticated, PUBLIC;
+
+-- Inside _finalize_daily, in the `IF p_won THEN` branch (after the flawless badge):
+--   IF NOT COALESCE(v_used, false) THEN
+--     v_grant := public._twist_powerup(public._daily_modifier());
+--     IF v_grant IS NOT NULL THEN PERFORM public._award_powerup(p_uid, v_grant, 'cash'); END IF;
+--   END IF;


### PR DESCRIPTION
Solving the Daily without using the Twist now banks it as a usable power-up in Cash Game & Challenges (on top of the ×1.5 bounty).

Each weekday Twist maps to an existing active cross-mode power-up, granted into the v2 'cash' pool inside `_finalize_daily` (win + !twist_used). No money-handling RPCs change — the client already surfaces 'cash'-pool power-ups in both modes.

Verified live: pure solve → `free_vowel` granted; `get_powerups()` returns it as owned. Result modal notes the reward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)