### PR TITLE
Win-streak bounty multiplier + green-glow tiles

### DIFF
--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -159,7 +159,6 @@
             <span class="letter-box {shakeIndexes.has(gi) ? 'shake' : ''} {won ? 'win' : ''} {intro ? 'intro' : ''}"
               style={won ? `animation-delay:${Math.min(gi, 14) * 0.095}s` : intro ? `animation-delay:${introDelay(gi)}s` : ''}>
               {$gameStore.purchasedLetters[gi] || ""}
-              <span class="tile-dollar" aria-hidden="true">$</span>
               {#if won}
                 <span class="coin c1" style="animation-delay:{Math.min(gi, 14) * 0.095}s">$</span>
                 <span class="coin c2" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.07}s">$</span>
@@ -227,10 +226,6 @@
     60%  { transform: scale(1.12) rotate(4deg); }
     100% { transform: scale(1); }
   }
-  /* subtle green $ in each tile's corner — every slot carries value toward the bounty */
-  .tile-dollar { position: absolute; bottom: 2px; right: 4px; pointer-events: none; z-index: 2;
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.62rem; line-height: 1;
-    color: #4ade80; opacity: 0.55; text-shadow: 0 0 5px rgba(74,222,128,0.5); }
   .coin, .plus { position: absolute; pointer-events: none; left: 50%; font-family: 'Orbitron', var(--font-display);
     font-weight: 800; color: #4ade80; text-shadow: 0 0 8px rgba(74,222,128,0.7); opacity: 0; }
   .coin { top: 6px; font-size: 0.9rem; animation: coinSpray 0.75s ease-out backwards; }
@@ -293,7 +288,7 @@
     align-items: center;
     justify-content: center;
     text-align: center;
-    border: 1px solid var(--border);
+    border: 1px solid rgba(74, 222, 128, 0.32);
     background: var(--surface);
     font-family: var(--font-display);
     font-size: 22px;
@@ -301,7 +296,8 @@
     border-radius: 11px;
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.05),
-      0 2px 8px rgba(0, 0, 0, 0.3);
+      0 2px 8px rgba(0, 0, 0, 0.3),
+      0 0 9px rgba(74, 222, 128, 0.16);
     color: var(--text);
     backdrop-filter: blur(8px);
     box-sizing: border-box;

--- a/supabase-daily-winstreak-multiplier.sql
+++ b/supabase-daily-winstreak-multiplier.sql
@@ -1,0 +1,25 @@
+-- ⭐ Win-streak bounty multiplier (migration `daily_winstreak_multiplier`, 2026-06-25)
+--
+-- The Daily bounty is multiplied by your WIN streak (consecutive solves):
+--   bounty_mult = 1.0 + min(0.1 × win_streak, 0.5)   → ×1.5 cap at a 5-win streak.
+-- Uses the streak COMING IN (today not yet solved) so the gold ×N badge shown at
+-- puzzle start matches the payout. Win streak chosen over play streak because play
+-- streak already pays attendance $; the bounty bonus rewards actually solving.
+--
+-- New helpers:
+CREATE OR REPLACE FUNCTION public._daily_bounty_mult(p_uid uuid)
+ RETURNS numeric LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT 1.0 + LEAST(0.1 * GREATEST(0, COALESCE(
+    (SELECT CASE WHEN last_daily_solve_date >= CURRENT_DATE - 1 THEN current_solve_streak ELSE 0 END
+     FROM public.profiles WHERE id = p_uid), 0)), 0.5);
+$$;
+CREATE OR REPLACE FUNCTION public._daily_reward_final(p_uid uuid, p_pid uuid)
+ RETURNS integer LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT (round(public._daily_reward(p_pid) * public._daily_bounty_mult(p_uid) / 10.0) * 10)::int;
+$$;
+-- daily_start / _daily_resolve_and_return / _finalize_daily now use _daily_reward_final
+-- for the bounty and emit bounty_mult = _daily_bounty_mult(uid). (daily_start keeps the
+-- test1 auto-replay hook; _finalize_daily keeps the Twist carry-over.) The flat ×1.0
+-- _daily_reward_eff is now unused for the bounty.
+--
+-- NEXT: Bounty Boost power-ups (active, bought) that STACK on top of this streak bonus.


### PR DESCRIPTION
The gold ×N badge now does something: the Daily bounty is multiplied by your win streak (+0.1× per consecutive solve, capped +0.5× / ×1.5 at 5 wins), applied to the displayed bounty and the payout. Tiles get a subtle green glow instead of the $ corner.

Verified (rolled back): $520 base → ×1.4 $730 at streak 4, ×1.5 $780 capped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)