### PR TITLE
V2 Phase 0: remove Free Play, Credits/Exchange & dead Arcade (code side)

### DIFF
--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -1,5 +1,5 @@
 // The 12 puzzle categories. `value` is the exact string stored on
-// daily_puzzles.category (emoji included) and passed to freeplay_start.
+// daily_puzzles.category (emoji included); used by the Challenge builder's picker.
 /** @type {{ value: string, label: string, emoji: string }[]} */
 export const CATEGORIES = [
   { value: 'Movies & TV 🎬',        label: 'Movies & TV',       emoji: '🎬' },

--- a/src/lib/components/HistoryList.svelte
+++ b/src/lib/components/HistoryList.svelte
@@ -29,7 +29,7 @@
     { k: 'challenge', label: '⚔️ Versus' }
   ];
   const icon = (/** @type {string} */ m) =>
-    m === 'daily' ? '📅' : m === 'makeup' ? '🗓️' : m === 'climb' ? '🎰' : m === 'arcade' ? '🎲' : m === 'challenge' ? '⚔️' : '🎮';
+    m === 'daily' ? '📅' : m === 'makeup' ? '🗓️' : m === 'climb' ? '🎰' : m === 'challenge' ? '⚔️' : '🎮';
   const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
   const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
   const when = (/** @type {string} */ t) => new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -32,10 +32,7 @@
 
   // Effective per-letter prices after active discount / vowel_vision (server matches this):
   // daily uses the shared modifier.
-  // Free Play: letters are free (the cost is your limited reveal budget).
-  $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: effCosts = (() => {
-    if ($gameStore.gameMode === 'freeplay') { const out: Record<string, number> = {}; for (const k of Object.keys(letterCosts)) out[k] = 0; return out; }
     let discount = false, vowelHalf = false;
     if ($gameStore.gameMode === 'daily') {
       const m = $gameStore.modifier;
@@ -60,13 +57,8 @@
   $: lockedLetters = ($gameStore.lockedLetters || {}) as LockedLetters;
   $: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
 
-  // 🔹 Disable keys. Free Play: all disabled when out of reveals, else only wrong letters.
-  //    Other modes: unaffordable or incorrect keys (modifier-adjusted prices).
-  $: disabledKeys = isFreeplay
-    ? ((($gameStore as any).revealsRemaining ?? 0) <= 0
-        ? Object.keys(letterCosts)
-        : Object.keys(letterCosts).filter((letter: string) => incorrectLetters.includes(letter)))
-    : Object.keys(letterCosts).filter((letter: string) =>
+  // 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
+  $: disabledKeys = Object.keys(letterCosts).filter((letter: string) =>
         (effCosts[letter] ?? 0) > $gameStore.bankroll || incorrectLetters.includes(letter));
 
   /**
@@ -181,7 +173,7 @@
       >
         <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
-        {#if !isFreeplay}<div class="price">${effCosts[letter] ?? 0}</div>{/if}
+        <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
   </div>
@@ -206,7 +198,7 @@
       >
         <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
-        {#if !isFreeplay}<div class="price">${effCosts[letter] ?? 0}</div>{/if}
+        <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
   </div>
@@ -231,7 +223,7 @@
       >
         <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
-        {#if !isFreeplay}<div class="price">${effCosts[letter] ?? 0}</div>{/if}
+        <div class="price">${effCosts[letter] ?? 0}</div>
       </button>
     {/each}
 

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -31,7 +31,7 @@
   };
 
   // Effective per-letter prices after active discount / vowel_vision (server matches this):
-  // daily uses the shared modifier; arcade uses the run's armed power-ups.
+  // daily uses the shared modifier.
   // Free Play: letters are free (the cost is your limited reveal budget).
   $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: effCosts = (() => {
@@ -40,9 +40,6 @@
     if ($gameStore.gameMode === 'daily') {
       const m = $gameStore.modifier;
       discount = m === 'discount'; vowelHalf = m === 'vowel_vision';
-    } else if ($gameStore.gameMode === 'arcade') {
-      const a: string[] = ($gameStore.arcadeRun && $gameStore.arcadeRun.active) || [];
-      discount = a.includes('discount'); vowelHalf = a.includes('vowel_vision');
     }
     const out: Record<string, number> = {};
     for (const k of Object.keys(letterCosts)) {

--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -32,10 +32,6 @@
         goal: 'Climb an endless ladder of puzzles.',
         win: 'Solve each one cheaply to grow your bankroll.',
         bar: "Don't go broke." };
-      case 'freeplay': return { icon: '🎟️', title: 'Free Play',
-        goal: 'Solve with 3 free reveals + 6 guesses.',
-        win: 'Earn credits for solving — the fewer reveals you use, the more you earn (up to +300).',
-        bar: 'Cash out credits → Cash in the Bank (40 credits = $1).' };
       case 'makeup': return { icon: '🗓️', title: 'Make-up Daily',
         goal: 'Play a daily you missed.',
         win: 'Same rules — solve it as cheaply as you can.',

--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -32,10 +32,6 @@
         goal: 'Climb an endless ladder of puzzles.',
         win: 'Solve each one cheaply to grow your bankroll.',
         bar: "Don't go broke." };
-      case 'arcade': return { icon: '🎲', title: 'Arcade Run',
-        goal: 'Survival mode — keep your streak alive.',
-        win: 'The bigger your streak, the bigger the payout.',
-        bar: 'One slip ends the run.' };
       case 'freeplay': return { icon: '🎟️', title: 'Free Play',
         goal: 'Solve with 3 free reveals + 6 guesses.',
         win: 'Earn credits for solving — the fewer reveals you use, the more you earn (up to +300).',

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -32,12 +32,6 @@
       title: 'Cash Game & Challenges',
       isNew: true,
       body: 'Endless puzzles for Cash, or wager friends — spend the least to take the pot.'
-    },
-    {
-      icon: '🎲',
-      title: 'Broke? Free Play',
-      isNew: true,
-      body: 'Free Play costs nothing and pays per solve. Grind back anytime.'
     }
   ];
 

--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -1,5 +1,4 @@
-// Power-up catalog. Keys match the server ids. Arcade earns exactly 3, each by a
-// special feat (most solves earn nothing). `armed`: arms on the CURRENT puzzle
+// Power-up catalog. Keys match the server ids. `armed`: arms on the CURRENT puzzle
 // (shown as ON). Otherwise it fires instantly when used. `feat`: the move that
 // earns it (shown in the solve modal so players learn the feats).
 /** @type {Record<string, { emoji: string, name: string, desc: string, feat: string, armed?: boolean }>} */

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -4,7 +4,6 @@ import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
 import { dailyStart, dailyUseTwist, dailyUseBoost, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue } from '$lib/stores/statsStore.js';
-import { freeplayStart, freeplayNext, freeplayResume, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
 import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, climbDoubleOrNothing, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
@@ -83,7 +82,7 @@ export const gameStore = writable(/** @type {GameState} */ ({
   shakenLetters: [],
   message: '',
   subcategory: '',
-  gameMode: 'daily', // 'daily' | 'freeplay' | 'climb' | 'challenge' | 'match' | 'makeup'
+  gameMode: 'daily', // 'daily' | 'climb' | 'challenge' | 'match' | 'makeup'
   freeReveals: 0, // owned Free Reveal power-ups (daily)
   modifier: null, // today's Daily Twist power-up id (daily only)
   twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
@@ -133,7 +132,7 @@ let dailyInFlight = false;
  * @param {any} board - board JSON returned by a daily_* RPC
  */
 /**
- * boardToState — shared masked-board → gameStore partial (used by daily + freeplay).
+ * boardToState — shared masked-board → gameStore partial.
  * @param {any} board @param {GameState} prev
  */
 function boardToState(board, prev) {
@@ -216,109 +215,6 @@ function reconcileDailyBoard(board) {
   // analytics: fire once, only on the actual solve transition
   if (board.daily_result && prev.gameState !== 'won' && prev.gameState !== 'lost') {
     track('daily_result', { won: true, bankroll: board.bankroll ?? 0 });
-  }
-}
-
-/* ===== Free Play (unranked, category-picked, endless) ===== */
-
-/** @param {any} board */
-function reconcileFreeplayBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-  const finished = board.state !== 'active';
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(board, prev),
-    gameMode: 'freeplay',
-    revealsRemaining: board.reveals_remaining ?? 0,
-    gameState: finished ? board.state : 'default',
-    modifier: null  }));
-  if (board.state === 'won') {
-    setTimeout(() => launchConfetti(), 300); fx('win');
-    const rw = /** @type {any} */ (board).freeplay_reward;
-    if (rw > 0) gameStore.update(s => ({ ...s, cashToast: { amount: rw, label: 'Free Play reward' } }));
-  }
-  else if (finished) fx('bust');
-  else playMoveCue(prev, board);
-}
-
-async function refreshFreeplayClue() {
-  try {
-    const clue = await getFreeplayClue();
-    gameStore.update(s => ({ ...s, clue }));
-  } catch { /* non-fatal */ }
-}
-
-/** Start Free Play in a category (random puzzle from it). @param {string} category */
-export async function fetchFreeplayGame(category) {
-  try {
-    track('freeplay_start', { category });
-    const board = await freeplayStart(category);
-    if (!board) { console.error('❌ freeplay_start returned nothing'); return false; }
-    reconcileFreeplayBoard(board);
-    await refreshFreeplayClue();
-    return true;
-  } catch (err) {
-    console.error('❌ Error starting free play:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
-}
-
-/** Resume the in-progress Free Play puzzle. Returns true if a live board was
- *  restored, false if there's nothing to resume (caller picks a category). */
-export async function fetchFreeplayResume() {
-  try {
-    const board = await freeplayResume();
-    if (!board) return false;
-    reconcileFreeplayBoard(board);
-    await refreshFreeplayClue();
-    return true;
-  } catch (err) {
-    console.error('❌ Error resuming free play:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
-}
-
-/** Next free-play puzzle in the same category. */
-export async function freeplayContinue() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await freeplayNext();
-    if (board) { reconcileFreeplayBoard(board); await refreshFreeplayClue(); }
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** @param {GameState} state */
-async function confirmPurchaseFreeplay(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    let board = null;
-    if (purchase.type === 'letter') board = await freeplayBuyLetter(purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await freeplayReveal();
-    if (board) reconcileFreeplayBoard(board);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** @param {GameState} state */
-async function submitGuessFreeplay(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const board = await freeplaySubmitGuess(guess);
-    if (board) reconcileFreeplayBoard(board);
-  } finally {
-    dailyInFlight = false;
   }
 }
 
@@ -857,10 +753,7 @@ export async function matchFold() {
  */
 export function selectLetter(letter) {
   gameStore.update(/** @param {GameState} state */ (state) => {
-    // Free Play: letters are free (gated by the reveal budget, not the wallet).
-    const isFree = state.gameMode === 'freeplay';
-    if (isFree && (state.revealsRemaining ?? 0) <= 0) return state; // out of reveals
-    const cost = isFree ? 0 : (LETTER_COSTS[letter] || 0);
+    const cost = LETTER_COSTS[letter] || 0;
     if (state.bankroll < cost) {
       console.log(`Insufficient funds to purchase letter ${letter}`);
       return state;
@@ -923,7 +816,6 @@ export function confirmPurchase() {
   // All modes are server-authoritative: commit via RPC and reconcile.
   const current = get(gameStore);
   if (current.gameMode === 'daily') confirmPurchaseDaily(current);
-  else if (current.gameMode === 'freeplay') confirmPurchaseFreeplay(current);
   else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
   else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
   else if (current.gameMode === 'climb') confirmPurchaseClimb(current);
@@ -1026,7 +918,6 @@ export function submitGuess() {
   // All modes are server-authoritative: the server validates + scores.
   const current = get(gameStore);
   if (current.gameMode === 'daily') submitGuessDaily(current);
-  else if (current.gameMode === 'freeplay') submitGuessFreeplay(current);
   else if (current.gameMode === 'challenge') submitGuessChallenge(current);
   else if (current.gameMode === 'makeup') submitGuessMakeup(current);
   else if (current.gameMode === 'climb') submitGuessClimb(current);

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,8 +3,7 @@
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
-import { dailyStart, dailyUseTwist, dailyUseBoost, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue, getArcadeClue } from '$lib/stores/statsStore.js';
-import { arcadeStart, arcadeBuyLetter, arcadeReveal, arcadeSubmitGuess, arcadeNext, arcadeUsePowerup, arcadeCashout } from '$lib/stores/statsStore.js';
+import { dailyStart, dailyUseTwist, dailyUseBoost, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue } from '$lib/stores/statsStore.js';
 import { freeplayStart, freeplayNext, freeplayResume, freeplayBuyLetter, freeplayReveal, freeplaySubmitGuess, getFreeplayClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
@@ -40,8 +39,6 @@ import { track } from '$lib/analytics.js';
  *   subcategory: string,
  *   gameMode: string,
  *   freeReveals?: number,
- *   arcadeRun?: any,
- *   arcadeCashedOut?: boolean,
  *   modifier?: string | null,
  *   bountyMult?: number,
  *   twistUsed?: boolean,
@@ -86,10 +83,8 @@ export const gameStore = writable(/** @type {GameState} */ ({
   shakenLetters: [],
   message: '',
   subcategory: '',
-  gameMode: 'daily', // 'daily' | 'arcade'
+  gameMode: 'daily', // 'daily' | 'freeplay' | 'climb' | 'challenge' | 'match' | 'makeup'
   freeReveals: 0, // owned Free Reveal power-ups (daily)
-  arcadeRun: null, // arcade gauntlet run state { state, banked, multiplier, position, total, furthest, last_gain }
-  arcadeCashedOut: false, // true when the last arcade run ended via "Bank it" (vs bust)
   modifier: null, // today's Daily Twist power-up id (daily only)
   twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
   bountyMult: 1, // bounty multiplier (1.0 once Twist used, else 1.5)
@@ -138,7 +133,7 @@ let dailyInFlight = false;
  * @param {any} board - board JSON returned by a daily_* RPC
  */
 /**
- * boardToState — shared masked-board → gameStore partial (used by daily + arcade).
+ * boardToState — shared masked-board → gameStore partial (used by daily + freeplay).
  * @param {any} board @param {GameState} prev
  */
 function boardToState(board, prev) {
@@ -224,108 +219,6 @@ function reconcileDailyBoard(board) {
   }
 }
 
-/**
- * reconcileArcadeBoard — arcade gauntlet { board, run } → gameStore.
- * @param {any} resp
- */
-function reconcileArcadeBoard(resp) {
-  if (!resp || !resp.board) return;
-  const prev = get(gameStore);
-  const board = resp.board;
-  const run = resp.run || {};
-  // Rolling-survival outcome: solved -> won (continue), over -> lost (run ends).
-  let gs = 'default';
-  if (run.state === 'solved') gs = 'won';
-  else if (run.state === 'over') gs = 'lost';
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(board, prev),
-    gameMode: 'arcade',
-    gameState: gs,
-    arcadeRun: run,
-    arcadeCashedOut: false,
-    freeReveals: 0,
-    modifier: null
-  }));
-  if (run.state === 'solved') {
-    setTimeout(() => launchConfetti(), 300);
-    fx('win');
-    if ((run.last_gain || 0) > 0) setTimeout(() => fx('multiplier'), 240);
-    if (prev.gameState !== 'won') track('arcade_solve', { position: run.position ?? 0, payout: run.last_gain ?? 0, earned: run.last_earn ?? null });
-  } else if (run.state === 'over') {
-    fx('bust');
-    if (prev.gameState !== 'lost') track('arcade_over', { peak: run.banked ?? 0, solved: run.furthest ?? 0 });
-  } else {
-    playMoveCue(prev, board);
-  }
-}
-
-/** confirmPurchaseArcade — commit a letter/reveal on the current gauntlet puzzle. @param {GameState} state */
-async function confirmPurchaseArcade(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    let resp = null;
-    if (purchase.type === 'letter') resp = await arcadeBuyLetter(purchase.value ?? '');
-    else if (purchase.type === 'hint') resp = await arcadeReveal();
-    if (resp) reconcileArcadeBoard(resp);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** submitGuessArcade — submit a guess on the current gauntlet puzzle. @param {GameState} state */
-async function submitGuessArcade(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const resp = await arcadeSubmitGuess(guess);
-    if (resp) reconcileArcadeBoard(resp);
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** Refresh the clue for the current arcade puzzle (changes each rung). */
-async function refreshArcadeClue() {
-  try {
-    const clue = await getArcadeClue();
-    gameStore.update(s => ({ ...s, clue }));
-  } catch { /* non-fatal */ }
-}
-
-/** Start or resume today's arcade gauntlet. */
-export async function fetchArcadeGame() {
-  try {
-    track('arcade_start');
-    const resp = await arcadeStart();
-    if (!resp) { console.error('❌ arcade_start returned nothing'); return false; }
-    reconcileArcadeBoard(resp);
-    await refreshArcadeClue();
-    return true;
-  } catch (err) {
-    console.error('❌ Error starting arcade:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
-}
-
-/** Advance to the next puzzle after a solve, or retry after a bust. */
-export async function arcadeContinue() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const resp = await arcadeNext();
-    if (resp) { reconcileArcadeBoard(resp); await refreshArcadeClue(); }
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
 /* ===== Free Play (unranked, category-picked, endless) ===== */
 
 /** @param {any} board */
@@ -338,8 +231,7 @@ function reconcileFreeplayBoard(board) {
     gameMode: 'freeplay',
     revealsRemaining: board.reveals_remaining ?? 0,
     gameState: finished ? board.state : 'default',
-    modifier: null, arcadeRun: null
-  }));
+    modifier: null  }));
   if (board.state === 'won') {
     setTimeout(() => launchConfetti(), 300); fx('win');
     const rw = /** @type {any} */ (board).freeplay_reward;
@@ -443,7 +335,7 @@ function reconcileChallengeBoard(board) {
     ...prev, ...boardToState(board, prev),
     gameMode: 'challenge',
     gameState: finished ? board.state : 'default',
-    modifier: null, arcadeRun: null,
+    modifier: null,
     challengeInfo: board.challenge ?? prev.challengeInfo ?? null
   }));
   if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
@@ -532,7 +424,7 @@ function reconcileMakeupBoard(board) {
     ...prev, ...boardToState(board, prev),
     gameMode: 'makeup',
     gameState: finished ? board.state : 'default',
-    modifier: null, arcadeRun: null,
+    modifier: null,
     clue: board.clue ?? prev.clue ?? null,
     makeupDate: board.makeup?.date ?? prev.makeupDate ?? activeMakeupDate
   }));
@@ -627,7 +519,7 @@ function reconcileClimbBoard(board) {
     ...prev, ...boardToState(board, prev),
     gameMode: 'climb',
     gameState: solved ? 'won' : 'default',
-    modifier: null, arcadeRun: null,
+    modifier: null,
     climbInfo: climb
   }));
   // No confetti — the slot-machine reveal (box-by-box win pop) is the celebration, like Daily.
@@ -770,7 +662,7 @@ function reconcileMatchBoard(board) {
     ...prev, ...(done ? {} : boardToState(board, prev)),
     gameMode: 'match',
     gameState: done ? 'won' : 'default',
-    modifier: null, arcadeRun: null,
+    modifier: null,
     clue: done ? prev.clue : (board.clue ?? null),
     matchInfo: { ...match, id: activeMatchId, standing: board.standing ?? null }
   }));
@@ -874,35 +766,6 @@ async function submitGuessMatch(state) {
   try {
     const board = await matchSubmitGuess(activeMatchId, guess);
     if (board) reconcileMatchBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** Spend an earned power-up during the current arcade run. @param {string} powerup */
-export async function useArcadePowerup(powerup) {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const resp = await arcadeUsePowerup(powerup);
-    if (resp) reconcileArcadeBoard(resp);
-  } finally {
-    dailyInFlight = false;
-  }
-}
-
-/** Cash out the current arcade run's winnings into your Bank (ends the run). */
-export async function arcadeCashOut() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const resp = await arcadeCashout();
-    if (resp) {
-      reconcileArcadeBoard(resp);
-      // reconcile cleared the flag; mark this as a cash-out so the modal differs from a bust
-      gameStore.update(s => ({ ...s, arcadeCashedOut: true }));
-      fx('multiplier');
-    }
   } finally {
     dailyInFlight = false;
   }
@@ -1060,7 +923,6 @@ export function confirmPurchase() {
   // All modes are server-authoritative: commit via RPC and reconcile.
   const current = get(gameStore);
   if (current.gameMode === 'daily') confirmPurchaseDaily(current);
-  else if (current.gameMode === 'arcade') confirmPurchaseArcade(current);
   else if (current.gameMode === 'freeplay') confirmPurchaseFreeplay(current);
   else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
   else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
@@ -1158,13 +1020,12 @@ export function deleteGuessLetter() {
 
 /**
  * submitGuess
- * Routes the full guess to the server (daily or arcade), which validates and scores.
+ * Routes the full guess to the server, which validates and scores.
  */
 export function submitGuess() {
   // All modes are server-authoritative: the server validates + scores.
   const current = get(gameStore);
   if (current.gameMode === 'daily') submitGuessDaily(current);
-  else if (current.gameMode === 'arcade') submitGuessArcade(current);
   else if (current.gameMode === 'freeplay') submitGuessFreeplay(current);
   else if (current.gameMode === 'challenge') submitGuessChallenge(current);
   else if (current.gameMode === 'makeup') submitGuessMakeup(current);

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -24,7 +24,6 @@ import { track } from '$lib/analytics.js';
  *   bankroll: number,
  *   wagerAmount: number,
  *   guessesRemaining: number,
- *   revealsRemaining?: number,
  *   category: string,
  *   currentPhrase: string,
  *   gameState: string,

--- a/src/lib/stores/localGameUtils.js
+++ b/src/lib/stores/localGameUtils.js
@@ -34,7 +34,7 @@ export function saveGameToLocalStorage() {
   }
   
   /**
-   * 📋 Peek at saved game without restoring (for menu labels: Resume daily/arcade)
+   * 📋 Peek at saved game without restoring (for menu labels: Resume daily/etc.)
    * @param {string} userId
    * @returns {{ gameMode: string, gameState: string } | null}
    */
@@ -46,7 +46,7 @@ export function saveGameToLocalStorage() {
     try {
       const parsed = JSON.parse(saved);
       if (!parsed || typeof parsed.currentPhrase !== 'string' || !parsed.currentPhrase.trim()) return null;
-      const gameMode = parsed.gameMode === 'practice' ? 'arcade' : (parsed.gameMode || 'arcade');
+      const gameMode = parsed.gameMode || 'daily';
       const gameState = parsed.gameState || 'default';
       return { gameMode, gameState };
     } catch {

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -335,50 +335,6 @@ export async function getCategoryStats() {
   return data ?? [];
 }
 
-/* ===== Free Play (unranked, pick-a-category) — return a masked board ===== */
-/** @param {string} category @returns {Promise<object|null>} */
-export async function freeplayStart(category) {
-  const { data, error } = await supabase.rpc('freeplay_start', { p_category: category });
-  if (error) { console.error('❌ freeplay_start error:', error); return null; }
-  return data;
-}
-/** @returns {Promise<object|null>} */
-export async function freeplayNext() {
-  const { data, error } = await supabase.rpc('freeplay_next');
-  if (error) { console.error('❌ freeplay_next error:', error); return null; }
-  return data;
-}
-/** Resume an in-progress Free Play puzzle (null if none active). @returns {Promise<object|null>} */
-export async function freeplayResume() {
-  const { data, error } = await supabase.rpc('freeplay_resume');
-  if (error) { console.error('❌ freeplay_resume error:', error); return null; }
-  return data ?? null;
-}
-/** @param {string} letter @returns {Promise<object|null>} */
-export async function freeplayBuyLetter(letter) {
-  const { data, error } = await supabase.rpc('freeplay_buy_letter', { p_letter: letter });
-  if (error) { console.error('❌ freeplay_buy_letter error:', error); return null; }
-  return data;
-}
-/** @returns {Promise<object|null>} */
-export async function freeplayReveal() {
-  const { data, error } = await supabase.rpc('freeplay_reveal');
-  if (error) { console.error('❌ freeplay_reveal error:', error); return null; }
-  return data;
-}
-/** @param {Record<string,string>} guess @returns {Promise<object|null>} */
-export async function freeplaySubmitGuess(guess) {
-  const { data, error } = await supabase.rpc('freeplay_submit_guess', { p_guess: guess });
-  if (error) { console.error('❌ freeplay_submit_guess error:', error); return null; }
-  return data;
-}
-/** @returns {Promise<string|null>} */
-export async function getFreeplayClue() {
-  const { data, error } = await supabase.rpc('freeplay_clue');
-  if (error) { console.error('❌ freeplay_clue error:', error); return null; }
-  return data ?? null;
-}
-
 /** Witty clue for the caller's current daily puzzle. @returns {Promise<string|null>} */
 export async function getDailyClue() {
   const { data, error } = await supabase.rpc('daily_clue');

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -676,19 +676,6 @@ export async function buyPowerup(id) {
   if (error || !data) { if (error) console.error('❌ buy_powerup:', error); return { ok: false }; }
   return data;
 }
-/* ===== Free Play cash-out (credits → real Cash, 40:1, $50/day cap) ===== */
-/** @returns {Promise<{credits:number,cashable_credits:number,max_cash:number,rate:number,floor:number,daily_cap:number,cap_remaining:number}|null>} */
-export async function getFreeplayCashoutStatus() {
-  const { data, error } = await supabase.rpc('freeplay_cashout_status');
-  if (error || !data) { if (error) console.error('❌ freeplay_cashout_status:', error); return null; }
-  return data;
-}
-/** Cash out credits (null = the max allowed). @param {number|null} amount @returns {Promise<any>} */
-export async function freeplayCashout(amount = null) {
-  const { data, error } = await supabase.rpc('freeplay_cashout', { p_amount: amount });
-  if (error || !data) { if (error) console.error('❌ freeplay_cashout:', error); return { ok: false }; }
-  return data;
-}
 /** Use a power-up in the Climb. @param {string} id @returns {Promise<any>} */
 export async function climbUsePowerup(id) {
   const { data, error } = await supabase.rpc('climb_use_powerup', { p_id: id });

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -386,13 +386,6 @@ export async function getDailyClue() {
   return data ?? null;
 }
 
-/** Witty clue for the caller's current arcade puzzle. @returns {Promise<string|null>} */
-export async function getArcadeClue() {
-  const { data, error } = await supabase.rpc('arcade_clue');
-  if (error) { console.error('❌ arcade_clue error:', error); return null; }
-  return data ?? null;
-}
-
 /** Witty clue for the caller's current Cash Game (climb) puzzle. @returns {Promise<string|null>} */
 export async function getClimbClue() {
   const { data, error } = await supabase.rpc('climb_clue');
@@ -419,19 +412,6 @@ export async function getDailyGhost() {
   const { data, error } = await supabase.rpc('get_daily_ghost');
   if (error) { console.error('❌ get_daily_ghost error:', error); return null; }
   return data;
-}
-
-/**
- * Fetch the arcade gauntlet leaderboard (best banked run + furthest reached).
- * @param {string} period - 'daily' | 'weekly' | 'monthly' | 'yearly' | 'all'
- */
-export async function fetchArcadeLeaderboard(period = 'daily') {
-  const { data, error } = await supabase.rpc('get_arcade_gauntlet_leaderboard', { p_period: period });
-  if (error) {
-    console.error('❌ Error fetching arcade leaderboard:', error);
-    return [];
-  }
-  return data ?? [];
 }
 
 /* ============================================================
@@ -725,52 +705,6 @@ export async function makeupReveal(date) {
 export async function makeupSubmitGuess(date, guess) {
   const { data, error } = await supabase.rpc('makeup_submit_guess', { p_date: date, p_guess: guess });
   if (error) { console.error('❌ makeup_submit_guess error:', error); return null; }
-  return data;
-}
-
-/* ===== Arcade Press-Your-Luck gauntlet (server-authoritative) =====
-   Each returns { board, run } where run = { state, banked, multiplier, position,
-   total, furthest, last_gain }. */
-/** @returns {Promise<any>} */
-export async function arcadeStart() {
-  const { data, error } = await supabase.rpc('arcade_start');
-  if (error) { console.error('❌ arcade_start error:', error); return null; }
-  return data;
-}
-/** @param {string} letter @returns {Promise<any>} */
-export async function arcadeBuyLetter(letter) {
-  const { data, error } = await supabase.rpc('arcade_buy_letter', { p_letter: letter });
-  if (error) { console.error('❌ arcade_buy_letter error:', error); return null; }
-  return data;
-}
-/** @returns {Promise<any>} */
-export async function arcadeReveal() {
-  const { data, error } = await supabase.rpc('arcade_reveal');
-  if (error) { console.error('❌ arcade_reveal error:', error); return null; }
-  return data;
-}
-/** @param {Record<string,string>} guess @returns {Promise<any>} */
-export async function arcadeSubmitGuess(guess) {
-  const { data, error } = await supabase.rpc('arcade_submit_guess', { p_guess: guess });
-  if (error) { console.error('❌ arcade_submit_guess error:', error); return null; }
-  return data;
-}
-/** Advance after a solve / retry after a bust. @returns {Promise<any>} */
-export async function arcadeNext() {
-  const { data, error } = await supabase.rpc('arcade_next');
-  if (error) { console.error('❌ arcade_next error:', error); return null; }
-  return data;
-}
-/** Spend an earned power-up during the current run. @param {string} powerup @returns {Promise<any>} */
-export async function arcadeUsePowerup(powerup) {
-  const { data, error } = await supabase.rpc('arcade_use_powerup', { p_powerup: powerup });
-  if (error) { console.error('❌ arcade_use_powerup error:', error); return null; }
-  return data;
-}
-/** Cash out the current arcade run's winnings into your Bank. @returns {Promise<any>} */
-export async function arcadeCashout() {
-  const { data, error } = await supabase.rpc('arcade_cashout');
-  if (error) { console.error('❌ arcade_cashout error:', error); return null; }
   return data;
 }
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -498,7 +498,7 @@ export async function expireStaleDailies() {
   return data ?? 0;
 }
 
-/** The caller's currently-resumable solo games (daily/climb/freeplay), newest first.
+/** The caller's currently-resumable solo games (daily/climb), newest first.
  *  Server truth for menu resume labels + the top-level Resume shortcut.
  *  @returns {Promise<{mode:string, updated_at:string}[]>} */
 export async function getOpenGames() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
 
-  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, fetchFreeplayGame, fetchFreeplayResume, freeplayContinue, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, getMatchDebuffs, getMatchOpponents, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
@@ -66,23 +66,24 @@
   let menuDailyPlayed = false;
   /** Today's daily result for the menu indicator (won/lost + score). */
   let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, arcade_bankroll: number, current_streak: number, streak_freezes: number, today_score: number, win_streak: number, daily_in_progress?: boolean } | null} */ (null);
-  // 🎮 Live solo games from SERVER truth (daily/climb/freeplay), newest first. The old
+  // 🎮 Live solo games from SERVER truth (daily/climb), newest first. The old
   // single localStorage save slot got overwritten whenever you played another mode, which
   // made a live Daily show as "complete + lost". openGames lets every mode resume independently.
   /** @type {{mode:string, updated_at:string}[]} */
   let openGames = [];
   async function refreshOpenGames() {
     const u = get(user); if (!u?.id) return;
-    try { openGames = await getOpenGames(); } catch { /* keep last */ }
+    // Filter out any legacy Free Play rows the server may still return (mode retired in V2).
+    try { openGames = (await getOpenGames()).filter((/** @type {any} */ g) => g.mode !== 'freeplay'); } catch { /* keep last */ }
   }
   // "In progress" must come from SERVER truth, not the clobberable localStorage slot.
   $: dailyInProgress = openGames.some((g) => g.mode === 'daily') || (dailyStatus?.daily_in_progress ?? false);
   $: dailyDone = menuDailyPlayed && !dailyInProgress;
   $: climbInProgress = openGames.some((g) => g.mode === 'climb');
   // 🔁 Resume: every in-progress game — solo modes AND challenges you've started.
-  const RESUME_LABEL = /** @type {Record<string,string>} */ ({ daily: 'Daily', climb: 'Cash Game', freeplay: 'Free Play' });
+  const RESUME_LABEL = /** @type {Record<string,string>} */ ({ daily: 'Daily', climb: 'Cash Game' });
   $: resumables = [
-    ...openGames.map((/** @type {any} */ g) => ({ key: 'solo-' + g.mode, label: RESUME_LABEL[g.mode] ?? 'Game', icon: (/** @type {Record<string,string>} */ ({daily:'📅',climb:'🎰',freeplay:'🎯'}))[g.mode] ?? '▶', go: () => resumeSolo(g.mode) })),
+    ...openGames.map((/** @type {any} */ g) => ({ key: 'solo-' + g.mode, label: RESUME_LABEL[g.mode] ?? 'Game', icon: (/** @type {Record<string,string>} */ ({daily:'📅',climb:'🎰'}))[g.mode] ?? '▶', go: () => resumeSolo(g.mode) })),
     ...((myMatches ?? []).filter((/** @type {any} */ m) => m.status === 'open' && m.my_state === 'active')
         .map((/** @type {any} */ m) => ({ key: 'match-' + m.id, label: m.group_name || (m.opponent ? '@' + m.opponent : 'Challenge'), icon: '⚔️', go: () => respondToMatch(m) })))
   ];
@@ -90,7 +91,6 @@
   function resumeSolo(/** @type {string} */ mode) {
     if (mode === 'daily') handleMenuDaily();
     else if (mode === 'climb') handleMenuClimb();
-    else if (mode === 'freeplay') handleMenuFreeplay();
   }
   function onResume() {
     fx('tap');
@@ -231,10 +231,7 @@
     !$gameWasRestored
   ) {
     const gameMode = localStorage.getItem('gameMode') || 'daily';
-    if (gameMode === 'freeplay') {
-      // Free Play isn't deep-link restorable — send back to the menu to re-pick.
-      showMainMenu = true;
-    } else if (gameMode === 'makeup') {
+    if (gameMode === 'makeup') {
       fetchMakeupGame().then((ok) => { if (!ok) showMainMenu = true; });
     } else if (gameMode === 'climb') {
       fetchClimbGame().then((ok) => { if (!ok) showMainMenu = true; });
@@ -324,7 +321,6 @@
   // Live Daily HUD metrics (only while actively playing the daily).
   $: dLive = (($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'makeup') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
     ? $gameStore.dailyLive : null;
-  $: isFreeplay = $gameStore.gameMode === 'freeplay';
   $: isChallenge = $gameStore.gameMode === 'challenge';
   $: isMakeup = $gameStore.gameMode === 'makeup';
   // Auto-dismiss the Cash-earned toast after a few seconds.
@@ -340,7 +336,6 @@
   $: modeLabel = ({
     daily:     { emoji: '📅', name: 'Daily' },
     climb:     { emoji: '🎰', name: 'Cash Game' },
-    freeplay:  { emoji: '🎯', name: 'Free Play' },
     makeup:    { emoji: '📅', name: 'Make-up' },
     match:     { emoji: '⚔️', name: 'Challenge' },
     challenge: { emoji: '⚔️', name: 'Challenge' }
@@ -369,9 +364,6 @@
   $: matchLive = (isMatch && matchInfo && !matchInfo.done && matchInfo.mode !== 'blitz')
     ? { spent: matchInfo.spent ?? 0, budget: matchInfo.budget ?? 0 } : null;
   $: matchLeft = matchLive ? Math.max(0, (matchLive.budget ?? 0) - (matchLive.spent ?? 0)) : 0;
-  // Free Play live: clean status + the trickle you'd earn.
-  $: freeLive = ($gameStore.gameMode === 'freeplay' && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
-    ? { clean: ($gameStore.incorrectLetters?.length ?? 0) === 0 } : null;
   // Unified money hero (Daily · Cash Game = net you keep; Challenge = ante left to spend).
   $: soloHero = climbLive ? { net: climbLive.net } : (dLive ? { net: dLive.net } : (matchLive ? { net: matchLeft } : null));
 
@@ -635,7 +627,6 @@
       fx(auto ? 'bust' : 'tap');
       if ($gameStore.gameMode === 'daily') await dailyFold();
       else if ($gameStore.gameMode === 'match') await matchFold();
-      else if ($gameStore.gameMode === 'freeplay') await freeplayContinue(); // skip to a fresh puzzle
       else if ($gameStore.gameMode === 'climb') { await climbSkipPuzzle(); await tick(); playDailyIntroIfArmed(); } // fresh puzzle; heat resets; replay the dramatic build
     } finally { brokeFiring = false; }
   }
@@ -935,7 +926,7 @@
   /** @type {{ mode: string, ctx: any } | null} */
   let objective = null;
   let _wasMenu = true;
-  const SOLO_MODES = ['daily', 'climb', 'freeplay', 'makeup'];
+  const SOLO_MODES = ['daily', 'climb', 'makeup'];
 
   function buildObjectiveCtx(/** @type {string} */ mode) {
     if (mode !== 'match') return {};
@@ -1145,31 +1136,6 @@
     }
   }
 
-  // ----- Free Play (unranked, pick a category) -----
-  let showCategorySelect = false;
-  $: freeplayInProgress = openGames.some((g) => g.mode === 'freeplay');
-  async function handleMenuFreeplay() {
-    if (!get(user)?.id) return;
-    // Resume the exact in-progress puzzle if there is one; otherwise pick a category.
-    if (freeplayInProgress) {
-      localStorage.setItem('gameMode', 'freeplay');
-      const ok = await fetchFreeplayResume();
-      if (ok) { hasInitialized = true; showMainMenu = false; return; }
-    }
-    showCategorySelect = true;
-  }
-  /** @param {string} category */
-  async function startFreeplay(category) {
-    showCategorySelect = false;
-    localStorage.setItem('gameMode', 'freeplay');
-    const ok = await fetchFreeplayGame(category);
-    if (ok) {
-      hasInitialized = true;
-      showMainMenu = false;
-    } else {
-      initError = 'Free Play failed to load.';
-    }
-  }
   // ===== Challenge Builder (configurable packs vs friends/groups) =====
   let showChallenges = false; // the New-Challenge builder modal
   /** Which Community hub tab is showing. */
@@ -1347,13 +1313,6 @@
     refreshClimbPups(); // load owned power-ups for the match tray
   }
 
-  // After solving / going broke in Free Play, load the next puzzle in the category.
-  async function handleFreeplayContinue() {
-    showResultModal = false;
-    hasTriggeredModal = false;
-    await freeplayContinue();
-  }
-
   function handleMenuLeaderboard() {
     goto('/leaderboard');
   }
@@ -1518,8 +1477,8 @@
 {#if loggedIn && hasInitialized && !showMainMenu}
   <button class="audio-btn" title="Sound & music" aria-label="Sound and music settings" on:click={() => { fx('tap'); showAudio = true; }}>{$soundEnabled || $musicEnabled ? '🔊' : '🔇'}</button>
 {/if}
-<!-- 🏳️ Give up (top-right) — Daily / Challenges / Free Play -->
-{#if loggedIn && hasInitialized && !showMainMenu && (foldMode || isFreeplay) && gameActive}
+<!-- 🏳️ Give up (top-right) — Daily / Challenges -->
+{#if loggedIn && hasInitialized && !showMainMenu && foldMode && gameActive}
   <button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
 {/if}
 <!-- ⏭️ Skip (top-right) — Cash Game only; resets heat. Hidden once Double-or-Nothing is armed (committed). -->
@@ -1565,13 +1524,11 @@
   <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Give up">
     <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelGiveUp}></button>
     <div class="modal-content giveup-modal">
-      <h2 class="gu-title">{isClimb ? 'Skip this puzzle?' : `Give up ${$gameStore.gameMode === 'match' ? 'this puzzle' : $gameStore.gameMode === 'freeplay' ? 'this one' : "today's Daily"}?`}</h2>
+      <h2 class="gu-title">{isClimb ? 'Skip this puzzle?' : `Give up ${$gameStore.gameMode === 'match' ? 'this puzzle' : "today's Daily"}?`}</h2>
       <p class="gu-text">{isClimb
         ? `Your heat resets to ×1.0${(climb?.spent ?? 0) > 0 ? ` and you forfeit the $${(climb?.spent ?? 0).toLocaleString()} spent on this one` : ''} — then a fresh puzzle.`
         : $gameStore.gameMode === 'match'
         ? 'Skip this puzzle — you pay its full price and move on.'
-        : $gameStore.gameMode === 'freeplay'
-        ? 'You’ll skip to a fresh puzzle — you keep your credits (you only lose what you spent on this one).'
         : 'It counts as a loss and reveals the answer.'}</p>
       <div class="gu-actions">
         <button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
@@ -2020,11 +1977,7 @@
             <span class="mc-title">Cash Game</span>
             {#if climbInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
           </button>
-          <button class="menu-card" class:resumable={freeplayInProgress} style="--i: 2" on:click={handleMenuFreeplay}>
-            <span class="mc-title">{freeplayInProgress ? 'Resume Free Play' : 'Free Play'}</span>
-            {#if freeplayInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
-          </button>
-          <button class="menu-card" style="--i: 3" on:click={() => { blitzSoon = true; fx('tap'); setTimeout(() => blitzSoon = false, 2500); }}>
+          <button class="menu-card" style="--i: 2" on:click={() => { blitzSoon = true; fx('tap'); setTimeout(() => blitzSoon = false, 2500); }}>
             <span class="mc-title">Blitz</span><span class="mc-stat">Soon</span>
           </button>
           {#if blitzSoon}<p class="pm-soon-note">⚡ Solo Blitz is coming soon!</p>{/if}
@@ -2092,26 +2045,6 @@
         {/if}
       {/if}
     </div>
-
-    <!-- Free Play: category picker -->
-    {#if showCategorySelect}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a category">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showCategorySelect = false}></button>
-        <div class="modal-content main-menu-modal cat-modal">
-          <button class="close-btn" on:click={() => showCategorySelect = false}>❌</button>
-          <h2>Free Play</h2>
-          <p class="cat-sub">Pick a category — solve as many as you like. Unranked.</p>
-          <div class="cat-grid">
-            {#each CATEGORIES as c}
-              <button class="cat-tile" on:click={() => startFreeplay(c.value)}>
-                <span class="cat-emoji">{c.emoji}</span>
-                <span class="cat-label">{c.label}</span>
-              </button>
-            {/each}
-          </div>
-        </div>
-      </div>
-    {/if}
 
     <!-- Challenges: wager vs friends -->
     {#if showChallenges}
@@ -2359,13 +2292,7 @@
 
     <!-- 💰 Bankroll — top of every mode. Challenge ante now lives in the bounty hero below. -->
     {#if $gameStore.currentPhrase && $gameStore.gameMode}
-      {#if isFreeplay}
-        <div class="fp-hud">
-          <span class="fp-stat"><span class="fp-cap">🎟️ Credits</span><span class="fp-val cr">{Math.round($gameStore.bankroll ?? 0).toLocaleString()}</span></span>
-          <span class="fp-stat"><span class="fp-cap">🔍 Reveals</span><span class="fp-val">{$gameStore.revealsRemaining ?? 0}</span></span>
-          <span class="fp-stat"><span class="fp-cap">🎯 Guesses</span><span class="fp-val">{$gameStore.guessesRemaining ?? 0}</span></span>
-        </div>
-      {:else if !matchBlitz}
+      {#if !matchBlitz}
         <button class="top-bank solo" class:pop-up={bankFlash === 'up'} class:pop-down={bankFlash === 'down'} title="Your Cash" on:click={openBankModal}>
           {#if isMatch}<span class="tb-wallet-cap">💰 Wallet</span>{/if}
           <span class="tb-solo">{#if !isMatch}💰 {/if}${Math.round($tweenBank).toLocaleString()}</span>
@@ -2505,11 +2432,6 @@
             🔥 {climbRun.solves}-solve run · <b class="run-profit" class:neg={climbRun.profit < 0}>{climbRun.profit >= 0 ? '+' : '−'}${Math.abs(climbRun.profit).toLocaleString()}</b> this run{#if climbRunIsBest} · 🏆 personal best{/if}
           </p>
         {/if}
-      {:else if isFreeplay}
-        <!-- Free Play: budgets + credits are up top; the reward shrinks as you use reveals. -->
-        {#if $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
-          <p class="live-line">Solve now for <b>+{Math.max(150, 300 - 50 * (3 - ($gameStore.revealsRemaining ?? 3)))}</b> credits</p>
-        {/if}
       {/if}
     </section>
 
@@ -2637,21 +2559,6 @@
                 <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); newChallenge(); }}>Challenge Friends</button>
               {/if}
               <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
-            </div>
-          {:else if isFreeplay}
-            <!-- Free Play transition (unranked) -->
-            {#if resultWon}
-              <div class="result-medal">✅</div>
-              <h2>Solved!</h2>
-              <p class="result-sub">{$gameStore.currentPhrase}</p>
-            {:else}
-              <div class="result-medal">💸</div>
-              <h2>Out of Cash</h2>
-              <p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
-            {/if}
-            <div class="result-actions">
-              <button class="share-btn" on:click={() => { showResultModal = false; showCategorySelect = true; }}>Categories</button>
-              <button class="next-puzzle-button" on:click={handleFreeplayContinue}>Next</button>
             </div>
           {:else if isMakeup}
             <!-- Make-up daily result (calendar fill; no streak/Bank) -->
@@ -3564,8 +3471,6 @@
   .main-menu-modal { text-align: center; }
   .main-menu-modal .main-menu-btn { margin-top: 1rem; }
 
-  /* Free Play category picker */
-  .cat-modal { max-width: 420px; }
   .cat-sub { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 16px; }
 
   /* Challenges modal */
@@ -3636,34 +3541,6 @@
   .ch-result.win { color: var(--brand-2); }
   .ch-result.loss { color: #fb7185; }
   .ch-result.tie { color: var(--text-muted); }
-  .cat-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 10px;
-  }
-  .cat-tile {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 6px;
-    padding: 14px 8px;
-    border-radius: var(--r-md, 14px);
-    background: var(--surface, rgba(255, 255, 255, 0.05));
-    border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
-    color: var(--text);
-    cursor: pointer;
-    transition: transform 0.15s var(--ease-spring, ease), border-color 0.2s, background 0.2s;
-  }
-  .cat-tile:hover { transform: translateY(-2px); border-color: rgba(253, 224, 71, 0.5); background: var(--surface-2, rgba(255, 255, 255, 0.07)); }
-  .cat-tile:active { transform: scale(0.97); }
-  .cat-emoji { font-size: 1.6rem; line-height: 1; }
-  .cat-label {
-    font-family: var(--font-display);
-    font-weight: 600;
-    font-size: 0.82rem;
-    text-align: center;
-    line-height: 1.1;
-  }
 
   /* Streak + freeze chips (My Account) */
   .account-stats {
@@ -4066,13 +3943,6 @@
   /* 💰 Top bankroll bar (very top, all modes) */
   .top-bank { width: 100%; max-width: 340px; margin: 0 auto 12px; padding: 9px 16px; border-radius: 14px;
     border: 1px solid rgba(253, 224, 71, 0.4); background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.03)); }
-  /* Free Play HUD: credits wallet + reveal/guess budgets */
-  .fp-hud { display: flex; justify-content: center; gap: 10px; width: fit-content; max-width: 360px; margin: 0 auto 12px; }
-  .fp-stat { display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 6px 14px; border-radius: 12px;
-    border: 1px solid var(--border); background: var(--surface); }
-  .fp-cap { font-size: 0.62rem; color: var(--text-faint); font-weight: 700; white-space: nowrap; }
-  .fp-val { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.1rem; color: var(--text); }
-  .fp-val.cr { color: #6ee7b7; }
   /* solo bankroll = a centered gold chip below WordBank (matches the menu) — tap → /bank */
   .top-bank.solo { width: fit-content; max-width: none; margin: 0 auto 12px; padding: 7px 18px; text-align: center; cursor: pointer; }
   .top-bank.solo:active { transform: scale(0.97); }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, getMatchDebuffs, getMatchOpponents, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getFreeplayCashoutStatus, freeplayCashout, getDailyModifier, deleteMyAccount, getMyAvatar } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getDailyModifier, deleteMyAccount, getMyAvatar } from '$lib/stores/statsStore.js';
   import Avatar from '$lib/components/Avatar.svelte';
   import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
@@ -657,39 +657,6 @@
     finally { donBusy = false; showDon = false; }
   }
 
-  // Free Play: cash out credits → real Cash right from the board (40:1, $50/day cap).
-  let fpCashBusy = false;
-  // Tapping the credits number cashes out when you're above the $1 floor.
-  function tapCredits() {
-    if (($gameStore.bankroll ?? 0) - 2000 >= 40) doFreeplayCashout();
-    else gameStore.update((s) => ({ ...s, cashToast: { amount: 0, label: 'Reach 2,040 credits to cash out for real Cash' } }));
-  }
-  async function doFreeplayCashout() {
-    if (fpCashBusy) return;
-    fpCashBusy = true;
-    const st = await getFreeplayCashoutStatus();
-    fpCashBusy = false;
-    if (!st) return;
-    const amt = Math.min(st.max_cash ?? 0, st.cap_remaining ?? 0);
-    if (amt <= 0) {
-      gameStore.update((s) => ({ ...s, cashToast: { amount: 0, label: "Daily $50 cash-out cap reached — back tomorrow" } }));
-      return;
-    }
-    try {
-      await requirePin(`Cash out ${(amt * 40).toLocaleString()} credits → $${amt}`, [
-        { label: 'Credits', value: (amt * 40).toLocaleString() },
-        { label: 'You receive', value: '$' + amt }
-      ]);
-    } catch { return; }
-    fpCashBusy = true;
-    const res = await freeplayCashout(amt);
-    fpCashBusy = false;
-    if (res?.ok) {
-      fx('win');
-      gameStore.update((s) => ({ ...s, bankroll: res.bankroll, cashToast: { amount: res.cashed, label: 'Cashed out to your Cash!' } }));
-      await refreshBank();
-    }
-  }
   $: matchRemaining = (() => {
     if (!matchBlitz || !matchInfo?.started_at) return 0;
     const start = new Date(matchInfo.started_at).getTime();
@@ -4130,27 +4097,6 @@
   @keyframes bankColorDown { 0%,100% { color: #fcd34d; } 25% { color: #fb7185; text-shadow: 0 0 20px rgba(251,113,133,0.9); } }
   .tb-solo { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.55rem; color: #fcd34d; font-variant-numeric: tabular-nums; }
   .tb-wallet-cap { display: block; font-size: 0.62rem; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-faint); }
-  .top-bank.tap { cursor: pointer; display: block; text-align: left;
-    border-color: rgba(167, 139, 250, 0.55); border-style: dashed;
-    background: linear-gradient(135deg, rgba(167, 139, 250, 0.13), rgba(167, 139, 250, 0.03)); }
-  .top-bank.tap:disabled { cursor: default; opacity: 0.6; }
-  .tb-row { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
-  .tb-cap { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--brand-2); }
-  .tb-amt { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.7rem; line-height: 1; color: #fcd34d; font-variant-numeric: tabular-nums; }
-  .tb-amt.cr { color: #c4b5fd; }
-  .top-bank.tap .tb-cap { color: #c4b5fd; }
-  .tb-bar { margin-top: 7px; height: 9px; border-radius: 999px; background: rgba(255,255,255,0.10); overflow: hidden; }
-  .tb-fill { display: block; height: 100%; border-radius: 999px; background: linear-gradient(90deg, #fbbf24, #fde047); transition: width 0.35s ease; }
-  .tb-sub { margin-top: 5px; font-size: 0.66rem; color: var(--text-faint); }
-  /* Free Play play-money "Credits" — violet + dashed so it reads as not-real-Cash */
-  .credits-panel { display: flex; flex-direction: column; align-items: center; gap: 1px;
-    width: 100%; max-width: 320px; margin: 0 auto; padding: 13px 18px; border-radius: var(--r-lg, 18px);
-    border: 1px dashed rgba(167, 139, 250, 0.55); background: linear-gradient(135deg, rgba(167, 139, 250, 0.13), rgba(167, 139, 250, 0.03)); }
-  .cr-note { margin-top: 2px; font-size: 0.68rem; color: var(--text-faint); }
-  .cr-cashout { margin-top: 5px; padding: 0.4rem 0.9rem; border-radius: 999px; cursor: pointer; font-weight: 800; font-size: 0.8rem;
-    color: #04240f; background: linear-gradient(135deg, #6ee7b7, #34d399); border: none; }
-  .cr-cashout:disabled { opacity: 0.5; cursor: default; }
-  .cr-wallet { margin-top: 4px; font-size: 0.66rem; color: var(--text-faint); }
   /* 🏷️ Game-mode pill — centered under the wordmark, same for every mode */
   .mode-pill {
     display: inline-flex; align-items: center; gap: 6px; margin: -2px auto 10px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,9 +58,9 @@
   let pinNotSet = false;   // logged in on this device with no PIN yet → prompt setup
   /** @type {string | null} */
   let initError = null; // 🔍 Diagnostic: what failed during init
-  /** Show main menu (Daily / Arcade / Leaderboard / My account) when true; game when false */
+  /** Show main menu (Daily / Cash Game / Leaderboard / My account) when true; game when false */
   let showMainMenu = false;
-  /** When showing menu: can we show "Resume daily" / "Resume arcade"? */
+  /** When showing menu: can we show "Resume daily" / "Resume in-progress game"? */
   let savedGameInfo = /** @type {{ gameMode: string, gameState: string } | null} */ (null);
   /** When showing menu: has user already played daily today? */
   let menuDailyPlayed = false;
@@ -869,7 +869,7 @@
       }
       return `🧠 WordBank Daily · ${todayLabel}\nDidn't crack it today 😬\n${link}`;
     }
-    return `🏦 WordBank Arcade\n${resultMedal.emoji} ${br} banked\n${link}`;
+    return `🏦 WordBank\n${resultMedal.emoji} ${br} banked\n${link}`;
   }
   async function handleShare() {
     const text = buildShareText();
@@ -1491,7 +1491,7 @@
     if (showStreakMessage) showStreakMessage = false;
   }
 
-  // Daily result → go to the daily leaderboard (arcade uses handleArcadeContinue instead).
+  // Daily result → go to the daily leaderboard.
   const goToDailyLeaderboard = () => {
     showResultModal = false;
     hasTriggeredModal = false;
@@ -2422,7 +2422,6 @@
       </div>
     {/if}
 
-    <!-- 🕹️ Arcade gauntlet HUD -->
     <!-- ⏱️ Pressure-mode challenge clock -->
     {#if pressureActive}
       <div class="pressure-hud" class:danger={pressureRemaining <= 10}>
@@ -2758,13 +2757,6 @@
     justify-content: safe center;
   }
 
-  .arcade-hud {
-    display: flex;
-    gap: 8px;
-    width: 100%;
-    max-width: 360px;
-    margin: 0 auto 14px;
-  }
   .pressure-hud {
     display: flex; flex-direction: column; align-items: center; gap: 2px;
     width: 100%; max-width: 360px; margin: 0 auto 14px; padding: 0.5rem 1rem;
@@ -2784,43 +2776,6 @@
   }
   .makeup-banner .mb-tag { font-family: var(--font-display); font-weight: 800; font-size: 0.8rem; color: #38bdf8; white-space: nowrap; }
   .makeup-banner .mb-text { font-size: 0.74rem; color: var(--text-muted); }
-  .bank-it-btn {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 8px;
-    margin: 0 auto 14px;
-    padding: 0.6rem 1.3rem;
-    border: 1px solid rgba(253, 224, 71, 0.5);
-    border-radius: 999px;
-    background: linear-gradient(135deg, rgba(251, 191, 36,0.16), rgba(253, 224, 71,0.08));
-    color: var(--brand-2);
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 1rem;
-    cursor: pointer;
-    box-shadow: 0 0 16px rgba(253, 224, 71, 0.18);
-    transition: transform 0.15s, box-shadow 0.2s;
-  }
-  .bank-it-btn:hover { transform: translateY(-1px); box-shadow: 0 0 22px rgba(253, 224, 71, 0.3); }
-  .bank-it-btn:active { transform: scale(0.97); }
-  .bank-it-btn:disabled { opacity: 0.6; }
-  .bib-sub { font-family: var(--font-ui); font-weight: 500; font-size: 0.72rem; color: var(--text-faint); }
-  .ah-cell {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    padding: 10px 6px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--r-md);
-  }
-  .ah-mult { border-color: rgba(253, 224, 71, 0.35); background: linear-gradient(135deg, rgba(251, 191, 36,0.12), rgba(253, 224, 71,0.04)); }
-  .ah-val { font-family: var(--font-display); font-weight: 700; font-size: 1.15rem; color: var(--text); font-variant-numeric: tabular-nums; }
-  .ah-mult .ah-val { color: var(--brand-2); }
-  .ah-gold { color: #fcd34d; }
-  .ah-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
   /* Cash Game (Climb) HUD */
   .climb-hud { display: flex; gap: 8px; width: 100%; max-width: 360px; margin: 0 auto 12px; }
   .match-pos { text-align: center; font-family: var(--font-display); font-weight: 700; font-size: 0.8rem; color: var(--text-muted); margin: 0 0 8px; }
@@ -4406,7 +4361,7 @@
   .next-puzzle-button:hover { transform: translateY(-2px); filter: brightness(1.05); }
   .next-puzzle-button:active { transform: scale(0.97); }
 
-  /* Result modal (daily/arcade) */
+  /* Result modal */
   .result-modal h2 { font-size: 1.7rem; margin: 4px 0 2px; }
   .result-medal {
     font-size: 3.4rem;

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,59 +1,29 @@
 <script>
   import { onMount } from 'svelte';
   import PageNav from "$lib/components/PageNav.svelte";
-  import { getBank, getFreeplayCashoutStatus, freeplayCashout } from '$lib/stores/statsStore.js';
+  import { getBank } from '$lib/stores/statsStore.js';
   import InventoryList from '$lib/components/InventoryList.svelte';
-  import { requirePin } from '$lib/pinConfirm.js';
   import { track } from '$lib/analytics.js';
-  import { fx } from '$lib/sound.js';
 
   /** @type {{ bank:number, net_worth:number, ledger:any[] }|null} */
   let b = null;
-  /** @type {any|null} */
-  let cashout = null;
   let loading = true;
-  let busy = '';
-  let msg = '';
   /** @type {{title:string, desc:string}|null} */
   let info = null;
 
   async function load() {
-    const [bank, co] = await Promise.all([getBank(500), getFreeplayCashoutStatus()]);
-    b = bank; cashout = co;
+    b = await getBank(500);
   }
   onMount(async () => {
     track('bank_view');
     try { await load(); } finally { loading = false; }
   });
 
-  // ── Currency exchange (always 40 credits = $1) ──
-  let dollars = 1; // the $ amount on the dial
-  $: cash = b ? b.bank : 0;
-  $: credits = cashout ? (cashout.credits ?? 0) : 0;
-  // All credits are cashable now (server-computed max_cash), within today's $50 cap.
-  $: sellableDollars = cashout ? Math.min(cashout.max_cash ?? 0, cashout.cap_remaining ?? 0) : 0;
-  $: maxDollars = Math.max(1, Math.min(50, Math.max(Math.floor(cash), sellableDollars)));
-  $: if (dollars > maxDollars) dollars = maxDollars;
-  $: canSell = dollars >= 1 && dollars <= sellableDollars;
-
-  async function sell() {
-    if (busy || !canSell) return;
-    try { await requirePin(`Sell ${(dollars * 40).toLocaleString()} credits → $${dollars}`, [
-      { label: 'Credits', value: (dollars * 40).toLocaleString() },
-      { label: 'You receive', value: '$' + dollars }
-    ]); } catch { return; }
-    busy = 'sell'; msg = '';
-    const res = await freeplayCashout(dollars);
-    busy = '';
-    if (res?.ok) { fx('win'); track('freeplay_cashout', { cash: res.cashed }); await load(); }
-    else { msg = res?.reason === 'daily_cap' ? 'Daily $50 limit reached.' : 'Could not sell right now.'; }
-  }
-
   const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
   const dateOnly = (/** @type {string} */ at) => at ? new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '';
 
   // Ledger filters: by type, and sort by date/amount. Custom dropdowns so the menu
-  // opens downward over the ledger (native <select> popped upward over the exchange).
+  // opens downward over the ledger.
   let typeFilter = 'all';
   let sortBy = 'newest';
   /** @type {null|'type'|'sort'} */
@@ -98,36 +68,11 @@
         <span class="bal-label">💰 Cash <span class="bal-i">ⓘ</span></span>
         <span class="bal-value">{fmt(b.bank)}</span>
       </button>
-      {#if cashout}
-        <button class="bal credits" onclick={() => info = { title: '🎟️ Credits', desc: 'Earned in Free Play — a practice stack you can build up. Exchange them for Cash right here in the Bank (40 credits = $1, up to $50 a day).' }}>
-          <span class="bal-label">🎟️ Credits <span class="bal-i">ⓘ</span></span>
-          <span class="bal-value cr">{(cashout.credits ?? 0).toLocaleString()}</span>
-        </button>
-      {/if}
     </div>
 
     <!-- Items (your vault) -->
     <h2 class="hist-title">🎒 Your Items</h2>
     <InventoryList addHref="/shop?from=bank" />
-
-    <!-- Exchange (always 40 🎟️ = $1) -->
-    <div class="exchange">
-      <h2 class="ex-h">💱 Exchange</h2>
-      <div class="ex-rate-pill"><span class="ex-rate-lbl">Rate</span><b>40</b>&nbsp;🎟️<span class="ex-eq">=</span><b>$1</b>&nbsp;💰</div>
-
-      <div class="ex-dial">
-        <button class="ex-step" onclick={() => dollars = Math.max(1, dollars - 1)} aria-label="Less" disabled={dollars <= 1}>−</button>
-        <div class="ex-amt">
-          <span class="ex-usd">${dollars}</span>
-          <span class="ex-cr">{(dollars * 40).toLocaleString()} credits</span>
-        </div>
-        <button class="ex-step" onclick={() => dollars = Math.min(maxDollars, dollars + 1)} aria-label="More" disabled={dollars >= maxDollars}>+</button>
-      </div>
-      <input class="ex-slider" type="range" min="1" max={maxDollars} bind:value={dollars} />
-
-      <button class="ex-act sell" disabled={!canSell || !!busy} onclick={sell}>🎟️&nbsp;→&nbsp;💰&nbsp; Sell for ${dollars}</button>
-      {#if msg}<p class="msg">{msg}</p>{/if}
-    </div>
 
     <!-- Ledger -->
     <div class="led-head">
@@ -187,7 +132,7 @@
   .bank-title { font-family: var(--font-display); font-size: 1.5rem; margin: 4px 0 16px; text-align: center; }
   .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
 
-  .balances { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 14px; }
+  .balances { display: grid; grid-template-columns: 1fr; gap: 10px; margin-bottom: 14px; }
   .bal { display: flex; flex-direction: column; gap: 2px; padding: 14px; border-radius: 16px; background: var(--surface); border: 1px solid var(--border);
     text-align: left; cursor: pointer; font: inherit; color: inherit; }
   .bal:hover { border-color: var(--brand-2); }
@@ -206,32 +151,6 @@
   .si-close { margin-top: 4px; height: 44px; border-radius: 12px; border: none; cursor: pointer; font-weight: 800; color: #3a2a00;
     background: linear-gradient(135deg, #fde047, #f59e0b); }
   .bal-value { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.7rem; color: var(--brand-2); }
-  .bal-value.cr { color: #6ee7b7; }
-  .bal-sub { font-size: 0.68rem; color: var(--text-faint); }
-
-  .exchange { padding: 18px 16px; border-radius: 18px; margin-bottom: 16px; text-align: center;
-    display: flex; flex-direction: column; align-items: center;
-    background: linear-gradient(135deg, rgba(110,231,183,0.09), rgba(110,231,183,0.02)); border: 1px solid rgba(110,231,183,0.3); }
-  .ex-h { font-family: var(--font-display); font-size: 1.05rem; font-weight: 800; margin: 0 0 12px; }
-  .ex-rate-pill { display: inline-flex; align-items: center; gap: 6px; padding: 6px 14px; border-radius: 999px; margin-bottom: 16px;
-    background: rgba(0,0,0,0.25); border: 1px solid var(--border); font-family: 'Orbitron', var(--font-display); color: var(--text); }
-  .ex-rate-pill b { color: #6ee7b7; font-size: 1.05rem; }
-  .ex-rate-lbl { font-size: 0.6rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-faint); margin-right: 4px; }
-  .ex-eq { color: var(--text-faint); margin: 0 2px; }
-  .ex-dial { display: flex; align-items: center; justify-content: center; gap: 12px; width: 100%; max-width: 300px; }
-  .ex-step { width: 46px; height: 46px; flex: none; border-radius: 12px; cursor: pointer; font-size: 1.5rem; font-weight: 800;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); display: grid; place-items: center; }
-  .ex-step:hover:not(:disabled) { border-color: #34d399; }
-  .ex-step:disabled { opacity: 0.3; cursor: default; }
-  .ex-amt { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 8px 6px; border-radius: 12px;
-    background: rgba(0,0,0,0.25); border: 1px solid var(--border); }
-  .ex-usd { font-family: 'Orbitron', var(--font-display); font-weight: 800; color: var(--brand-2); font-size: 1.8rem; line-height: 1; }
-  .ex-cr { font-size: 0.72rem; color: #6ee7b7; font-weight: 700; }
-  .ex-slider { width: 100%; max-width: 300px; margin: 16px 0; accent-color: #34d399; }
-  .ex-act { width: 100%; max-width: 300px; padding: 0.85rem; border: none; border-radius: 13px; cursor: pointer; font-weight: 800; font-size: 0.98rem; }
-  .ex-act.sell { color: #06281d; background: linear-gradient(135deg, #6ee7b7, #34d399); }
-  .ex-act:disabled { opacity: 0.4; cursor: default; }
-  .msg { text-align: center; color: #fb7185; font-size: 0.85rem; margin: 0.6rem 0 0; }
 
   .led-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 1.4rem 0 0.6rem; flex-wrap: wrap; }
   .hist-title { font-family: var(--font-display); font-size: 1rem; margin: 0; }

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -98,7 +98,7 @@
       </div>
 
       <div class="grid ov-summary">
-        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Total Solves', () => statInfo = { title: 'Total solves', desc: 'Every puzzle you’ve solved across all modes — Daily, Cash Game, Free Play, and challenges.' })}
+        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Total Solves', () => statInfo = { title: 'Total solves', desc: 'Every puzzle you’ve solved across all modes — Daily, Cash Game, and challenges.' })}
         {@render chipAct(d.overall.games_played ?? 0, 'Games Played', () => statInfo = { title: 'Games played', desc: 'How many games you’ve started across every mode — whether you solved them or not.' })}
         {@render chipAct('🔥 ' + (d.daily.current_streak ?? 0), 'Play Streak', () => statInfo = { title: '🔥 Play streak', desc: 'Days in a row you’ve shown up for the Daily. Miss a day and it resets (a freeze can save it).', link: '/streak', linkLabel: 'View Daily Calendar' })}
         {@render chipAct('🏆 ' + (d.daily.win_streak ?? 0), 'Win Streak', () => statInfo = { title: '🏆 Win streak', desc: 'Daily puzzles you’ve solved in a row. Powers your bounty multiplier — the longer it runs, the more you earn.', link: '/streak', linkLabel: 'View Daily Calendar' })}

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -99,7 +99,7 @@
     <h1>🛍️ Store</h1>
     <span class="bank-chip">💰 ${bank.toLocaleString()}</span>
   </div>
-  <p class="sub">Power-ups for the Cash Game &amp; challenges, plus cosmetics. <a class="bank-link" href="/bank">Exchange credits → Cash in the Bank ›</a></p>
+  <p class="sub">Power-ups for the Cash Game &amp; challenges, plus cosmetics.</p>
 
   {#if loading}
     <p class="loading">Loading…</p>
@@ -223,24 +223,8 @@
   h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0; }
   .bank-chip { font-family: var(--font-display); font-weight: 800; color: #fbbf24; font-size: 1.05rem; }
   .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1.4rem; }
-  .bank-link { color: var(--brand-2); text-decoration: none; font-weight: 600; white-space: nowrap; }
-  .bank-link:hover { text-decoration: underline; }
   .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
   .msg { text-align: center; color: #f87171; font-size: 0.88rem; margin: 0 0 1rem; }
-  .cashout-card {
-    border: 1px solid rgba(110, 231, 183, 0.35); border-radius: 16px; padding: 0.9rem 1rem; margin: 0 0 1.2rem;
-    background: linear-gradient(135deg, rgba(16, 185, 129, 0.12), rgba(20, 26, 38, 0.6));
-  }
-  .co-top { display: flex; align-items: center; justify-content: space-between; gap: 0.7rem; }
-  .co-label { display: block; font-size: 0.74rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.05em; }
-  .co-credits { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.6rem; color: #6ee7b7; }
-  .co-btn {
-    padding: 0.6rem 0.95rem; border-radius: 11px; border: none; cursor: pointer; font-weight: 800; font-size: 0.9rem;
-    color: #04240f; background: linear-gradient(135deg, #6ee7b7, #34d399); white-space: nowrap;
-  }
-  .co-btn:disabled { opacity: 0.5; cursor: default; }
-  .co-pending { font-size: 0.78rem; color: var(--text-muted); text-align: right; }
-  .co-note { font-size: 0.72rem; color: var(--text-faint); margin: 0.6rem 0 0; line-height: 1.35; }
   .owned-x { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.78rem; color: #fde047; }
   .inv-details { margin: 0 0 0.4rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 0 0.9rem; }
   .inv-summary { cursor: pointer; padding: 0.85rem 0; font-family: var(--font-display); font-weight: 700; font-size: 0.98rem; list-style: none; }


### PR DESCRIPTION
First slice of the V2 overhaul — the **reversible, code-only** removal of three retired systems. **No DB changes** (destructive drops are gated on the Supabase incident clearing and happen in a follow-up). The app stays fully functional: Daily, Cash Game, Challenges, and Make-up all work; the removed RPCs/columns simply go unused until the DB step.

### What's removed
- **(A) Arcade** — a dead-wired legacy mode (no menu entry, no live path). Pure dead-code excision across GameStore/statsStore + leaf components.
- **(C) Credits + Exchange** — the Free Play wallet + Bank "sell credits → Cash" flow.
- **(B) Free Play** — the unranked category-picked endless mode (menu card, category picker, HUD, mode reactives, dispatch, result transition).

### Verified
- `npm run build` ✅
- `svelte-check`: 34 errors — all pre-existing baseline, **none in edited files**.
- **E2E `qa-e2e.mjs`: 19/19 passed · 0 console errors** (signup → gates → 11 pages → daily open/solve → history).

### Kept on purpose (name collisions / DB-coupled)
`arcade_bankroll` profile column reads (renamed in the DB step), `arcade_cashout` ledger label (a Cash Game row), `.arcade-gain`/`.arcade-earn` win-banner CSS, OAuth `exchangeCodeForSession`/`auth_error=exchange`, terms "exchanged" copy, `CATEGORIES` + `.cat-sub` (Challenge builder still uses them), `freeplay_reward` ledger label (historical rows).

### Follow-up (gated on the Supabase incident clearing)
Drop the now-orphaned `arcade_*` / `freeplay_*` RPCs + the arcade `profiles` columns, and update `handle_new_user`/`get_daily_status` — with the PITR timestamp logged first. Rollback point for this PR: tag `v1-stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)