### PR TITLE
Daily: wrong-guess penalty (−0.2× mult floor 1.0 + Efficiency dock)

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -43,6 +43,9 @@ import { track } from '$lib/analytics.js';
  *   arcadeRun?: any,
  *   arcadeCashedOut?: boolean,
  *   modifier?: string | null,
+ *   bountyMult?: number,
+ *   twistUsed?: boolean,
+ *   wrongGuesses?: number,
  *   clue?: string | null,
  *   challengeInfo?: any,
  *   makeupDate?: string | null,
@@ -90,6 +93,7 @@ export const gameStore = writable(/** @type {GameState} */ ({
   modifier: null, // today's Daily Twist power-up id (daily only)
   twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
   bountyMult: 1, // bounty multiplier (1.0 once Twist used, else 1.5)
+  wrongGuesses: 0, // wrong phrase guesses this Daily (each −0.2× mult, floor 1.0)
   clue: null, // witty one-line hint for the current puzzle
   challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
@@ -206,7 +210,8 @@ function reconcileDailyBoard(board) {
     // Daily Twist: the available modifier id + whether you've used it + bounty multiplier.
     modifier: board.modifier !== undefined ? board.modifier : prev.modifier,
     twistUsed: board.twist_used !== undefined ? board.twist_used : (prev.twistUsed ?? false),
-    bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1)
+    bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1),
+    wrongGuesses: board.wrong_guesses !== undefined ? board.wrong_guesses : (prev.wrongGuesses ?? 0)
   }));
   // Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
   // not when re-opening an already-completed daily (which comes back 'won' with no result).

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -544,7 +544,9 @@
   $: dlNet = dlReward - dlSpent;
   $: dlWinStreak = dailyStatus?.win_streak ?? 0;
   $: dlStreakBonus = Math.min(0.1 * dlWinStreak, 0.5);
-  $: dlBoost = Math.max(0, Math.round((dlMult - 1 - dlStreakBonus) * 10) / 10);
+  $: dlWrong = $gameStore.wrongGuesses ?? 0;
+  $: dlPenalty = Math.min(0.2 * dlWrong, Math.max(0, dlMult - 1)); // shown penalty, can't push below ×1.0 floor
+  $: dlBoost = Math.max(0, Math.round((dlMult - 1 - dlStreakBonus + dlPenalty) * 10) / 10);
   const fmtMult = (/** @type {number} */ n) => '×' + n.toFixed(1);
   let _prevBank = /** @type {number|null} */ (null);
   let _floatId = 0;
@@ -1743,9 +1745,11 @@
         <div class="info-rows">
           <div class="info-row"><span>Base</span><b>×1.0</b></div>
           {#if dlStreakBonus > 0}<div class="info-row"><span>🏆 Win streak ({dlWinStreak} in a row)</span><b class="pos">+{dlStreakBonus.toFixed(1)}</b></div>{/if}
+          {#if dlBoost > 0}<div class="info-row"><span>💥 Boosts</span><b class="pos">+{dlBoost.toFixed(1)}</b></div>{/if}
+          {#if dlWrong > 0}<div class="info-row"><span>❌ Wrong guesses ({dlWrong})</span><b class="neg">−{dlPenalty.toFixed(1)}</b></div>{/if}
           <div class="info-row total"><span>Your multiplier</span><b>{fmtMult(dlMult)}</b></div>
         </div>
-        <p class="info-note">Grows with your <button class="info-inline" on:click|stopPropagation={() => dailyInfo = 'streak'}>win streak</button> — <b>+0.1×</b> per solve, up to <b>×1.5</b>.</p>
+        <p class="info-note">Grows with your <button class="info-inline" on:click|stopPropagation={() => dailyInfo = 'streak'}>win streak</button> (<b>+0.1×</b>/solve, up to <b>×1.5</b>). Each wrong guess costs <b>−0.2×</b> (never below ×1.0).</p>
       {:else if dailyInfo === 'twist'}
         <div class="info-big">{dailyMod?.emoji ?? '🎁'}</div>
         <h3 class="info-title">{dailyMod?.name ?? "Today's Twist"}</h3>

--- a/supabase-board-wrong-guesses.sql
+++ b/supabase-board-wrong-guesses.sql
@@ -1,0 +1,98 @@
+-- surface wrong_guesses in the daily board response (for the multiplier explainer)
+BEGIN;
+CREATE OR REPLACE FUNCTION public._daily_resolve_and_return(p_uid uuid, p_phrase text, p_cat text, p_sub text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE s public.daily_sessions; v_won BOOLEAN; v_board JSONB; v_bank BIGINT; v_reward INT; v_base INT; v_mult NUMERIC;
+BEGIN
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+  v_base := public._daily_reward(s.puzzle_id);
+  v_mult := public._daily_bounty_mult(p_uid);                 -- pre-finalize → matches the credited reward
+  v_reward := (round(v_base * v_mult / 10.0) * 10)::int;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(p_phrase)-1) g(i)
+    WHERE substr(p_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions)));
+  IF v_won AND s.state = 'active' THEN
+    UPDATE public.daily_sessions SET state = 'won', updated_at = NOW(), finished_at = COALESCE(finished_at, NOW())
+      WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+    s.state := 'won';
+    PERFORM public._finalize_daily(p_uid, true, s.spent, COALESCE(array_length(s.incorrect_letters,1),0));
+    PERFORM public._record_category_solve(p_uid, p_cat);
+  END IF;
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = p_uid;
+  v_board := public._daily_board(p_phrase, s.state, v_bank::int, s.guesses_remaining, s.revealed_positions, s.incorrect_letters, p_cat, p_sub)
+    || jsonb_build_object('live', public._daily_live(s.spent, v_reward),
+         'modifier', s.active_powerups[1], 'twist_used', s.twist_used, 'bounty_mult', public._daily_bounty_mult(p_uid), 'wrong_guesses', COALESCE((SELECT p_wrong_guesses FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE),0));
+  IF s.state = 'won' THEN
+    v_board := v_board || jsonb_build_object('daily_result', jsonb_build_object(
+      'reward', v_reward, 'base', v_base, 'mult', v_mult, 'spent', s.spent,
+      'net', v_reward - s.spent, 'score', v_reward - s.spent, 'twist_used', s.twist_used));
+  END IF;
+  RETURN v_board;
+END; $function$
+
+;
+CREATE OR REPLACE FUNCTION public.daily_start(p_powerups text[] DEFAULT '{}'::text[], p_use_twist boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; s public.daily_sessions; v_mod TEXT;
+  v_bank BIGINT; v_streak INT; v_high INT; v_last DATE; v_freezes INT; v_day INT; v_att INT := 0; v_new BOOLEAN := false;
+  v_fv TEXT; v_reveal INT[] := '{}'; i INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_start: not authenticated'; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_pid := public._todays_puzzle_id();
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
+    v_mod := public._daily_modifier();
+    INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining, active_powerups, spent, twist_used)
+    VALUES (v_uid, CURRENT_DATE, v_pid, 0, 999, ARRAY[v_mod], 0, true) RETURNING * INTO s;
+    v_new := true;
+    -- 🎁 auto-apply: reveal letters for the reveal-type Twists
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = v_pid;
+    IF v_mod = 'free_vowel' THEN
+      SELECT substr(v_phrase, g.i+1, 1) INTO v_fv FROM generate_series(0, length(v_phrase)-1) g(i)
+        WHERE substr(v_phrase, g.i+1, 1) IN ('A','E','I','O','U') ORDER BY g.i LIMIT 1;
+      IF v_fv IS NOT NULL THEN
+        SELECT array_agg(g.i) INTO v_reveal FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1, 1) = v_fv;
+      END IF;
+    ELSIF v_mod = 'head_start' THEN
+      FOR i IN 0 .. length(v_phrase)-1 LOOP
+        IF substr(v_phrase, i+1, 1) <> ' ' AND (i = 0 OR substr(v_phrase, i, 1) = ' ') THEN v_reveal := v_reveal || i; END IF;
+      END LOOP;
+    END IF;
+    IF array_length(v_reveal, 1) > 0 THEN
+      UPDATE public.daily_sessions SET revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_reveal) ORDER BY 1)
+        WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE RETURNING * INTO s;
+    END IF;
+    -- attendance + streak
+    SELECT current_daily_play_streak, best_daily_play_streak, last_daily_play_date, COALESCE(streak_freezes,0)
+      INTO v_streak, v_high, v_last, v_freezes FROM public.profiles WHERE id = v_uid;
+    IF v_last = CURRENT_DATE THEN v_day := COALESCE(v_streak,0);
+    ELSIF v_last = CURRENT_DATE - 1 THEN v_day := COALESCE(v_streak,0) + 1;
+    ELSIF v_last = CURRENT_DATE - 2 AND v_freezes > 0 AND COALESCE(v_streak,0) > 0 THEN v_freezes := v_freezes - 1; v_day := COALESCE(v_streak,0) + 1;
+    ELSE v_day := 1; END IF;
+    IF v_day > 0 AND v_day % 7 = 0 THEN v_freezes := LEAST(v_freezes + 1, 3); END IF;
+    v_high := GREATEST(COALESCE(v_high,0), v_day);
+    UPDATE public.profiles SET current_daily_play_streak = v_day, best_daily_play_streak = v_high,
+      last_daily_play_date = CURRENT_DATE, streak_freezes = v_freezes WHERE id = v_uid;
+    v_att := 50 + CASE WHEN v_day % 30 = 0 THEN 1500 WHEN v_day % 14 = 0 THEN 500
+                       WHEN v_day % 7 = 0 THEN 250 WHEN v_day = 3 THEN 100 ELSE 0 END;
+    PERFORM public._bank_credit(v_uid, v_att, 'attendance');
+    IF v_day >= 7 THEN PERFORM public._award_badge(v_uid, 'streak_7'); END IF;
+    IF v_day >= 30 THEN PERFORM public._award_badge(v_uid, 'streak_30'); END IF;
+  END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory, '') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = v_uid;
+  RETURN public._daily_board(v_phrase, s.state, v_bank::int, s.guesses_remaining, s.revealed_positions, s.incorrect_letters, v_cat, v_sub)
+    || jsonb_build_object('live', public._daily_live(s.spent, public._daily_reward_final(v_uid, s.puzzle_id)),
+         'modifier', s.active_powerups[1], 'twist_used', s.twist_used, 'bounty_mult', public._daily_bounty_mult(v_uid), 'wrong_guesses', COALESCE((SELECT p_wrong_guesses FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE),0))
+    || CASE WHEN v_new THEN jsonb_build_object('attendance', v_att, 'attendance_day', v_day) ELSE '{}'::jsonb END;
+END; $function$
+
+;
+COMMIT;

--- a/supabase-wrong-guess-penalty.sql
+++ b/supabase-wrong-guess-penalty.sql
@@ -1,0 +1,115 @@
+-- Wrong-guess penalty: each wrong phrase guess drops the bounty multiplier by 0.2 (floor 1.0)
+-- and docks 5 off the Efficiency score (floor 0). Uses daily_sessions.p_wrong_guesses.
+BEGIN;
+ALTER TABLE public.game_results ADD COLUMN IF NOT EXISTS wrong_guesses int NOT NULL DEFAULT 0;
+CREATE OR REPLACE FUNCTION public._daily_bounty_mult(p_uid uuid)
+RETURNS numeric LANGUAGE sql STABLE SECURITY DEFINER AS $fn$
+  SELECT GREATEST(1.0, LEAST(3.0,
+    1.0
+    + LEAST(0.1 * GREATEST(0, COALESCE(
+        (SELECT CASE WHEN last_daily_solve_date >= CURRENT_DATE - 1 THEN current_daily_solve_streak ELSE 0 END
+         FROM public.profiles WHERE id = p_uid), 0)), 0.5)
+    + COALESCE((SELECT bounty_boost FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE), 0)
+  ) - 0.2 * COALESCE((SELECT p_wrong_guesses FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE), 0));
+$fn$;
+CREATE OR REPLACE FUNCTION public._finalize_daily(p_uid uuid, p_won boolean, p_spent integer, p_incorrect_count integer DEFAULT 0)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_week_start DATE; v_pid UUID; v_reward INT; v_net INT; v_streak INT; v_cat TEXT; v_spent INT; v_started TIMESTAMPTZ; v_time INT; v_used BOOLEAN; v_earned INT; v_wrong INT;
+  v_ss INT; v_bss INT; v_lss DATE; v_grant TEXT;
+BEGIN
+  v_week_start := date_trunc('week', CURRENT_DATE)::DATE + 1;
+  SELECT puzzle_id, created_at, twist_used, COALESCE(p_wrong_guesses,0) INTO v_pid, v_started, v_used, v_wrong FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+  SELECT category INTO v_cat FROM public.daily_puzzles WHERE id = v_pid;
+  v_reward := public._daily_reward_final(p_uid, v_pid);
+  v_spent  := GREATEST(0, COALESCE(p_spent,0));
+  v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - v_started)) * 1000, 0), 1800000)::int;
+  IF p_won THEN v_earned := v_reward; v_net := v_reward - v_spent; ELSE v_earned := 0; v_net := -v_spent; END IF;
+  SELECT COALESCE(current_daily_play_streak,0) INTO v_streak FROM public.profiles WHERE id = p_uid;
+  INSERT INTO public.game_results (
+    user_id, played_at, won, bankroll_left, game_mode, score, outcome, puzzle_id, category,
+    solved_count, puzzle_count, spent, earned, net, multiple_x100, time_ms, clean, wrong_guesses)
+  VALUES (
+    p_uid, NOW(), p_won, v_spent, 'daily', v_net, CASE WHEN p_won THEN 'won' ELSE 'lost' END, v_pid, v_cat,
+    CASE WHEN p_won THEN 1 ELSE 0 END, 1, v_spent, v_earned, v_net,
+    CASE WHEN p_won AND v_spent > 0 THEN round(v_reward * 100.0 / v_spent)::int ELSE NULL END,
+    CASE WHEN p_won THEN v_time ELSE NULL END,
+    (p_won AND COALESCE(p_incorrect_count,0) = 0), COALESCE(v_wrong,0));
+  INSERT INTO public.user_weekly_stats (user_id, week_start, puzzles_completed, bankroll_earned, highest_bankroll, total_wins, total_played, win_streak)
+  VALUES (p_uid, v_week_start, CASE WHEN p_won THEN 1 ELSE 0 END, v_net, GREATEST(v_net,0), CASE WHEN p_won THEN 1 ELSE 0 END, 1, v_streak)
+  ON CONFLICT (user_id, week_start) DO UPDATE SET
+    total_played = user_weekly_stats.total_played + 1,
+    total_wins = user_weekly_stats.total_wins + CASE WHEN p_won THEN 1 ELSE 0 END,
+    puzzles_completed = user_weekly_stats.puzzles_completed + CASE WHEN p_won THEN 1 ELSE 0 END,
+    bankroll_earned = user_weekly_stats.bankroll_earned + v_net,
+    highest_bankroll = GREATEST(user_weekly_stats.highest_bankroll, v_net),
+    win_streak = GREATEST(user_weekly_stats.win_streak, v_streak);
+  SELECT COALESCE(current_daily_solve_streak,0), COALESCE(best_daily_solve_streak,0), last_daily_solve_date INTO v_ss, v_bss, v_lss
+    FROM public.profiles WHERE id = p_uid;
+  IF p_won THEN
+    IF v_lss = CURRENT_DATE THEN v_ss := v_ss;
+    ELSIF v_lss = CURRENT_DATE - 1 THEN v_ss := v_ss + 1;
+    ELSE v_ss := 1; END IF;
+    v_bss := GREATEST(v_bss, v_ss);
+    UPDATE public.profiles SET current_daily_solve_streak = v_ss, best_daily_solve_streak = v_bss, last_daily_solve_date = CURRENT_DATE WHERE id = p_uid;
+    PERFORM public._bank_credit(p_uid, v_reward, 'daily_reward');
+    IF COALESCE(p_incorrect_count,0) = 0 THEN PERFORM public._award_badge(p_uid, 'flawless'); END IF;
+    IF NOT COALESCE(v_used, false) THEN
+      v_grant := public._twist_powerup(public._daily_modifier());
+      IF v_grant IS NOT NULL THEN PERFORM public._award_powerup(p_uid, v_grant, 'cash'); END IF;
+    END IF;
+  ELSE
+    UPDATE public.profiles SET current_daily_solve_streak = 0 WHERE id = p_uid;
+  END IF;
+  PERFORM public._check_calendar_badges(p_uid, CURRENT_DATE);
+END; $function$
+
+;
+CREATE OR REPLACE FUNCTION public.get_daily_board(p_scope text DEFAULT 'everyone'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB; v_base int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  v_base := public._daily_reward(public._todays_puzzle_id());
+  WITH circle AS (
+    SELECT v_uid AS id
+    UNION SELECT friend_id FROM public.friendships WHERE user_id = v_uid AND p_scope = 'friends'
+    UNION SELECT user_id FROM public.group_members WHERE group_id = p_group AND p_scope = 'group'
+    UNION SELECT id FROM public.profiles WHERE p_scope IN ('global','everyone')
+  ),
+  d AS (
+    SELECT c.id,
+      COALESCE(pr.bank, 0)::bigint AS net_worth,
+      (CASE WHEN pr.last_daily_play_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_play_streak,0) ELSE 0 END) AS play_streak,
+      (CASE WHEN pr.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_solve_streak,0) ELSE 0 END) AS win_streak,
+      g.score AS score,
+      (CASE WHEN g.won AND v_base > 0 THEN GREATEST(0, round((v_base - g.spent)::numeric / v_base * 100)::int - 5 * COALESCE(g.wrong_guesses,0)) ELSE NULL END) AS efficiency,
+      pr.equipped_title, pr.equipped_color
+    FROM circle c
+    JOIN public.profiles pr ON pr.id = c.id
+    LEFT JOIN LATERAL (
+      SELECT gr.score, gr.spent, gr.won, gr.wrong_guesses FROM public.game_results gr
+      WHERE gr.user_id = c.id AND gr.game_mode = 'daily' AND gr.played_at::date = CURRENT_DATE
+      ORDER BY gr.played_at DESC LIMIT 1
+    ) g ON true
+    WHERE c.id IS NOT NULL
+  ),
+  ranked AS (
+    SELECT *, row_number() OVER (ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC) AS rank
+    FROM d ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC LIMIT 100
+  )
+  SELECT jsonb_agg(jsonb_build_object(
+    'rank', rank, 'name', public._display_name(id), 'net_worth', net_worth, 'score', score,
+    'efficiency', efficiency,
+    'play_streak', play_streak, 'win_streak', win_streak, 'played', score IS NOT NULL,
+    'is_me', id = v_uid, 'title', equipped_title, 'color', equipped_color) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$
+
+;
+COMMIT;


### PR DESCRIPTION
Wrong guesses cut the bounty multiplier −0.2× (floored ×1.0, so base is always kept) and dock 5 off Efficiency. Live chip + explainer updated. Verified via SQL + E2E 19/19. 🤖 Generated with [Claude Code](https://claude.com/claude-code)