### PR TITLE
Cash Game Double or Nothing, multi-game Resume, and Daily loss-model rework

### DIFF
--- a/scripts/check-daily-resume.mjs
+++ b/scripts/check-daily-resume.mjs
@@ -1,0 +1,60 @@
+// Regression for "Daily shows complete+lost after playing another mode".
+// Injects the exact bug state via psql: today's Daily session is ACTIVE (started,
+// not won) while the local save slot does NOT point at the Daily (empty = the
+// clobbered-by-Cash-Game case). Then loads the menu and checks the Daily card.
+//   BUG:   ❌ lost chip (.daily-chip.lost) + title "Daily"
+//   FIXED: ▶ Resume chip (.daily-chip.prog) + title "Resume Daily"
+//   BASE=http://localhost:5173 node scripts/check-daily-resume.mjs
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const DB = process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots', { recursive: true });
+const sql = (q) => execSync(`psql "${DB}" -tAc "${q.replace(/"/g, '\\"')}"`, { encoding: 'utf8' }).trim();
+
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 }, deviceScaleFactor: 2 })).newPage();
+p.setDefaultTimeout(8000);
+const wait = (ms) => p.waitForTimeout(ms);
+const skipPin = async () => { await p.getByText(/skip for now/i).first().click({ timeout: 1500 }).catch(()=>{}); await wait(600); };
+const skipTut = async () => { for (let i=0;i<3;i++){ await p.getByText('Skip', { exact: true }).first().click({ timeout: 900 }).catch(()=>{}); await wait(400); } };
+
+try {
+  const uid = sql(`SELECT id FROM auth.users WHERE email='${EMAIL}'`);
+  // Inject the bug state: started today's Daily, still ACTIVE, not won.
+  sql(`UPDATE public.profiles SET username=COALESCE(username,'pwtest_wb'), last_daily_play_date=CURRENT_DATE WHERE id='${uid}'`);
+  sql(`DELETE FROM public.game_results WHERE user_id='${uid}' AND game_mode='daily' AND played_at::date=CURRENT_DATE`);
+  sql(`INSERT INTO public.daily_sessions(user_id, puzzle_date, puzzle_id, state) SELECT '${uid}', CURRENT_DATE, (SELECT id FROM public.daily_puzzles LIMIT 1), 'active' ON CONFLICT (user_id, puzzle_date) DO UPDATE SET state='active'`);
+  console.log('server:', sql(`SELECT 'played='||(last_daily_play_date=CURRENT_DATE) FROM public.profiles WHERE id='${uid}'`), '|', sql(`SELECT 'session='||state FROM public.daily_sessions WHERE user_id='${uid}' AND puzzle_date=CURRENT_DATE`));
+
+  await p.goto(BASE, { waitUntil: 'domcontentloaded' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);
+    await p.locator('input[type=password]').first().fill(PASS);
+    await p.getByRole('button', { name: /^log in$/i }).first().click().catch(()=>{}); await wait(2800);
+  }
+  // Ensure the local save slot is NOT a daily-in-progress (the clobbered case).
+  await p.evaluate((u) => localStorage.removeItem('wordbank_game_state_' + u), uid);
+  await skipPin();
+
+  // Open Play Now → game-select submenu (clear PIN/tutorial gates if they appear).
+  for (let i = 0; i < 4 && !(await p.locator('.menu-card', { hasText: 'Daily' }).count()); i++) {
+    await p.getByRole('button', { name: /play now/i }).first().click().catch(()=>{});
+    await skipPin(); await skipTut(); await wait(1000);
+  }
+
+  const lost = await p.locator('.daily-chip.lost').count();
+  const resume = await p.locator('.daily-chip.prog').count();
+  const title = await p.locator('.menu-card', { hasText: 'Daily' }).locator('.mc-title').first().innerText().catch(()=>'?');
+  console.log(`RESULT → Daily card title="${title}" | ❌lost chip=${lost} | ▶resume chip=${resume}`);
+  console.log(resume > 0 && lost === 0 ? '✅ FIXED: active Daily shown as resumable' : (lost > 0 ? '❌ BUG: active Daily shown as lost' : '⚠️ inconclusive (card not found)'));
+  await p.screenshot({ path: 'screenshots/daily-resume-menu.png' });
+
+  // cleanup: remove the injected session
+  sql(`DELETE FROM public.daily_sessions WHERE user_id='${uid}' AND puzzle_date=CURRENT_DATE; UPDATE public.profiles SET last_daily_play_date=NULL WHERE id='${uid}'`);
+} catch (e) { console.log('FATAL', e.message); await p.screenshot({ path: 'screenshots/daily-resume-fatal.png' }).catch(()=>{}); }
+finally { await b.close(); }

--- a/scripts/check-don.mjs
+++ b/scripts/check-don.mjs
@@ -1,0 +1,75 @@
+// Visual check: Double or Nothing CTA + armed state + run line + Cash Game leaderboard tab.
+// Logs in as the shared pwtest account, opens Cash Game (creates climb_state), then the
+// caller injects heat≥1.5 via psql and we reload to surface the DoN UI. Run:
+//   BASE=http://localhost:5173 node scripts/check-don.mjs
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const DB = process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots', { recursive: true });
+const sql = (q) => execSync(`psql "${DB}" -tAc "${q.replace(/"/g, '\\"')}"`, { encoding: 'utf8' }).trim();
+
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 }, deviceScaleFactor: 2 })).newPage();
+p.setDefaultTimeout(8000);
+const wait = (ms) => p.waitForTimeout(ms);
+const dismiss = async () => { for (const s of ['.close-btn', '.wc-cta', 'button:has-text("Got it")', 'button:has-text("Skip")']) { await p.locator(s).first().click({ timeout: 800 }).catch(()=>{}); } };
+const letsGo = async () => { await p.getByRole('button', { name: /let.?s go/i }).first().click({ timeout: 2000 }).catch(()=>{}); await wait(1500); };
+
+try {
+  // Make sure the shared test account has a username so it clears the gate → menu.
+  const uid0 = sql(`SELECT id FROM auth.users WHERE email='${EMAIL}'`);
+  sql(`UPDATE public.profiles SET username = COALESCE(username, 'pwtest_wb') WHERE id='${uid0}'`);
+
+  await p.goto(BASE, { waitUntil: 'domcontentloaded' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);
+    await p.locator('input[type=password]').first().fill(PASS);
+    await p.getByRole('button', { name: /^log in$/i }).first().click().catch(()=>{}); await wait(2800);
+  }
+  await dismiss(); await wait(400);
+
+  // Open Cash Game (ensures a climb_state row exists for the account).
+  await p.getByRole('button', { name: /play now/i }).first().click().catch(()=>{}); await wait(900);
+  await p.getByRole('button', { name: /cash game/i }).first().click().catch(()=>{}); await wait(2600);
+  await dismiss(); await letsGo();
+
+  const uid = sql(`SELECT id FROM auth.users WHERE email='${EMAIL}'`);
+  console.log('uid:', uid);
+  // Inject a hot run so DoN unlocks (heat ×1.6, 4-solve run, +$1,200).
+  sql(`UPDATE public.climb_state SET heat_x100=160, run_solves=4, run_profit=1200, best_run_profit=1200, best_run_solves=4, don_armed=false, state='active' WHERE user_id='${uid}'`);
+
+  // Reload Cash Game to pull the fresh board.
+  await p.goto(BASE, { waitUntil: 'domcontentloaded' }); await wait(600); await dismiss();
+  await p.getByRole('button', { name: /play now/i }).first().click().catch(()=>{}); await wait(900);
+  await p.getByRole('button', { name: /cash game/i }).first().click().catch(()=>{}); await wait(2600); await dismiss(); await letsGo();
+
+  const ctaSeen = await p.locator('.don-cta').count();
+  const runSeen = await p.locator('.climb-run-line').count();
+  console.log('DoN CTA visible:', ctaSeen, '| run line visible:', runSeen);
+  await p.screenshot({ path: 'screenshots/don-cta.png' });
+
+  // Arm Double or Nothing → modal → confirm → armed indicator.
+  if (ctaSeen) {
+    await p.locator('.don-cta').first().click(); await wait(500);
+    await p.screenshot({ path: 'screenshots/don-modal.png' });
+    await p.locator('.don-confirm').first().click().catch(()=>{}); await wait(1800);
+    const armedSeen = await p.locator('.don-armed').count();
+    console.log('Armed indicator visible:', armedSeen);
+    await p.screenshot({ path: 'screenshots/don-armed.png' });
+  }
+
+  // Leaderboard → Cash Game tab.
+  await p.goto(BASE + '/leaderboard', { waitUntil: 'domcontentloaded' }); await wait(1200);
+  await p.getByRole('button', { name: /cash game/i }).first().click().catch(()=>{}); await wait(1400);
+  await p.screenshot({ path: 'screenshots/leaderboard-cashgame.png' });
+
+  // Reset the test account's heat so we don't leave it armed/hot.
+  sql(`UPDATE public.climb_state SET heat_x100=100, run_solves=0, run_profit=0, don_armed=false WHERE user_id='${uid}'`);
+  console.log('done');
+} catch (e) { console.log('FATAL', e.message); await p.screenshot({ path: 'screenshots/don-fatal.png' }).catch(()=>{}); }
+finally { await b.close(); }

--- a/scripts/check-resume.mjs
+++ b/scripts/check-resume.mjs
@@ -1,0 +1,51 @@
+// Verify the multi-game Resume shortcut: with an active Daily AND active Cash Game,
+// the home menu shows "▶ Resume <most-recent>" + "+1 more in progress", driven by
+// server truth (get_open_games), independent of the localStorage save slot.
+//   BASE=http://localhost:5173 node scripts/check-resume.mjs
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5173';
+const EMAIL = 'pwtest+wb@example.com', PASS = 'TestPass123!';
+const DB = process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots', { recursive: true });
+const sql = (q) => execSync(`psql "${DB}" -tAc "${q.replace(/"/g, '\\"')}"`, { encoding: 'utf8' }).trim();
+
+const b = await chromium.launch();
+const p = await (await b.newContext({ viewport: { width: 430, height: 900 }, deviceScaleFactor: 2 })).newPage();
+p.setDefaultTimeout(8000);
+const wait = (ms) => p.waitForTimeout(ms);
+const skipPin = async () => { await p.getByText(/skip for now/i).first().click({ timeout: 1500 }).catch(()=>{}); await wait(600); };
+const skipTut = async () => { for (let i=0;i<3;i++){ await p.getByText('Skip', { exact: true }).first().click({ timeout: 900 }).catch(()=>{}); await wait(400); } };
+
+try {
+  const uid = sql(`SELECT id FROM auth.users WHERE email='${EMAIL}'`);
+  // Two live games: active Daily (most recent) + active Cash Game.
+  sql(`UPDATE public.profiles SET username=COALESCE(username,'pwtest_wb'), last_daily_play_date=CURRENT_DATE WHERE id='${uid}'`);
+  sql(`INSERT INTO public.climb_state(user_id, position, puzzle_id, state) SELECT '${uid}', 1, (SELECT id FROM public.daily_puzzles LIMIT 1), 'active' ON CONFLICT (user_id) DO UPDATE SET state='active', updated_at=now() - interval '5 min'`);
+  sql(`INSERT INTO public.daily_sessions(user_id, puzzle_date, puzzle_id, state) SELECT '${uid}', CURRENT_DATE, (SELECT id FROM public.daily_puzzles LIMIT 1), 'active' ON CONFLICT (user_id, puzzle_date) DO UPDATE SET state='active', updated_at=now()`);
+  console.log('open games (server):', sql(`SELECT string_agg(state,',') FROM (SELECT state FROM daily_sessions WHERE user_id='${uid}' AND puzzle_date=CURRENT_DATE UNION ALL SELECT state FROM climb_state WHERE user_id='${uid}') q`));
+
+  await p.goto(BASE, { waitUntil: 'domcontentloaded' }); await wait(700);
+  await p.evaluate(() => localStorage.setItem('wb_tutorial_seen', 'true'));
+  if (await p.locator('input[type=password]').count()) {
+    await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);
+    await p.locator('input[type=password]').first().fill(PASS);
+    await p.getByRole('button', { name: /^log in$/i }).first().click().catch(()=>{}); await wait(2800);
+  }
+  await p.evaluate((u) => localStorage.removeItem('wordbank_game_state_' + u), uid); // clobbered slot
+  await skipPin(); await skipTut(); await wait(800);
+
+  // Home menu — the Resume card should be present without entering Play.
+  const hasResume = await p.locator('.resume-card').count();
+  const resumeText = await p.locator('.resume-card .mc-title').first().innerText().catch(()=>'?');
+  const moreText = await p.locator('.resume-more').first().innerText().catch(()=>'');
+  console.log(`RESULT → resume-card=${hasResume} | title="${resumeText}" | more="${moreText}"`);
+  console.log(hasResume > 0 && /resume/i.test(resumeText) ? '✅ Resume shortcut shown' : '⚠️ Resume shortcut missing');
+  await p.screenshot({ path: 'screenshots/resume-home.png' });
+
+  // cleanup
+  sql(`DELETE FROM public.daily_sessions WHERE user_id='${uid}' AND puzzle_date=CURRENT_DATE; UPDATE public.profiles SET last_daily_play_date=NULL WHERE id='${uid}'`);
+} catch (e) { console.log('FATAL', e.message); await p.screenshot({ path: 'screenshots/resume-fatal.png' }).catch(()=>{}); }
+finally { await b.close(); }

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -63,6 +63,8 @@
 {/if}
 
 <div class="main-button-wrapper">
+  <!-- Optional left accessory (e.g. Cash Game vault). Absolutely positioned so Solve stays centered. -->
+  <slot name="left" />
   {#if dualButtonMode}
     <div class="dual-button-container">
       <button

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -3,13 +3,14 @@
   // Community ▸ Leaderboard tab. The page/hub provides its own title + back.
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getWealthLeaderboard, getDailyBoard, getMyGroups } from '$lib/stores/statsStore.js';
+  import { getWealthLeaderboard, getDailyBoard, getClimbRunLeaderboard, getMyGroups } from '$lib/stores/statsStore.js';
 
-  /** @type {'cash'|'daily'} */
+  /** @type {'cash'|'daily'|'cash_game'} */
   let board = $state('cash');
   const TABS = [
     { k: 'cash', label: '💰 Cash' },
-    { k: 'daily', label: '📅 Daily' }
+    { k: 'daily', label: '📅 Daily' },
+    { k: 'cash_game', label: '🎰 Cash Game' }
   ];
   const PERIOD_BOARDS = ['cash'];
   /** scope: 'global' (Everyone) | 'friends' | a group id */
@@ -55,6 +56,7 @@
       const sc = isGroup ? 'group' : scope;
       const grp = isGroup ? scope : null;
       if (board === 'cash') rows = await getWealthLeaderboard(sc, period, grp);
+      else if (board === 'cash_game') rows = await getClimbRunLeaderboard(sc, grp);
       else rows = await getDailyBoard(sc, grp);
     } catch (e) {
       error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
@@ -94,6 +96,7 @@
 
 <p class="caption">
   {#if board === 'cash'}{period === 'week' ? 'Cash gained this week' : 'Richest players — total Cash'}
+  {:else if board === 'cash_game'}Biggest Cash Game run — most profit banked in one heat streak
   {:else}Ranked by today's Daily score · {scope === 'global' ? 'everyone' : scope === 'friends' ? 'your friends' : 'this group'}{/if}
 </p>
 
@@ -110,6 +113,7 @@
         <tr>
           <th>#</th>
           {#if board === 'cash'}<th>Player</th><th>{period === 'week' ? 'Gained' : 'Cash'}</th>
+          {:else if board === 'cash_game'}<th>Player</th><th class="num">Best run</th><th class="num">Streak</th>
           {:else}
             <th><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}>Player{arrow('name')}</button></th>
             <th class="num"><button class="sort" class:on={sortKey === 'net_worth'} onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button></th>
@@ -136,6 +140,9 @@
               <td class="metric" class:neg={period === 'week' && Number(r.metric) < 0}>
                 {period === 'week' ? (r.metric >= 0 ? '+' : '') + fmt(r.metric) : fmt(r.net_worth)}
               </td>
+            {:else if board === 'cash_game'}
+              <td class="metric gold">{fmt(r.best_run_profit)}</td>
+              <td class="metric small">{r.best_run_solves > 0 ? '🔥' + r.best_run_solves : '—'}</td>
             {:else}
               <td class="metric">{fmt(r.net_worth)}</td>
               <td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
@@ -151,6 +158,7 @@
 
 <p class="hint">
   {#if board === 'cash'}Your total Cash, earned across every mode. The weekly view resets Monday — fair for newcomers.
+  {:else if board === 'cash_game'}Your best single run — profit banked before your heat reset. Build a streak, push your luck with Double or Nothing.
   {:else}Same puzzle for everyone today. Spend less, score more.{/if}
 </p>
 

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,7 +8,7 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
 import { freeplayStart, freeplayNext, freeplayResume, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
+import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, climbDoubleOrNothing, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
 import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchFold as matchFoldRpc, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
@@ -716,6 +716,19 @@ export async function climbSkipPuzzle() {
   try {
     const board = await climbSkip();
     if (board) { reconcileClimbBoard(board); maybeArmClimbIntro(); await refreshClimbClue(); }
+  } finally {
+    dailyInFlight = false;
+  }
+}
+
+/** Arm Double-or-Nothing on the current Cash Game puzzle (heat ≥ ×1.5).
+ *  Solve → payout doubles; get stuck → $0 and you forfeit your spend. You can't skip once armed. */
+export async function climbArmDoubleOrNothing() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const board = await climbDoubleOrNothing();
+    if (board) reconcileClimbBoard(board);
   } finally {
     dailyInFlight = false;
   }

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,7 +8,7 @@ import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNe
 import { freeplayStart, freeplayNext, freeplayResume, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
+import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
 import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchFold as matchFoldRpc, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
@@ -630,8 +630,18 @@ function reconcileClimbBoard(board) {
     modifier: null, arcadeRun: null,
     climbInfo: climb
   }));
-  if (solved) { setTimeout(() => launchConfetti(), 250); fx('win'); }
+  // No confetti — the slot-machine reveal (box-by-box win pop) is the celebration, like Daily.
+  if (solved) { fx('win'); }
   else playMoveCue(prev, board);
+}
+
+/** Arm the dramatic opening reveal for a FRESH (untouched) climb puzzle. */
+function maybeArmClimbIntro() {
+  const s = get(gameStore);
+  const hasProgress = (s.purchasedLetters || []).some(Boolean) || (s.climbInfo?.spent ?? 0) > 0;
+  if (!hasProgress && s.gameState === 'default') {
+    gameStore.update(st => ({ ...st, dailyIntro: (st.dailyIntro || 0) + 1 }));
+  }
 }
 
 /** Start or resume the Climb. @returns {Promise<boolean>} */
@@ -641,6 +651,7 @@ export async function fetchClimbGame() {
     const board = await climbStart();
     if (!board) return false;
     reconcileClimbBoard(board);
+    maybeArmClimbIntro();
     await refreshClimbClue();
     return true;
   } catch (err) {
@@ -687,7 +698,7 @@ export async function climbAdvance() {
   dailyInFlight = true;
   try {
     const board = await climbNext();
-    if (board) { reconcileClimbBoard(board); await refreshClimbClue(); }
+    if (board) { reconcileClimbBoard(board); maybeArmClimbIntro(); await refreshClimbClue(); }
   } finally {
     dailyInFlight = false;
   }
@@ -696,6 +707,18 @@ export async function climbAdvance() {
 /** Leave the Cash Game (clears heat; position + Cash persist). */
 export async function climbLeaveGame() {
   try { await climbLeave(); } catch { /* non-fatal */ }
+}
+
+/** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). */
+export async function climbSkipPuzzle() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    const board = await climbSkip();
+    if (board) { reconcileClimbBoard(board); maybeArmClimbIntro(); await refreshClimbClue(); }
+  } finally {
+    dailyInFlight = false;
+  }
 }
 
 /** Equip a power-up in the Climb (v3: charges Cash on use, counts as spend). @param {string} id */

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -507,10 +507,24 @@ export async function climbSkip() {
   if (error) { console.error('❌ climb_skip:', error); return null; }
   return data;
 }
+/** Arm Double-or-Nothing on the current Cash Game puzzle (heat ≥ ×1.5). @returns {Promise<any>} */
+export async function climbDoubleOrNothing() {
+  const { data, error } = await supabase.rpc('climb_double_or_nothing');
+  if (error) { console.error('❌ climb_double_or_nothing:', error); return null; }
+  return data;
+}
 /** @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getClimbLeaderboard(scope = 'friends', group = null) {
   const { data, error } = await supabase.rpc('get_climb_leaderboard', { p_scope: scope, p_group: group });
   if (error) { console.error('❌ get_climb_leaderboard:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
+
+/** Cash Game run leaderboard — ranks by best run profit (skill, not longevity).
+ *  @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
+export async function getClimbRunLeaderboard(scope = 'friends', group = null) {
+  const { data, error } = await supabase.rpc('get_climb_run_leaderboard', { p_scope: scope, p_group: group });
+  if (error) { console.error('❌ get_climb_run_leaderboard:', error); return []; }
   return Array.isArray(data) ? data : [];
 }
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -521,6 +521,15 @@ export async function getClimbLeaderboard(scope = 'friends', group = null) {
   return Array.isArray(data) ? data : [];
 }
 
+/** The caller's currently-resumable solo games (daily/climb/freeplay), newest first.
+ *  Server truth for menu resume labels + the top-level Resume shortcut.
+ *  @returns {Promise<{mode:string, updated_at:string}[]>} */
+export async function getOpenGames() {
+  const { data, error } = await supabase.rpc('get_open_games');
+  if (error) { console.error('❌ get_open_games:', error); return []; }
+  return Array.isArray(data) ? data : [];
+}
+
 /** Cash Game run leaderboard — ranks by best run profit (skill, not longevity).
  *  @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getClimbRunLeaderboard(scope = 'friends', group = null) {

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -44,7 +44,7 @@ export async function getDailyStatus(userId) {
   });
   if (error) {
     console.error('❌ Error fetching daily status:', error);
-    return { has_played_today: false, last_daily_won: null, daily_bankroll: 0, arcade_bankroll: 1000, current_streak: 0, streak_freezes: 0, today_score: 0, win_streak: 0 };
+    return { has_played_today: false, last_daily_won: null, daily_bankroll: 0, arcade_bankroll: 1000, current_streak: 0, streak_freezes: 0, today_score: 0, win_streak: 0, daily_in_progress: false };
   }
   const row = Array.isArray(data) ? data[0] : data;
   return {
@@ -55,7 +55,8 @@ export async function getDailyStatus(userId) {
     current_streak: row?.current_streak ?? 0, // PLAY streak (attendance / showing up)
     streak_freezes: row?.streak_freezes ?? 0,
     today_score: row?.today_score ?? 0,
-    win_streak: row?.win_streak ?? 0 // WIN streak (consecutive solves)
+    win_streak: row?.win_streak ?? 0, // WIN streak (consecutive solves)
+    daily_in_progress: !!row?.daily_in_progress // SERVER truth: today's session still active → resume, don't mark lost
   };
 }
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -501,6 +501,12 @@ export async function climbLeave() {
   if (error) { console.error('❌ climb_leave:', error); return null; }
   return data;
 }
+/** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). @returns {Promise<any>} */
+export async function climbSkip() {
+  const { data, error } = await supabase.rpc('climb_skip');
+  if (error) { console.error('❌ climb_skip:', error); return null; }
+  return data;
+}
 /** @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getClimbLeaderboard(scope = 'friends', group = null) {
   const { data, error } = await supabase.rpc('get_climb_leaderboard', { p_scope: scope, p_group: group });

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -521,6 +521,15 @@ export async function getClimbLeaderboard(scope = 'friends', group = null) {
   return Array.isArray(data) ? data : [];
 }
 
+/** Finalize the caller's unfinished Daily puzzles from prior days as losses (no broke
+ *  timer anymore — an unsolved Daily expires at day's end, forfeiting the spend, and
+ *  shows in History). Lazy "midnight" finalization; call on app open. @returns {Promise<number>} */
+export async function expireStaleDailies() {
+  const { data, error } = await supabase.rpc('expire_stale_dailies');
+  if (error) { console.error('❌ expire_stale_dailies:', error); return 0; }
+  return data ?? 0;
+}
+
 /** The caller's currently-resumable solo games (daily/climb/freeplay), newest first.
  *  Server truth for menu resume labels + the top-level Resume shortcut.
  *  @returns {Promise<{mode:string, updated_at:string}[]>} */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getOpenGames, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout, getDailyModifier } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout, getDailyModifier } from '$lib/stores/statsStore.js';
   import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
@@ -172,10 +172,14 @@
       hasInitialized = true;
 
       // Secondary menu data: must NOT block the loading screen or each other.
-      getDailyStatus(session.user.id)
-        .then((ds) => { dailyStatus = ds; menuDailyPlayed = ds.has_played_today; })
-        .catch((e) => console.error('daily status:', e));
-      refreshOpenGames();
+      // Finalize any unfinished Daily from a prior day (no timer → it expires as a loss)
+      // BEFORE reading status/open games, so the menu reflects it.
+      expireStaleDailies().catch(() => {}).finally(() => {
+        getDailyStatus(session.user.id)
+          .then((ds) => { dailyStatus = ds; menuDailyPlayed = ds.has_played_today; })
+          .catch((e) => console.error('daily status:', e));
+        refreshOpenGames();
+      });
       refreshBank();
       refreshChallengeCount();
       // First-run username gate: prompt if this account hasn't claimed one yet.
@@ -552,12 +556,17 @@
   // a 60s clock starts; guess it or you auto-Fold (lose the puzzle).
   // Mirror of the server-authoritative public.letter_cost() (economy v3.2: −25%, cheapest $20).
   const LETTER_COSTS = { Q:20,W:40,E:100,R:90,T:90,Y:50,U:60,I:80,O:70,P:60,A:100,S:90,D:60,F:50,G:50,H:50,J:20,K:40,L:60,Z:30,X:30,C:60,V:40,B:50,N:80,M:50 };
+  // foldMode = modes with a "Give up" button (Daily + Challenges).
   $: foldMode = ($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'match');
+  // brokeMode = modes with the out-of-Cash auto-fold CLOCK. The Daily has NO timer —
+  // guesses are free + unlimited, so being broke isn't a dead end; you solve it or you
+  // don't (an unfinished Daily expires as a loss at day's end). Only live challenges,
+  // where stalling stalls a real opponent, keep the broke clock.
+  $: brokeMode = ($gameStore.gameMode === 'match');
   $: gameActive = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
   $: isBroke = (() => {
-    // Only while actively on a game screen — never on the menu, so the broke clock
-    // can't keep ticking (or auto-fold the wrong mode) after you leave a game.
-    if (!foldMode || !gameActive || showMainMenu) return false;
+    // Only while actively on a game screen — never on the menu.
+    if (!brokeMode || !gameActive || showMainMenu) return false;
     const mod = $gameStore.modifier, discount = mod === 'discount', vowelHalf = mod === 'vowel_vision';
     const purchased = new Set(($gameStore.purchasedLetters || []).filter(Boolean));
     const incorrect = new Set($gameStore.incorrectLetters || []);
@@ -2295,11 +2304,11 @@
       <PhraseDisplay on:revealComplete={onPhraseRevealComplete} on:introDone={onDailyIntroDone} />
     </section>
 
-    <!-- ⏱ Out-of-Cash broke-timer (Daily/Challenge) — give up lives in the top-right arrow -->
-    {#if (foldMode || isFreeplay) && gameActive && isBroke}
+    <!-- ⏱ Out-of-Cash broke-timer — live Challenges only (Daily has no timer) -->
+    {#if brokeMode && gameActive && isBroke}
       <div class="fold-bar broke">
         <span class="fold-timer">⏱ 0:{String(brokeLeft).padStart(2, '0')}</span>
-        <span class="fold-warn">Out of Cash — guess in time or you {$gameStore.gameMode === 'match' ? 'give up this one' : 'lose the Daily'}</span>
+        <span class="fold-warn">Out of Cash — guess in time or you give up this one</span>
       </div>
     {/if}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout, getDailyModifier } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getOpenGames, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout, getDailyModifier } from '$lib/stores/statsStore.js';
   import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
   import { modifierInfo } from '$lib/powerups.js';
@@ -65,12 +65,22 @@
   let menuDailyPlayed = false;
   /** Today's daily result for the menu indicator (won/lost + score). */
   let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, arcade_bankroll: number, current_streak: number, streak_freezes: number, today_score: number, win_streak: number, daily_in_progress?: boolean } | null} */ (null);
-  // "In progress" must come from SERVER truth (today's session still active), not the
-  // single shared localStorage save slot — that slot gets overwritten when you play
-  // another mode, which used to make a live Daily show as "complete + lost".
-  $: dailyInProgress = (dailyStatus?.daily_in_progress ?? false) || (savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
+  // 🎮 Live solo games from SERVER truth (daily/climb/freeplay), newest first. The old
+  // single localStorage save slot got overwritten whenever you played another mode, which
+  // made a live Daily show as "complete + lost". openGames lets every mode resume independently.
+  /** @type {{mode:string, updated_at:string}[]} */
+  let openGames = [];
+  async function refreshOpenGames() {
+    const u = get(user); if (!u?.id) return;
+    try { openGames = await getOpenGames(); } catch { /* keep last */ }
+  }
+  // "In progress" must come from SERVER truth, not the clobberable localStorage slot.
+  $: dailyInProgress = openGames.some((g) => g.mode === 'daily') || (dailyStatus?.daily_in_progress ?? false);
   $: dailyDone = menuDailyPlayed && !dailyInProgress;
-  $: climbInProgress = savedGameInfo?.gameMode === 'climb' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
+  $: climbInProgress = openGames.some((g) => g.mode === 'climb');
+  // 🔁 Resume shortcut: jump back to your most-recently-played live game.
+  const RESUME_LABEL = /** @type {Record<string,string>} */ ({ daily: 'Daily', climb: 'Cash Game', freeplay: 'Free Play' });
+  $: resumeGame = openGames[0] ?? null;
   /** Net Worth for the menu chip. */
   let netWorth = /** @type {number|null} */ (null);
   async function refreshBank() {
@@ -165,6 +175,7 @@
       getDailyStatus(session.user.id)
         .then((ds) => { dailyStatus = ds; menuDailyPlayed = ds.has_played_today; })
         .catch((e) => console.error('daily status:', e));
+      refreshOpenGames();
       refreshBank();
       refreshChallengeCount();
       // First-run username gate: prompt if this account hasn't claimed one yet.
@@ -544,7 +555,9 @@
   $: foldMode = ($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'match');
   $: gameActive = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
   $: isBroke = (() => {
-    if (!foldMode || !gameActive) return false;
+    // Only while actively on a game screen — never on the menu, so the broke clock
+    // can't keep ticking (or auto-fold the wrong mode) after you leave a game.
+    if (!foldMode || !gameActive || showMainMenu) return false;
     const mod = $gameStore.modifier, discount = mod === 'discount', vowelHalf = mod === 'vowel_vision';
     const purchased = new Set(($gameStore.purchasedLetters || []).filter(Boolean));
     const incorrect = new Set($gameStore.incorrectLetters || []);
@@ -1065,7 +1078,7 @@
 
   // ----- Free Play (unranked, pick a category) -----
   let showCategorySelect = false;
-  $: freeplayInProgress = savedGameInfo?.gameMode === 'freeplay' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
+  $: freeplayInProgress = openGames.some((g) => g.mode === 'freeplay');
   async function handleMenuFreeplay() {
     if (!get(user)?.id) return;
     // Resume the exact in-progress puzzle if there is one; otherwise pick a category.
@@ -1075,6 +1088,14 @@
       if (ok) { hasInitialized = true; showMainMenu = false; return; }
     }
     showCategorySelect = true;
+  }
+  /** ▶ Resume the most-recently-played live game (the top-level menu shortcut). */
+  function resumeOpen() {
+    if (!resumeGame) return;
+    fx('tap');
+    if (resumeGame.mode === 'daily') handleMenuDaily();
+    else if (resumeGame.mode === 'climb') handleMenuClimb();
+    else if (resumeGame.mode === 'freeplay') handleMenuFreeplay();
   }
   /** @param {string} category */
   async function startFreeplay(category) {
@@ -1308,6 +1329,7 @@
     showMainMenu = true;
     // Refresh the daily completion indicator (e.g. just finished today's daily).
     getDailyStatus(currentUser.id).then((s) => { dailyStatus = s; menuDailyPlayed = s.has_played_today; });
+    refreshOpenGames();
     refreshBank();
     refreshChallengeCount();
     refreshNotifications();
@@ -1773,6 +1795,13 @@
                 {#if actNow.sub}<small>{actNow.sub}</small>{/if}
               </span>
               <span class="ab-cta">{actNow.cta}</span>
+            </button>
+          {/if}
+          <!-- ▶ Resume your most-recent live game (multiple games can be open at once) -->
+          {#if resumeGame}
+            <button class="menu-card resume-card" style="--i: 0" on:click={resumeOpen}>
+              <span class="mc-title">▶ Resume {RESUME_LABEL[resumeGame.mode] ?? 'game'}</span>
+              {#if openGames.length > 1}<span class="resume-more">+{openGames.length - 1} more in progress</span>{/if}
             </button>
           {/if}
           <button class="menu-card primary" style="--i: 0" on:click={() => { menuView = 'play'; fx('tap'); }}>
@@ -3110,6 +3139,19 @@
     background: linear-gradient(180deg, #d1fae5, #6ee7b7); -webkit-background-clip: text; background-clip: text;
     -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
   }
+  /* ▶ Resume shortcut card (home menu) — green, mirrors the in-progress accent */
+  .menu-card.resume-card {
+    flex-direction: column; gap: 2px;
+    background: linear-gradient(180deg, #16352b 0%, #0f2a22 100%);
+    border-color: rgba(16,185,129,0.6);
+    box-shadow: inset 0 1px 0 rgba(110,231,183,0.2), inset 0 0 0 1px rgba(16,185,129,0.3), 0 4px 14px rgba(0,0,0,0.5), 0 0 20px rgba(16,185,129,0.25);
+  }
+  .menu-card.resume-card::before, .menu-card.resume-card::after { display: none; }
+  .menu-card.resume-card .mc-title {
+    background: linear-gradient(180deg, #d1fae5, #6ee7b7); -webkit-background-clip: text; background-clip: text;
+    -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
+  }
+  .resume-more { position: relative; z-index: 1; font-size: 0.72rem; color: rgba(167,243,208,0.82); font-weight: 600; }
   .progress-modes { border-left-color: rgba(251,191,36,0.3); }
   .mc-arrow { color: var(--text-faint); font-size: 1.1rem; transition: transform 0.2s, color 0.2s; }
   .mc-count {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
 
-  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -339,10 +339,21 @@
   $: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
   $: matchCombo = ((matchInfo?.combo ?? 100) / 100).toFixed(2);
   let matchExpiredFired = false;
-  // Climb live: Spent · Payout (bounty × heat) · Net.
+  // 💥 Double or Nothing (Cash Game): server exposes don_armed + don_available (heat ≥ ×1.5).
+  $: donArmed = !!climb?.don_armed;
+  $: donAvailable = !!climb?.don_available;
+  // The doubled target payout (matches server: bounty ×2, then × heat, rounded).
+  $: donTarget = (isClimb && climb) ? Math.round((climb.bounty ?? 0) * 2 * (climb.heat ?? 100) / 100) : 0;
+  // Climb live: Spent · Payout (bounty × heat, doubled while armed) · Net.
   $: climbLive = (isClimb && climb && climb.state === 'active')
-    ? (() => { const pay = Math.round((climb.bounty ?? 0) * (climb.heat ?? 100) / 100); const sp = climb.spent ?? 0; return { spent: sp, payout: pay, net: pay - sp }; })()
+    ? (() => { const m = climb.don_armed ? 2 : 1; const pay = Math.round((climb.bounty ?? 0) * m * (climb.heat ?? 100) / 100); const sp = climb.spent ?? 0; return { spent: sp, payout: pay, net: pay - sp }; })()
     : null;
+  // Win banner needs to know the solve was a Double-or-Nothing (server clears don_armed on solve).
+  let donArmedThisPuzzle = false;
+  $: if (isClimb && climb) {
+    if (climb.don_armed) donArmedThisPuzzle = true;
+    else if (climb.state === 'stuck' || (climb.state === 'active' && (climb.spent ?? 0) === 0)) donArmedThisPuzzle = false;
+  }
   // Challenge live: Spent of your wager budget — lowest spend wins (standard only).
   $: matchLive = (isMatch && matchInfo && !matchInfo.done && matchInfo.mode !== 'blitz')
     ? { spent: matchInfo.spent ?? 0, budget: matchInfo.budget ?? 0 } : null;
@@ -576,6 +587,18 @@
   function cancelGiveUp() { fx('tap'); showGiveUp = false; }
   function doGiveUp() { showGiveUp = false; doFold(false); }
 
+  // 💥 Double or Nothing confirm layer (Cash Game). Solve → ×2; get stuck → forfeit.
+  let showDon = false;
+  let donBusy = false;
+  function openDon() { fx('tap'); showDon = true; }
+  function cancelDon() { fx('tap'); showDon = false; }
+  async function armDon() {
+    if (donBusy) return;
+    donBusy = true;
+    try { fx('tap'); await climbArmDoubleOrNothing(); }
+    finally { donBusy = false; showDon = false; }
+  }
+
   // Free Play: cash out credits → real Cash right from the board (40:1, $50/day cap).
   let fpCashBusy = false;
   // Tapping the credits number cashes out when you're above the $1 floor.
@@ -624,6 +647,9 @@
   $: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
   // Heat IS the Cash Game win streak: each solve +0.1× (cap ×2.0), reset to ×1.0 when stuck.
   $: climbStreak = Math.max(0, Math.round(((climb?.heat ?? 100) - 100) / 10));
+  // 🔥 The run: solves + cumulative profit since heat last reset (run_profit can be negative early).
+  $: climbRun = (isClimb && climb) ? { solves: climb.run_solves ?? 0, profit: climb.run_profit ?? 0, best: climb.best_run_profit ?? 0 } : null;
+  $: climbRunIsBest = climbRun != null && climbRun.profit > 0 && climbRun.profit >= climbRun.best;
   // Owned, not-yet-used climb buffs — drives the vault badge by the Solve button.
   $: usableClimbPups = isClimb ? selfPups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0 && !((climb?.equipped ?? []).includes(i.id))).length : 0;
   /** @type {'heat'|'earn'|null} ℹ️ Cash Game explainers (mirror of dailyInfo). */
@@ -1408,8 +1434,8 @@
 {#if loggedIn && hasInitialized && !showMainMenu && (foldMode || isFreeplay) && gameActive}
   <button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
 {/if}
-<!-- ⏭️ Skip (top-right) — Cash Game only; resets heat -->
-{#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && (climb?.state === 'active' || climb?.state === 'stuck')}
+<!-- ⏭️ Skip (top-right) — Cash Game only; resets heat. Hidden once Double-or-Nothing is armed (committed). -->
+{#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && !donArmed && (climb?.state === 'active' || climb?.state === 'stuck')}
   <button class="giveup-btn" title="Skip this puzzle" aria-label="Skip this puzzle" on:click={confirmFold}>↪</button>
 {/if}
 
@@ -1462,6 +1488,24 @@
       <div class="gu-actions">
         <button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
         <button class="gu-confirm" on:click={doGiveUp}>{isClimb ? '⏭️ Skip' : '🏳️ Give up'}</button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+<!-- 💥 Double or Nothing confirm layer (Cash Game) -->
+{#if showDon}
+  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Double or Nothing">
+    <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelDon}></button>
+    <div class="modal-content giveup-modal don-modal">
+      <h2 class="gu-title">💥 Double or Nothing?</h2>
+      <p class="gu-text">
+        Solve this puzzle and your payout <b>doubles</b> to <b class="don-win">${donTarget.toLocaleString()}</b>.
+        But you're all in — you <b>can't skip</b>, and if you get stuck you walk away with <b class="don-loss">$0</b>{(climb?.spent ?? 0) > 0 ? ` and forfeit the $${(climb?.spent ?? 0).toLocaleString()} you've spent` : ''}.
+      </p>
+      <div class="gu-actions">
+        <button class="gu-cancel" on:click={cancelDon}>Not now</button>
+        <button class="gu-confirm don-confirm" on:click={armDon} disabled={donBusy}>💥 Double it</button>
       </div>
     </div>
   </div>
@@ -2248,6 +2292,11 @@
           {/if}
           {#each spendFloaters as f (f.id)}<span class="spend-float">{f.text}</span>{/each}
         </div>
+        {#if isClimb && climbRun && climbRun.solves >= 2}
+          <p class="climb-run-line" class:best={climbRunIsBest}>
+            🔥 {climbRun.solves}-solve run · <b class="run-profit" class:neg={climbRun.profit < 0}>{climbRun.profit >= 0 ? '+' : '−'}${Math.abs(climbRun.profit).toLocaleString()}</b> this run{#if climbRunIsBest} · 🏆 personal best{/if}
+          </p>
+        {/if}
       {:else if isFreeplay}
         <!-- Free Play: credits are up top; here just the cash-out + your Cash + reward -->
         <div class="credits-panel">
@@ -2265,6 +2314,21 @@
         {/if}
       {/if}
     </section>
+
+    <!-- 💥 Double or Nothing — Cash Game only, when heat ≥ ×1.5. Arm to double the payout. -->
+    {#if isClimb && climb && $gameStore.gameState !== 'won'}
+      {#if donAvailable}
+        <button class="don-cta" on:click={openDon}>
+          <span class="don-cta-title">💥 Double or Nothing</span>
+          <span class="don-cta-sub">Solve for <b>${donTarget.toLocaleString()}</b> — but get stuck and you forfeit it all</span>
+        </button>
+      {:else if donArmed}
+        <div class="don-armed" role="status">
+          <span class="don-armed-title">💥 Doubled — all in</span>
+          <span class="don-armed-sub">Solve for <b>${donTarget.toLocaleString()}</b> · no skip, no backing out</span>
+        </div>
+      {/if}
+    {/if}
 
     <!-- 🎮 Solve / Cancel Buttons (Cash Game gets a vault to the left for power-ups) -->
     <section class="buttons-section">
@@ -2340,10 +2404,11 @@
             {@const payout = climb?.last_gain ?? 0}
             {@const cspent = climb?.spent ?? 0}
             {@const earnedMult = (climb?.bounty ?? 0) > 0 ? (payout / climb.bounty) : ((climb?.heat ?? 100) / 100)}
-            <h2 class="win-h">🎉 Solved!</h2>
+            {@const heatMult = donArmedThisPuzzle ? earnedMult / 2 : earnedMult}
+            <h2 class="win-h">{donArmedThisPuzzle ? '💥 Doubled!' : '🎉 Solved!'}</h2>
             <p class="result-sub">{$gameStore.currentPhrase}</p>
             <div class="win-math">
-              <div class="wm-row"><span>Bounty <small>(🔥 ×{earnedMult.toFixed(1)} heat)</small></span><b>${payout.toLocaleString()}</b></div>
+              <div class="wm-row"><span>Bounty <small>(🔥 ×{heatMult.toFixed(1)} heat{#if donArmedThisPuzzle} · 💥 ×2{/if})</small></span><b>${payout.toLocaleString()}</b></div>
               <div class="wm-row"><span>− Spent on letters</span><b class="neg">−${cspent.toLocaleString()}</b></div>
               <div class="wm-row total"><span>Profit</span><b class="profit">{$resultProfit >= 0 ? '+' : '−'}${Math.abs(Math.round($resultProfit)).toLocaleString()}</b></div>
             </div>
@@ -3146,6 +3211,41 @@
   .gu-cancel { border: 1px solid var(--border-strong, var(--border)); background: var(--surface-2, rgba(255,255,255,0.05)); color: var(--text); }
   .gu-confirm { border: none; background: rgba(248,113,113,0.18); border: 1px solid rgba(248,113,113,0.5); color: #fca5a5; }
   .gu-confirm:hover { background: rgba(248,113,113,0.28); }
+  /* 💥 Double or Nothing — high-stakes gold/amber accent (distinct from the red Skip/Give-up) */
+  .don-modal .don-win { color: #fbbf24; }
+  .don-modal .don-loss { color: #fca5a5; }
+  .don-confirm { background: rgba(251,191,36,0.16) !important; border: 1px solid rgba(251,191,36,0.6) !important; color: #fcd34d !important; }
+  .don-confirm:hover { background: rgba(251,191,36,0.28) !important; }
+  .don-confirm:disabled { opacity: 0.55; cursor: default; }
+  /* CTA shown in the Cash Game when heat ≥ ×1.5 */
+  .don-cta {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    width: 100%; margin: 0 auto 0.5rem; padding: 0.6rem 0.9rem; border-radius: 14px; cursor: pointer;
+    background: linear-gradient(180deg, rgba(251,191,36,0.16), rgba(245,158,11,0.10));
+    border: 1px solid rgba(251,191,36,0.55); color: #fcd34d;
+    box-shadow: 0 0 18px rgba(251,191,36,0.18); animation: donPulse 1.8s ease-in-out infinite;
+  }
+  .don-cta:active { transform: scale(0.98); }
+  .don-cta-title { font-family: var(--font-display); font-weight: 900; font-size: 1rem; letter-spacing: 0.02em; }
+  .don-cta-sub { font-size: 0.74rem; color: var(--text-muted); }
+  .don-cta-sub b, .don-armed-sub b { color: #fbbf24; }
+  /* 🔥 Cash Game run line — momentum under the money hero */
+  .climb-run-line { margin: 0.35rem auto 0; text-align: center; font-size: 0.8rem; color: var(--text-muted); }
+  .climb-run-line .run-profit { color: #4ade80; }
+  .climb-run-line .run-profit.neg { color: #fca5a5; }
+  .climb-run-line.best { color: #fcd34d; }
+  @keyframes donPulse {
+    0%, 100% { box-shadow: 0 0 14px rgba(251,191,36,0.16); }
+    50% { box-shadow: 0 0 26px rgba(251,191,36,0.36); }
+  }
+  /* Armed (committed) indicator */
+  .don-armed {
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    width: 100%; margin: 0 auto 0.5rem; padding: 0.55rem 0.9rem; border-radius: 14px;
+    background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.7);
+  }
+  .don-armed-title { font-family: var(--font-display); font-weight: 900; font-size: 0.95rem; color: #fcd34d; }
+  .don-armed-sub { font-size: 0.74rem; color: var(--text-muted); }
   .chat-modal { max-width: 440px; }
   .chat-h { font-family: var(--font-display); font-size: 1.15rem; margin: 0 0 0.8rem; }
   .chat-msgs {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -64,9 +64,12 @@
   /** When showing menu: has user already played daily today? */
   let menuDailyPlayed = false;
   /** Today's daily result for the menu indicator (won/lost + score). */
-  let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, arcade_bankroll: number, current_streak: number, streak_freezes: number, today_score: number } | null} */ (null);
-  $: dailyDone = menuDailyPlayed && !(savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
-  $: dailyInProgress = savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
+  let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, arcade_bankroll: number, current_streak: number, streak_freezes: number, today_score: number, win_streak: number, daily_in_progress?: boolean } | null} */ (null);
+  // "In progress" must come from SERVER truth (today's session still active), not the
+  // single shared localStorage save slot — that slot gets overwritten when you play
+  // another mode, which used to make a live Daily show as "complete + lost".
+  $: dailyInProgress = (dailyStatus?.daily_in_progress ?? false) || (savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
+  $: dailyDone = menuDailyPlayed && !dailyInProgress;
   $: climbInProgress = savedGameInfo?.gameMode === 'climb' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
   /** Net Worth for the menu chip. */
   let netWorth = /** @type {number|null} */ (null);
@@ -959,7 +962,8 @@
       dailyStatus = await getDailyStatus(currentUser.id);
       menuDailyPlayed = dailyStatus.has_played_today;
     }
-    const inProgress = savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost';
+    // Resume an active Daily based on SERVER truth, not the clobberable local save slot.
+    const inProgress = (dailyStatus?.daily_in_progress ?? false) || (savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
     if (dailyStatus?.has_played_today && !inProgress) {
       showStreakMessage = true;  // already solved today → come-back summary
       return;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
 
-  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -325,6 +325,15 @@
   }
   $: isClimb = $gameStore.gameMode === 'climb';
   $: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
+  // 🏷️ Which mode you're in — a consistent pill under the wordmark on every game screen.
+  $: modeLabel = ({
+    daily:     { emoji: '📅', name: 'Daily' },
+    climb:     { emoji: '🎰', name: 'Cash Game' },
+    freeplay:  { emoji: '🎯', name: 'Free Play' },
+    makeup:    { emoji: '📅', name: 'Make-up' },
+    match:     { emoji: '⚔️', name: 'Challenge' },
+    challenge: { emoji: '⚔️', name: 'Challenge' }
+  })[$gameStore.gameMode] ?? null;
   $: isMatch = $gameStore.gameMode === 'match';
   $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, solved, spent, budget, wager, items_allowed, used_powerups, started_at, clock_seconds, combo }
   $: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
@@ -438,6 +447,11 @@
         const avail = ($gameStore.gameMode === 'daily') && (dailyAvailBoosts[it.id] ?? 0) > 0 && gameActive;
         out.push({ id: it.id, emoji: BOOST_META[it.id]?.emoji ?? '💥', name: it.name, blurb: BOOST_META[it.id]?.blurb ?? '', count: it.owned,
           usable: avail, reason: avail ? '' : 'Bought after you started — usable on your next puzzle.' });
+      } else if (it.kind === 'climb') {
+        const used = (climb?.equipped ?? []).includes(it.id);
+        const avail = $gameStore.gameMode === 'climb' && gameActive && !used && (it.owned ?? 0) > 0;
+        out.push({ id: it.id, emoji: PUP_ICON[it.id] ?? '✨', name: it.name, blurb: avail ? 'Tap to use now' : '', count: it.owned, usable: avail,
+          reason: used ? 'Already used on this puzzle.' : ($gameStore.gameMode === 'climb' ? '' : 'For the Cash Game — not this mode.') });
       } else {
         out.push({ id: it.id, emoji: PUP_ICON[it.id] ?? '✨', name: it.name, blurb: '', count: it.owned, usable: false,
           reason: it.kind === 'sabotage' ? 'For challenges — sabotage an opponent there, not the Daily.' : 'For the Cash Game or challenges — not the Daily.' });
@@ -456,6 +470,7 @@
   function useFromBag(item) {
     if (item?.id === 'twist') useTwist();
     else if (item?.id === 'bounty_boost' || item?.id === 'jackpot_boost') { useBoost(item.id); loadVault(); }
+    else if ($gameStore.gameMode === 'climb') { climbPowerup(item.id).then(() => { refreshClimbPups(); loadVault(); }); }
     showBag = false;
   }
 
@@ -552,6 +567,7 @@
       if ($gameStore.gameMode === 'daily') await dailyFold();
       else if ($gameStore.gameMode === 'match') await matchFold();
       else if ($gameStore.gameMode === 'freeplay') await freeplayContinue(); // skip to a fresh puzzle
+      else if ($gameStore.gameMode === 'climb') { await climbSkipPuzzle(); await tick(); playDailyIntroIfArmed(); } // fresh puzzle; heat resets; replay the dramatic build
     } finally { brokeFiring = false; }
   }
   // Give-up confirm layer (in-app, not window.confirm).
@@ -606,6 +622,12 @@
     await matchTimeoutCheck();
   }
   $: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
+  // Heat IS the Cash Game win streak: each solve +0.1× (cap ×2.0), reset to ×1.0 when stuck.
+  $: climbStreak = Math.max(0, Math.round(((climb?.heat ?? 100) - 100) / 10));
+  // Owned, not-yet-used climb buffs — drives the vault badge by the Solve button.
+  $: usableClimbPups = isClimb ? selfPups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0 && !((climb?.equipped ?? []).includes(i.id))).length : 0;
+  /** @type {'heat'|'earn'|null} ℹ️ Cash Game explainers (mirror of dailyInfo). */
+  let climbInfo = null;
   $: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
   /** @type {{rank:number, total:number}|null} */
   let dailyPlacement = null;
@@ -714,13 +736,6 @@
   }
   onDestroy(teardownMatchChat);
 
-  /** @param {any} item */
-  async function handleClimbPup(item) {
-    const usedThisPuzzle = (climb?.equipped ?? []).includes(item.id);
-    if ((item.owned ?? 0) <= 0 || usedThisPuzzle) return;  // must own one, can't reuse this puzzle
-    await climbPowerup(item.id);
-    await refreshClimbPups();
-  }
   $: makeupLabel = (() => {
     const d = $gameStore.makeupDate;
     if (!d) return '';
@@ -1009,6 +1024,10 @@
       hasInitialized = true;
       showMainMenu = false;
       refreshClimbPups();
+      // Play the dramatic opening reveal once reactives settle (no-ops if the
+      // "How it works" card shows — it then fires on dismiss).
+      await tick();
+      playDailyIntroIfArmed();
     } else {
       initError = 'Cash Game failed to load.';
     }
@@ -1363,6 +1382,14 @@
           resultBankAnim.set(newBank - profit, { duration: 0 });
           setTimeout(() => { resultProfit.set(profit); fx('win'); }, 350);
           setTimeout(() => { resultBankAnim.set(newBank); }, 1100);
+        } else if ($gameStore.gameMode === 'climb' && won) {
+          const c = $gameStore.climbInfo || {};
+          const profit = Math.round((c.last_gain ?? 0) - (c.spent ?? 0));
+          const newBank = Math.round($gameStore.bankroll ?? 0);
+          resultProfit.set(0, { duration: 0 });
+          resultBankAnim.set(newBank - profit, { duration: 0 });
+          setTimeout(() => { resultProfit.set(profit); fx('win'); }, 350);
+          setTimeout(() => { resultBankAnim.set(newBank); }, 1100);
         }
       }, 1000);
     }
@@ -1380,6 +1407,10 @@
 <!-- 🏳️ Give up (top-right) — Daily / Challenges / Free Play -->
 {#if loggedIn && hasInitialized && !showMainMenu && (foldMode || isFreeplay) && gameActive}
   <button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
+{/if}
+<!-- ⏭️ Skip (top-right) — Cash Game only; resets heat -->
+{#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && (climb?.state === 'active' || climb?.state === 'stuck')}
+  <button class="giveup-btn" title="Skip this puzzle" aria-label="Skip this puzzle" on:click={confirmFold}>↪</button>
 {/if}
 
 <!-- 💬 Match chat (1v1 + group challenges) — only inside a live match, never on the menu -->
@@ -1420,15 +1451,17 @@
   <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Give up">
     <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelGiveUp}></button>
     <div class="modal-content giveup-modal">
-      <h2 class="gu-title">Give up {$gameStore.gameMode === 'match' ? 'this puzzle' : $gameStore.gameMode === 'freeplay' ? 'this one' : "today's Daily"}?</h2>
-      <p class="gu-text">{$gameStore.gameMode === 'match'
+      <h2 class="gu-title">{isClimb ? 'Skip this puzzle?' : `Give up ${$gameStore.gameMode === 'match' ? 'this puzzle' : $gameStore.gameMode === 'freeplay' ? 'this one' : "today's Daily"}?`}</h2>
+      <p class="gu-text">{isClimb
+        ? `Your heat resets to ×1.0${(climb?.spent ?? 0) > 0 ? ` and you forfeit the $${(climb?.spent ?? 0).toLocaleString()} spent on this one` : ''} — then a fresh puzzle.`
+        : $gameStore.gameMode === 'match'
         ? 'You lose this puzzle and move on — your unspent budget is refunded to your Cash.'
         : $gameStore.gameMode === 'freeplay'
         ? 'You’ll skip to a fresh puzzle — you keep your credits (you only lose what you spent on this one).'
         : 'It counts as a loss and reveals the answer.'}</p>
       <div class="gu-actions">
         <button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
-        <button class="gu-confirm" on:click={doGiveUp}>🏳️ Give up</button>
+        <button class="gu-confirm" on:click={doGiveUp}>{isClimb ? '⏭️ Skip' : '🏳️ Give up'}</button>
       </div>
     </div>
   </div>
@@ -1444,7 +1477,7 @@
       <ul class="wc-list">
         <li><span>💰</span> <b>$2,000</b> in the bank to play with</li>
         <li><span>📅</span> Today is <b>Day 1</b> of the Daily</li>
-        <li><span>🎰</span> The Cash Game ladder restarts at puzzle 1</li>
+        <li><span>🎰</span> Fresh puzzles waiting in the Cash Game</li>
         <li><span>🏆</span> Leaderboards are wide open — go claim a spot</li>
       </ul>
       <button class="wc-btn" on:click={dismissLaunchWelcome}>Let’s play →</button>
@@ -1578,6 +1611,48 @@
         <p class="info-note">The base bounty comes from the letters' value. Spend less on letters to keep more — and grow the <button class="info-inline" on:click|stopPropagation={() => dailyInfo = 'mult'}>multiplier</button>.</p>
       {/if}
       <button class="info-close" on:click={() => dailyInfo = null}>Got it</button>
+    </div>
+  </div>
+{/if}
+
+<!-- ℹ️ Cash Game explainers: heat (= win streak) / Solve-to-Earn calculation -->
+{#if climbInfo}
+  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
+    on:click={() => climbInfo = null} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') climbInfo = null; }}>
+    <div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
+      <button class="modal-x" on:click={() => climbInfo = null} aria-label="Close">✕</button>
+      {#if climbInfo === 'heat'}
+        <div class="info-big">🔥 ×{climbHeat}</div>
+        <h3 class="info-title">Heat — your multiplier</h3>
+        <p class="info-sub">Everything you earn from a puzzle is multiplied by your heat.</p>
+        <div class="info-rows">
+          <div class="info-row"><span>Base</span><b>×1.0</b></div>
+          <div class="info-row"><span>Each solve in a row</span><b class="pos">+0.1×</b></div>
+          <div class="info-row"><span>Maxes out at</span><b>×2.0</b></div>
+          <div class="info-row total"><span>Your heat</span><b>×{climbHeat}</b></div>
+        </div>
+        <p class="info-note">Heat climbs with your <button class="info-inline" on:click|stopPropagation={() => climbInfo = 'streak'}>win streak</button> and resets to ×1.0 if you get stuck or skip.</p>
+      {:else if climbInfo === 'streak'}
+        <div class="info-big">🏆 {climbStreak}</div>
+        <h3 class="info-title">Win Streak</h3>
+        <p class="info-sub">Cash Game puzzles you've solved in a row.</p>
+        <div class="info-rows">
+          <div class="info-row"><span>Solve a puzzle</span><b class="pos">+1</b></div>
+          <div class="info-row"><span>Get stuck or skip</span><b class="neg">back to 0</b></div>
+        </div>
+        <p class="info-note">Your streak powers your <button class="info-inline" on:click|stopPropagation={() => climbInfo = 'heat'}>heat</button> — every win adds <b>+0.1×</b> to your payout (up to ×2.0).</p>
+      {:else}
+        <div class="info-big green">${Math.max(0, climbLive?.net ?? 0).toLocaleString()}</div>
+        <h3 class="info-title">Solve to Earn</h3>
+        <p class="info-sub">What you pocket if you solve right now.</p>
+        <div class="info-rows">
+          <div class="info-row"><span>Bounty × heat ({fmtMult(Number(climbHeat))})</span><b class="pos">${(climbLive?.payout ?? 0).toLocaleString()}</b></div>
+          <div class="info-row"><span>− Spent on letters</span><b class="neg">−${(climbLive?.spent ?? 0).toLocaleString()}</b></div>
+          <div class="info-row total"><span>You keep</span><b class="green">${(climbLive?.net ?? 0).toLocaleString()}</b></div>
+        </div>
+        <p class="info-note">Spend less on letters to keep more — and grow your <button class="info-inline" on:click|stopPropagation={() => climbInfo = 'heat'}>heat</button>.</p>
+      {/if}
+      <button class="info-close" on:click={() => climbInfo = null}>Got it</button>
     </div>
   </div>
 {/if}
@@ -1984,6 +2059,13 @@
     <!-- 🧠 Game Logo -->
     <img class="game-logo" src="/wordmark.png" alt="WordBank" />
 
+    <!-- 🏷️ Game-mode pill — same spot & style for every mode; tap to see the rules -->
+    {#if $gameStore.currentPhrase && $gameStore.gameMode && modeLabel}
+      <button class="mode-pill" title="How {modeLabel.name} works" on:click={() => { fx('tap'); showObjectiveFor($gameStore.gameMode, true); }}>
+        <span class="mp-emoji">{modeLabel.emoji}</span>{modeLabel.name}<span class="mp-info">ⓘ</span>
+      </button>
+    {/if}
+
     <!-- 💰 Bankroll — top of every mode. Challenge/1v1 = one number (left to spend) + one depleting bar. -->
     {#if $gameStore.currentPhrase && $gameStore.gameMode}
       {#if isMatch && matchInfo && !matchBlitz && !matchInfo.done}
@@ -2039,30 +2121,9 @@
       </div>
     {/if}
 
-    <!-- 🎰 Cash Game (Climb) HUD -->
+    <!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
+         Solve-to-Earn box; power-ups live in the vault beside Solve. -->
     {#if isClimb && climb}
-      <div class="climb-top">
-        <span class="climb-level">🎰 Cash&nbsp;Game&nbsp;#{climb.position}</span>
-        <div class="heat-meter" class:hot={(climb.heat ?? 100) > 100}>
-          <span class="heat-fill" style="width:{Math.min(100, Math.max(0, (climb.heat ?? 100) - 100))}%"></span>
-          <span class="heat-x">🔥 ×{climbHeat}</span>
-        </div>
-      </div>
-      {#if climb.state === 'active'}
-        {@const ownedClimb = selfPups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0)}
-        {#if ownedClimb.length}
-          <div class="climb-pups owned">
-            {#each ownedClimb as item}
-              {@const used = (climb.equipped ?? []).includes(item.id)}
-              <button class="cp" class:equipped={used} disabled={used}
-                on:click={() => handleClimbPup(item)} title={item.name}>
-                <span class="cp-ic">{PUP_ICON[item.id] ?? '✨'}</span>
-                <span class="cp-tag">{used ? '✓' : '×' + item.owned}</span>
-              </button>
-            {/each}
-          </div>
-        {/if}
-      {/if}
       {#if climb.stuck && $gameStore.gameState !== 'won'}
         <div class="climb-stuck">
           <span class="cs-text">Out of Cash for this one — leave and earn in the Daily, then come back to finish it.</span>
@@ -2173,10 +2234,15 @@
           {#if $gameStore.gameMode === 'daily'}
             <button class="bp-mult-badge" title="How your multiplier works" on:click={() => { fx('tap'); dailyInfo = 'mult'; }}>×{Number($gameStore.bountyMult ?? 1).toFixed(1)}</button>
             <button class="bp-winstreak" title="Win streak" on:click={() => { fx('tap'); dailyInfo = 'streak'; }}>🏆 {dailyStatus?.win_streak ?? 0}</button>
+          {:else if isClimb}
+            <button class="bp-mult-badge" title="Heat — your payout multiplier" on:click={() => { fx('tap'); climbInfo = 'heat'; }}>🔥 ×{climbHeat}</button>
+            <button class="bp-winstreak" title="Win streak" on:click={() => { fx('tap'); climbInfo = 'streak'; }}>🏆 {climbStreak}</button>
           {/if}
           <span class="bp-label">{soloHero.net >= 0 ? 'Solve to Earn' : '⚠️ You’re losing money'}</span>
           {#if $gameStore.gameMode === 'daily'}
             <button class="bp-amount bp-amount-btn" title="How this is calculated" on:click={() => { fx('tap'); dailyInfo = 'bounty'; }}>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</button>
+          {:else if isClimb}
+            <button class="bp-amount bp-amount-btn" title="How this is calculated" on:click={() => { fx('tap'); climbInfo = 'earn'; }}>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</button>
           {:else}
             <span class="bp-amount">{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</span>
           {/if}
@@ -2200,9 +2266,18 @@
       {/if}
     </section>
 
-    <!-- 🎮 Solve / Cancel Buttons -->
+    <!-- 🎮 Solve / Cancel Buttons (Cash Game gets a vault to the left for power-ups) -->
     <section class="buttons-section">
-      <GameButtons />
+      <GameButtons>
+        <svelte:fragment slot="left">
+          {#if isClimb && climb?.state === 'active'}
+            <button class="solve-vault" on:click={openBag} title="Your power-ups" aria-label="Open your vault">
+              <img src="/vault.png" alt="" />
+              {#if usableClimbPups > 0}<span class="solve-vault-badge">{usableClimbPups}</span>{/if}
+            </button>
+          {/if}
+        </svelte:fragment>
+      </GameButtons>
     </section>
 
     <!-- ⌨️ Keyboard Section (keyboard disables itself via gameStore state) -->
@@ -2260,15 +2335,26 @@
               <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
               <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
             </div>
-          {:else if isClimb}
-            <!-- Cash Game solve → advance up the Climb -->
-            <div class="result-medal">🎰</div>
-            <h2>Solved! +${(climb?.last_gain ?? 0).toLocaleString()}</h2>
+          {:else if isClimb && resultWon}
+            <!-- 🎰 Cash Game win banner (mirrors Daily): bounty × heat − spent = profit -->
+            {@const payout = climb?.last_gain ?? 0}
+            {@const cspent = climb?.spent ?? 0}
+            {@const earnedMult = (climb?.bounty ?? 0) > 0 ? (payout / climb.bounty) : ((climb?.heat ?? 100) / 100)}
+            <h2 class="win-h">🎉 Solved!</h2>
             <p class="result-sub">{$gameStore.currentPhrase}</p>
-            <p class="arcade-gain">Cash Game #{climb?.position} · Heat ×{climbHeat}{#if (climb?.heat ?? 100) >= 200} 🔥 maxed{/if}</p>
+            <div class="win-math">
+              <div class="wm-row"><span>Bounty <small>(🔥 ×{earnedMult.toFixed(1)} heat)</small></span><b>${payout.toLocaleString()}</b></div>
+              <div class="wm-row"><span>− Spent on letters</span><b class="neg">−${cspent.toLocaleString()}</b></div>
+              <div class="wm-row total"><span>Profit</span><b class="profit">{$resultProfit >= 0 ? '+' : '−'}${Math.abs(Math.round($resultProfit)).toLocaleString()}</b></div>
+            </div>
+            <p class="win-twist">🔥 Heat now ×{climbHeat}{#if climbStreak > 0} · 🏆 {climbStreak} win streak{/if}{#if (climb?.heat ?? 100) >= 200} · maxed{/if}</p>
+            <div class="win-bank">
+              <span class="wb-label">💰 Your Cash</span>
+              <span class="wb-amount">${Math.round($resultBankAnim).toLocaleString()}</span>
+            </div>
             <div class="result-actions">
               <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Leave</button>
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance(); }}>Next →</button>
+              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance().then(() => tick().then(playDailyIntroIfArmed)); }}>Next →</button>
             </div>
           {:else if isMatch}
             <!-- Challenge match: finished the whole pack -->
@@ -2445,7 +2531,6 @@
   .ch-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
   .cp-hint { font-size: 0.66rem; color: var(--text-faint); text-align: center; margin: 0 0 5px; }
   .climb-pups { display: flex; gap: 6px; width: 100%; max-width: 360px; margin: 0 auto 12px; justify-content: space-between; }
-  .climb-pups.owned { justify-content: center; gap: 10px; margin-bottom: 10px; }
   .cp {
     flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 7px 2px;
     border-radius: 10px; cursor: pointer; border: 1px solid var(--border); background: var(--surface);
@@ -3494,6 +3579,16 @@
   .bag-fab-badge { position: absolute; top: -5px; right: -5px; min-width: 18px; height: 18px; padding: 0 4px; border-radius: 999px;
     background: #ea580c; color: #fff; font-family: var(--font-display); font-weight: 800; font-size: 0.66rem; display: grid; place-items: center; }
   .bag-chip { width: 54px; height: 54px; padding: 0; border-radius: 50%; display: grid; place-items: center; }
+  /* 🔐 Cash Game vault — sits to the left of Solve; absolute so Solve stays centered */
+  .solve-vault { position: absolute; right: 100%; margin-right: 12px; top: 50%; transform: translateY(-50%);
+    width: 50px; height: 50px; border-radius: 14px; display: grid; place-items: center; cursor: pointer;
+    background: var(--surface-strong, rgba(20,28,40,0.9)); border: 1px solid rgba(253,224,71,0.5);
+    backdrop-filter: blur(10px); box-shadow: 0 4px 12px rgba(0,0,0,0.4); transition: transform 0.16s var(--ease-spring); }
+  .solve-vault:active { transform: translateY(-50%) scale(0.93); }
+  .solve-vault img { width: 34px; height: 34px; object-fit: contain; }
+  .solve-vault-badge { position: absolute; top: -6px; right: -6px; min-width: 18px; height: 18px; padding: 0 4px; border-radius: 999px;
+    background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); color: #3a2a00;
+    font-family: var(--font-display); font-weight: 800; font-size: 0.66rem; display: grid; place-items: center; }
   .vault-ic { width: 34px; height: 34px; object-fit: contain; }
   .vault-ic-sm { width: 46px; height: 46px; object-fit: contain; display: block; }
   .vault-ic-xs { width: 22px; height: 22px; object-fit: contain; vertical-align: -5px; }
@@ -3621,23 +3716,19 @@
     color: #04240f; background: linear-gradient(135deg, #6ee7b7, #34d399); border: none; }
   .cr-cashout:disabled { opacity: 0.5; cursor: default; }
   .cr-wallet { margin-top: 4px; font-size: 0.66rem; color: var(--text-faint); }
-  /* Cash Game (Climb) gamified HUD */
-  .climb-top { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%; max-width: 360px; margin: 0 auto 14px; }
-  .climb-level {
-    font-family: var(--font-display); font-weight: 800; font-size: 0.95rem; white-space: nowrap;
-    padding: 6px 14px; border-radius: 999px; color: var(--brand-2);
-    background: rgba(253, 224, 71,0.1); border: 1px solid rgba(253, 224, 71,0.35);
+  /* 🏷️ Game-mode pill — centered under the wordmark, same for every mode */
+  .mode-pill {
+    display: inline-flex; align-items: center; gap: 6px; margin: -2px auto 10px;
+    padding: 4px 14px; border-radius: 999px; white-space: nowrap; cursor: pointer;
+    font-family: var(--font-display); font-weight: 800; font-size: 0.72rem;
+    text-transform: uppercase; letter-spacing: 0.1em; color: var(--brand-2);
+    background: rgba(253, 224, 71, 0.08); border: 1px solid rgba(253, 224, 71, 0.3);
+    transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
   }
-  .heat-meter {
-    position: relative; flex: 1; height: 30px; max-width: 180px; border-radius: 999px; overflow: hidden;
-    background: rgba(255,255,255,0.06); border: 1px solid var(--border); display: flex; align-items: center; justify-content: center;
-  }
-  .heat-fill {
-    position: absolute; left: 0; top: 0; bottom: 0; border-radius: 999px;
-    background: linear-gradient(90deg, #fb923c, #f43f5e); transition: width 0.4s var(--ease-out, ease); opacity: 0.85;
-  }
-  .heat-x { position: relative; z-index: 1; font-family: var(--font-display); font-weight: 800; font-size: 0.85rem; color: #fff; text-shadow: 0 1px 3px rgba(0,0,0,0.5); }
-  .heat-meter.hot { border-color: rgba(251,146,60,0.6); box-shadow: 0 0 16px rgba(251,146,60,0.3); }
+  .mode-pill:hover { background: rgba(253, 224, 71, 0.14); border-color: rgba(253, 224, 71, 0.5); }
+  .mode-pill:active { transform: scale(0.95); }
+  .mp-emoji { font-size: 0.9rem; letter-spacing: 0; }
+  .mp-info { font-size: 0.72rem; opacity: 0.6; letter-spacing: 0; }
 
 
   .bankroll-amount {

--- a/supabase-cash-game-polish.sql
+++ b/supabase-cash-game-polish.sql
@@ -1,0 +1,226 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Cash Game polish: cleanup + run-tracking + run leaderboard + anomaly       ║
+-- ║  (migration: cash_game_polish_2026_06 — applied via psql)                   ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- Bundles the post-Double-or-Nothing pass:
+--   B  (cleanup): drop legacy `attempts_remaining` column + orphaned climb_reveal;
+--      remove the DEAD inactive-power-up effect code (double_down / insurance /
+--      heat_shield) from _climb_resolve. These power-ups are active=false, so they
+--      can never enter active_powerups (climb_use_powerup requires active) — the
+--      branches were unreachable. Catalog rows are LEFT in place (active=false) to
+--      avoid breaking _grant_random_powerup's FK; "cut" = de-fanged, not deleted.
+--   C1 (insurance ✕ DoN): resolved for free by the above — with the insurance
+--      branch gone, a Double-or-Nothing bust can never be refunded. (If insurance
+--      is ever reactivated, re-add its effect so it explicitly does NOT fire while
+--      cs.don_armed — the gamble must stay all-or-nothing.)
+--   C3 (run leaderboard): persist best_run_solves / best_run_profit on climb_state
+--      (all-time hot-streak bests, never reset), update them on each solve, and add
+--      get_climb_run_leaderboard(scope, group) ranked by best_run_profit.
+--   C4 (anomaly): get_climb_anomaly_summary(days) from game_results (game_mode=climb)
+--      — fast/instant solves, volume, profit — Cash Game was uncovered (the Daily
+--      anomaly summary only reads daily_sessions).
+--
+-- Idempotent; safe to re-run. Apply inside one transaction.
+
+BEGIN;
+
+-- ── C3: all-time run bests (never reset; only run_solves/run_profit reset on stuck) ──
+ALTER TABLE public.climb_state
+  ADD COLUMN IF NOT EXISTS best_run_solves int    NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS best_run_profit bigint NOT NULL DEFAULT 0;
+
+-- Backfill bests from the current live run so existing players aren't zeroed.
+UPDATE public.climb_state
+   SET best_run_solves = GREATEST(best_run_solves, run_solves),
+       best_run_profit = GREATEST(best_run_profit, run_profit);
+
+-- ── B + C1 + C3: resolve logic (removes dead pup branches, tracks run bests) ──
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_bounty INT; v_payout INT; v_min INT; v_cash BIGINT; v_cat TEXT; v_time INT; v_newprofit BIGINT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state IN ('solved','complete') THEN RETURN public._climb_board(p_uid); END IF;
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    v_bounty := public._climb_bounty(cs.puzzle_id);
+    IF cs.don_armed THEN v_bounty := v_bounty * 2; END IF;  -- Double or Nothing paid off
+    v_payout := round(v_bounty * cs.heat_x100 / 100.0)::int;
+    v_newprofit := cs.run_profit + (v_payout - cs.spent);
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    PERFORM public._bank_credit(p_uid, v_payout, 'climb_bounty');
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_payout,
+      heat_x100 = LEAST(200, cs.heat_x100 + 10),
+      run_solves = cs.run_solves + 1, run_profit = v_newprofit,
+      best_run_solves = GREATEST(cs.best_run_solves, cs.run_solves + 1),
+      best_run_profit = GREATEST(cs.best_run_profit, v_newprofit),
+      don_armed = false, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_payout, v_time);
+  ELSE
+    SELECT min(public.letter_cost(t.ch)) INTO v_min FROM (
+      SELECT DISTINCT substr(v_phrase, g.i+1, 1) AS ch FROM generate_series(0, length(v_phrase)-1) g(i)
+      WHERE substr(v_phrase, g.i+1, 1) ~ '[A-Z]' AND NOT (g.i = ANY(cs.revealed_positions))) t;
+    SELECT bank INTO v_cash FROM public.profiles WHERE id = p_uid;
+    IF v_min IS NULL OR v_cash < v_min THEN
+      -- Stuck: can't afford the cheapest unrevealed letter. Heat + run wiped.
+      -- (A Double-or-Nothing bust lands here → don_armed cleared, $0, nothing refunded.)
+      UPDATE public.climb_state SET state = 'stuck',
+        heat_x100 = 100, run_solves = 0, run_profit = 0,
+        don_armed = false, updated_at = now() WHERE user_id = p_uid;
+      PERFORM public._log_game_result(p_uid,'climb','lost', cs.puzzle_id, v_cat, 0, 1, cs.spent::int, 0);
+    ELSE
+      UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;
+    END IF;
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- ── B: board (drop attempts_remaining; pass unlimited-guess sentinel; expose bests) ──
+CREATE OR REPLACE FUNCTION public._climb_board(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_cash BIGINT; v_state TEXT; v_board JSONB;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  IF cs.state = 'complete' THEN
+    RETURN jsonb_build_object('climb', jsonb_build_object('complete', true, 'position', cs.position, 'heat', cs.heat_x100));
+  END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT bank INTO v_cash FROM public.profiles WHERE id = p_uid;
+  v_state := CASE cs.state WHEN 'solved' THEN 'won' ELSE 'active' END;
+  -- guesses are unlimited in the Cash Game; pass a high sentinel to the shared board.
+  v_board := public._daily_board(v_phrase, v_state, v_cash::int, 99, cs.revealed_positions, cs.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('climb', jsonb_build_object(
+    'bounty', public._climb_bounty(cs.puzzle_id), 'heat', cs.heat_x100,
+    'spent', cs.spent, 'position', cs.position, 'stuck', cs.state = 'stuck', 'last_gain', cs.last_gain,
+    'state', cs.state, 'pups_locked', cs.pups_locked, 'equipped', to_jsonb(cs.active_powerups),
+    'don_armed', cs.don_armed, 'don_available', (cs.state = 'active' AND cs.heat_x100 >= 150 AND NOT cs.don_armed),
+    'run_solves', cs.run_solves, 'run_profit', cs.run_profit,
+    'best_run_solves', cs.best_run_solves, 'best_run_profit', cs.best_run_profit));
+END; $function$;
+
+-- ── B: advance (drop attempts_remaining=3; run + bests persist across solves) ──
+CREATE OR REPLACE FUNCTION public.climb_next()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_pid UUID; v_newpos INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_next: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state <> 'solved' THEN RETURN public._climb_board(v_uid); END IF;
+  v_newpos := cs.position + 1;
+  v_pid := public._pick_casual(v_uid, null, cs.puzzle_id, 0);
+  IF v_pid IS NULL THEN
+    UPDATE public.climb_state SET state = 'complete', position = v_newpos, updated_at = now() WHERE user_id = v_uid;
+    RETURN public._climb_board(v_uid);
+  END IF;
+  UPDATE public.climb_state SET position = v_newpos, puzzle_id = v_pid, revealed_positions = '{}',
+    incorrect_letters = '{}', spent = 0, last_gain = 0, active_powerups = '{}',
+    pups_locked = false, don_armed = false, state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  IF v_newpos = 50 THEN PERFORM public._award_badge(v_uid, 'climb_50');
+  ELSIF v_newpos = 100 THEN PERFORM public._award_badge(v_uid, 'climb_100');
+  ELSIF v_newpos = 500 THEN PERFORM public._award_badge(v_uid, 'climb_500'); END IF;
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- ── B: skip (drop attempts_remaining=3; still wipes heat + run) ──
+CREATE OR REPLACE FUNCTION public.climb_skip()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_skip: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  IF cs.don_armed THEN RETURN public._climb_board(v_uid); END IF;  -- committed; can't skip
+  v_pid := public._pick_casual(v_uid, null, cs.puzzle_id, 0);
+  IF v_pid IS NULL THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.climb_state SET puzzle_id = v_pid, revealed_positions = '{}', incorrect_letters = '{}',
+    spent = 0, last_gain = 0, active_powerups = '{}', pups_locked = false,
+    heat_x100 = 100, run_solves = 0, run_profit = 0, don_armed = false,
+    state = 'active', puzzle_started_at = now(), updated_at = now()
+  WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- ── B: drop orphaned reveal RPC (became the Free Reveal power-up) ──
+DROP FUNCTION IF EXISTS public.climb_reveal();
+
+-- ── B: drop legacy column now that no function references it ──
+ALTER TABLE public.climb_state DROP COLUMN IF EXISTS attempts_remaining;
+
+-- ── C3: profit/run leaderboard (skill-based; complements the position board) ──
+CREATE OR REPLACE FUNCTION public.get_climb_run_leaderboard(p_scope text DEFAULT 'friends'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  WITH pool AS (
+    SELECT cs.user_id AS id, cs.best_run_profit, cs.best_run_solves, cs.position
+    FROM public.climb_state cs
+    WHERE cs.best_run_profit > 0 AND (
+         p_scope = 'global' OR cs.user_id = v_uid
+      OR (p_scope = 'friends' AND cs.user_id IN (SELECT friend_id FROM public.friendships WHERE user_id = v_uid))
+      OR (p_scope = 'group'   AND cs.user_id IN (SELECT user_id FROM public.group_members WHERE group_id = p_group)))
+  ),
+  ranked AS (SELECT *, row_number() OVER (ORDER BY best_run_profit DESC, best_run_solves DESC) AS rank
+             FROM pool ORDER BY best_run_profit DESC LIMIT 50)
+  SELECT jsonb_agg(jsonb_build_object('rank', rank, 'name', public._display_name(id),
+    'best_run_profit', best_run_profit, 'best_run_solves', best_run_solves,
+    'position', position, 'is_me', id = v_uid) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+-- ── C4: Cash Game anomaly summary (anti-AI-solving) ──
+CREATE OR REPLACE FUNCTION public.get_climb_anomaly_summary(p_days int DEFAULT 30)
+ RETURNS TABLE(user_id uuid, display_name text, solves int, losses int,
+               avg_solve_seconds numeric, fast_solves int, instant_solves int,
+               total_profit bigint, max_position int)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  RETURN QUERY
+  WITH g AS (
+    SELECT gr.user_id, gr.won,
+           GREATEST(0, COALESCE(gr.time_ms, 0)) / 1000.0 AS secs,
+           COALESCE(gr.net, 0) AS net
+    FROM public.game_results gr
+    WHERE gr.game_mode = 'climb'
+      AND gr.played_at >= now() - make_interval(days => GREATEST(p_days, 1))
+  ),
+  agg AS (
+    SELECT g.user_id,
+      COUNT(*) FILTER (WHERE g.won)::int       AS solves,
+      COUNT(*) FILTER (WHERE NOT g.won)::int    AS losses,
+      ROUND(AVG(g.secs) FILTER (WHERE g.won), 1) AS avg_secs,
+      COUNT(*) FILTER (WHERE g.won AND g.secs < 15)::int AS fast_solves,
+      COUNT(*) FILTER (WHERE g.won AND g.secs < 5)::int  AS instant_solves,
+      SUM(g.net)::bigint AS total_profit
+    FROM g GROUP BY g.user_id
+  )
+  SELECT a.user_id, public._display_name(a.user_id), a.solves, a.losses, a.avg_secs,
+         a.fast_solves, a.instant_solves, a.total_profit, COALESCE(cs.position, 0)
+  FROM agg a
+  LEFT JOIN public.climb_state cs ON cs.user_id = a.user_id
+  ORDER BY a.instant_solves DESC, a.fast_solves DESC, a.solves DESC;
+END; $function$;
+
+COMMIT;

--- a/supabase-daily-expire.sql
+++ b/supabase-daily-expire.sql
@@ -1,0 +1,44 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Daily: no broke timer — unfinished puzzles expire as a loss at day's end    ║
+-- ║  (migration: expire_stale_dailies_2026_06 — applied via psql)               ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- The Daily no longer has a broke auto-fold timer (guesses are free + unlimited,
+-- so being out of Cash isn't a dead end). The only way to "lose" the Daily is to
+-- not solve it before the day ends. Because letters are paid from your real
+-- profiles.bank, the Cash you spent is already gone — not solving forfeits it.
+--
+-- No pg_cron here, so this finalizes lazily: the client calls expire_stale_dailies()
+-- on app open. Any of the caller's still-active sessions from a PRIOR day are marked
+-- lost, the answer is revealed, and a game_results 'lost' row is logged so it shows
+-- (with the answer) in History. Streaks are intentionally NOT touched — the date-gap
+-- logic in daily_start/get_daily_status already handles streak breaks, and we must not
+-- retroactively zero a streak the player has since rebuilt.
+-- Idempotent: only 'active' prior-day sessions are processed, then flipped to 'lost'.
+
+CREATE OR REPLACE FUNCTION public.expire_stale_dailies()
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); r public.daily_sessions; v_phrase text; v_cat text; v_all int[]; v_n int := 0;
+BEGIN
+  IF v_uid IS NULL THEN RETURN 0; END IF;
+  FOR r IN SELECT * FROM public.daily_sessions
+           WHERE user_id = v_uid AND state = 'active' AND puzzle_date < CURRENT_DATE
+           FOR UPDATE LOOP
+    SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = r.puzzle_id;
+    SELECT array_agg(g.i) INTO v_all FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1, 1) <> ' ';
+    UPDATE public.daily_sessions
+      SET state = 'lost', finished_at = (r.puzzle_date + 1)::timestamptz,
+          revealed_positions = COALESCE(v_all, '{}'), updated_at = now()
+      WHERE user_id = v_uid AND puzzle_date = r.puzzle_date;
+    INSERT INTO public.game_results
+      (user_id, played_at, won, bankroll_left, game_mode, score, outcome, puzzle_id, category,
+       solved_count, puzzle_count, spent, earned, net)
+    VALUES
+      (v_uid, (r.puzzle_date + 1)::timestamptz, false, 0, 'daily', -r.spent, 'lost', r.puzzle_id, v_cat,
+       0, 1, r.spent, 0, -r.spent);
+    v_n := v_n + 1;
+  END LOOP;
+  RETURN v_n;
+END; $function$;

--- a/supabase-daily-resume-fix.sql
+++ b/supabase-daily-resume-fix.sql
@@ -1,0 +1,50 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Fix: Daily shown as "complete + lost" after playing another mode           ║
+-- ║  (migration: daily_status_in_progress_2026_06 — applied via psql)           ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- ROOT CAUSE: the client decided "Daily in progress vs finished" from a SINGLE
+-- shared localStorage slot (wordbank_game_state_<uid>), which every mode's
+-- goToMainMenu() overwrites. After starting a Daily (server session = 'active',
+-- so has_played_today=true) then playing Cash Game, that slot held climb state →
+-- the menu computed dailyInProgress=false → dailyDone=true → and since the still-
+-- active Daily isn't won (last_daily_won=false) it rendered the ❌ "lost" chip and
+-- refused to resume. has_played_today means "started today", NOT "finished today",
+-- so an active Daily and a finished-lost Daily were indistinguishable to the client.
+--
+-- FIX: expose SERVER truth. get_daily_status now returns daily_in_progress (today's
+-- session exists and is still 'active'). The client derives dailyInProgress from
+-- this instead of the clobberable localStorage, so it resumes correctly regardless
+-- of what other mode was played in between.
+--
+-- Adds an OUT column → must DROP then CREATE (REPLACE can't change return type).
+
+DROP FUNCTION IF EXISTS public.get_daily_status(uuid);
+
+CREATE FUNCTION public.get_daily_status(p_user_id uuid)
+ RETURNS TABLE(has_played_today boolean, last_daily_won boolean, daily_bankroll integer,
+               arcade_bankroll integer, current_streak integer, streak_freezes integer,
+               today_score integer, win_streak integer, daily_in_progress boolean)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN RETURN; END IF;
+  RETURN QUERY
+  SELECT
+    -- 🔁 test1 auto-replay: always report not-played so the client re-enters Daily (testing only).
+    (CASE WHEN v_uid = 'a5832b8b-278d-4f66-9ef3-b2067fe8312d'::uuid THEN false
+          ELSE (p.last_daily_play_date = CURRENT_DATE) END) AS has_played_today,
+    EXISTS (SELECT 1 FROM public.game_results gr WHERE gr.user_id = v_uid AND gr.game_mode = 'daily'
+      AND gr.played_at::date = CURRENT_DATE AND gr.outcome = 'won') AS last_daily_won,
+    COALESCE(p.daily_bankroll, 0)::INT, COALESCE(p.arcade_bankroll, 1000)::INT,
+    COALESCE(p.current_win_streak, 0)::INT AS current_streak,
+    COALESCE(p.streak_freezes, 0)::INT,
+    COALESCE((SELECT gr.score FROM public.game_results gr WHERE gr.user_id = v_uid AND gr.game_mode = 'daily'
+      AND gr.played_at::date = CURRENT_DATE ORDER BY gr.played_at DESC LIMIT 1), 0)::INT AS today_score,
+    (CASE WHEN p.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(p.current_solve_streak,0) ELSE 0 END)::INT AS win_streak,
+    -- ✅ SERVER truth for "resume vs finished": today's session still open?
+    EXISTS (SELECT 1 FROM public.daily_sessions ds
+            WHERE ds.user_id = v_uid AND ds.puzzle_date = CURRENT_DATE AND ds.state = 'active') AS daily_in_progress
+  FROM public.profiles p WHERE p.id = v_uid;
+END; $function$;

--- a/supabase-open-games.sql
+++ b/supabase-open-games.sql
@@ -1,0 +1,37 @@
+-- ╔══════════════════════════════════════════════════════════════════════════╗
+-- ║  Multiple live games: server-truth "open games" for menu resume             ║
+-- ║  (migration: get_open_games_2026_06 — applied via psql)                     ║
+-- ╚══════════════════════════════════════════════════════════════════════════╝
+-- The server already keeps independent per-mode sessions (daily_sessions,
+-- climb_state, freeplay_sessions), so several solo games can be live at once.
+-- The client used to infer "in progress" from a single shared localStorage slot,
+-- which any mode's goToMainMenu() overwrote (the "Daily shows lost" bug).
+--
+-- get_open_games() returns the caller's currently-resumable SOLO games, newest
+-- first, so the menu can: (a) label each mode's card from server truth, and
+-- (b) offer a top-level "Resume" shortcut to the most-recently-played one.
+
+CREATE OR REPLACE FUNCTION public.get_open_games()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v jsonb;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  SELECT COALESCE(jsonb_agg(to_jsonb(t) ORDER BY t.updated_at DESC), '[]'::jsonb) INTO v
+  FROM (
+    SELECT 'daily'::text AS mode, ds.updated_at
+      FROM public.daily_sessions ds
+      WHERE ds.user_id = v_uid AND ds.puzzle_date = CURRENT_DATE AND ds.state = 'active'
+    UNION ALL
+    SELECT 'climb', cs.updated_at
+      FROM public.climb_state cs
+      WHERE cs.user_id = v_uid AND cs.state IN ('active','stuck')
+    UNION ALL
+    SELECT 'freeplay', fs.updated_at
+      FROM public.freeplay_sessions fs
+      WHERE fs.user_id = v_uid AND fs.state = 'active'
+  ) t;
+  RETURN v;
+END; $function$;


### PR DESCRIPTION
Four related changes to the solo modes. Every DB migration listed is **already applied to prod** via psql (the `supabase-*.sql` files are the committed record).

## 1. Cash Game: Double or Nothing + polish (`f11db3f`)
- **Double or Nothing** UI for the already-live backend: gold CTA gated on `don_available` (heat ≥ ×1.5), confirm modal, armed indicator, Skip hidden once committed, live payout doubles, "💥 Doubled!" win banner. Verified economics via psql rollback sim (solve → bounty×heat×2; bust → $0, spend forfeited) and full UI screenshots.
- **Run arc**: HUD shows "{n}-solve run · +$X this run · 🏆 personal best" from `run_solves`/`run_profit`.
- **Profit leaderboard**: new 🎰 Cash Game tab ranked by best single-run profit (`get_climb_run_leaderboard`).
- **Cleanup** (`supabase-cash-game-polish.sql`): dropped legacy `attempts_remaining` + orphaned `climb_reveal`; stripped dead inactive-power-up effect code; persisted `best_run_*`; added `get_climb_anomaly_summary` (Cash Game was uncovered by anomaly detection).

## 2. Fix: active Daily shown as "complete + lost" after playing another mode (`66e4b91`)
Root cause: the menu inferred Daily in-progress from a single shared localStorage slot that every mode's `goToMainMenu()` overwrote. Now `get_daily_status` returns `daily_in_progress` (server truth) and the client derives from it. (`supabase-daily-resume-fix.sql`)

## 3. Multiple live games + Resume (`4d15204`)
- `get_open_games()` returns resumable solo games (daily/climb/freeplay), newest first.
- Each mode's card resumes from server truth; new **▶ Resume** card on the home menu jumps to your most-recent live game ("+N more in progress"). (`supabase-open-games.sql`)
- Timer scoping: `isBroke` is false on the menu so the broke clock can't fire across modes.

## 4. Daily loss-model rework (`d3b3424`)
- **Removed the Daily broke timer** — guesses are free + unlimited, so being broke isn't a dead end. Split `foldMode` (Give up: Daily + Challenges) from `brokeMode` (auto-fold clock: Challenges only).
- **Give up** stays on the Daily (reveals the answer, counts as a loss).
- Only way to lose the Daily is to not solve it before day's end; the spent real Cash is forfeited. `expire_stale_dailies()` finalizes unfinished prior-day sessions lazily on app open → `lost` + answer revealed + `−spent` History row. (`supabase-daily-expire.sql`)

## Verification
- `npm run build` passes; `svelte-check` went 54 → 49 errors (fixed a pre-existing missing `win_streak` type; no new errors).
- Server logic proven with psql rollback sims; UI flows screenshotted via `scripts/check-don.mjs`, `check-daily-resume.mjs`, `check-resume.mjs`.

## Notes / follow-ups
- No `pg_cron`, so Daily expiry runs on next app open rather than exactly at midnight (same user-visible result).
- Playing a Daily *across* midnight breaks the session (pre-existing edge, not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)