### PR TITLE
Leaderboard/profile/social overhaul + Daily gold + auto-friend

### DIFF
--- a/scripts/check-daily-gold.mjs
+++ b/scripts/check-daily-gold.mjs
@@ -1,0 +1,24 @@
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+const BASE=process.env.BASE||'http://localhost:5173', EMAIL='pwtest+wb@example.com', PASS='TestPass123!', DB=process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots/menu',{recursive:true});
+const sql=(q)=>execSync(`psql "${DB}"`,{input:q,encoding:'utf8'});
+const b=await chromium.launch(); const p=await(await b.newContext({viewport:{width:430,height:932},deviceScaleFactor:2})).newPage();
+p.setDefaultTimeout(8000); const wait=(ms)=>p.waitForTimeout(ms);
+const kill=()=>p.evaluate(()=>{localStorage.setItem('wb_tutorial_v3','true');localStorage.setItem('wb_launch_welcome_v1','1');for(const m of['daily','climb','freeplay','match','makeup'])localStorage.setItem('wb_obj_'+m,'1');}).catch(()=>{});
+const skipPin=async()=>{await p.getByText(/skip for now/i).first().click({timeout:1200}).catch(()=>{});await wait(400);};
+try{
+  // reset pwtest's daily so it shows NOT started
+  sql(`UPDATE profiles SET username=COALESCE(username,'pwtest_wb'), last_daily_play_date=NULL WHERE id=(SELECT id FROM auth.users WHERE email='${EMAIL}');
+    DELETE FROM daily_sessions WHERE user_id=(SELECT id FROM auth.users WHERE email='${EMAIL}') AND puzzle_date=CURRENT_DATE;
+    DELETE FROM game_results WHERE user_id=(SELECT id FROM auth.users WHERE email='${EMAIL}') AND game_mode='daily' AND created_at::date=CURRENT_DATE;`);
+  await p.goto(BASE,{waitUntil:'domcontentloaded'});await wait(500);await kill();
+  if(await p.locator('input[type=password]').count()){await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);await p.locator('input[type=password]').first().fill(PASS);await p.getByRole('button',{name:/^log in$/i}).first().click().catch(()=>{});await wait(2800);}
+  await kill();await skipPin();await wait(700);
+  await p.getByRole('button',{name:/play now/i}).first().click().catch(()=>{}); await skipPin(); await wait(900);
+  const dailyCard = p.locator('.menu-card', { hasText: 'Daily' }).first();
+  console.log('daily card classes:', await dailyCard.getAttribute('class'));
+  await p.screenshot({path:'screenshots/menu/30-daily-gold.png'});
+  console.log('done');
+}catch(e){console.log('FATAL',e.message);} finally{await b.close();}

--- a/scripts/check-lb2.mjs
+++ b/scripts/check-lb2.mjs
@@ -1,0 +1,22 @@
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+const BASE=process.env.BASE||'http://localhost:5173', EMAIL='pwtest+wb@example.com', PASS='TestPass123!', DB=process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots/lb',{recursive:true});
+const sql=(q)=>execSync(`psql "${DB}" -tAc "${q.replace(/"/g,'\\"')}"`,{encoding:'utf8'}).trim();
+const b=await chromium.launch(); const p=await(await b.newContext({viewport:{width:430,height:932},deviceScaleFactor:2})).newPage();
+p.setDefaultTimeout(8000); const wait=(ms)=>p.waitForTimeout(ms);
+const kill=()=>p.evaluate(()=>{localStorage.setItem('wb_tutorial_v3','true');localStorage.setItem('wb_launch_welcome_v1','1');for(const m of['daily','climb','freeplay','match','makeup'])localStorage.setItem('wb_obj_'+m,'1');}).catch(()=>{});
+const skipPin=async()=>{await p.getByText(/skip for now/i).first().click({timeout:1200}).catch(()=>{});await wait(400);};
+try{
+  sql(`UPDATE profiles SET username=COALESCE(username,'pwtest_wb') WHERE id=(SELECT id FROM auth.users WHERE email='${EMAIL}')`);
+  await p.goto(BASE,{waitUntil:'domcontentloaded'});await wait(500);await kill();
+  if(await p.locator('input[type=password]').count()){await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);await p.locator('input[type=password]').first().fill(PASS);await p.getByRole('button',{name:/^log in$/i}).first().click().catch(()=>{});await wait(2800);}
+  await kill();await skipPin();await wait(800);
+  console.log('challenge-friends label:', await p.locator('.vs-main').first().innerText().catch(()=>'?'));
+  await p.screenshot({path:'screenshots/lb/10-menu.png'});
+  await p.locator('.menu-card', { hasText: 'Leaderboard' }).click().catch(()=>{}); await wait(1400);
+  console.log('board tabs (should be 0):', await p.locator('.tab').count(), '| scope select:', await p.locator('.filter-select').count(), '| sort headers:', await p.locator('th .sort').count(), '| comm-tabs:', await p.locator('.comm-tab').count());
+  await p.screenshot({path:'screenshots/lb/11-daily-only.png'});
+  console.log('done');
+}catch(e){console.log('FATAL',e.message);} finally{await b.close();}

--- a/scripts/check-lb3.mjs
+++ b/scripts/check-lb3.mjs
@@ -1,0 +1,26 @@
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+const BASE=process.env.BASE||'http://localhost:5173', EMAIL='pwtest+wb@example.com', PASS='TestPass123!', DB=process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots/lb',{recursive:true});
+const sql=(q)=>execSync(`psql "${DB}" -tAc "${q.replace(/"/g,'\\"')}"`,{encoding:'utf8'}).trim();
+const b=await chromium.launch(); const p=await(await b.newContext({viewport:{width:430,height:932},deviceScaleFactor:2})).newPage();
+p.setDefaultTimeout(8000); const wait=(ms)=>p.waitForTimeout(ms);
+const kill=()=>p.evaluate(()=>{localStorage.setItem('wb_tutorial_v3','true');localStorage.setItem('wb_launch_welcome_v1','1');for(const m of['daily','climb','freeplay','match','makeup'])localStorage.setItem('wb_obj_'+m,'1');}).catch(()=>{});
+const skipPin=async()=>{await p.getByText(/skip for now/i).first().click({timeout:1200}).catch(()=>{});await wait(400);};
+try{
+  sql(`UPDATE profiles SET username=COALESCE(username,'pwtest_wb') WHERE id=(SELECT id FROM auth.users WHERE email='${EMAIL}')`);
+  await p.goto(BASE,{waitUntil:'domcontentloaded'});await wait(500);await kill();
+  if(await p.locator('input[type=password]').count()){await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);await p.locator('input[type=password]').first().fill(PASS);await p.getByRole('button',{name:/^log in$/i}).first().click().catch(()=>{});await wait(2800);}
+  await kill();await skipPin();await wait(800);
+  await p.locator('.menu-card', { hasText: 'Leaderboard' }).click().catch(()=>{}); await wait(1400);
+  console.log('sub-people on lb (should be 0):', await p.locator('.sub-people').count(), '| # header present:', await p.locator('th .sort').first().innerText().catch(()=>'?'));
+  await p.screenshot({path:'screenshots/lb/20-centered.png'});
+  // click # twice → reverse (last to top)
+  await p.locator('th .sort', { hasText: '#' }).click().catch(()=>{}); await wait(300);
+  await p.locator('th .sort', { hasText: '#' }).click().catch(()=>{}); await wait(400);
+  const firstPlace = await p.locator('tbody tr td.rank').first().innerText().catch(()=>'?');
+  console.log('after reversing #, top row rank:', firstPlace);
+  await p.screenshot({path:'screenshots/lb/21-reversed.png'});
+  console.log('done');
+}catch(e){console.log('FATAL',e.message);} finally{await b.close();}

--- a/scripts/check-prof2.mjs
+++ b/scripts/check-prof2.mjs
@@ -1,0 +1,23 @@
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+const BASE=process.env.BASE||'http://localhost:5173', EMAIL='pwtest+wb@example.com', PASS='TestPass123!', DB=process.env.SUPABASE_DB_URL;
+mkdirSync('screenshots/profile',{recursive:true});
+const sql=(q)=>execSync(`psql "${DB}"`,{input:q,encoding:'utf8'});
+const b=await chromium.launch(); const p=await(await b.newContext({viewport:{width:430,height:932},deviceScaleFactor:2})).newPage();
+p.setDefaultTimeout(8000); const wait=(ms)=>p.waitForTimeout(ms);
+const kill=()=>p.evaluate(()=>{localStorage.setItem('wb_tutorial_v3','true');localStorage.setItem('wb_launch_welcome_v1','1');for(const m of['daily','climb','freeplay','match','makeup'])localStorage.setItem('wb_obj_'+m,'1');}).catch(()=>{});
+const skipPin=async()=>{await p.getByText(/skip for now/i).first().click({timeout:1200}).catch(()=>{});await wait(400);};
+try{
+  const uid='(SELECT id FROM auth.users WHERE email=\''+EMAIL+'\')';
+  sql(`UPDATE profiles SET username=COALESCE(username,'pwtest_wb'), avatar='{"top":"shortFlat","clothing":"hoodie","clothesColor":"5199e4","frame":"neon"}'::jsonb WHERE id=${uid};
+    INSERT INTO user_badges(user_id,badge) VALUES (${uid},'flawless'),(${uid},'gold_bank') ON CONFLICT DO NOTHING;`);
+  await p.goto(BASE,{waitUntil:'domcontentloaded'});await wait(500);await kill();
+  if(await p.locator('input[type=password]').count()){await p.getByPlaceholder(/email or username/i).first().fill(EMAIL);await p.locator('input[type=password]').first().fill(PASS);await p.getByRole('button',{name:/^log in$/i}).first().click().catch(()=>{});await wait(2800);}
+  await kill();await skipPin();await wait(500);
+  await p.goto(BASE+'/profile',{waitUntil:'domcontentloaded'});await wait(1200);
+  console.log('tabs(should be 0):', await p.locator('.tabs .tab').count(), '| home btn(0):', await p.locator('[title="Main menu"]').count(), '| nav cards:', await p.locator('.ov-link').count(), '| clickable stats:', await p.locator('.ov-summary .stat-link').count());
+  await p.screenshot({path:'screenshots/profile/10-clean.png'});
+  sql(`DELETE FROM user_badges WHERE user_id=${uid} AND badge IN ('flawless','gold_bank'); UPDATE profiles SET avatar=NULL WHERE id=${uid};`);
+  console.log('done');
+}catch(e){console.log('FATAL',e.message);} finally{await b.close();}

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -14,25 +14,33 @@
   let loading = $state(true);
   let error = $state('');
 
-  // Sortable columns (client-side). Default: today's score, high → low.
-  /** @type {'name'|'net_worth'|'score'|'play_streak'|'win_streak'} */
-  let sortKey = $state('score');
-  /** @type {'asc'|'desc'} */
-  let sortDir = $state('desc');
-  /** @param {typeof sortKey} k */
+  // Sortable columns (client-side). Default: by place, best → worst. Tap # again to
+  // flip and bring LAST place to the top.
+  /** @typedef {'place'|'name'|'net_worth'|'score'|'play_streak'|'win_streak'} SortKey */
+  let sortKey = $state(/** @type {SortKey} */ ('place'));
+  let sortDir = $state(/** @type {'asc'|'desc'} */ ('asc'));
+  /** @param {SortKey} k */
   function setSort(k) {
     if (sortKey === k) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
-    else { sortKey = k; sortDir = k === 'name' ? 'asc' : 'desc'; }
+    else { sortKey = k; sortDir = (k === 'name' || k === 'place') ? 'asc' : 'desc'; }
   }
-  /** @param {typeof sortKey} k */
+  /** @param {SortKey} k */
   const arrow = (k) => sortKey === k ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
+  // Canonical place = rank by today's score (played first, high → low). Stays fixed
+  // no matter how the list is sorted, so the # column always shows the real place.
+  let ranked = $derived.by(() =>
+    [...rows]
+      .sort((a, b) => (b.score ?? -Infinity) - (a.score ?? -Infinity) || String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' }))
+      .map((r, i) => ({ ...r, _place: i + 1 }))
+  );
   let sortedRows = $derived.by(() => {
     const dir = sortDir === 'asc' ? 1 : -1;
-    return [...rows].sort((a, b) => {
+    return [...ranked].sort((a, b) => {
+      if (sortKey === 'place') return dir * (a._place - b._place);
       if (sortKey === 'name') return dir * String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' });
       const av = sortKey === 'score' ? (a.score ?? -Infinity) : Number(a[sortKey] ?? 0);
       const bv = sortKey === 'score' ? (b.score ?? -Infinity) : Number(b[sortKey] ?? 0);
-      return dir * (av - bv) || String(a.name || '').localeCompare(String(b.name || ''));
+      return dir * (av - bv) || (a._place - b._place);
     });
   });
 
@@ -77,7 +85,7 @@
     <table>
       <thead>
         <tr>
-          <th>#</th>
+          <th><button class="sort" class:on={sortKey === 'place'} onclick={() => setSort('place')}>#{arrow('place')}</button></th>
           <th><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}>Player{arrow('name')}</button></th>
           <th class="num"><button class="sort" class:on={sortKey === 'net_worth'} onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button></th>
           <th class="num"><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}>Score{arrow('score')}</button></th>
@@ -87,8 +95,8 @@
       </thead>
       <tbody>
         {#each sortedRows as r, i}
-          <tr class={r.is_me ? 'me' : (i < 3 ? 'top' : '')}>
-            <td class="rank">{medal(i + 1)}</td>
+          <tr class={r.is_me ? 'me' : (r._place <= 3 ? 'top' : '')}>
+            <td class="rank">{medal(r._place)}</td>
             <td class="name">
               {#if r.is_me}
                 <button class="name-link" onclick={() => goto('/profile')} style={r.color ? `color:${r.color}` : ''}>You</button>

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -1,22 +1,12 @@
 <script>
-  // Leaderboard content (Cash · Daily). Reused by the /leaderboard route and the
-  // Community ▸ Leaderboard tab. The page/hub provides its own title + back.
+  // Today's Daily leaderboard. Sort by any column (name / cash / score / streaks);
+  // scope dropdown: Everyone · Friends · a specific group.
   import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
-  import { getWealthLeaderboard, getDailyBoard, getClimbRunLeaderboard, getMyGroups } from '$lib/stores/statsStore.js';
+  import { getDailyBoard, getMyGroups } from '$lib/stores/statsStore.js';
 
-  /** @type {'cash'|'daily'|'cash_game'} */
-  let board = $state('cash');
-  const TABS = [
-    { k: 'cash', label: '💰 Cash' },
-    { k: 'daily', label: '📅 Daily' },
-    { k: 'cash_game', label: '🎰 Cash Game' }
-  ];
-  const PERIOD_BOARDS = ['cash'];
   /** scope: 'global' (Everyone) | 'friends' | a group id */
   let scope = $state('global');
-  /** @type {'week'|'all'} */
-  let period = $state('all');
   /** @type {any[]} */
   let rows = $state([]);
   /** @type {any[]} */
@@ -24,7 +14,7 @@
   let loading = $state(true);
   let error = $state('');
 
-  // Sortable daily columns (client-side). Default: today's score, high → low.
+  // Sortable columns (client-side). Default: today's score, high → low.
   /** @type {'name'|'net_worth'|'score'|'play_streak'|'win_streak'} */
   let sortKey = $state('score');
   /** @type {'asc'|'desc'} */
@@ -37,7 +27,6 @@
   /** @param {typeof sortKey} k */
   const arrow = (k) => sortKey === k ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
   let sortedRows = $derived.by(() => {
-    if (board !== 'daily') return rows;
     const dir = sortDir === 'asc' ? 1 : -1;
     return [...rows].sort((a, b) => {
       if (sortKey === 'name') return dir * String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' });
@@ -53,84 +42,53 @@
     loading = true; error = '';
     try {
       const isGroup = scope !== 'global' && scope !== 'friends';
-      const sc = isGroup ? 'group' : scope;
-      const grp = isGroup ? scope : null;
-      if (board === 'cash') rows = await getWealthLeaderboard(sc, period, grp);
-      else if (board === 'cash_game') rows = await getClimbRunLeaderboard(sc, grp);
-      else rows = await getDailyBoard(sc, grp);
+      rows = await getDailyBoard(isGroup ? 'group' : scope, isGroup ? scope : null);
     } catch (e) {
       error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
     } finally { loading = false; }
   }
 
   onMount(async () => { groups = await getMyGroups(); await load(); });
-
-  // reload whenever the board / scope / period changes
-  $effect(() => { board; scope; period; load(); });
+  $effect(() => { scope; load(); });
 
   /** @param {number} rank */
   const medal = (rank) => rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : String(rank);
 </script>
 
-<!-- Board selector -->
-<div class="tabs">
-  {#each TABS as t}
-    <button class="tab" class:active={board === t.k} onclick={() => board = /** @type {any} */ (t.k)}>{t.label}</button>
-  {/each}
+<!-- Scope: Everyone · Friends · a specific group -->
+<div class="filters">
+  <select class="filter-select" bind:value={scope}>
+    <option value="global">🌍 Everyone</option>
+    <option value="friends">👋 Friends</option>
+    {#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
+  </select>
 </div>
 
-<!-- Scope: Everyone · Friends · each of your groups -->
-<div class="scope-row">
-  <button class="scope-pill" class:on={scope === 'global'} onclick={() => scope = 'global'}>🌍 Everyone</button>
-  <button class="scope-pill" class:on={scope === 'friends'} onclick={() => scope = 'friends'}>👋 Friends</button>
-  {#each groups as g}
-    <button class="scope-pill" class:on={scope === g.id} onclick={() => scope = g.id}>👥 {g.name}</button>
-  {/each}
-</div>
-
-{#if PERIOD_BOARDS.includes(board)}
-  <div class="filters">
-    <div class="seg">
-      <button class="seg-btn" class:on={period === 'week'} onclick={() => period = 'week'}>This Week</button>
-      <button class="seg-btn" class:on={period === 'all'} onclick={() => period = 'all'}>All-Time</button>
-    </div>
-  </div>
-{/if}
-
-<p class="caption">
-  {#if board === 'cash'}{period === 'week' ? 'Cash gained this week' : 'Richest players — total Cash'}
-  {:else if board === 'cash_game'}Biggest Cash Game run — most profit banked in one heat streak
-  {:else}Ranked by today's Daily score · {scope === 'global' ? 'everyone' : scope === 'friends' ? 'your friends' : 'this group'}{/if}
-</p>
+<p class="caption">Today's Daily — same puzzle for everyone. Tap a column to sort.</p>
 
 {#if loading}
   <p class="muted">Loading…</p>
 {:else if error}
   <p class="error">{error}</p>
 {:else if rows.length === 0}
-  <p class="muted">Nobody here yet — add friends or play!</p>
+  <p class="muted">Nobody here yet — add friends or play today's Daily!</p>
 {:else}
   <div class="table-wrap">
     <table>
       <thead>
         <tr>
           <th>#</th>
-          {#if board === 'cash'}<th>Player</th><th>{period === 'week' ? 'Gained' : 'Cash'}</th>
-          {:else if board === 'cash_game'}<th>Player</th><th class="num">Best run</th><th class="num">Streak</th>
-          {:else}
-            <th><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}>Player{arrow('name')}</button></th>
-            <th class="num"><button class="sort" class:on={sortKey === 'net_worth'} onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button></th>
-            <th class="num"><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}>Score{arrow('score')}</button></th>
-            <th class="num"><button class="sort" class:on={sortKey === 'play_streak'} onclick={() => setSort('play_streak')}>🔥{arrow('play_streak')}</button></th>
-            <th class="num"><button class="sort" class:on={sortKey === 'win_streak'} onclick={() => setSort('win_streak')}>🏆{arrow('win_streak')}</button></th>
-          {/if}
+          <th><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}>Player{arrow('name')}</button></th>
+          <th class="num"><button class="sort" class:on={sortKey === 'net_worth'} onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button></th>
+          <th class="num"><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}>Score{arrow('score')}</button></th>
+          <th class="num"><button class="sort" class:on={sortKey === 'play_streak'} onclick={() => setSort('play_streak')}>🔥{arrow('play_streak')}</button></th>
+          <th class="num"><button class="sort" class:on={sortKey === 'win_streak'} onclick={() => setSort('win_streak')}>🏆{arrow('win_streak')}</button></th>
         </tr>
       </thead>
       <tbody>
         {#each sortedRows as r, i}
-          {@const pos = board === 'daily' ? i + 1 : r.rank}
-          <tr class={r.is_me ? 'me' : (pos <= 3 ? 'top' : '')}>
-            <td class="rank">{medal(pos)}</td>
+          <tr class={r.is_me ? 'me' : (i < 3 ? 'top' : '')}>
+            <td class="rank">{medal(i + 1)}</td>
             <td class="name">
               {#if r.is_me}
                 <button class="name-link" onclick={() => goto('/profile')} style={r.color ? `color:${r.color}` : ''}>You</button>
@@ -139,19 +97,10 @@
               {/if}
               {#if r.title}<span class="title">{r.title}</span>{/if}
             </td>
-            {#if board === 'cash'}
-              <td class="metric" class:neg={period === 'week' && Number(r.metric) < 0}>
-                {period === 'week' ? (r.metric >= 0 ? '+' : '') + fmt(r.metric) : fmt(r.net_worth)}
-              </td>
-            {:else if board === 'cash_game'}
-              <td class="metric gold">{fmt(r.best_run_profit)}</td>
-              <td class="metric small">{r.best_run_solves > 0 ? '🔥' + r.best_run_solves : '—'}</td>
-            {:else}
-              <td class="metric">{fmt(r.net_worth)}</td>
-              <td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
-              <td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>
-              <td class="metric small">{r.win_streak > 0 ? '🏆' + r.win_streak : '—'}</td>
-            {/if}
+            <td class="metric">{fmt(r.net_worth)}</td>
+            <td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
+            <td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>
+            <td class="metric small">{r.win_streak > 0 ? '🏆' + r.win_streak : '—'}</td>
           </tr>
         {/each}
       </tbody>
@@ -159,51 +108,31 @@
   </div>
 {/if}
 
-<p class="hint">
-  {#if board === 'cash'}Your total Cash, earned across every mode. The weekly view resets Monday — fair for newcomers.
-  {:else if board === 'cash_game'}Your best single run — profit banked before your heat reset. Build a streak, push your luck with Double or Nothing.
-  {:else}Same puzzle for everyone today. Spend less, score more.{/if}
-</p>
+<p class="hint">Same puzzle for everyone today. Spend less, score more.</p>
 
 <style>
-  .tabs { display: flex; gap: 0.4rem; margin-bottom: 0.8rem; overflow-x: auto; padding-bottom: 4px; -webkit-overflow-scrolling: touch; justify-content: center; }
-  .tabs::-webkit-scrollbar { display: none; }
-  .tab { flex: 0 0 auto; padding: 0.5rem 0.8rem; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.82rem; white-space: nowrap; border: 1px solid var(--border); background: var(--surface); color: var(--text-muted); }
-  .tab.active { color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border-color: transparent; }
   .filters { display: flex; gap: 0.5rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 0.5rem; }
-  .scope-row { display: flex; gap: 0.4rem; margin-bottom: 0.6rem; overflow-x: auto; padding-bottom: 4px; -webkit-overflow-scrolling: touch; }
-  .scope-row::-webkit-scrollbar { display: none; }
-  .scope-pill { flex: 0 0 auto; padding: 0.42rem 0.8rem; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.8rem; white-space: nowrap;
-    border: 1px solid var(--border); background: var(--surface); color: var(--text-muted); }
-  .scope-pill.on { color: var(--text); background: var(--surface-2, rgba(56,189,248,0.16)); border-color: var(--brand-2); box-shadow: inset 0 0 0 1px var(--brand-2); }
-  .seg { display: inline-flex; border: 1px solid var(--border); border-radius: 999px; overflow: hidden; }
-  .seg-btn { padding: 0.45rem 0.9rem; cursor: pointer; font-size: 0.82rem; font-weight: 600; background: transparent; color: var(--text-muted); border: none; }
-  .seg-btn.on { background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); color: #3a2a00; }
+  .filter-select { padding: 0.55rem 1rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; font-weight: 600; }
   .caption { color: var(--text-faint); font-size: 0.8rem; margin: 0.2rem 0 1rem; text-align: center; }
   .muted { color: var(--text-muted); padding: 2rem 0; text-align: center; }
   .error { color: #fb7185; text-align: center; }
   .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; }
   table { width: 100%; border-collapse: collapse; }
-  th { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-faint); padding: 0.7rem 0.6rem; text-align: left; border-bottom: 1px solid var(--border); }
-  td { padding: 0.7rem 0.6rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; text-align: left; }
+  th { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-faint); padding: 0.6rem 0.45rem; text-align: left; border-bottom: 1px solid var(--border); }
+  td { padding: 0.6rem 0.45rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; text-align: left; }
   tr:last-child td { border-bottom: none; }
-  td.rank { width: 34px; }
+  td.rank { width: 30px; padding-left: 0.5rem; }
   td.name { font-weight: 600; }
   .name-link { background: none; border: none; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.2); text-underline-offset: 2px; }
   .name-link:hover { text-decoration-color: var(--gold); }
   td.metric { font-family: var(--font-display); font-weight: 700; color: var(--text); text-align: right; white-space: nowrap; }
   td.metric.gold { color: var(--brand-2); }
   td.metric.small { font-weight: 700; font-size: 0.82rem; color: var(--text-muted); }
-  td.metric.neg { color: #fb7185; }
   th.num { text-align: right; }
-  th:last-child { text-align: right; }
   th button.sort { background: none; border: none; padding: 0; margin: 0; cursor: pointer; font: inherit;
     color: inherit; text-transform: inherit; letter-spacing: inherit; white-space: nowrap; }
   th button.sort:hover { color: var(--text-muted); }
   th button.sort.on { color: var(--brand-2); }
-  /* tighter cells when the Daily board shows 6 columns */
-  th, td { padding: 0.6rem 0.45rem; }
-  td.rank { width: 30px; padding-left: 0.5rem; }
   tr.me { background: rgba(56,189,248,0.1); }
   tr.me td.name { color: #7dd3fc; }
   .title { font-size: 0.68rem; color: var(--text-faint); margin-left: 0.35rem; white-space: nowrap; }

--- a/src/lib/components/NotificationsPanel.svelte
+++ b/src/lib/components/NotificationsPanel.svelte
@@ -2,24 +2,21 @@
   // Your personal notifications inbox (results, sabotages, friend requests,
   // incoming challenges). Shown in Community ▸ Activity. Friend requests can be
   // accepted/declined inline; tapping a row routes via onNavigate.
-  import { notifications, refreshNotifications } from '$lib/stores/notificationStore.js';
+  import { notifications, dismissNotification } from '$lib/stores/notificationStore.js';
   import { respondFriendRequest } from '$lib/stores/statsStore.js';
   import { fx } from '$lib/sound.js';
 
   /** @type {{ onNavigate?: ((n:any)=>void)|null, onChange?: (()=>void)|null }} */
   let { onNavigate = null, onChange = null } = $props();
 
-  let responded = $state(/** @type {Record<string,'accepted'|'declined'>} */ ({}));
-
   /** @param {any} n @param {boolean} accept */
   async function respond(n, accept) {
     const fromId = n?.data?.from_id;
-    if (!fromId || responded[n.id]) return;
+    if (!fromId) return;
     const res = await respondFriendRequest(fromId, accept);
     if (res?.ok) {
-      responded = { ...responded, [n.id]: accept ? 'accepted' : 'declined' };
       fx(accept ? 'win' : 'tap');
-      refreshNotifications();
+      dismissNotification(n.id); // acting on it clears it
       onChange?.();
     }
   }
@@ -31,19 +28,16 @@
   <div class="notif-list">
     {#each $notifications as n (n.id)}
       <div class="notif-item" class:fresh={!n.read}>
-        <button class="ni-main" onclick={() => onNavigate?.(n)}>
+        <button class="ni-dismiss" onclick={() => dismissNotification(n.id)} aria-label="Dismiss" title="Dismiss">✕</button>
+        <button class="ni-main" onclick={() => { onNavigate?.(n); dismissNotification(n.id); }}>
           <span class="ni-title">{n.title}</span>
           <span class="ni-body">{n.body}</span>
         </button>
         {#if n.type === 'friend_request' && n.data?.from_id}
-          {#if responded[n.id]}
-            <span class="ni-done {responded[n.id]}">{responded[n.id] === 'accepted' ? '✓ Friends' : 'Declined'}</span>
-          {:else}
-            <div class="ni-actions">
-              <button class="ni-act accept" onclick={() => respond(n, true)}>Accept</button>
-              <button class="ni-act decline" onclick={() => respond(n, false)}>Decline</button>
-            </div>
-          {/if}
+          <div class="ni-actions">
+            <button class="ni-act accept" onclick={() => respond(n, true)}>Accept</button>
+            <button class="ni-act decline" onclick={() => respond(n, false)}>Decline</button>
+          </div>
         {/if}
       </div>
     {/each}
@@ -53,7 +47,10 @@
 <style>
   .empty { color: var(--text-muted); font-size: 0.88rem; text-align: center; padding: 1rem 0.4rem; }
   .notif-list { display: flex; flex-direction: column; gap: 0.5rem; }
-  .notif-item { padding: 0.7rem 0.85rem; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); }
+  .notif-item { position: relative; padding: 0.7rem 2.1rem 0.7rem 0.85rem; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); }
+  .ni-dismiss { position: absolute; top: 6px; right: 6px; width: 26px; height: 26px; border-radius: 8px; border: none; cursor: pointer;
+    background: transparent; color: var(--text-faint); font-size: 0.9rem; }
+  .ni-dismiss:hover { background: var(--surface-2, rgba(255,255,255,0.06)); color: var(--text); }
   .notif-item.fresh { border-color: rgba(253, 224, 71,0.45); background: linear-gradient(135deg, rgba(251, 191, 36,0.08), rgba(253, 224, 71,0.03)); }
   .ni-main { text-align: left; display: flex; flex-direction: column; gap: 2px; width: 100%; background: none; border: none; color: inherit; cursor: pointer; padding: 0; }
   .ni-title { font-family: var(--font-display); font-weight: 700; font-size: 0.92rem; }

--- a/src/lib/components/NotificationsPanel.svelte
+++ b/src/lib/components/NotificationsPanel.svelte
@@ -3,7 +3,7 @@
   // incoming challenges). Shown in Community ▸ Activity. Friend requests can be
   // accepted/declined inline; tapping a row routes via onNavigate.
   import { notifications, dismissNotification } from '$lib/stores/notificationStore.js';
-  import { respondFriendRequest } from '$lib/stores/statsStore.js';
+  import { respondFriendRequest, respondJoinRequest } from '$lib/stores/statsStore.js';
   import { fx } from '$lib/sound.js';
 
   /** @type {{ onNavigate?: ((n:any)=>void)|null, onChange?: (()=>void)|null }} */
@@ -19,6 +19,14 @@
       dismissNotification(n.id); // acting on it clears it
       onChange?.();
     }
+  }
+
+  /** @param {any} n @param {boolean} accept */
+  async function respondGroup(n, accept) {
+    const { group_id, from_id } = n?.data || {};
+    if (!group_id || !from_id) return;
+    const res = await respondJoinRequest(group_id, from_id, accept);
+    if (res?.ok) { fx(accept ? 'win' : 'tap'); dismissNotification(n.id); onChange?.(); }
   }
 </script>
 
@@ -37,6 +45,11 @@
           <div class="ni-actions">
             <button class="ni-act accept" onclick={() => respond(n, true)}>Accept</button>
             <button class="ni-act decline" onclick={() => respond(n, false)}>Decline</button>
+          </div>
+        {:else if n.type === 'group_join' && n.data?.group_id && n.data?.from_id}
+          <div class="ni-actions">
+            <button class="ni-act accept" onclick={() => respondGroup(n, true)}>Approve</button>
+            <button class="ni-act decline" onclick={() => respondGroup(n, false)}>Decline</button>
           </div>
         {/if}
       </div>

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -119,3 +119,13 @@ export async function markFriendNotifRead(/** @type {string} */ fromId) {
   await markNotificationsRead(null, fromId);
   if (started) await poll();
 }
+/** Permanently dismiss (delete) one notification. @param {string} id */
+export async function dismissNotification(id) {
+  if (!id) return;
+  notifications.update((list) => {
+    const n = list.find((x) => x.id === id);
+    if (n && !n.read) unreadCount.update((c) => Math.max(0, c - 1));
+    return list.filter((x) => x.id !== id);
+  });
+  try { await supabase.rpc('dismiss_notification', { p_id: id }); } catch { /* best-effort */ }
+}

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -119,6 +119,18 @@ export async function getGroup(id) {
   if (error) { console.error('❌ get_group:', error); return null; }
   return data;
 }
+/** Ask to join a group (owner approves). @param {string} groupId @returns {Promise<{ok:boolean, reason?:string, status?:string}>} */
+export async function requestJoinGroup(groupId) {
+  const { data, error } = await supabase.rpc('request_join_group', { p_group: groupId });
+  if (error || !data) { if (error) console.error('❌ request_join_group:', error); return { ok: false }; }
+  return data;
+}
+/** Owner: approve/decline a join request. @param {string} groupId @param {string} userId @param {boolean} accept */
+export async function respondJoinRequest(groupId, userId, accept) {
+  const { data, error } = await supabase.rpc('respond_join_request', { p_group: groupId, p_user: userId, p_accept: accept });
+  if (error || !data) { if (error) console.error('❌ respond_join_request:', error); return { ok: false }; }
+  return data;
+}
 /** @param {string} name @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
 export async function createGroup(name) {
   const { data, error } = await supabase.rpc('create_group', { p_name: name });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2021,7 +2021,7 @@
           <h2 class="sub-title">Play</h2>
         </div>
         <div class="main-menu-buttons stagger">
-          <button class="menu-card" class:done={dailyDone} class:resumable={dailyInProgress} style="--i: 0" on:click={handleMenuDaily}>
+          <button class="menu-card" class:done={dailyDone} class:resumable={dailyInProgress} class:fresh={!dailyDone && !dailyInProgress} style="--i: 0" on:click={handleMenuDaily}>
             <span class="mc-streak left" title="Attendance streak — days in a row">📅 {dailyStatus?.current_streak ?? 0}</span>
             <span class="mc-title">{dailyInProgress ? 'Resume Daily' : 'Daily'}</span>
             <span class="mc-streak right" title="Win streak — solves in a row">🏆 {dailyStatus?.win_streak ?? 0}</span>
@@ -3350,6 +3350,14 @@
     background: linear-gradient(180deg, #d1fae5, #6ee7b7); -webkit-background-clip: text; background-clip: text;
     -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
   }
+  /* 📅 Fresh Daily (not started today) — solid gold, "play me" */
+  .menu-card.fresh {
+    background: linear-gradient(135deg, #fde047, #f59e0b); border-color: transparent;
+    box-shadow: 0 4px 16px rgba(245,158,11,0.45), 0 0 24px rgba(251,191,36,0.3);
+  }
+  .menu-card.fresh::before, .menu-card.fresh::after { display: none; }
+  .menu-card.fresh .mc-title { color: #3a2a00; -webkit-text-fill-color: #3a2a00; background: none; text-shadow: none; }
+  .menu-card.fresh .mc-streak { color: #5a4200; text-shadow: none; }
   /* ▶ Resume shortcut card (home menu) — green, mirrors the in-progress accent */
   .menu-card.resume-card {
     background: linear-gradient(180deg, #16352b 0%, #0f2a22 100%);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2001,7 +2001,7 @@
           <!-- ⚔️ Challenges hub (list + New) — carries the pending-invite badge; 👥+ = friends/groups -->
           <div class="vs-cta-group">
             <button class="vs-main" on:click={() => { fx('tap'); openCommunity('challenges'); }}>
-              ⚔️ Challenges{#if challengeInvites.length}<span class="vs-badge">{challengeInvites.length}</span>{/if}
+              ⚔️ Challenge Friends{#if challengeInvites.length}<span class="vs-badge">{challengeInvites.length}</span>{/if}
             </button>
             <button class="vs-people" title="Friends &amp; Groups" aria-label="Friends and groups" on:click={() => { fx('tap'); openCommunity('people'); }}>
               <span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span>
@@ -2068,11 +2068,6 @@
           <div class="comm-tabs">
             <button class="comm-tab" class:active={peopleTab === 'friends'} on:click={() => { peopleTab = 'friends'; fx('tap'); }}>Friends{#if friendReqCount > 0} · {friendReqCount}{/if}</button>
             <button class="comm-tab" class:active={peopleTab === 'groups'} on:click={() => { peopleTab = 'groups'; fx('tap'); }}>Groups</button>
-          </div>
-        {:else}
-          <div class="comm-tabs">
-            <button class="comm-tab" class:active={communityTab === 'challenges'} on:click={() => { communityTab = 'challenges'; fx('tap'); }}>Challenges</button>
-            <button class="comm-tab" class:active={communityTab === 'leaderboard'} on:click={() => { communityTab = 'leaderboard'; fx('tap'); }}>Leaderboard</button>
           </div>
         {/if}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2061,7 +2061,9 @@
           {:else}
             <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
             <h2 class="sub-title">{communityTab === 'leaderboard' ? '🏆 Leaderboard' : '⚔️ Challenges'}</h2>
-            <button class="sub-people" title="Friends & Groups" aria-label="Friends & Groups" on:click={() => { communityTab = 'people'; peopleBackToHome = false; fx('tap'); }}><span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span></button>
+            {#if communityTab === 'challenges'}
+              <button class="sub-people" title="Friends & Groups" aria-label="Friends & Groups" on:click={() => { communityTab = 'people'; peopleBackToHome = false; fx('tap'); }}><span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span></button>
+            {/if}
           {/if}
         </div>
         {#if communityTab === 'people'}
@@ -3008,8 +3010,9 @@
     gap: 1.2rem;
   }
   .sub-head {
-    width: 100%; display: flex; align-items: center; gap: 0.6rem; margin-bottom: 0.2rem;
+    width: 100%; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 0.6rem; margin-bottom: 0.2rem;
   }
+  .sub-head .sub-back { justify-self: start; }
   .sub-back {
     display: inline-flex; align-items: center; gap: 4px; padding: 0.5rem 0.9rem;
     background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
@@ -3017,9 +3020,9 @@
     transition: transform 0.15s, border-color 0.2s, background 0.2s;
   }
   .sub-back:hover { transform: translateX(-2px); border-color: var(--border-strong); background: var(--surface-2); }
-  .sub-title { font-family: var(--font-display); font-size: 1.15rem; font-weight: 800; }
+  .sub-title { font-family: var(--font-display); font-size: 1.15rem; font-weight: 800; text-align: center; grid-column: 2; }
   .sub-people {
-    position: relative; margin-left: auto; width: 40px; height: 40px; display: grid; place-items: center; font-size: 1.1rem;
+    position: relative; justify-self: end; width: 40px; height: 40px; display: grid; place-items: center; font-size: 1.1rem;
     background: var(--surface); border: 1px solid var(--border); border-radius: 12px; cursor: pointer;
   }
   .sub-people:hover { border-color: var(--brand-2); }
@@ -3799,6 +3802,7 @@
   .ma-version { text-align: center; font-size: 0.72rem; color: var(--text-faint); margin: 14px 0 2px; }
   /* ── Sectioned settings layout ── */
   .settings-modal { text-align: left; }
+  .settings-modal > h2 { text-align: center; }
   .set-profile { display: flex; align-items: center; gap: 13px; margin: 6px 0 4px; }
   .set-av { position: relative; background: none; border: none; cursor: pointer; padding: 0; flex: none; }
   .set-av-edit { position: absolute; bottom: -4px; left: 50%; transform: translateX(-50%); font-size: 0.62rem; font-weight: 800;

--- a/src/routes/my-friends/+page.svelte
+++ b/src/routes/my-friends/+page.svelte
@@ -1,0 +1,87 @@
+<script>
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import PageNav from '$lib/components/PageNav.svelte';
+  import { listFriends, removeFriend } from '$lib/stores/statsStore.js';
+  import { requireConfirm } from '$lib/confirm.js';
+  import { fx } from '$lib/sound.js';
+  import { track } from '$lib/analytics.js';
+
+  /** @type {any[]} */ let friends = $state([]);
+  let loading = $state(true);
+  let q = $state('');
+  let busy = $state('');
+
+  onMount(async () => { track('my_friends_view'); try { friends = await listFriends(); } finally { loading = false; } });
+
+  let shown = $derived(
+    friends
+      .filter((f) => (f.name || f.username || '').toLowerCase().includes(q.trim().toLowerCase()))
+      .sort((a, b) => (a.username || a.name || '').localeCompare(b.username || b.name || '', undefined, { sensitivity: 'base' }))
+  );
+
+  /** @param {any} f */
+  async function remove(f) {
+    if (busy) return;
+    if (!(await requireConfirm({ title: 'Remove friend?', message: `Remove @${f.username || f.name} from your friends?`, confirmText: 'Remove', danger: true }))) return;
+    busy = f.id;
+    await removeFriend(f.id);
+    friends = friends.filter((x) => x.id !== f.id);
+    busy = '';
+    fx('tap');
+  }
+  /** @param {any} f */
+  const initial = (f) => (f.name || f.username || '?').slice(0, 1).toUpperCase();
+</script>
+
+<svelte:head><title>WordBank — My Friends</title></svelte:head>
+
+<main class="ml-page">
+  <PageNav />
+  <h1 class="ml-title">My Friends{#if friends.length} · {friends.length}{/if}</h1>
+
+  {#if loading}
+    <p class="ml-muted">Loading…</p>
+  {:else if friends.length === 0}
+    <p class="ml-muted">No friends yet. Add some from <button class="ml-link" onclick={() => goto('/?people=1')}>Friends & Groups</button>.</p>
+  {:else}
+    <input class="ml-search" type="search" placeholder="Search your friends" bind:value={q} />
+    {#if shown.length === 0}
+      <p class="ml-muted">No match for “{q}”.</p>
+    {:else}
+      <div class="ml-list">
+        {#each shown as f (f.id)}
+          <div class="ml-row">
+            <button class="ml-main" onclick={() => goto('/u/' + encodeURIComponent(f.username || ''))}>
+              <span class="ml-coin" style={f.color ? `--c:${f.color}` : ''}>{initial(f)}</span>
+              <span class="ml-name">@{f.username || f.name}</span>
+              <span class="ml-go">›</span>
+            </button>
+            <button class="ml-rm" disabled={busy === f.id} onclick={() => remove(f)} title="Remove friend" aria-label="Remove friend">✕</button>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</main>
+
+<style>
+  .ml-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
+  .ml-title { font-family: var(--font-display); font-size: 1.4rem; margin: 4px 0 14px; }
+  .ml-muted { color: var(--text-muted); padding: 1.5rem 0; text-align: center; }
+  .ml-link { background: none; border: none; color: var(--brand-2); font: inherit; cursor: pointer; text-decoration: underline; }
+  .ml-search { width: 100%; padding: 0.7rem 1rem; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; margin-bottom: 14px; }
+  .ml-list { display: flex; flex-direction: column; gap: 8px; }
+  .ml-row { display: flex; align-items: center; gap: 8px; }
+  .ml-main { flex: 1; display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-radius: 14px; cursor: pointer;
+    background: var(--surface); border: 1px solid var(--border); color: var(--text); text-align: left; }
+  .ml-main:hover { border-color: var(--brand-2); }
+  .ml-coin { width: 36px; height: 36px; flex: none; border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display); font-weight: 800; color: #3a2a00;
+    background: linear-gradient(135deg, var(--c, #fde047), #f59e0b); }
+  .ml-name { flex: 1; font-weight: 700; font-size: 0.98rem; }
+  .ml-go { color: var(--text-faint); }
+  .ml-rm { width: 40px; height: 40px; flex: none; border-radius: 12px; cursor: pointer; font-size: 0.9rem;
+    background: rgba(248,113,113,0.1); color: #f87171; border: 1px solid rgba(248,113,113,0.4); }
+  .ml-rm:hover { background: rgba(248,113,113,0.2); }
+  .ml-rm:disabled { opacity: 0.5; }
+</style>

--- a/src/routes/my-groups/+page.svelte
+++ b/src/routes/my-groups/+page.svelte
@@ -1,0 +1,98 @@
+<script>
+  import { onMount } from 'svelte';
+  import { goto } from '$app/navigation';
+  import PageNav from '$lib/components/PageNav.svelte';
+  import { getMyGroups, getGroup } from '$lib/stores/statsStore.js';
+  import { fx } from '$lib/sound.js';
+  import { track } from '$lib/analytics.js';
+
+  /** @type {any[]} */ let groups = $state([]);
+  let loading = $state(true);
+  let q = $state('');
+  /** @type {string|null} */ let openId = $state(null);
+  /** @type {any} */ let openGroup = $state(null);
+  let loadingMembers = $state(false);
+
+  onMount(async () => { track('my_groups_view'); try { groups = await getMyGroups(); } finally { loading = false; } });
+
+  let shown = $derived(
+    groups
+      .filter((g) => (g.name || '').toLowerCase().includes(q.trim().toLowerCase()))
+      .sort((a, b) => (a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' }))
+  );
+
+  /** @param {any} g */
+  async function toggle(g) {
+    fx('tap');
+    if (openId === g.id) { openId = null; openGroup = null; return; }
+    openId = g.id; openGroup = null; loadingMembers = true;
+    openGroup = await getGroup(g.id);
+    loadingMembers = false;
+  }
+  const members = (/** @type {any} */ g) => g?.members ?? g?.standings ?? [];
+</script>
+
+<svelte:head><title>WordBank — My Groups</title></svelte:head>
+
+<main class="ml-page">
+  <PageNav />
+  <h1 class="ml-title">My Groups{#if groups.length} · {groups.length}{/if}</h1>
+
+  {#if loading}
+    <p class="ml-muted">Loading…</p>
+  {:else if groups.length === 0}
+    <p class="ml-muted">You're not in any groups yet. Create or join one from <button class="ml-link" onclick={() => goto('/groups')}>Groups</button>.</p>
+  {:else}
+    <input class="ml-search" type="search" placeholder="Search your groups" bind:value={q} />
+    {#if shown.length === 0}
+      <p class="ml-muted">No match for “{q}”.</p>
+    {:else}
+      <div class="ml-list">
+        {#each shown as g (g.id)}
+          <div class="mg-block">
+            <button class="ml-main" onclick={() => toggle(g)}>
+              <span class="ml-coin">👥</span>
+              <span class="ml-name">{g.name}{#if g.member_count} · {g.member_count}{/if}</span>
+              <span class="ml-go">{openId === g.id ? '▾' : '›'}</span>
+            </button>
+            {#if openId === g.id}
+              <div class="mg-members">
+                {#if loadingMembers}<p class="ml-muted small">Loading members…</p>
+                {:else}
+                  {#each members(openGroup) as m}
+                    <button class="mg-member" onclick={() => m.username && goto('/u/' + encodeURIComponent(m.username))}>
+                      <span class="mg-mname">@{m.username || m.name}{#if m.is_owner} <span class="mg-owner">owner</span>{/if}</span>
+                      {#if m.username}<span class="ml-go">›</span>{/if}
+                    </button>
+                  {/each}
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  {/if}
+</main>
+
+<style>
+  .ml-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
+  .ml-title { font-family: var(--font-display); font-size: 1.4rem; margin: 4px 0 14px; }
+  .ml-muted { color: var(--text-muted); padding: 1.5rem 0; text-align: center; }
+  .ml-muted.small { padding: 0.6rem 0; font-size: 0.85rem; }
+  .ml-link { background: none; border: none; color: var(--brand-2); font: inherit; cursor: pointer; text-decoration: underline; }
+  .ml-search { width: 100%; padding: 0.7rem 1rem; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; margin-bottom: 14px; }
+  .ml-list { display: flex; flex-direction: column; gap: 8px; }
+  .ml-main { width: 100%; display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-radius: 14px; cursor: pointer;
+    background: var(--surface); border: 1px solid var(--border); color: var(--text); text-align: left; }
+  .ml-main:hover { border-color: var(--brand-2); }
+  .ml-coin { width: 36px; height: 36px; flex: none; border-radius: 50%; display: grid; place-items: center; font-size: 1.1rem; background: var(--surface-2, rgba(255,255,255,0.06)); }
+  .ml-name { flex: 1; font-weight: 700; font-size: 0.98rem; }
+  .ml-go { color: var(--text-faint); }
+  .mg-members { display: flex; flex-direction: column; gap: 4px; padding: 6px 0 4px 12px; }
+  .mg-member { display: flex; align-items: center; justify-content: space-between; padding: 9px 12px; border-radius: 10px; cursor: pointer;
+    background: var(--surface-2, rgba(255,255,255,0.04)); border: 1px solid var(--border); color: var(--text); }
+  .mg-member:hover { border-color: var(--brand-2); }
+  .mg-mname { font-weight: 600; font-size: 0.9rem; }
+  .mg-owner { font-size: 0.66rem; color: var(--gold); margin-left: 4px; }
+</style>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -5,13 +5,11 @@
   import { getProfileDetail, getMyAvatar, getUserBadges } from '$lib/stores/statsStore.js';
   import { badgeInfo } from '$lib/badges.js';
   import Avatar from '$lib/components/Avatar.svelte';
-  import HistoryList from '$lib/components/HistoryList.svelte';
-  import BadgesPanel from '$lib/components/BadgesPanel.svelte';
   import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
   import { unreadCount, markAllNotificationsRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
 
-  /** @type {'overview'|'stats'|'history'|'badges'|'alerts'} */
+  /** @type {'overview'|'stats'|'alerts'} */
   let tab = $state('overview');
   /** @type {any|null} */
   let d = $state(null);
@@ -24,7 +22,7 @@
   onMount(async () => {
     track('profile_view');
     const t = $page.url.searchParams.get('tab');
-    if (t === 'stats' || t === 'history' || t === 'badges' || t === 'alerts') tab = /** @type {any} */ (t);
+    if (t === 'stats' || t === 'alerts') tab = /** @type {any} */ (t);
     getMyAvatar().then((a) => { avatar = a.config; });
     getUserBadges().then((b) => { earned = b; });
     try { d = await getProfileDetail(); } finally { loading = false; }
@@ -57,28 +55,20 @@
 {#snippet chipLink(/** @type {any} */ value, /** @type {string} */ label, /** @type {string} */ href)}
   <button class="stat stat-link" onclick={() => goto(href)}><span class="sv">{value}</span><span class="sc">{label} ›</span></button>
 {/snippet}
+{#snippet chipAct(/** @type {any} */ value, /** @type {string} */ label, /** @type {() => void} */ action)}
+  <button class="stat stat-link" onclick={action}><span class="sv">{value}</span><span class="sc">{label} ›</span></button>
+{/snippet}
 
 <main class="you-page">
   <div class="topbar">
     <button class="back-btn" onclick={back}>← Back</button>
-    <h1 class="page-title">Profile</h1>
-    <div class="tb-right">
-      <button class="gear" onclick={() => goto('/')} title="Main menu" aria-label="Main menu">🏠</button>
-      <button class="gear" onclick={() => goto('/?account=1')} title="Settings" aria-label="Settings">⚙️</button>
-    </div>
+    <h1 class="page-title">{tab === 'overview' ? 'Profile' : tab === 'stats' ? 'Full Stats' : 'Notifications'}</h1>
+    <button class="gear" onclick={() => goto('/?account=1')} title="Settings" aria-label="Settings">⚙️</button>
   </div>
 
   {#if loading}
     <p class="muted">Loading…</p>
   {:else if d}
-    <div class="tabs">
-      <button class="tab" class:active={tab === 'overview'} onclick={() => tab = 'overview'}>Overview</button>
-      <button class="tab" class:active={tab === 'stats'} onclick={() => tab = 'stats'}>Stats</button>
-      <button class="tab" class:active={tab === 'history'} onclick={() => tab = 'history'}>History</button>
-      <button class="tab" class:active={tab === 'badges'} onclick={() => tab = 'badges'}>Badges</button>
-      <button class="tab" class:active={tab === 'alerts'} onclick={() => tab = 'alerts'}>🔔{#if $unreadCount > 0}<span class="tab-count">{$unreadCount > 99 ? '99+' : $unreadCount}</span>{/if}</button>
-    </div>
-
     {#if tab === 'overview'}
       <div class="ov-hero">
         <button class="prof-avatar" onclick={() => goto('/avatar')}>
@@ -87,7 +77,7 @@
         </button>
         <div class="ov-id">
           <div class="uname">{d.username ? '@' + d.username : 'You'}</div>
-          <div class="nw">{fmt(d.net_worth)}<span class="nw-sub"> Cash</span></div>
+          <button class="nw nw-btn" onclick={() => goto('/bank')}>{fmt(d.net_worth)}<span class="nw-go"> ›</span></button>
           <button class="ov-people" onclick={() => goto('/?people=1')} aria-label="Friends & groups">
             <span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span><span class="ov-people-lbl">Friends</span>
           </button>
@@ -95,25 +85,28 @@
       </div>
 
       <div class="grid ov-summary">
-        {@render chip((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles')}
-        {@render chip(d.overall.games_played ?? 0, 'Games')}
+        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles', () => tab = 'stats')}
+        {@render chipAct(d.overall.games_played ?? 0, 'Games', () => tab = 'stats')}
         {@render chipLink('🔥 ' + (d.daily.current_streak ?? 0), 'Streak', '/streak')}
-        {@render chip('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak')}
-        {@render chip(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily win%')}
-        {@render chip(d.overall.clean_solves ?? 0, 'Clean solves')}
+        {@render chipLink('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak', '/streak')}
+        {@render chipAct(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily win%', () => tab = 'stats')}
+        {@render chipAct(d.overall.clean_solves ?? 0, 'Clean solves', () => tab = 'stats')}
       </div>
 
-      {#if earnedBadges.length}
-        <div class="sec-title">🏅 Badges <button class="sec-link" onclick={() => tab = 'badges'}>View all ›</button></div>
-        <div class="ov-badges">
-          {#each earnedBadges.slice(0, 12) as bdg}<span class="ov-badge" title={bdg.name}>{bdg.emoji}</span>{/each}
-        </div>
-      {/if}
+      <button class="ov-badges-card" onclick={() => goto('/badges')}>
+        <span class="ov-badges-h">🏅 Badges <span class="arrow">›</span></span>
+        <span class="ov-badges">
+          {#if earnedBadges.length}
+            {#each earnedBadges.slice(0, 14) as bdg}<span class="ov-badge" title={bdg.name}>{bdg.emoji}</span>{/each}
+          {:else}<span class="ov-badges-empty">None yet — play to earn them</span>{/if}
+        </span>
+      </button>
 
       <div class="ov-nav">
         <button class="ov-link" onclick={() => tab = 'stats'}>📊 Full stats <span class="arrow">›</span></button>
-        <button class="ov-link" onclick={() => tab = 'history'}>📜 Play history <span class="arrow">›</span></button>
+        <button class="ov-link" onclick={() => goto('/history')}>📜 Play history <span class="arrow">›</span></button>
         <button class="ov-link" onclick={() => goto('/streak')}>🔥 Streak &amp; calendar <span class="arrow">›</span></button>
+        <button class="ov-link" onclick={() => tab = 'alerts'}>🔔 Notifications{#if $unreadCount > 0}<span class="ov-count">{$unreadCount > 99 ? '99+' : $unreadCount}</span>{/if}<span class="arrow">›</span></button>
       </div>
     {:else if tab === 'stats'}
       <div class="sec-title">📊 Overall</div>
@@ -188,10 +181,6 @@
           {/each}
         </div>
       {/if}
-    {:else if tab === 'history'}
-      <HistoryList />
-    {:else if tab === 'badges'}
-      <BadgesPanel />
     {:else}
       <NotificationsPanel onNavigate={notifNav} />
     {/if}
@@ -244,9 +233,18 @@
   .ov-people:active { transform: scale(0.97); }
   .ov-summary { margin-bottom: 4px; }
   .sec-link { float: right; background: none; border: none; color: var(--brand-2); font-weight: 700; font-size: 0.72rem; cursor: pointer; text-transform: none; letter-spacing: 0; }
+  .nw-btn { background: none; border: none; padding: 0; cursor: pointer; display: inline-flex; align-items: baseline; }
+  .nw-go { font-size: 1rem; color: var(--text-faint); font-family: var(--font-display); }
+  .ov-badges-card { display: block; width: 100%; text-align: left; cursor: pointer; margin-top: 16px; padding: 12px 14px; border-radius: 14px;
+    background: var(--surface); border: 1px solid var(--border); }
+  .ov-badges-card:hover { border-color: var(--brand-2); }
+  .ov-badges-h { display: flex; justify-content: space-between; font-family: var(--font-display); font-size: 0.82rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--gold); margin-bottom: 8px; }
+  .ov-badges-h .arrow { color: var(--text-faint); }
   .ov-badges { display: flex; flex-wrap: wrap; gap: 8px; padding: 4px 0; }
   .ov-badge { font-size: 1.5rem; line-height: 1; }
-  .ov-nav { display: flex; flex-direction: column; gap: 8px; margin-top: 18px; }
+  .ov-badges-empty { font-size: 0.85rem; color: var(--text-muted); }
+  .ov-nav { display: flex; flex-direction: column; gap: 8px; margin-top: 16px; }
+  .ov-count { margin-left: auto; margin-right: 8px; min-width: 20px; height: 20px; display: inline-grid; place-items: center; padding: 0 5px; border-radius: 999px; background: #dc2626; color: #fff; font-size: 0.72rem; font-weight: 800; }
   .ov-link { display: flex; justify-content: space-between; align-items: center; padding: 13px 15px; border-radius: 14px; cursor: pointer;
     background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 700; font-size: 0.95rem; text-align: left; }
   .ov-link:hover { border-color: var(--brand-2); }

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -85,19 +85,20 @@
             </button>
           </div>
           <button class="nw nw-btn" onclick={() => goto('/bank')}>{fmt(d.net_worth)}<span class="nw-go"> ›</span></button>
-          <button class="ov-people" onclick={() => goto('/?people=1')} aria-label="Friends & groups">
-            <span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span><span class="ov-people-lbl">Friends</span>
-          </button>
+          <div class="ov-social">
+            <button class="ov-social-btn" onclick={() => goto('/my-friends')}>👋 My Friends ›</button>
+            <button class="ov-social-btn" onclick={() => goto('/my-groups')}>👥 My Groups ›</button>
+          </div>
         </div>
       </div>
 
       <div class="grid ov-summary">
-        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles', () => statInfo = { title: 'Puzzles solved', desc: 'Every puzzle you’ve cracked across all modes — Daily, Cash Game, Free Play, and challenges.' })}
-        {@render chipAct(d.overall.games_played ?? 0, 'Games', () => statInfo = { title: 'Games played', desc: 'How many games you’ve started across every mode — whether you solved them or not.' })}
-        {@render chipAct('🔥 ' + (d.daily.current_streak ?? 0), 'Streak', () => statInfo = { title: '📅 Play streak', desc: 'Days in a row you’ve shown up for the Daily. Miss a day and it resets (a freeze can save it).', link: '/streak', linkLabel: 'View streak & calendar' })}
-        {@render chipAct('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak', () => statInfo = { title: '🏆 Win streak', desc: 'Daily puzzles you’ve solved in a row. Powers your bounty multiplier — the longer it runs, the more you earn.', link: '/streak', linkLabel: 'View streak & calendar' })}
-        {@render chipAct(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily win%', () => statInfo = { title: 'Daily win rate', desc: 'The share of Dailies you’ve played that you actually solved.' })}
-        {@render chipAct(d.overall.clean_solves ?? 0, 'Clean solves', () => statInfo = { title: 'Clean solves', desc: 'Puzzles you solved with zero wrong letters — pure deduction, no misses.' })}
+        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Total Solves', () => statInfo = { title: 'Total solves', desc: 'Every puzzle you’ve solved across all modes — Daily, Cash Game, Free Play, and challenges.' })}
+        {@render chipAct(d.overall.games_played ?? 0, 'Games Played', () => statInfo = { title: 'Games played', desc: 'How many games you’ve started across every mode — whether you solved them or not.' })}
+        {@render chipAct('🔥 ' + (d.daily.current_streak ?? 0), 'Daily Streak', () => statInfo = { title: '📅 Daily streak', desc: 'Days in a row you’ve shown up for the Daily. Miss a day and it resets (a freeze can save it).', link: '/streak', linkLabel: 'View Daily Calendar' })}
+        {@render chipAct('🏆 ' + (d.daily.win_streak ?? 0), 'Win Streak', () => statInfo = { title: '🏆 Win streak', desc: 'Daily puzzles you’ve solved in a row. Powers your bounty multiplier — the longer it runs, the more you earn.', link: '/streak', linkLabel: 'View Daily Calendar' })}
+        {@render chipAct(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily Win %', () => statInfo = { title: 'Daily win rate', desc: 'The share of Dailies you’ve played that you actually solved.' })}
+        {@render chipAct(d.overall.clean_solves ?? 0, 'Clean Solves', () => statInfo = { title: 'Clean solves', desc: 'Puzzles you solved with zero wrong letters — pure deduction, no misses.' })}
       </div>
 
       <button class="ov-badges-card" onclick={() => goto('/badges')}>
@@ -256,6 +257,10 @@
   .bell-count { position: absolute; top: -4px; right: -7px; min-width: 17px; height: 17px; display: grid; place-items: center; padding: 0 4px;
     border-radius: 999px; background: #dc2626; color: #fff; font-size: 0.62rem; font-weight: 800; }
   .ov-id .uname { font-size: 1.15rem; }
+  .ov-social { display: flex; flex-direction: column; gap: 5px; margin-top: 8px; align-items: flex-start; }
+  .ov-social-btn { background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer;
+    padding: 6px 12px; border-radius: 999px; font-weight: 700; font-size: 0.82rem; }
+  .ov-social-btn:hover { border-color: var(--brand-2); }
   .ov-id .nw { font-size: 1.7rem; }
   .ov-id .nw-sub { font-size: 0.8rem; color: var(--text-faint); -webkit-text-fill-color: var(--text-faint); }
   .ov-people { display: inline-flex; align-items: center; gap: 6px; margin-top: 6px; padding: 7px 14px 7px 30px; position: relative;

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -18,6 +18,8 @@
   /** @type {string[]} */
   let earned = $state([]);
   let earnedBadges = $derived(earned.map((id) => badgeInfo(id)).filter(Boolean));
+  /** @type {{title:string, desc:string, link?:string, linkLabel?:string}|null} */
+  let statInfo = $state(null);
 
   onMount(async () => {
     track('profile_view');
@@ -56,7 +58,7 @@
   <button class="stat stat-link" onclick={() => goto(href)}><span class="sv">{value}</span><span class="sc">{label} ›</span></button>
 {/snippet}
 {#snippet chipAct(/** @type {any} */ value, /** @type {string} */ label, /** @type {() => void} */ action)}
-  <button class="stat stat-link" onclick={action}><span class="sv">{value}</span><span class="sc">{label} ›</span></button>
+  <button class="stat stat-link" onclick={action}><span class="sv">{value}</span><span class="sc">{label} ⓘ</span></button>
 {/snippet}
 
 <main class="you-page">
@@ -76,7 +78,12 @@
           <span class="prof-avatar-edit">🎨 Edit Avatar</span>
         </button>
         <div class="ov-id">
-          <div class="uname">{d.username ? '@' + d.username : 'You'}</div>
+          <div class="uname-row">
+            <span class="uname">{d.username ? '@' + d.username : 'You'}</span>
+            <button class="bell-btn" onclick={() => tab = 'alerts'} aria-label="Notifications" title="Notifications">
+              🔔{#if $unreadCount > 0}<span class="bell-count">{$unreadCount > 99 ? '99+' : $unreadCount}</span>{/if}
+            </button>
+          </div>
           <button class="nw nw-btn" onclick={() => goto('/bank')}>{fmt(d.net_worth)}<span class="nw-go"> ›</span></button>
           <button class="ov-people" onclick={() => goto('/?people=1')} aria-label="Friends & groups">
             <span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span><span class="ov-people-lbl">Friends</span>
@@ -85,12 +92,12 @@
       </div>
 
       <div class="grid ov-summary">
-        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles', () => tab = 'stats')}
-        {@render chipAct(d.overall.games_played ?? 0, 'Games', () => tab = 'stats')}
-        {@render chipLink('🔥 ' + (d.daily.current_streak ?? 0), 'Streak', '/streak')}
-        {@render chipLink('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak', '/streak')}
-        {@render chipAct(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily win%', () => tab = 'stats')}
-        {@render chipAct(d.overall.clean_solves ?? 0, 'Clean solves', () => tab = 'stats')}
+        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles', () => statInfo = { title: 'Puzzles solved', desc: 'Every puzzle you’ve cracked across all modes — Daily, Cash Game, Free Play, and challenges.' })}
+        {@render chipAct(d.overall.games_played ?? 0, 'Games', () => statInfo = { title: 'Games played', desc: 'How many games you’ve started across every mode — whether you solved them or not.' })}
+        {@render chipAct('🔥 ' + (d.daily.current_streak ?? 0), 'Streak', () => statInfo = { title: '📅 Play streak', desc: 'Days in a row you’ve shown up for the Daily. Miss a day and it resets (a freeze can save it).', link: '/streak', linkLabel: 'View streak & calendar' })}
+        {@render chipAct('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak', () => statInfo = { title: '🏆 Win streak', desc: 'Daily puzzles you’ve solved in a row. Powers your bounty multiplier — the longer it runs, the more you earn.', link: '/streak', linkLabel: 'View streak & calendar' })}
+        {@render chipAct(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily win%', () => statInfo = { title: 'Daily win rate', desc: 'The share of Dailies you’ve played that you actually solved.' })}
+        {@render chipAct(d.overall.clean_solves ?? 0, 'Clean solves', () => statInfo = { title: 'Clean solves', desc: 'Puzzles you solved with zero wrong letters — pure deduction, no misses.' })}
       </div>
 
       <button class="ov-badges-card" onclick={() => goto('/badges')}>
@@ -105,8 +112,7 @@
       <div class="ov-nav">
         <button class="ov-link" onclick={() => tab = 'stats'}>📊 Full stats <span class="arrow">›</span></button>
         <button class="ov-link" onclick={() => goto('/history')}>📜 Play history <span class="arrow">›</span></button>
-        <button class="ov-link" onclick={() => goto('/streak')}>🔥 Streak &amp; calendar <span class="arrow">›</span></button>
-        <button class="ov-link" onclick={() => tab = 'alerts'}>🔔 Notifications{#if $unreadCount > 0}<span class="ov-count">{$unreadCount > 99 ? '99+' : $unreadCount}</span>{/if}<span class="arrow">›</span></button>
+        <button class="ov-link" onclick={() => goto('/streak')}>📅 Daily Calendar <span class="arrow">›</span></button>
       </div>
     {:else if tab === 'stats'}
       <div class="sec-title">📊 Overall</div>
@@ -185,10 +191,33 @@
       <NotificationsPanel onNavigate={notifNav} />
     {/if}
   {/if}
+
+  {#if statInfo}
+    <div class="si-overlay" role="button" tabindex="0" onclick={() => statInfo = null}
+      onkeydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') statInfo = null; }}>
+      <div class="si-card" role="document" onclick={(e) => e.stopPropagation()}>
+        <h3 class="si-title">{statInfo.title}</h3>
+        <p class="si-desc">{statInfo.desc}</p>
+        {#if statInfo.link}<button class="si-link" onclick={() => goto(/** @type {string} */ (statInfo?.link))}>{statInfo.linkLabel} →</button>{/if}
+        <button class="si-close" onclick={() => statInfo = null}>Got it</button>
+      </div>
+    </div>
+  {/if}
 </main>
 
 <style>
   .you-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
+  /* stat explanation popup */
+  .si-overlay { position: fixed; inset: 0; z-index: 4000; display: grid; place-items: center; padding: 24px;
+    background: rgba(4,8,14,0.72); backdrop-filter: blur(6px); border: none; }
+  .si-card { width: 100%; max-width: 320px; padding: 22px; border-radius: 18px; text-align: center;
+    background: var(--surface-strong, rgba(20,26,38,0.96)); border: 1px solid var(--border-strong, rgba(255,255,255,0.16));
+    box-shadow: 0 20px 50px rgba(0,0,0,0.5); display: flex; flex-direction: column; gap: 10px; }
+  .si-title { font-family: var(--font-display); font-size: 1.15rem; margin: 0; }
+  .si-desc { font-size: 0.92rem; line-height: 1.5; color: var(--text-muted); margin: 0; }
+  .si-link { background: none; border: none; color: var(--brand-2); font-weight: 700; cursor: pointer; padding: 4px; font-size: 0.92rem; }
+  .si-close { margin-top: 4px; height: 44px; border-radius: 12px; border: none; cursor: pointer; font-weight: 800; color: #3a2a00;
+    background: linear-gradient(135deg, #fde047, #f59e0b); }
   .topbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
   .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
   .tb-right { display: flex; gap: 6px; }
@@ -222,6 +251,10 @@
   .ov-hero { display: flex; align-items: center; gap: 16px; margin: 6px 0 16px; }
   .ov-hero .prof-avatar { margin: 0; }
   .ov-id { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; min-width: 0; }
+  .uname-row { display: flex; align-items: center; gap: 8px; }
+  .bell-btn { position: relative; background: none; border: none; cursor: pointer; font-size: 1.3rem; line-height: 1; padding: 2px; }
+  .bell-count { position: absolute; top: -4px; right: -7px; min-width: 17px; height: 17px; display: grid; place-items: center; padding: 0 4px;
+    border-radius: 999px; background: #dc2626; color: #fff; font-size: 0.62rem; font-weight: 800; }
   .ov-id .uname { font-size: 1.15rem; }
   .ov-id .nw { font-size: 1.7rem; }
   .ov-id .nw-sub { font-size: 0.8rem; color: var(--text-faint); -webkit-text-fill-color: var(--text-faint); }

--- a/src/routes/streak/+page.svelte
+++ b/src/routes/streak/+page.svelte
@@ -76,7 +76,7 @@
   }
 </script>
 
-<svelte:head><title>WordBank — Streak</title></svelte:head>
+<svelte:head><title>WordBank — Daily Calendar</title></svelte:head>
 
 <main class="streak-page">
   <PageNav />

--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -3,9 +3,11 @@
   import { goto } from '$app/navigation';
   import PageNav from "$lib/components/PageNav.svelte";
   import { page } from '$app/stores';
-  import { getPublicProfile, addFriend } from '$lib/stores/statsStore.js';
+  import { getPublicProfile, addFriend, requestJoinGroup } from '$lib/stores/statsStore.js';
   import Avatar from '$lib/components/Avatar.svelte';
   import { track } from '$lib/analytics.js';
+  /** @type {Record<string,string>} */ let busyFriend = $state({});
+  /** @type {Record<string,string>} */ let groupState = $state({});
 
   /** @type {any} */
   let p = $state(null);
@@ -34,6 +36,21 @@
     if (res?.ok) { addMsg = 'Request sent ✓'; p = { ...p, request_outgoing: true }; }
     else addMsg = res?.reason || 'Could not send request';
     addBusy = false;
+  }
+
+  /** @param {string} uname */
+  async function addOne(uname) {
+    if (busyFriend[uname]) return;
+    busyFriend = { ...busyFriend, [uname]: 'busy' };
+    const res = await addFriend(uname);
+    busyFriend = { ...busyFriend, [uname]: res?.ok ? 'sent' : 'err' };
+  }
+  /** @param {any} g */
+  async function join(g) {
+    if (groupState[g.id]) return;
+    groupState = { ...groupState, [g.id]: 'busy' };
+    const res = await requestJoinGroup(g.id);
+    groupState = { ...groupState, [g.id]: res?.ok ? 'requested' : 'err' };
   }
 
   onMount(() => { track('public_profile_view'); load(); });
@@ -117,6 +134,38 @@
         <div class="b-wrap">{#each p.badges as b}<span class="badge">🏅 {(b || '').replace(/_/g, ' ').replace(/\b\w/g, (/** @type {string} */ c) => c.toUpperCase())}</span>{/each}</div>
       </section>
     {/if}
+
+    {#if !p.is_self && (p.friends ?? []).length}
+      <section class="social">
+        <div class="b-h">Friends · {p.friends.length}</div>
+        {#each p.friends as f}
+          <div class="soc-row">
+            <button class="soc-main" onclick={() => goto('/u/' + encodeURIComponent(f.username))}>@{f.username}<span class="soc-go">›</span></button>
+            <button class="soc-act" disabled={!!busyFriend[f.username]} onclick={() => addOne(f.username)}>
+              {busyFriend[f.username] === 'sent' ? '✓ Sent' : busyFriend[f.username] === 'err' ? 'Failed' : '+ Add'}
+            </button>
+          </div>
+        {/each}
+      </section>
+    {/if}
+
+    {#if !p.is_self && (p.groups ?? []).length}
+      <section class="social">
+        <div class="b-h">Groups · {p.groups.length}</div>
+        {#each p.groups as g}
+          <div class="soc-row">
+            <span class="soc-main static">👥 {g.name}</span>
+            {#if g.my_status === 'member'}
+              <span class="soc-tag">✓ Member</span>
+            {:else if groupState[g.id] === 'requested' || g.my_status === 'requested'}
+              <span class="soc-tag">Requested</span>
+            {:else}
+              <button class="soc-act" disabled={groupState[g.id] === 'busy'} onclick={() => join(g)}>{groupState[g.id] === 'err' ? 'Failed' : 'Ask to join'}</button>
+            {/if}
+          </div>
+        {/each}
+      </section>
+    {/if}
   {/if}
 </main>
 
@@ -166,6 +215,17 @@
   .badges { margin-top: 6px; }
   .b-h { color: var(--text-faint); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
   .b-wrap { display: flex; flex-wrap: wrap; gap: 7px; }
+  .social { margin-top: 18px; }
+  .soc-row { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+  .soc-main { flex: 1; display: flex; align-items: center; justify-content: space-between; padding: 10px 13px; border-radius: 12px;
+    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; font-size: 0.92rem; cursor: pointer; text-align: left; }
+  .soc-main.static { cursor: default; }
+  button.soc-main:hover { border-color: var(--brand-2); }
+  .soc-go { color: var(--text-faint); }
+  .soc-act { flex: none; padding: 9px 14px; border-radius: 12px; cursor: pointer; font-weight: 800; font-size: 0.82rem; color: #3a2a00;
+    background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border: none; }
+  .soc-act:disabled { opacity: 0.6; cursor: default; }
+  .soc-tag { flex: none; padding: 9px 12px; font-size: 0.8rem; font-weight: 700; color: var(--text-faint); }
   .badge { font-size: 0.78rem; padding: 5px 10px; border-radius: var(--r-pill); background: var(--surface); border: 1px solid var(--border); color: var(--text-muted); }
 
   @media (max-width: 380px) { .grid { grid-template-columns: repeat(3, 1fr); } }

--- a/supabase-challenge-autofriend.sql
+++ b/supabase-challenge-autofriend.sql
@@ -1,0 +1,71 @@
+-- Auto-friend: accepting a challenge makes you friends with the host.
+BEGIN;
+CREATE OR REPLACE FUNCTION public.accept_match(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; me public.challenge_participants; v_cash BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR m.status <> 'open' THEN RETURN jsonb_build_object('ok',false,'reason','closed'); END IF;
+  SELECT * INTO me FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','not_invited'); END IF;
+  IF me.state <> 'invited' THEN RETURN jsonb_build_object('ok',true, 'match', public.get_match(p_id)); END IF;
+  IF m.wager > 0 THEN
+    PERFORM public._ensure_bank(v_uid);
+    SELECT bank INTO v_cash FROM public.profiles WHERE id = v_uid;
+    IF v_cash < m.wager THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+    PERFORM public._bank_credit(v_uid, -m.wager, 'wager_stake');
+  END IF;
+  UPDATE public.challenge_participants SET paid = (m.wager > 0), state = 'active', joined_at = now(),
+    bankroll = GREATEST(m.wager, 500)
+  WHERE match_id = p_id AND user_id = v_uid;
+  IF m.host_id IS NOT NULL AND m.host_id <> v_uid THEN
+    INSERT INTO public.friendships(user_id, friend_id) VALUES (v_uid, m.host_id), (m.host_id, v_uid) ON CONFLICT DO NOTHING;
+  END IF;
+  RETURN jsonb_build_object('ok',true, 'match', public.get_match(p_id));
+END; $function$
+
+;
+CREATE OR REPLACE FUNCTION public.accept_match(p_id uuid, p_reduced boolean DEFAULT false)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; me public.challenge_participants;
+  v_cash BIGINT; v_stake BIGINT; v_budget BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR m.status <> 'open' THEN RETURN jsonb_build_object('ok',false,'reason','closed'); END IF;
+  SELECT * INTO me FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','not_invited'); END IF;
+  IF me.state <> 'invited' THEN RETURN jsonb_build_object('ok',true, 'match', public.get_match(p_id)); END IF;
+  v_budget := GREATEST(m.wager, 500);
+  IF m.wager > 0 THEN
+    PERFORM public._ensure_bank(v_uid);
+    SELECT bank INTO v_cash FROM public.profiles WHERE id = v_uid;
+    IF v_cash >= m.wager THEN
+      v_stake := m.wager;
+    ELSIF p_reduced AND v_cash > 0 THEN
+      v_stake := v_cash;
+    ELSE
+      RETURN jsonb_build_object('ok',false,'reason','insufficient','cash',COALESCE(v_cash,0),'wager',m.wager);
+    END IF;
+    PERFORM public._bank_credit(v_uid, -v_stake, 'wager_stake');
+    v_budget := v_stake;
+  END IF;
+  UPDATE public.challenge_participants SET paid = (m.wager > 0), state = 'active', joined_at = now(),
+    bankroll = v_budget, start_budget = v_budget
+  WHERE match_id = p_id AND user_id = v_uid;
+  PERFORM public._mark_seen_many(v_uid, (select array_agg(puzzle_id) from public.challenge_pack where match_id = p_id));
+  IF m.host_id IS NOT NULL AND m.host_id <> v_uid THEN
+    INSERT INTO public.friendships(user_id, friend_id) VALUES (v_uid, m.host_id), (m.host_id, v_uid) ON CONFLICT DO NOTHING;
+  END IF;
+  RETURN jsonb_build_object('ok',true, 'match', public.get_match(p_id));
+END; $function$
+
+;
+COMMIT;

--- a/supabase-dismiss-notif.sql
+++ b/supabase-dismiss-notif.sql
@@ -1,0 +1,7 @@
+-- Dismiss (delete) a single notification for the caller.
+CREATE OR REPLACE FUNCTION public.dismiss_notification(p_id uuid)
+RETURNS void LANGUAGE sql SECURITY DEFINER AS $$
+  DELETE FROM public.notifications WHERE id = p_id AND user_id = auth.uid();
+$$;
+REVOKE ALL ON FUNCTION public.dismiss_notification(uuid) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.dismiss_notification(uuid) TO authenticated;

--- a/supabase-group-join.sql
+++ b/supabase-group-join.sql
@@ -1,0 +1,49 @@
+-- ── Group join-requests (owner approval) + public-profile friends/groups ──
+CREATE TABLE IF NOT EXISTS public.group_join_requests (
+  group_id     uuid NOT NULL REFERENCES public.groups(id) ON DELETE CASCADE,
+  requester_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (group_id, requester_id)
+);
+ALTER TABLE public.group_join_requests ENABLE ROW LEVEL SECURITY;
+
+-- Ask to join a group → notify the owner.
+CREATE OR REPLACE FUNCTION public.request_join_group(p_group uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid uuid := auth.uid(); v_owner uuid; v_name text; v_gname text;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  SELECT owner_id, name INTO v_owner, v_gname FROM public.groups WHERE id = p_group;
+  IF v_owner IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','no_group'); END IF;
+  IF EXISTS (SELECT 1 FROM public.group_members WHERE group_id=p_group AND user_id=v_uid) THEN
+    RETURN jsonb_build_object('ok',false,'reason','already_member'); END IF;
+  INSERT INTO public.group_join_requests(group_id, requester_id) VALUES (p_group, v_uid) ON CONFLICT DO NOTHING;
+  v_name := public._display_name(v_uid);
+  PERFORM public._notify(v_owner, 'group_join', 'Join request',
+    v_name || ' wants to join ' || v_gname,
+    jsonb_build_object('group_id', p_group, 'group_name', v_gname, 'from_id', v_uid, 'from_name', v_name));
+  RETURN jsonb_build_object('ok',true,'status','requested');
+END; $$;
+
+-- Owner approves/declines a join request.
+CREATE OR REPLACE FUNCTION public.respond_join_request(p_group uuid, p_user uuid, p_accept boolean)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid uuid := auth.uid(); v_owner uuid; v_gname text;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  SELECT owner_id, name INTO v_owner, v_gname FROM public.groups WHERE id = p_group;
+  IF v_owner IS DISTINCT FROM v_uid THEN RETURN jsonb_build_object('ok',false,'reason','not_owner'); END IF;
+  DELETE FROM public.group_join_requests WHERE group_id=p_group AND requester_id=p_user;
+  IF p_accept THEN
+    INSERT INTO public.group_members(group_id, user_id) VALUES (p_group, p_user) ON CONFLICT DO NOTHING;
+    PERFORM public._notify(p_user, 'group_join_ok', 'Request approved',
+      'You''re now in ' || v_gname, jsonb_build_object('group_id', p_group, 'group_name', v_gname));
+  END IF;
+  RETURN jsonb_build_object('ok',true);
+END; $$;
+
+REVOKE ALL ON FUNCTION public.request_join_group(uuid), public.respond_join_request(uuid,uuid,boolean) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.request_join_group(uuid), public.respond_join_request(uuid,uuid,boolean) TO authenticated;
+
+-- Also applied: get_public_profile now returns the target's 'friends' (username/name)
+-- and 'groups' (id/name/my_status: member|requested|none), so others can see them.


### PR DESCRIPTION
## Summary
- **Menu:** Challenge Friends (challenges hub) + 🏆 Leaderboard direct doors; Activity removed; Daily card gold when not started.
- **Leaderboard:** daily-only board; sortable columns incl. a Place (#) sort that reverses to bring last to top; Everyone/Friends/Groups scope dropdown.
- **Profile:** single Overview hub (no tabs); everything tappable; stat-explanation popups; notification bell + dismissable notifications; My Friends + My Groups pages; renamed stat labels; centered titles.
- **Social:** public profiles show Friends/Groups; add friends + ask-to-join groups (owner approval + notifications); accepting a challenge auto-friends you with the host.
- **Daily Calendar:** renamed; make-up never-opened days + Perfect Week/Month badges (already wired).
- In-app confirm modals everywhere; consistent ← Back / 🏠 nav.

All DB migrations already applied to prod. Build clean; E2E sweep 19/19, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)