### PR TITLE
Add GitHub Actions CI workflow (lint, type-check, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  build:
+    name: Lint, type-check, and build
+    runs-on: ubuntu-latest
+    env:
+      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type-check
+        run: npm run check
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Implemented by the ExInq build agent for task **t5**.

Acceptance criteria:
- .github/workflows/ci.yml exists and triggers on push and pull_request to main
- Workflow runs: npm ci, npm run lint, npm run check (svelte-check), npm run build — all must pass
- Workflow uses repository secrets for VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY (dummy values acceptable for build step)
- A passing badge or green check is visible on a test PR before merging

Do not merge without review.