### PR TITLE
Menu/HUD polish: arrow flip, grayed done-Daily, green resume cards

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1238,7 +1238,7 @@
 {/if}
 <!-- 🏳️ Give up (top-right) — Daily / Challenges / Free Play -->
 {#if loggedIn && hasInitialized && !showMainMenu && (foldMode || isFreeplay) && gameActive}
-  <button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↩</button>
+  <button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
 {/if}
 
 <!-- 💬 Match chat (1v1 + group challenges) — only inside a live match, never on the menu -->
@@ -1421,21 +1421,25 @@
           <h2 class="sub-title">Play</h2>
         </div>
         <div class="main-menu-buttons stagger">
-          <button class="menu-card" class:done={dailyDone} style="--i: 0" on:click={handleMenuDaily}>
+          <button class="menu-card" class:done={dailyDone} class:resumable={dailyInProgress} style="--i: 0" on:click={handleMenuDaily}>
             <span class="mc-title">{dailyInProgress ? 'Resume Daily' : 'Daily'}</span>
             {#if dailyDone}
-              <span class="daily-chip {dailyStatus?.last_daily_won ? 'won' : 'lost'}">{dailyStatus?.last_daily_won ? `✅ Solved${dailyStatus?.today_score ? ' · +' + dailyStatus.today_score.toLocaleString() : ''}` : '❌ Didn’t solve'}</span>
+              {#if dailyStatus?.last_daily_won}
+                <span class="daily-chip won">✅ +${(dailyStatus?.today_score ?? 0).toLocaleString()}</span>
+              {:else}
+                <span class="daily-chip lost">❌{dailyStatus?.today_score ? ' −$' + Math.abs(dailyStatus.today_score).toLocaleString() : ''}</span>
+              {/if}
             {:else if dailyInProgress}
-              <span class="daily-chip prog">Resume</span>
+              <span class="daily-chip prog">▶ Resume</span>
             {/if}
           </button>
-          <button class="menu-card" style="--i: 1" on:click={handleMenuClimb}>
+          <button class="menu-card" class:resumable={climbInProgress} style="--i: 1" on:click={handleMenuClimb}>
             <span class="mc-title">Cash Game</span>
-            {#if climbInProgress}<span class="daily-chip prog">Resume</span>{/if}
+            {#if climbInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
           </button>
-          <button class="menu-card" style="--i: 2" on:click={handleMenuFreeplay}>
+          <button class="menu-card" class:resumable={freeplayInProgress} style="--i: 2" on:click={handleMenuFreeplay}>
             <span class="mc-title">{freeplayInProgress ? 'Resume Free Play' : 'Free Play'}</span>
-            {#if freeplayInProgress}<span class="daily-chip prog">Resume</span>{/if}
+            {#if freeplayInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
           </button>
           <button class="menu-card" style="--i: 3" on:click={() => { blitzSoon = true; fx('tap'); setTimeout(() => blitzSoon = false, 2500); }}>
             <span class="mc-title">Blitz</span><span class="mc-stat">Soon</span>
@@ -2650,10 +2654,33 @@
     font-size: 0.68rem; font-weight: 800; padding: 3px 9px; border-radius: 999px; white-space: nowrap;
     border: 1px solid var(--border); background: rgba(0,0,0,0.25); color: var(--text);
   }
-  /* solid fills so chips read clearly on the silver buttons */
-  .daily-chip.won   { color: #3a2a00; border-color: rgba(217,160,20,0.8); background: linear-gradient(135deg, #fde047, #f59e0b); box-shadow: 0 1px 6px rgba(245,158,11,0.45); }
+  /* solid fills so chips read clearly */
+  .daily-chip.won   { color: #052e16; border-color: rgba(22,163,74,0.85); background: linear-gradient(135deg, #4ade80, #16a34a); box-shadow: 0 1px 6px rgba(22,163,74,0.5); }
   .daily-chip.lost  { color: #fff; border-color: rgba(225,80,100,0.85); background: linear-gradient(135deg, #fb7185, #e11d48); box-shadow: 0 1px 6px rgba(225,29,72,0.45); text-shadow: 0 1px 1px rgba(0,0,0,0.25); }
   .daily-chip.prog  { color: #fff; border-color: rgba(5,150,105,0.85); background: linear-gradient(135deg, #34d399, #059669); box-shadow: 0 1px 6px rgba(5,150,105,0.5); text-shadow: 0 1px 1px rgba(0,0,0,0.25); }
+
+  /* ✅ Completed Daily — grayed-out plate (no chrome shine), result chip shows the score */
+  .menu-card.done {
+    background: linear-gradient(180deg, #39414c 0%, #2b323b 100%);
+    border-color: #49525e;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), inset 0 -2px 4px rgba(0,0,0,0.4), 0 3px 8px rgba(0,0,0,0.45);
+  }
+  .menu-card.done::before, .menu-card.done::after { display: none; } /* kill chrome sheen + shine streak */
+  .menu-card.done .mc-title {
+    background: linear-gradient(180deg, #aeb7c2, #7f8893); -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
+  }
+  /* ▶ Resumable mode — clean green accent instead of the gold chrome */
+  .menu-card.resumable {
+    background: linear-gradient(180deg, #16352b 0%, #0f2a22 100%);
+    border-color: rgba(16,185,129,0.55);
+    box-shadow: inset 0 1px 0 rgba(110,231,183,0.18), inset 0 0 0 1px rgba(16,185,129,0.25), 0 4px 12px rgba(0,0,0,0.5), 0 0 16px rgba(16,185,129,0.18);
+  }
+  .menu-card.resumable::before, .menu-card.resumable::after { display: none; }
+  .menu-card.resumable .mc-title {
+    background: linear-gradient(180deg, #d1fae5, #6ee7b7); -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
+  }
   .progress-modes { border-left-color: rgba(251,191,36,0.3); }
   .mc-arrow { color: var(--text-faint); font-size: 1.1rem; transition: transform 0.2s, color 0.2s; }
   .mc-count {


### PR DESCRIPTION
- Give-up arrow flipped to ↪
- Completed Daily card grays out + green ✅ +$score (win) / red ❌ −$lost (loss)
- Resumable cards → clean green plate + ▶ Resume (no gold chrome)

Verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)