### PR TITLE
V2 Phase 2: the Loan Shark — borrow/repay + auto-skim + debt lockout

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -66,9 +66,24 @@ export async function getDailyStatus(userId) {
 /** @param {number} [limit] ledger rows to return (default 12; pass a big number for full history) */
 export async function getBank(limit) {
   const { data, error } = await supabase.rpc('get_bank', limit ? { p_limit: limit } : {});
-  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, net_worth: 0, ledger: [] }; }
+  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, net_worth: 0, loan: 0, loan_cap: 0, in_the_red: false, ledger: [] }; }
   return { bank: data.bank ?? 0, net_worth: data.net_worth ?? data.bank ?? 0,
+    loan: data.loan ?? 0, loan_cap: data.loan_cap ?? 0, in_the_red: !!data.in_the_red,
     ledger: Array.isArray(data.ledger) ? data.ledger : [] };
+}
+
+/** Borrow from the Loan Shark (25% fee, one at a time, ≤ credit limit). @param {number} amount */
+export async function takeLoan(amount) {
+  const { data, error } = await supabase.rpc('take_loan', { p_amount: amount });
+  if (error || !data) { if (error) console.error('❌ take_loan:', error); return { ok: false }; }
+  return data;
+}
+
+/** Repay the loan from Cash (null = pay the max you can afford). @param {number|null} amount */
+export async function repayLoan(amount = null) {
+  const { data, error } = await supabase.rpc('repay_loan', { p_amount: amount });
+  if (error || !data) { if (error) console.error('❌ repay_loan:', error); return { ok: false }; }
+  return data;
 }
 
 /** Lowest winning spend per mode (e.g. { daily: 20, climb: 60 }) — powers the

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -99,8 +99,9 @@
   }
   /** Net Worth for the menu chip. */
   let netWorth = /** @type {number|null} */ (null);
+  let menuLoan = 0; // outstanding loan → drives the menu debt banner
   async function refreshBank() {
-    try { netWorth = (await getBank()).net_worth; } catch { /* non-fatal */ }
+    try { const gb = await getBank(); netWorth = gb.net_worth; menuLoan = gb.loan ?? 0; } catch { /* non-fatal */ }
   }
 
   // ✅ Load Supabase user profile and sync bankroll (creates profile if missing)
@@ -1923,6 +1924,13 @@
       </div>
       {#if menuView === 'home'}
         <div class="main-menu-buttons stagger">
+          <!-- 🦈 Debt banner — you owe the Loan Shark; Store locked + payouts auto-skim. -->
+          {#if menuLoan > 0}
+            <button class="debt-banner" style="--i: 0" on:click={() => { fx('tap'); goto('/bank'); }}>
+              🦈 <span class="db-text">You owe <b>${Math.round(menuLoan).toLocaleString()}</b> — half of every payout auto-repays it</span>
+              <span class="db-go">Repay ›</span>
+            </button>
+          {/if}
           <!-- ▶ Resume — any in-progress game (solo + started challenges). One → straight in; many → the Resume menu. -->
           {#if resumables.length}
             <button class="resume-strip" style="--i: 0" on:click={onResume}>
@@ -3218,6 +3226,19 @@
   }
   .resume-strip:hover { border-color: rgba(16,185,129,0.65); }
   .resume-strip:active { transform: scale(0.99); }
+  .debt-banner {
+    display: flex; align-items: center; gap: 9px; width: 100%; margin-bottom: 2px;
+    padding: 9px 14px; border-radius: 12px; cursor: pointer;
+    background: linear-gradient(180deg, rgba(53,16,16,0.7), rgba(42,15,15,0.7));
+    border: 1px solid rgba(248,113,113,0.5);
+    font-family: var(--font-display); font-weight: 700; font-size: 0.82rem;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  }
+  .debt-banner:hover { border-color: rgba(248,113,113,0.75); }
+  .debt-banner:active { transform: scale(0.99); }
+  .db-text { flex: 1; text-align: left; color: #fecaca; font-weight: 600; }
+  .db-text b { color: #fb7185; }
+  .db-go { color: rgba(251,113,133,0.85); }
   .rs-dot { color: #34d399; font-size: 0.8rem; }
   .rs-label { flex: 1; text-align: left; color: #d1fae5; }
   .rs-go { color: rgba(110,231,183,0.7); }

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,23 +1,64 @@
 <script>
   import { onMount } from 'svelte';
   import PageNav from "$lib/components/PageNav.svelte";
-  import { getBank } from '$lib/stores/statsStore.js';
+  import { getBank, takeLoan, repayLoan } from '$lib/stores/statsStore.js';
   import InventoryList from '$lib/components/InventoryList.svelte';
+  import { requirePin } from '$lib/pinConfirm.js';
   import { track } from '$lib/analytics.js';
+  import { fx } from '$lib/sound.js';
 
-  /** @type {{ bank:number, net_worth:number, ledger:any[] }|null} */
+  /** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
   let b = null;
   let loading = true;
   /** @type {{title:string, desc:string}|null} */
   let info = null;
 
+  // 💸 Loan Shark
+  let borrowAmt = 100;      // $ to borrow (dial)
+  let repayAmt = 0;         // $ to repay (dial)
+  let loanBusy = '';
+  let loanMsg = '';
+  $: loanCap = b?.loan_cap ?? 0;
+  $: owed = b?.loan ?? 0;
+  $: feeOnBorrow = Math.round(borrowAmt * 0.25);
+  $: if (borrowAmt > loanCap) borrowAmt = loanCap;
+  $: if (borrowAmt < 10 && loanCap >= 10) borrowAmt = 10;
+  $: maxRepay = Math.max(0, Math.min(owed, b?.bank ?? 0));
+  $: if (repayAmt > maxRepay) repayAmt = maxRepay;
+
   async function load() {
     b = await getBank(500);
+    repayAmt = Math.max(0, Math.min(b?.loan ?? 0, b?.bank ?? 0));
   }
   onMount(async () => {
     track('bank_view');
     try { await load(); } finally { loading = false; }
   });
+
+  async function borrow() {
+    if (loanBusy || borrowAmt < 10) return;
+    const total = borrowAmt + Math.round(borrowAmt * 0.25);
+    try { await requirePin(`Borrow $${borrowAmt.toLocaleString()} — you'll owe $${total.toLocaleString()}`, [
+      { label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
+      { label: 'Fee (25%)', value: '$' + Math.round(borrowAmt * 0.25).toLocaleString() },
+      { label: 'You owe', value: '$' + total.toLocaleString() }
+    ]); } catch { return; }
+    loanBusy = 'borrow'; loanMsg = '';
+    const res = await takeLoan(borrowAmt);
+    loanBusy = '';
+    if (res?.ok) { fx('win'); track('take_loan', { amount: borrowAmt, owed: res.owed }); await load(); }
+    else { loanMsg = res?.reason === 'active_loan' ? 'Pay off your current loan first.' : res?.reason === 'over_cap' ? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.` : 'Could not borrow right now.'; }
+  }
+  async function repay(/** @type {number|null} */ amt) {
+    if (loanBusy) return;
+    const pay = amt ?? maxRepay;
+    if (pay <= 0) return;
+    loanBusy = 'repay'; loanMsg = '';
+    const res = await repayLoan(amt);
+    loanBusy = '';
+    if (res?.ok) { fx('tap'); track('repay_loan', { amount: res.paid, cleared: res.cleared }); await load(); }
+    else { loanMsg = res?.reason === 'insufficient' ? 'Not enough Cash to repay.' : 'Could not repay right now.'; }
+  }
 
   const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
   const dateOnly = (/** @type {string} */ at) => at ? new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '';
@@ -47,6 +88,7 @@
       attendance: 'Attendance reward', arcade_cashout: 'Cash Game cash-out', climb_bounty: 'Cash Game bounty',
       freeplay_reward: 'Free Play reward', freeplay_cashout: 'Exchanged credits → Cash',
       cosmetic_buy: 'Store purchase', powerup_buy: 'Power-up purchase',
+      loan_take: 'Loan received', loan_repay: 'Loan repayment', loan_skim: 'Loan auto-payment',
       wager_win: 'Won a wager', wager_stake: 'Wager staked', wager_refund: 'Wager refunded',
       makeup_reward: 'Make-up Daily', challenge_payout: 'Challenge payout'
     })[reason] || reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
@@ -69,6 +111,47 @@
         <span class="bal-value">{fmt(b.bank)}</span>
       </button>
     </div>
+
+    <!-- 💸 Loan Shark -->
+    {#if b.in_the_red}
+      <!-- In debt: repay panel + the teeth -->
+      <div class="loan-card debt">
+        <div class="loan-head">
+          <span class="loan-title">🦈 You owe the Shark</span>
+          <span class="loan-owed">{fmt(owed)}</span>
+        </div>
+        <p class="loan-note">Store is locked and half of every payout auto-pays your debt until it's clear. Your net worth is <b class="neg">{fmt(b.net_worth)}</b>.</p>
+        {#if maxRepay > 0}
+          <div class="loan-dial">
+            <button class="loan-step" onclick={() => repayAmt = Math.max(0, repayAmt - 50)} aria-label="Less" disabled={repayAmt <= 0}>−</button>
+            <div class="loan-amt"><span class="loan-usd">{fmt(repayAmt)}</span><span class="loan-sub">of {fmt(owed)} owed</span></div>
+            <button class="loan-step" onclick={() => repayAmt = Math.min(maxRepay, repayAmt + 50)} aria-label="More" disabled={repayAmt >= maxRepay}>+</button>
+          </div>
+          <input class="loan-slider" type="range" min="0" max={maxRepay} step="10" bind:value={repayAmt} />
+          <div class="loan-actions">
+            <button class="loan-btn ghost" disabled={!!loanBusy || repayAmt <= 0} onclick={() => repay(repayAmt)}>Repay {fmt(repayAmt)}</button>
+            <button class="loan-btn pay" disabled={!!loanBusy} onclick={() => repay(null)}>Pay max ({fmt(maxRepay)})</button>
+          </div>
+        {:else}
+          <p class="loan-note">Earn some Cash (play the Daily) then come back to repay.</p>
+        {/if}
+        {#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
+      </div>
+    {:else if loanCap > 0}
+      <!-- No debt: borrow panel -->
+      <details class="loan-card">
+        <summary class="loan-summary">🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary>
+        <p class="loan-note">A 25% fee, one loan at a time. While you owe, the Store locks and half of every payout auto-pays it down.</p>
+        <div class="loan-dial">
+          <button class="loan-step" onclick={() => borrowAmt = Math.max(10, borrowAmt - 50)} aria-label="Less" disabled={borrowAmt <= 10}>−</button>
+          <div class="loan-amt"><span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub">you'll owe {fmt(borrowAmt + feeOnBorrow)}</span></div>
+          <button class="loan-step" onclick={() => borrowAmt = Math.min(loanCap, borrowAmt + 50)} aria-label="More" disabled={borrowAmt >= loanCap}>+</button>
+        </div>
+        <input class="loan-slider" type="range" min="10" max={loanCap} step="10" bind:value={borrowAmt} />
+        <button class="loan-btn borrow" disabled={!!loanBusy || borrowAmt < 10} onclick={borrow}>🦈 Borrow {fmt(borrowAmt)} (fee {fmt(feeOnBorrow)})</button>
+        {#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
+      </details>
+    {/if}
 
     <!-- Items (your vault) -->
     <h2 class="hist-title">🎒 Your Items</h2>
@@ -151,6 +234,31 @@
   .si-close { margin-top: 4px; height: 44px; border-radius: 12px; border: none; cursor: pointer; font-weight: 800; color: #3a2a00;
     background: linear-gradient(135deg, #fde047, #f59e0b); }
   .bal-value { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.7rem; color: var(--brand-2); }
+
+  /* 💸 Loan Shark */
+  .loan-card { border-radius: 16px; padding: 14px 16px; margin: 0 0 14px; border: 1px solid var(--border); background: var(--surface); }
+  .loan-card.debt { border-color: rgba(248,113,113,0.5); background: linear-gradient(135deg, rgba(248,113,113,0.12), rgba(248,113,113,0.03)); }
+  .loan-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
+  .loan-title { font-family: var(--font-display); font-weight: 800; font-size: 1rem; }
+  .loan-owed { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.5rem; color: #fb7185; }
+  .loan-summary { cursor: pointer; font-family: var(--font-display); font-weight: 700; font-size: 0.95rem; list-style: none; display: flex; align-items: center; justify-content: space-between; }
+  .loan-summary::-webkit-details-marker { display: none; }
+  .loan-cv { color: var(--text-faint); font-size: 0.8rem; }
+  .loan-note { font-size: 0.78rem; color: var(--text-muted); margin: 8px 0; line-height: 1.4; }
+  .loan-note .neg { color: #fb7185; }
+  .loan-dial { display: flex; align-items: center; justify-content: center; gap: 12px; width: 100%; max-width: 320px; margin: 4px auto 0; }
+  .loan-step { width: 44px; height: 44px; flex: none; border-radius: 12px; cursor: pointer; font-size: 1.5rem; font-weight: 800; background: var(--surface); border: 1px solid var(--border); color: var(--text); display: grid; place-items: center; }
+  .loan-step:disabled { opacity: 0.3; cursor: default; }
+  .loan-amt { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; }
+  .loan-usd { font-family: 'Orbitron', var(--font-display); font-weight: 800; color: var(--brand-2); font-size: 1.6rem; line-height: 1; }
+  .loan-sub { font-size: 0.68rem; color: var(--text-faint); }
+  .loan-slider { width: 100%; max-width: 320px; display: block; margin: 12px auto; accent-color: #fb7185; }
+  .loan-actions { display: flex; gap: 8px; }
+  .loan-btn { flex: 1; padding: 0.8rem; border: none; border-radius: 12px; cursor: pointer; font-weight: 800; font-size: 0.92rem; }
+  .loan-btn.borrow { width: 100%; color: #2a1005; background: linear-gradient(135deg, #fbbf24, #f59e0b); }
+  .loan-btn.pay { color: #06281d; background: linear-gradient(135deg, #6ee7b7, #34d399); }
+  .loan-btn.ghost { background: var(--surface); border: 1px solid var(--border); color: var(--text); }
+  .loan-btn:disabled { opacity: 0.45; cursor: default; }
 
   .led-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 1.4rem 0 0.6rem; flex-wrap: wrap; }
   .hist-title { font-family: var(--font-display); font-size: 1rem; margin: 0; }

--- a/supabase-loans-v2.sql
+++ b/supabase-loans-v2.sql
@@ -1,0 +1,191 @@
+-- V2 Phase 2: the Loan Shark — borrow / repay + 50% auto-skim + debt lockout.
+--
+-- Builds the loan system now so the tiered risk modes (Cash Game V2, Challenges V2)
+-- have their "can't afford" answer. Loans live ONLY in the risk tiers — never gate the Daily.
+--   • profiles.loan = total OWED (principal + 25% fee); loan_accrued_at = when taken.
+--   • take_loan: 25% flat fee, credit-limit check, ONE active loan at a time.
+--   • repay_loan: pay manually (partial/full) from Cash.
+--   • _bank_credit auto-skims 50% of every positive payout toward an active loan (Daily,
+--     cash-outs, challenge wins, attendance) — the debt digs itself out; loan_take/repay/skim exempt.
+--   • Debt lockout: money-out (Store: buy_cosmetic/buy_powerup) blocked while loan > 0.
+--   • Negative net worth: get_bank + the Daily board show bank − loan (you look broke, rank drops).
+-- Credit limit is a flat $500 for now (Bronze default); _loan_cap scales with tier in Phase 3.
+-- Spec: Notion "Cash Game V2 → Loans". PITR point logged before apply.
+
+BEGIN;
+
+-- Credit limit (Phase 2: flat; Phase 3: scale with highest unlocked Cash Game tier).
+CREATE OR REPLACE FUNCTION public._loan_cap(p_uid uuid)
+ RETURNS bigint LANGUAGE sql STABLE SECURITY DEFINER
+AS $function$ SELECT 500::bigint; $function$;
+
+-- _bank_credit + 50% auto-skim toward an active loan (transparent: full payout line, then a skim line).
+CREATE OR REPLACE FUNCTION public._bank_credit(p_uid uuid, p_delta bigint, p_reason text)
+ RETURNS bigint LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_new BIGINT; v_loan BIGINT; v_skim BIGINT;
+BEGIN
+  PERFORM public._ensure_bank(p_uid);
+  INSERT INTO public.networth_snapshots(user_id, week_start, net_worth)
+    SELECT p_uid, date_trunc('week', CURRENT_DATE)::date, COALESCE(bank,0)
+    FROM public.profiles WHERE id = p_uid
+    ON CONFLICT DO NOTHING;
+  UPDATE public.profiles SET bank = GREATEST(0, COALESCE(bank,0) + p_delta) WHERE id = p_uid RETURNING bank INTO v_new;
+  INSERT INTO public.bank_ledger(user_id, delta, reason, balance_after) VALUES (p_uid, p_delta, p_reason, v_new);
+  -- Auto-skim 50% of positive payouts toward an outstanding loan (not the loan flows themselves).
+  IF p_delta > 0 AND p_reason NOT IN ('loan_take','loan_repay','loan_skim') THEN
+    SELECT COALESCE(loan,0) INTO v_loan FROM public.profiles WHERE id = p_uid;
+    IF v_loan > 0 THEN
+      v_skim := LEAST(v_loan, floor(p_delta * 0.5)::bigint);
+      IF v_skim > 0 THEN
+        UPDATE public.profiles SET bank = GREATEST(0, COALESCE(bank,0) - v_skim),
+          loan = v_loan - v_skim,
+          loan_accrued_at = CASE WHEN v_loan - v_skim <= 0 THEN NULL ELSE loan_accrued_at END
+          WHERE id = p_uid RETURNING bank INTO v_new;
+        INSERT INTO public.bank_ledger(user_id, delta, reason, balance_after) VALUES (p_uid, -v_skim, 'loan_skim', v_new);
+      END IF;
+    END IF;
+  END IF;
+  RETURN v_new;
+END; $function$;
+
+-- Borrow: 25% flat fee, one active loan, capped by _loan_cap.
+CREATE OR REPLACE FUNCTION public.take_loan(p_amount bigint)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_loan BIGINT; v_cap BIGINT; v_owed BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  IF p_amount IS NULL OR p_amount <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','bad_amount'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT COALESCE(loan,0) INTO v_loan FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan > 0 THEN RETURN jsonb_build_object('ok',false,'reason','active_loan'); END IF;
+  v_cap := public._loan_cap(v_uid);
+  IF p_amount > v_cap THEN RETURN jsonb_build_object('ok',false,'reason','over_cap','cap',v_cap); END IF;
+  v_owed := p_amount + round(p_amount * 0.25)::bigint;             -- 25% origination fee
+  UPDATE public.profiles SET loan = v_owed, loan_accrued_at = now() WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, p_amount, 'loan_take');       -- principal to Cash (skim-exempt)
+  RETURN jsonb_build_object('ok',true,'borrowed',p_amount,'owed',v_owed,'fee',v_owed - p_amount);
+END; $function$;
+
+-- Repay: pay down the loan from Cash (partial or, with NULL, the max you can afford).
+CREATE OR REPLACE FUNCTION public.repay_loan(p_amount bigint DEFAULT NULL)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_loan BIGINT; v_bank BIGINT; v_pay BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT COALESCE(loan,0), COALESCE(bank,0) INTO v_loan, v_bank FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','no_loan'); END IF;
+  v_pay := LEAST(COALESCE(p_amount, v_loan), v_loan, v_bank);
+  IF v_pay <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+  UPDATE public.profiles SET loan = v_loan - v_pay,
+    loan_accrued_at = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_accrued_at END WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, -v_pay, 'loan_repay');        -- debit Cash (skim-exempt)
+  RETURN jsonb_build_object('ok',true,'paid',v_pay,'remaining',v_loan - v_pay,'cleared',(v_loan - v_pay) <= 0);
+END; $function$;
+
+-- Debt lockout: no money-out (Store) while a loan is outstanding.
+CREATE OR REPLACE FUNCTION public.buy_cosmetic(p_id text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_price BIGINT; v_kind TEXT; v_bank BIGINT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  IF COALESCE((SELECT loan FROM public.profiles WHERE id = v_uid),0) > 0 THEN RETURN jsonb_build_object('ok',false,'reason','in_debt'); END IF;
+  SELECT price, kind INTO v_price, v_kind FROM public.cosmetics WHERE id = p_id;
+  IF v_price IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','no_item'); END IF;
+  IF EXISTS (SELECT 1 FROM public.user_cosmetics WHERE user_id = v_uid AND cosmetic_id = p_id) THEN
+    RETURN jsonb_build_object('ok',false,'reason','owned'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = v_uid;
+  IF v_bank < v_price THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+  PERFORM public._bank_credit(v_uid, -v_price, 'cosmetic_buy');
+  INSERT INTO public.user_cosmetics(user_id, cosmetic_id) VALUES (v_uid, p_id) ON CONFLICT DO NOTHING;
+  IF v_kind = 'title' THEN UPDATE public.profiles SET equipped_title = p_id WHERE id = v_uid;
+  ELSIF v_kind = 'color' THEN UPDATE public.profiles SET equipped_color = p_id WHERE id = v_uid;
+  END IF;
+  RETURN jsonb_build_object('ok',true);
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public.buy_powerup(p_id text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_price BIGINT; v_cash BIGINT; v_owned INT; v_kind TEXT; v_cap INT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  IF COALESCE((SELECT loan FROM public.profiles WHERE id = v_uid),0) > 0 THEN RETURN jsonb_build_object('ok',false,'reason','in_debt'); END IF;
+  SELECT price, kind INTO v_price, v_kind FROM public.powerups WHERE id = p_id AND active;
+  IF v_price IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','no_item'); END IF;
+  v_cap := CASE WHEN v_kind = 'daily' THEN 5 ELSE 1 END;
+  SELECT COALESCE(qty,0) INTO v_owned FROM public.user_powerups_v2 WHERE user_id=v_uid AND powerup_id=p_id AND pool='cash';
+  IF COALESCE(v_owned,0) >= v_cap THEN RETURN jsonb_build_object('ok',false,'reason','owned'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT bank INTO v_cash FROM public.profiles WHERE id = v_uid;
+  IF v_cash < v_price THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+  PERFORM public._bank_credit(v_uid, -v_price, 'powerup_buy');
+  PERFORM public._award_powerup(v_uid, p_id, 'cash');
+  RETURN jsonb_build_object('ok',true);
+END; $function$;
+
+-- get_bank: expose the real loan, capacity, and net worth (bank − loan).
+CREATE OR REPLACE FUNCTION public.get_bank(p_limit integer DEFAULT 12)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_bank BIGINT; v_loan BIGINT; v_led JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT COALESCE(bank,0), COALESCE(loan,0) INTO v_bank, v_loan FROM public.profiles WHERE id = v_uid;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('delta',delta,'reason',reason,'balance_after',balance_after,'at',created_at) ORDER BY created_at DESC), '[]'::jsonb)
+    INTO v_led FROM (SELECT * FROM public.bank_ledger WHERE user_id = v_uid ORDER BY created_at DESC LIMIT GREATEST(p_limit, 1)) t;
+  RETURN jsonb_build_object('bank', v_bank, 'net_worth', v_bank - v_loan,
+    'loan', v_loan, 'auto_repay', v_loan > 0, 'in_the_red', v_loan > 0,
+    'loan_cap', public._loan_cap(v_uid), 'ledger', v_led);
+END; $function$;
+
+-- Daily board: Cash (net worth) reflects debt = bank − loan (a debtor looks broke / ranks lower).
+CREATE OR REPLACE FUNCTION public.get_daily_board(p_scope text DEFAULT 'everyone'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB; v_base int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  v_base := public._daily_reward(public._todays_puzzle_id());
+  WITH circle AS (
+    SELECT v_uid AS id
+    UNION SELECT friend_id FROM public.friendships WHERE user_id = v_uid AND p_scope = 'friends'
+    UNION SELECT user_id FROM public.group_members WHERE group_id = p_group AND p_scope = 'group'
+    UNION SELECT id FROM public.profiles WHERE p_scope IN ('global','everyone')
+  ),
+  d AS (
+    SELECT c.id,
+      (COALESCE(pr.bank, 0) - COALESCE(pr.loan, 0))::bigint AS net_worth,
+      (CASE WHEN pr.last_daily_play_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_play_streak,0) ELSE 0 END) AS play_streak,
+      (CASE WHEN pr.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_solve_streak,0) ELSE 0 END) AS win_streak,
+      g.score AS score,
+      (CASE WHEN g.won AND v_base > 0 THEN GREATEST(0, LEAST(100, round(COALESCE(g.kept,0)::numeric / v_base * 100)::int)) ELSE NULL END) AS efficiency,
+      pr.equipped_title, pr.equipped_color
+    FROM circle c
+    JOIN public.profiles pr ON pr.id = c.id
+    LEFT JOIN LATERAL (
+      SELECT gr.score, gr.kept, gr.won FROM public.game_results gr
+      WHERE gr.user_id = c.id AND gr.game_mode = 'daily' AND gr.played_at::date = CURRENT_DATE
+      ORDER BY gr.played_at DESC LIMIT 1
+    ) g ON true
+    WHERE c.id IS NOT NULL
+  ),
+  ranked AS (
+    SELECT *, row_number() OVER (ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC) AS rank
+    FROM d ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC LIMIT 100
+  )
+  SELECT jsonb_agg(jsonb_build_object(
+    'rank', rank, 'name', public._display_name(id), 'net_worth', net_worth, 'score', score,
+    'efficiency', efficiency,
+    'play_streak', play_streak, 'win_streak', win_streak, 'played', score IS NOT NULL,
+    'is_me', id = v_uid, 'title', equipped_title, 'color', equipped_color) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Builds the loan system (borrow at a 25% fee, one at a time; 50% payout auto-skim; money-out lockout while in debt; negative net worth). DB applied to prod (PITR-protected) + full rollback sim green; Bank Borrow/Repay UI + menu debt banner; E2E 19/19. Loans live only in the risk tiers, ready for Cash Game V2 (Phase 3) to consume. Spec: Notion 'Cash Game V2 → Loans'. 🤖 Generated with [Claude Code](https://claude.com/claude-code)