### PR TITLE
Bounty Boost power-ups (buy + tap to multiply the Daily bounty)

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,7 +3,7 @@
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
-import { dailyStart, dailyUseTwist, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyUseTwist, dailyUseBoost, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
 import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayResume, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
@@ -1135,6 +1135,18 @@ export async function useDailyTwist() {
     return false;
   } catch (err) {
     console.error('❌ Error using daily twist:', err instanceof Error ? err.message : String(err));
+    return false;
+  }
+}
+
+/** Spend an owned Bounty Boost on today's Daily (bumps the bounty multiplier). */
+export async function useDailyBoost(id) {
+  try {
+    const board = await dailyUseBoost(id);
+    if (board) { reconcileDailyBoard(board); return true; }
+    return false;
+  } catch (err) {
+    console.error('❌ Error using daily boost:', err instanceof Error ? err.message : String(err));
     return false;
   }
 }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -427,6 +427,13 @@ export async function dailyUseTwist() {
   return data;
 }
 
+/** Spend an owned Bounty Boost on today's Daily (adds to the bounty multiplier). */
+export async function dailyUseBoost(id) {
+  const { data, error } = await supabase.rpc('daily_use_boost', { p_id: id });
+  if (error) { console.error('❌ daily_use_boost error:', error); return null; }
+  return data;
+}
+
 /* ===== Make-up daily (play a past missed day in the current month) =====
    No streak repair, no Bank deposit — fills the calendar + earns week/month badges.
    Each returns a daily board with an extra { makeup: { date } } marker. */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
 
-  import { gameStore, fetchDailyGame, useDailyTwist, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -836,18 +836,37 @@
 
   // ⚡ Power-up hotbar feed. Daily: today's Twist (mode allows only the Twist).
   // Cash Game / Challenges will feed mode-eligible inventory power-ups here later.
-  $: trayPowerups = ($gameStore.gameMode === 'daily' && dailyMod && !$gameStore.twistUsed && gameActive)
-    ? [{ id: 'twist', emoji: dailyMod.emoji, name: dailyMod.name, blurb: dailyMod.blurb, count: 1 }]
+  // Daily hotbar = today's Twist (if unused) + any owned Bounty Boosts you carry.
+  /** @type {{id:string,emoji:string,name:string,blurb:string,count:number}[]} */
+  let dailyBoosts = [];
+  const BOOST_META = /** @type {Record<string,{emoji:string,blurb:string}>} */ ({
+    bounty_boost: { emoji: '💥', blurb: 'Adds ×0.5 to your bounty' },
+    jackpot_boost: { emoji: '💎', blurb: 'Adds ×1.0 to your bounty' }
+  });
+  async function loadDailyBoosts() {
+    try {
+      const r = await getPowerups();
+      dailyBoosts = (r.items ?? [])
+        .filter((/** @type {any} */ i) => i.kind === 'daily' && (i.owned ?? 0) > 0)
+        .map((/** @type {any} */ i) => ({ id: i.id, emoji: BOOST_META[i.id]?.emoji ?? '💥', name: i.name, blurb: BOOST_META[i.id]?.blurb ?? '', count: i.owned }));
+    } catch { dailyBoosts = []; }
+  }
+  $: trayPowerups = ($gameStore.gameMode === 'daily' && gameActive)
+    ? [
+        ...((dailyMod && !$gameStore.twistUsed) ? [{ id: 'twist', emoji: dailyMod.emoji, name: dailyMod.name, blurb: dailyMod.blurb, count: 1 }] : []),
+        ...dailyBoosts
+      ]
     : [];
   /** @param {CustomEvent<any>} e */
   function onUsePowerup(e) {
     const item = e.detail;
     if (item?.id === 'twist') { useTwist(); return; }
-    // (cross-mode inventory power-ups will route here per game mode)
+    if (item?.id === 'bounty_boost' || item?.id === 'jackpot_boost') { useBoost(item.id); return; }
   }
 
   // Use today's Daily Twist power-up (tap the tray slot).
   let dailyTwistBusy = false;
+  let dailyBoostBusy = false;
   async function useTwist() {
     if (dailyTwistBusy || $gameStore.twistUsed) return;
     dailyTwistBusy = true;
@@ -855,12 +874,22 @@
     await useDailyTwist();
     dailyTwistBusy = false;
   }
+  /** @param {string} id */
+  async function useBoost(id) {
+    if (dailyBoostBusy) return;
+    dailyBoostBusy = true;
+    fx('multiplier');
+    await useDailyBoost(id);
+    await loadDailyBoosts();
+    dailyBoostBusy = false;
+  }
   async function startDaily() {
     localStorage.setItem('gameMode', 'daily');
     const ok = await fetchDailyGame();
     if (ok) {
       hasInitialized = true;
       showMainMenu = false;
+      loadDailyBoosts(); // surface any owned Bounty Boosts in the hotbar
       // If the "How to win" card is suppressed (already seen), the board is now
       // visible — play the opening reveal once reactives settle. If the card DOES
       // show, this no-ops (objective set) and the reveal fires on its dismiss.
@@ -1930,7 +1959,7 @@
 
     <!-- ⚡ Power-up hotbar: 2 slots each side of Solve, page through mode-eligible inventory -->
     {#if gameActive}
-      <PowerupHotbar items={trayPowerups} busy={dailyTwistBusy} on:use={onUsePowerup} />
+      <PowerupHotbar items={trayPowerups} busy={dailyTwistBusy || dailyBoostBusy} on:use={onUsePowerup} />
     {/if}
 
     <!-- ⌨️ Keyboard Section (keyboard disables itself via gameStore state) -->

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -27,11 +27,15 @@
     sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" },
     sabotage_toll:        { icon: '🚧', desc: "An opponent's next letter costs 3×" },
     sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
-    sabotage_lock:        { icon: '🔒', desc: 'Wipe a letter an opponent revealed' }
+    sabotage_lock:        { icon: '🔒', desc: 'Wipe a letter an opponent revealed' },
+    bounty_boost:  { icon: '💥', desc: 'Adds ×0.5 to your Daily bounty' },
+    jackpot_boost: { icon: '💎', desc: 'Adds ×1.0 to your Daily bounty' }
   });
 
   /** @type {any[]} */
   let sabs = $state([]);
+  /** @type {any[]} */
+  let dboost = $state([]);
 
   /** @type {any|null} */
   let cashout = $state(null);
@@ -42,6 +46,7 @@
     items = shop.items;
     pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
     sabs = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'sabotage');
+    dboost = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'daily');
     cashout = co;
   }
 
@@ -134,6 +139,27 @@
     <p class="loading">Loading…</p>
   {:else}
     {#if msg}<p class="msg">{msg}</p>{/if}
+
+    {#if dboost.length}
+      <h2 class="section">💥 Bounty Boosts</h2>
+      <p class="section-note">Stock up, then tap them in the Daily to multiply your bounty — they stack on your win-streak multiplier (carry up to 5 of each).</p>
+      <div class="grid">
+        {#each dboost as item}
+          <div class="card pup" class:owned={item.owned > 0}>
+            <span class="pup-ic">{PUP_META[item.id]?.icon ?? '💥'}</span>
+            <span class="c-label">{item.name}{#if item.owned > 0} <span class="owned-x">×{item.owned}</span>{/if}</span>
+            <span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
+            {#if item.owned >= 5}
+              <button class="c-btn equip on" disabled>✓ Maxed (5)</button>
+            {:else}
+              <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buyPup(item)}>
+                💰 ${item.price.toLocaleString()}
+              </button>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
 
     <h2 class="section">⚡ Power-ups</h2>
     <p class="section-note">Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like — the Daily stays power-up-free.</p>
@@ -240,6 +266,7 @@
   .co-btn:disabled { opacity: 0.5; cursor: default; }
   .co-pending { font-size: 0.78rem; color: var(--text-muted); text-align: right; }
   .co-note { font-size: 0.72rem; color: var(--text-faint); margin: 0.6rem 0 0; line-height: 1.35; }
+  .owned-x { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.78rem; color: #fde047; }
   .section { font-family: var(--font-display); font-size: 1.05rem; margin: 1.4rem 0 0.4rem; }
   .section-note { font-size: 0.76rem; color: var(--text-faint); margin: 0 0 0.8rem; }
   .card.pup { align-items: center; text-align: center; gap: 0.3rem; }

--- a/supabase-daily-bounty-boost.sql
+++ b/supabase-daily-bounty-boost.sql
@@ -1,0 +1,16 @@
+-- 💥 Bounty Boost power-ups (migrations `daily_bounty_boost_powerup` + `buy_powerup_stackable_daily`)
+--
+-- Active, owned consumables that ADD to the Daily bounty multiplier, stacking on the
+-- win-streak bonus (total capped ×3.0):
+--   bounty_boost  (+0.5×, $300)   jackpot_boost (+1.0×, $800)
+--
+-- - daily_sessions.bounty_boost numeric: this session's accumulated boost.
+-- - powerups: two kind='daily' entries (only surface in the Daily hotbar + a Store section).
+-- - _daily_bounty_mult(uid) = 1.0 + win-streak bonus (≤0.5) + session bounty_boost, cap 3.0.
+-- - daily_use_boost(p_id): consumes 1 from the 'cash' pool, adds to daily_sessions.bounty_boost,
+--   returns the resolved board. Guards: must be active, must own ≥1, mult < 3.0.
+-- - buy_powerup: kind='daily' items stack up to 5 (others stay one-of-each).
+--
+-- Client: GameStore.useDailyBoost + statsStore.dailyUseBoost; +page loads owned boosts
+-- (getPowerups, kind='daily') into the hotbar next to the Twist and routes use → useDailyBoost;
+-- Store gains a "💥 Bounty Boosts" section.


### PR DESCRIPTION
Active consumables that stack on the win-streak multiplier (cap ×3.0): Bounty Boost (+0.5×, $300), Jackpot (+1.0×, $800).

- daily_sessions.bounty_boost + two kind='daily' catalog entries; `_daily_bounty_mult` adds the session boost; `daily_use_boost` RPC; `buy_powerup` stacks daily items to 5.
- Hotbar surfaces owned boosts beside the Twist; Store gains a Bounty Boosts section.

Verified (rolled back): ×1.4 → ×1.9, $730 → $990, consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)