### PR TITLE
V2 Phase 3: Cash Game V2 — tiered buy-in runs

### DIFF
--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -28,10 +28,10 @@
         goal: 'Solve the hidden phrase.',
         win: 'Spend as little Cash as you can — your leftover is your score.',
         bar: 'Just showing up pays a streak reward.' };
-      case 'climb': return { icon: '🧗', title: 'Cash Game',
-        goal: 'Climb an endless ladder of puzzles.',
-        win: 'Solve each one cheaply to grow your bankroll.',
-        bar: "Don't go broke." };
+      case 'climb': return { icon: '🎰', title: 'Cash Game',
+        goal: 'Stake a buy-in → grow a run bankroll by solving cheaply.',
+        win: 'Cash out anytime to bank it — heat multiplies each solve.',
+        bar: 'Bust (a wrong final guess) loses the buy-in.' };
       case 'makeup': return { icon: '🗓️', title: 'Make-up Daily',
         goal: 'Play a daily you missed.',
         win: 'Same rules — solve it as cheaply as you can.',

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -6,7 +6,7 @@ import { fx } from '$lib/sound.js';
 import { dailyStart, dailyUseTwist, dailyUseBoost, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue } from '$lib/stores/statsStore.js';
 import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, climbDoubleOrNothing, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
+import { climbStart, cashgameStart, cashgameCashout, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, climbDoubleOrNothing, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
 import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchFold as matchFoldRpc, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
@@ -408,17 +408,19 @@ function reconcileClimbBoard(board) {
   if (!board) return;
   const prev = get(gameStore);
   const climb = board.climb || {};
-  // 'solved' shows a win beat (then climbAdvance); 'complete' = reached the top.
+  // 'solved' shows a win beat (then climbAdvance); 'busted' ends the run (you lost the buy-in).
   const solved = climb.state === 'solved';
+  const busted = climb.state === 'busted' || climb.busted === true;
   gameStore.set(/** @type {GameState} */ ({
     ...prev, ...boardToState(board, prev),
     gameMode: 'climb',
-    gameState: solved ? 'won' : 'default',
+    gameState: busted ? 'lost' : (solved ? 'won' : 'default'),
     modifier: null,
     climbInfo: climb
   }));
   // No confetti — the slot-machine reveal (box-by-box win pop) is the celebration, like Daily.
-  if (solved) { fx('win'); }
+  if (busted) fx('bust');
+  else if (solved) { fx('win'); }
   else playMoveCue(prev, board);
 }
 
@@ -441,19 +443,53 @@ function maybeArmMatchIntro() {
   }
 }
 
-/** Start or resume the Climb. @returns {Promise<boolean>} */
+/** Resume an in-progress Cash Game run. Returns 'needs_tier' when there's no live run
+ *  (the caller then shows the tier-select), true if a run was restored, false on error. */
 export async function fetchClimbGame() {
   try {
-    track('climb_start');
     const board = await climbStart();
     if (!board) return false;
+    if (board.needs_tier) return 'needs_tier';
     reconcileClimbBoard(board);
     maybeArmClimbIntro();
     await refreshClimbClue();
     return true;
   } catch (err) {
-    console.error('❌ Error starting climb:', err instanceof Error ? err.message : String(err));
+    console.error('❌ Error resuming Cash Game:', err instanceof Error ? err.message : String(err));
     return false;
+  }
+}
+
+/** Buy in at a tier and start a fresh run. @param {string} tier @returns {Promise<any>} */
+export async function startCashGame(tier) {
+  try {
+    track('cashgame_start', { tier });
+    const resp = await cashgameStart(tier);
+    if (!resp?.ok) return resp || { ok: false };
+    reconcileClimbBoard(resp);
+    maybeArmClimbIntro();
+    await refreshClimbClue();
+    return resp;
+  } catch (err) {
+    console.error('❌ Error starting Cash Game:', err instanceof Error ? err.message : String(err));
+    return { ok: false };
+  }
+}
+
+/** Cash out the current run → bank the bankroll, end the run. @returns {Promise<any>} */
+export async function cashOutClimb() {
+  if (dailyInFlight) return { ok: false };
+  dailyInFlight = true;
+  try {
+    const resp = await cashgameCashout();
+    if (resp?.ok) {
+      fx('multiplier');
+      // Surface a cash-out result the UI can celebrate, then clear the run.
+      gameStore.update(s => ({ ...s, gameState: 'won', climbInfo: { ...(s.climbInfo || {}), state: 'cashed_out', cashout: resp } }));
+    }
+    return resp || { ok: false };
+  } finally {
+    dailyInFlight = false;
   }
 }
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -455,6 +455,24 @@ export async function climbStart() {
   if (error) { console.error('❌ climb_start:', error); return null; }
   return data;
 }
+/** Cash Game V2: buy in at a tier → a fresh run. @param {string} tier @returns {Promise<any>} */
+export async function cashgameStart(tier) {
+  const { data, error } = await supabase.rpc('cashgame_start', { p_tier: tier });
+  if (error || !data) { if (error) console.error('❌ cashgame_start:', error); return { ok: false }; }
+  return data;
+}
+/** Cash out the current run → bank the bankroll, end the run. @returns {Promise<any>} */
+export async function cashgameCashout() {
+  const { data, error } = await supabase.rpc('cashgame_cashout');
+  if (error || !data) { if (error) console.error('❌ cashgame_cashout:', error); return { ok: false }; }
+  return data;
+}
+/** Tier-select meta: unlocked tiers + Cash Game stats. @returns {Promise<any>} */
+export async function getCashgameMeta() {
+  const { data, error } = await supabase.rpc('get_cashgame_meta');
+  if (error) { console.error('❌ get_cashgame_meta:', error); return null; }
+  return data;
+}
 /** @param {string} letter @returns {Promise<any>} */
 export async function climbBuyLetter(letter) {
   const { data, error } = await supabase.rpc('climb_buy_letter', { p_letter: letter });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,11 +6,11 @@
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
 
-  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, startCashGame, cashOutClimb, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, getMatchDebuffs, getMatchOpponents, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getDailyModifier, deleteMyAccount, getMyAvatar } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getDailyModifier, deleteMyAccount, getMyAvatar, getCashgameMeta } from '$lib/stores/statsStore.js';
   import Avatar from '$lib/components/Avatar.svelte';
   import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
@@ -1118,22 +1118,54 @@
   $: dailyMod = ($gameStore.gameMode === 'daily' && $gameStore.modifier) ? modifierInfo($gameStore.modifier) : null;
 
   /** Start or resume the Cash Game (the persistent real-Cash Climb). */
+  // ===== Cash Game V2 — tier select + run =====
+  let showTierSelect = false;
+  /** @type {any} */
+  let cgMeta = null;
+  let cgBusy = false;
+  /** @type {any} */
+  let cashoutResult = null; // { banked, buy_in, profit, multiple_x100, solves, tier }
+
+  async function enterClimbGame() {
+    hasInitialized = true;
+    showMainMenu = false;
+    showTierSelect = false;
+    refreshClimbPups();
+    await tick();
+    playDailyIntroIfArmed();
+  }
   async function handleMenuClimb() {
     const currentUser = get(user);
     if (!currentUser?.id) return;
     localStorage.setItem('gameMode', 'climb');
-    const ok = await fetchClimbGame();
-    if (ok) {
-      hasInitialized = true;
-      showMainMenu = false;
-      refreshClimbPups();
-      // Play the dramatic opening reveal once reactives settle (no-ops if the
-      // "How it works" card shows — it then fires on dismiss).
-      await tick();
-      playDailyIntroIfArmed();
+    const res = await fetchClimbGame();
+    if (res === 'needs_tier') {
+      cgMeta = await getCashgameMeta();
+      showTierSelect = true;
+    } else if (res) {
+      await enterClimbGame();
     } else {
       initError = 'Cash Game failed to load.';
     }
+  }
+  /** @param {string} tier */
+  async function pickTier(tier) {
+    if (cgBusy) return;
+    cgBusy = true;
+    const res = await startCashGame(tier);
+    cgBusy = false;
+    if (res?.ok) { await enterClimbGame(); }
+    else if (res?.reason === 'insufficient') {
+      // Can't afford the buy-in → offer the Loan Shark.
+      if (confirm(`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`)) { showTierSelect = false; goto('/bank'); }
+    } else if (res?.reason === 'locked') { fx('wrong'); }
+  }
+  async function cashOut() {
+    if (cgBusy) return;
+    cgBusy = true;
+    const res = await cashOutClimb();
+    cgBusy = false;
+    if (res?.ok) { cashoutResult = res; showResultModal = true; refreshBank(); }
   }
 
   // ===== Challenge Builder (configurable packs vs friends/groups) =====
@@ -2053,6 +2085,33 @@
       {/if}
     </div>
 
+    <!-- 🎰 Cash Game: tier select (buy-in run) -->
+    {#if showTierSelect}
+      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a tier">
+        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showTierSelect = false}></button>
+        <div class="modal-content main-menu-modal tier-modal">
+          <button class="close-btn" on:click={() => showTierSelect = false}>❌</button>
+          <h2>🎰 Cash Game</h2>
+          <p class="cat-sub">Stake a buy-in, grow the run, cash out — or bust. Higher tiers = bigger stakes, thinner margins, bigger jackpots.</p>
+          <div class="tier-grid">
+            {#each (cgMeta?.tiers ?? []) as t}
+              <button class="tier-tile" class:locked={!t.unlocked} disabled={cgBusy || !t.unlocked || (cgMeta?.bank ?? 0) < t.buy_in}
+                on:click={() => pickTier(t.tier)}>
+                <span class="tt-label">{t.label}</span>
+                <span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
+                <span class="tt-meta">k {Number(t.k).toFixed(2)} · heat ×{(t.heat_cap/100).toFixed(1)}</span>
+                {#if !t.unlocked}<span class="tt-lock">🔒 {t.tier === 'silver' ? '3 Bronze wins' : t.tier === 'gold' ? '3 Silver wins' : 'locked'}</span>
+                {:else if (cgMeta?.bank ?? 0) < t.buy_in}<span class="tt-lock">Need ${t.buy_in.toLocaleString()}</span>{/if}
+              </button>
+            {/each}
+          </div>
+          {#if (cgMeta?.best_run ?? 0) > 0}
+            <p class="tier-stats">Best run <b>${(cgMeta.best_run).toLocaleString()}</b> · best multiple <b>{((cgMeta.best_multiple_x100 ?? 0)/100).toFixed(1)}×</b> · run streak <b>{cgMeta.run_streak ?? 0}</b></p>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
     <!-- Challenges: wager vs friends -->
     {#if showChallenges}
       <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Challenge Friends">
@@ -2343,13 +2402,19 @@
     <!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
          Solve-to-Earn box; power-ups live in the vault beside Solve. -->
     {#if isClimb && climb}
-      {#if climb.stuck && $gameStore.gameState !== 'won'}
+      {#if climb.stuck && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
         <div class="climb-stuck">
-          <span class="cs-text">Out of Cash</span>
-          <div class="cs-actions">
-            <button class="cs-leave" on:click={goToMainMenu}>Leave &amp; earn</button>
-          </div>
+          <span class="cs-text">🎯 Final guess — solve it or bust the run</span>
         </div>
+      {/if}
+      <!-- 🏦 Cash Out — bank the run bankroll anytime (the press-your-luck valve). -->
+      {#if (climb.state === 'active' || climb.state === 'stuck') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+        {@const bankroll = Math.round(climb.bankroll ?? 0)}
+        {@const profit = bankroll - Math.round(climb.buy_in ?? 0)}
+        <button class="cashout-btn" class:up={profit > 0} disabled={cgBusy || bankroll <= 0} on:click={cashOut}>
+          🏦 Cash Out <b>${bankroll.toLocaleString()}</b>
+          {#if profit !== 0}<span class="co-profit" class:neg={profit < 0}>{profit > 0 ? '+' : '−'}${Math.abs(profit).toLocaleString()}</span>{/if}
+        </button>
       {/if}
     {/if}
 
@@ -2536,27 +2601,45 @@
               <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
               <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
             </div>
+          {:else if isClimb && cashoutResult}
+            <!-- 🏦 Cash Game: cashed out — banked the run bankroll -->
+            {@const co = cashoutResult}
+            <h2 class="win-h">🏦 Cashed Out!</h2>
+            <p class="result-sub">{(co.tier ?? '').charAt(0).toUpperCase() + (co.tier ?? '').slice(1)} run · {co.solves ?? 0} solve{co.solves === 1 ? '' : 's'}</p>
+            <div class="win-math">
+              <div class="wm-row"><span>Banked</span><b>${(co.banked ?? 0).toLocaleString()}</b></div>
+              <div class="wm-row"><span>− Buy-in</span><b class="neg">−${(co.buy_in ?? 0).toLocaleString()}</b></div>
+              <div class="wm-row total"><span>Profit</span><b class="profit">{(co.profit ?? 0) >= 0 ? '+' : '−'}${Math.abs(co.profit ?? 0).toLocaleString()}</b></div>
+            </div>
+            <p class="win-twist">{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× your buy-in · 🔥 peak ×{((co.heat ?? 100) / 100).toFixed(1)} — banked to your Cash</p>
+            <div class="result-actions">
+              <button class="share-btn" on:click={() => { cashoutResult = null; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Done</button>
+              <button class="next-puzzle-button" on:click={() => { cashoutResult = null; showResultModal = false; hasTriggeredModal = false; handleMenuClimb(); }}>New Run</button>
+            </div>
           {:else if isClimb && resultWon}
-            <!-- 🎰 Cash Game win banner (mirrors Daily): bounty × heat − spent = profit -->
+            <!-- 🎰 Solved a puzzle → the payout grew your RUN bankroll (not Cash yet) -->
             {@const payout = climb?.last_gain ?? 0}
-            {@const cspent = climb?.spent ?? 0}
-            {@const earnedMult = (climb?.bounty ?? 0) > 0 ? (payout / climb.bounty) : ((climb?.heat ?? 100) / 100)}
-            {@const heatMult = donArmedThisPuzzle ? earnedMult / 2 : earnedMult}
-            <h2 class="win-h">{donArmedThisPuzzle ? '💥 Doubled!' : '🎉 Solved!'}</h2>
+            {@const bankroll = Math.round(climb?.bankroll ?? 0)}
+            <h2 class="win-h">🎉 Solved!</h2>
             <p class="result-sub">{$gameStore.currentPhrase}</p>
             <div class="win-math">
-              <div class="wm-row"><span>Bounty <small>(🔥 ×{heatMult.toFixed(1)} heat{#if donArmedThisPuzzle} · 💥 ×2{/if})</small></span><b>${payout.toLocaleString()}</b></div>
-              <div class="wm-row"><span>− Spent on letters</span><b class="neg">−${cspent.toLocaleString()}</b></div>
-              <div class="wm-row total"><span>Profit</span><b class="profit">{$resultProfit >= 0 ? '+' : '−'}${Math.abs(Math.round($resultProfit)).toLocaleString()}</b></div>
+              <div class="wm-row"><span>Payout <small>(🔥 ×{climbHeat} heat)</small></span><b class="profit">+${payout.toLocaleString()}</b></div>
+              <div class="wm-row total"><span>🎰 Run bankroll</span><b>${bankroll.toLocaleString()}</b></div>
             </div>
-            <p class="win-twist">🔥 Heat now ×{climbHeat}{#if climbStreak > 0} · 🏆 {climbStreak} win streak{/if}{#if (climb?.heat ?? 100) >= 200} · maxed{/if}</p>
-            <div class="win-bank">
-              <span class="wb-label">💰 Your Cash</span>
-              <span class="wb-amount">${Math.round($resultBankAnim).toLocaleString()}</span>
+            <p class="win-twist">🔥 Heat now ×{climbHeat}{#if (climb?.run_solves ?? 0) > 1} · {climb.run_solves}-solve run{/if} — bank it or push on?</p>
+            <div class="result-actions">
+              <button class="share-btn co-inline" disabled={cgBusy} on:click={() => { showResultModal = false; hasTriggeredModal = false; cashOut(); }}>🏦 Cash Out ${bankroll.toLocaleString()}</button>
+              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance().then(() => tick().then(playDailyIntroIfArmed)); }}>Next →</button>
             </div>
+          {:else if isClimb}
+            <!-- 💥 Busted — lost the buy-in -->
+            <div class="result-medal">💥</div>
+            <h2>Busted</h2>
+            <p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
+            <p class="arcade-gain">You lost your ${(climb?.buy_in ?? 0).toLocaleString()} buy-in. The Daily always refills your Cash — come back for another run.</p>
             <div class="result-actions">
               <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Leave</button>
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance().then(() => tick().then(playDailyIntroIfArmed)); }}>Next →</button>
+              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; handleMenuClimb(); }}>New Run</button>
             </div>
           {:else if isMatch}
             <!-- Challenge match: finished the whole pack -->
@@ -2714,6 +2797,37 @@
   .cs-text { font-size: 0.82rem; color: #fca5a5; }
   .cs-actions { display: flex; gap: 8px; justify-content: center; }
   .cs-leave { padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 10px; cursor: pointer; font-weight: 700; color: var(--text-muted); background: transparent; }
+  /* 🏦 Cash Out button (during a run) */
+  .cashout-btn {
+    display: flex; align-items: center; justify-content: center; gap: 8px; width: 100%; max-width: 360px;
+    margin: 0 auto 12px; padding: 0.7rem 1rem; border-radius: 14px; cursor: pointer;
+    border: 1px solid rgba(110,231,183,0.5); background: linear-gradient(135deg, rgba(110,231,183,0.14), rgba(52,211,153,0.05));
+    color: #6ee7b7; font-family: var(--font-display); font-weight: 800; font-size: 1rem;
+  }
+  .cashout-btn.up { border-color: rgba(110,231,183,0.8); box-shadow: 0 0 16px rgba(52,211,153,0.25); }
+  .cashout-btn:disabled { opacity: 0.45; cursor: default; }
+  .cashout-btn b { color: #d1fae5; }
+  .co-profit { font-size: 0.85rem; color: #34d399; font-weight: 700; }
+  .co-profit.neg { color: #fb7185; }
+  .co-inline { background: linear-gradient(135deg, #6ee7b7, #34d399) !important; color: #06281d !important; }
+  /* 🎰 Cash Game tier select */
+  .tier-modal { max-width: 460px; }
+  .tier-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 4px 0 12px; }
+  .tier-tile {
+    display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 14px 10px; border-radius: 16px;
+    background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer;
+    transition: transform 0.15s, border-color 0.2s;
+  }
+  .tier-tile:hover:not(:disabled) { transform: translateY(-2px); border-color: var(--brand-2); }
+  .tier-tile:disabled { opacity: 0.5; cursor: default; }
+  .tier-tile.locked { border-style: dashed; }
+  .tt-label { font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; }
+  .tt-buyin { font-family: 'Orbitron', var(--font-display); font-weight: 800; color: var(--brand-2); font-size: 1.1rem; }
+  .tt-buyin small { font-family: var(--font-ui); font-weight: 500; font-size: 0.62rem; color: var(--text-faint); }
+  .tt-meta { font-size: 0.66rem; color: var(--text-faint); }
+  .tt-lock { font-size: 0.66rem; color: #fca5a5; margin-top: 2px; }
+  .tier-stats { text-align: center; font-size: 0.78rem; color: var(--text-muted); margin: 0; }
+  .tier-stats b { color: var(--brand-2); }
   .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
   .arcade-earn {
     font-family: var(--font-display); font-weight: 700; font-size: 0.95rem;

--- a/supabase-cashgame-v2.sql
+++ b/supabase-cashgame-v2.sql
@@ -1,0 +1,388 @@
+-- V2 Phase 3: Cash Game V2 — the Tiered-Run redesign.
+--
+-- Turns the endless global-Cash climb into a contained, tiered BUY-IN RUN:
+--   pick a tier → stake a buy-in → grow a run bankroll by solving efficiently →
+--   CASH OUT anytime to bank it, or BUST and lose the buy-in.
+--   • climb_state.bankroll = the run bankroll (from the buy-in); tier + buy_in stored.
+--   • Buying letters + wrong-guess penalties drain the bankroll (never global Cash).
+--   • Bounty = round_$10(k_tier × Σ distinct-letter-costs); k drops with tier (0.90→0.55).
+--   • Solve → bankroll += bounty × heat; heat +0.1, capped at the tier ceiling (×2.0→×3.0).
+--   • Wrong guess → bankroll −= GREATEST($10, round(0.2×bounty/10)×10); stuck (bankroll <
+--     cheapest buyable) → one final guess; wrong there → BUST (run ends, buy-in lost).
+--   • cashgame_cashout: bank the bankroll to Cash (loan auto-skim applies), record stats + mastery.
+--   • Skip → new puzzle, heat resets ×1.0, forfeit spend. Double-or-Nothing retired.
+--   • Tiers unlock via mastery (3 profitable cash-outs at the tier below). Loans fund buy-ins.
+-- Spec: Notion "Cash Game V2". PITR point logged before apply.
+
+BEGIN;
+
+-- Close the 11 legacy V1 runs (played on global Cash; no buy-in to migrate).
+DELETE FROM public.climb_state;
+
+-- Run-model + stats columns.
+ALTER TABLE public.climb_state ADD COLUMN IF NOT EXISTS bankroll bigint;
+ALTER TABLE public.climb_state ADD COLUMN IF NOT EXISTS tier text;
+ALTER TABLE public.climb_state ADD COLUMN IF NOT EXISTS buy_in bigint;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_wins jsonb DEFAULT '{}'::jsonb;      -- {tier: profitable_cashouts} → mastery
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_run_streak int DEFAULT 0;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_best_run_streak int DEFAULT 0;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_best_run bigint DEFAULT 0;           -- biggest cash-out
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_best_multiple_x100 int DEFAULT 0;    -- best cash-out ÷ buy-in
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_best_heat_x100 int DEFAULT 100;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS cg_lifetime_net bigint DEFAULT 0;       -- winnings − buy-ins
+
+-- Tier config: buy-in, k (bounty factor), heat ceiling (×100).
+CREATE OR REPLACE FUNCTION public._cg_tier(p_tier text)
+ RETURNS jsonb LANGUAGE sql IMMUTABLE
+AS $function$
+  SELECT CASE lower(p_tier)
+    WHEN 'micro'  THEN jsonb_build_object('buy_in', 100,   'k', 0.90, 'heat_cap', 200, 'label', '🪙 Micro',  'order', 1)
+    WHEN 'bronze' THEN jsonb_build_object('buy_in', 500,   'k', 0.85, 'heat_cap', 250, 'label', '🥉 Bronze', 'order', 2)
+    WHEN 'silver' THEN jsonb_build_object('buy_in', 2000,  'k', 0.70, 'heat_cap', 275, 'label', '🥈 Silver', 'order', 3)
+    WHEN 'gold'   THEN jsonb_build_object('buy_in', 10000, 'k', 0.55, 'heat_cap', 300, 'label', '🥇 Gold',   'order', 4)
+    ELSE NULL END;
+$function$;
+
+-- Mastery gate: Micro/Bronze default; Silver after 3 profitable Bronze cash-outs; Gold after 3 Silver.
+CREATE OR REPLACE FUNCTION public._cg_unlocked(p_uid uuid, p_tier text)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+AS $function$
+  SELECT CASE lower(p_tier)
+    WHEN 'micro'  THEN true
+    WHEN 'bronze' THEN true
+    WHEN 'silver' THEN COALESCE((SELECT (cg_wins->>'bronze')::int FROM public.profiles WHERE id = p_uid), 0) >= 3
+    WHEN 'gold'   THEN COALESCE((SELECT (cg_wins->>'silver')::int FROM public.profiles WHERE id = p_uid), 0) >= 3
+    ELSE false END;
+$function$;
+
+-- Bounty at a given k (per-tier). k < 1 → buying everything loses.
+DROP FUNCTION IF EXISTS public._climb_bounty(uuid);
+CREATE OR REPLACE FUNCTION public._climb_bounty(p_pid uuid, p_k numeric)
+ RETURNS integer LANGUAGE sql STABLE SECURITY DEFINER
+AS $function$
+  SELECT (round(p_k * COALESCE(SUM(public.letter_cost(t.ch)), 0) / 10.0) * 10)::int
+  FROM (
+    SELECT DISTINCT substr(upper(dp.phrase), g.i + 1, 1) AS ch
+    FROM public.daily_puzzles dp, generate_series(0, length(dp.phrase) - 1) g(i)
+    WHERE dp.id = p_pid AND substr(upper(dp.phrase), g.i + 1, 1) ~ '[A-Z]'
+  ) t;
+$function$;
+
+-- Cheapest still-buyable (unrevealed) letter for the current run puzzle (half_off aware).
+CREATE OR REPLACE FUNCTION public._climb_cheapest(cs public.climb_state, p_phrase text)
+ RETURNS integer LANGUAGE sql STABLE
+AS $function$
+  SELECT MIN(CASE WHEN 'half_off' = ANY(cs.active_powerups) THEN CEIL(public.letter_cost(t.ch) * 0.5)::int ELSE public.letter_cost(t.ch) END)
+  FROM (
+    SELECT DISTINCT substr(p_phrase, g.i + 1, 1) AS ch
+    FROM generate_series(0, length(p_phrase) - 1) g(i)
+    WHERE substr(p_phrase, g.i + 1, 1) ~ '[A-Z]' AND NOT (g.i = ANY(cs.revealed_positions))
+  ) t;
+$function$;
+
+-- Board: bankroll = the RUN bankroll; carries tier / buy-in / heat ceiling / stuck.
+CREATE OR REPLACE FUNCTION public._climb_board(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_state TEXT; v_board JSONB; v_tier JSONB; v_k NUMERIC;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_state := CASE cs.state WHEN 'solved' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  v_board := public._daily_board(v_phrase, v_state, cs.bankroll::int, 99, cs.revealed_positions, cs.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('climb', jsonb_build_object(
+    'bankroll', cs.bankroll, 'bounty', public._climb_bounty(cs.puzzle_id, v_k), 'heat', cs.heat_x100,
+    'heat_cap', (v_tier->>'heat_cap')::int, 'tier', cs.tier, 'buy_in', cs.buy_in, 'tier_label', v_tier->>'label',
+    'spent', cs.spent, 'position', cs.position, 'stuck', cs.state = 'stuck', 'last_gain', cs.last_gain,
+    'state', cs.state, 'pups_locked', cs.pups_locked, 'equipped', to_jsonb(cs.active_powerups),
+    'run_solves', cs.run_solves, 'run_profit', cs.bankroll - cs.buy_in));
+END; $function$;
+
+-- Start a run at a tier: validate unlock + affordability, debit buy-in, seed the bankroll.
+CREATE OR REPLACE FUNCTION public.cashgame_start(p_tier text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_tier JSONB; v_buy BIGINT; v_bank BIGINT; v_pid UUID; v_t text := lower(COALESCE(p_tier,''));
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_start: not authenticated'; END IF;
+  v_tier := public._cg_tier(v_t);
+  IF v_tier IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'bad_tier'); END IF;
+  IF NOT public._cg_unlocked(v_uid, v_t) THEN RETURN jsonb_build_object('ok', false, 'reason', 'locked'); END IF;
+  IF EXISTS (SELECT 1 FROM public.climb_state WHERE user_id = v_uid AND state IN ('active','stuck')) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'run_active'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_buy := (v_tier->>'buy_in')::bigint;
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = v_uid;
+  IF v_bank < v_buy THEN RETURN jsonb_build_object('ok', false, 'reason', 'insufficient', 'buy_in', v_buy, 'bank', v_bank); END IF;
+  v_pid := public._pick_casual(v_uid, null, null, 0);
+  IF v_pid IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_puzzles'); END IF;
+  PERFORM public._bank_credit(v_uid, -v_buy, 'cashgame_buyin');       -- stake leaves Cash → the run
+  DELETE FROM public.climb_state WHERE user_id = v_uid;              -- clear any finished remnant
+  INSERT INTO public.climb_state(user_id, position, puzzle_id, bankroll, tier, buy_in, heat_x100, state)
+    VALUES (v_uid, 1, v_pid, v_buy, v_t, v_buy, 100, 'active');
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid) || jsonb_build_object('ok', true);
+END; $function$;
+
+-- Deprecated no-arg entry: return the live run if any, else signal the client to pick a tier.
+CREATE OR REPLACE FUNCTION public.climb_start()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_board JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_start: not authenticated'; END IF;
+  v_board := public._climb_board(v_uid);
+  IF v_board IS NULL THEN RETURN jsonb_build_object('needs_tier', true); END IF;
+  RETURN v_board;
+END; $function$;
+
+-- Buy a letter: spend from the RUN bankroll (never global Cash).
+CREATE OR REPLACE FUNCTION public.climb_buy_letter(p_letter text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_buy_letter: no run'; END IF;
+  IF cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  IF 'half_off' = ANY(cs.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  IF v_letter = ANY(cs.incorrect_letters) OR cs.bankroll < v_cost THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cs.revealed_positions THEN RETURN public._climb_board(v_uid); END IF;
+  cs.bankroll := cs.bankroll - v_cost;
+  IF v_positions IS NULL THEN cs.incorrect_letters := array_append(cs.incorrect_letters, v_letter);
+  ELSE cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.climb_state SET bankroll = cs.bankroll, revealed_positions = cs.revealed_positions,
+    incorrect_letters = cs.incorrect_letters, spent = cs.spent + v_cost, pups_locked = true, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- Submit a guess: wrong drains the bankroll; stuck + wrong → BUST.
+CREATE OR REPLACE FUNCTION public.climb_submit_guess(p_guess jsonb)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}';
+  v_all BOOLEAN := true; pos INT; v_ch TEXT; v_tier JSONB; v_k NUMERIC; v_bounty INT; v_cheapest INT; v_pen INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_submit_guess: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_submit_guess: no run'; END IF;
+  IF cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._climb_board(v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_correct) ORDER BY 1);
+    UPDATE public.climb_state SET revealed_positions = cs.revealed_positions, updated_at = now() WHERE user_id = v_uid;
+    RETURN public._climb_resolve(v_uid);
+  END IF;
+  -- Wrong guess.
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_cheapest := public._climb_cheapest(cs, v_phrase);
+  IF v_cheapest IS NOT NULL AND cs.bankroll < v_cheapest THEN
+    RETURN public._cg_bust(v_uid);                                   -- stuck + wrong → bust
+  END IF;
+  v_bounty := public._climb_bounty(cs.puzzle_id, v_k);
+  v_pen := GREATEST(10, (round(0.2 * v_bounty / 10.0) * 10)::int);
+  cs.bankroll := GREATEST(0, cs.bankroll - v_pen);
+  UPDATE public.climb_state SET bankroll = cs.bankroll, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- Resolve after a move: solve grows the bankroll (bounty × heat); else mark stuck if broke.
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_tier JSONB; v_k NUMERIC; v_cap INT; v_bounty INT; v_payout INT; v_cheapest INT; v_cat TEXT; v_time INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(p_uid); END IF;
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85); v_cap := COALESCE((v_tier->>'heat_cap')::int, 250);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    v_bounty := public._climb_bounty(cs.puzzle_id, v_k);
+    v_payout := round(v_bounty * cs.heat_x100 / 100.0)::int;
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_payout,
+      bankroll = cs.bankroll + v_payout,
+      heat_x100 = LEAST(v_cap, cs.heat_x100 + 10),
+      run_solves = cs.run_solves + 1, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_payout, v_time);
+  ELSE
+    v_cheapest := public._climb_cheapest(cs, v_phrase);
+    IF v_cheapest IS NULL OR cs.bankroll < v_cheapest THEN
+      UPDATE public.climb_state SET state = 'stuck', updated_at = now() WHERE user_id = p_uid;   -- final guess
+    ELSE
+      UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;
+    END IF;
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- Advance to the next puzzle in the SAME run (heat + bankroll carry).
+CREATE OR REPLACE FUNCTION public.climb_next()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_next: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state <> 'solved' THEN RETURN public._climb_board(v_uid); END IF;
+  v_pid := public._pick_casual(v_uid, null, cs.puzzle_id, 0);
+  IF v_pid IS NULL THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.climb_state SET position = cs.position + 1, puzzle_id = v_pid, revealed_positions = '{}',
+    incorrect_letters = '{}', spent = 0, last_gain = 0, active_powerups = '{}',
+    pups_locked = false, state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- Skip: new puzzle, heat resets ×1.0, forfeit spend (bankroll already reduced). Run continues.
+CREATE OR REPLACE FUNCTION public.climb_skip()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_skip: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  v_pid := public._pick_casual(v_uid, null, cs.puzzle_id, 0);
+  IF v_pid IS NULL THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.climb_state SET puzzle_id = v_pid, revealed_positions = '{}', incorrect_letters = '{}',
+    spent = 0, last_gain = 0, active_powerups = '{}', pups_locked = false,
+    heat_x100 = 100, state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- Cash out: bank the run bankroll to global Cash (loan auto-skim applies), record stats + mastery, end the run.
+CREATE OR REPLACE FUNCTION public.cashgame_cashout()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_profit BIGINT; v_mult INT; v_wins jsonb; v_streak INT; v_bestrs INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_cashout: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','stuck','solved') THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_run'); END IF;
+  v_profit := cs.bankroll - cs.buy_in;
+  v_mult := CASE WHEN cs.buy_in > 0 THEN round(cs.bankroll * 100.0 / cs.buy_in)::int ELSE 0 END;
+  IF cs.bankroll > 0 THEN PERFORM public._bank_credit(v_uid, cs.bankroll, 'cashgame_cashout'); END IF;
+  -- stats + mastery (a profitable cash-out counts toward tier mastery + run streak)
+  SELECT COALESCE(cg_wins,'{}'::jsonb), COALESCE(cg_run_streak,0), COALESCE(cg_best_run_streak,0)
+    INTO v_wins, v_streak, v_bestrs FROM public.profiles WHERE id = v_uid;
+  IF v_profit > 0 THEN
+    v_wins := jsonb_set(v_wins, ARRAY[cs.tier], to_jsonb(COALESCE((v_wins->>cs.tier)::int,0) + 1), true);
+    v_streak := v_streak + 1;
+  ELSE
+    v_streak := 0;
+  END IF;
+  UPDATE public.profiles SET
+    cg_wins = v_wins,
+    cg_run_streak = v_streak,
+    cg_best_run_streak = GREATEST(v_bestrs, v_streak),
+    cg_best_run = GREATEST(COALESCE(cg_best_run,0), cs.bankroll),
+    cg_best_multiple_x100 = GREATEST(COALESCE(cg_best_multiple_x100,0), v_mult),
+    cg_best_heat_x100 = GREATEST(COALESCE(cg_best_heat_x100,100), cs.heat_x100),
+    cg_lifetime_net = COALESCE(cg_lifetime_net,0) + v_profit
+    WHERE id = v_uid;
+  DELETE FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object('ok', true, 'banked', cs.bankroll, 'buy_in', cs.buy_in, 'profit', v_profit,
+    'multiple_x100', v_mult, 'solves', cs.run_solves, 'tier', cs.tier, 'heat', cs.heat_x100);
+END; $function$;
+
+-- Bust: run ends, bankroll lost, buy-in gone. Run streak resets.
+CREATE OR REPLACE FUNCTION public._cg_bust(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase text; v_all int[]; v_cat text; v_board jsonb;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid FOR UPDATE;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i) INTO v_all FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) <> ' ';
+  UPDATE public.profiles SET cg_run_streak = 0, cg_lifetime_net = COALESCE(cg_lifetime_net,0) - cs.buy_in WHERE id = p_uid;
+  PERFORM public._log_game_result(p_uid,'climb','lost', cs.puzzle_id, v_cat, 0, 1, cs.spent::int, 0);
+  v_board := public._daily_board(v_phrase, 'lost', 0, 99, COALESCE(v_all,'{}'), cs.incorrect_letters, v_cat, '')
+    || jsonb_build_object('climb', jsonb_build_object('bankroll', 0, 'state', 'busted', 'tier', cs.tier,
+         'buy_in', cs.buy_in, 'run_solves', cs.run_solves, 'busted', true, 'position', cs.position));
+  DELETE FROM public.climb_state WHERE user_id = p_uid;
+  RETURN v_board;
+END; $function$;
+
+-- Leave = pause (the run persists; resume via get_open_games). No reset, no forfeit.
+CREATE OR REPLACE FUNCTION public.climb_leave()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- Double-or-Nothing retired in V2 (cash-out + run structure IS the press-your-luck valve).
+CREATE OR REPLACE FUNCTION public.climb_double_or_nothing()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+BEGIN RETURN public._climb_board(auth.uid()); END; $function$;
+
+-- Cash Game meta for the tier-select screen: which tiers are unlocked + stats.
+CREATE OR REPLACE FUNCTION public.get_cashgame_meta()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); p public.profiles; v_tiers jsonb := '[]'::jsonb; t text; cfg jsonb;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  FOREACH t IN ARRAY ARRAY['micro','bronze','silver','gold'] LOOP
+    cfg := public._cg_tier(t);
+    v_tiers := v_tiers || jsonb_build_array(cfg || jsonb_build_object('tier', t,
+      'unlocked', public._cg_unlocked(v_uid, t),
+      'wins', COALESCE((p.cg_wins->>t)::int, 0)));
+  END LOOP;
+  RETURN jsonb_build_object('bank', COALESCE(p.bank,0), 'loan', COALESCE(p.loan,0), 'tiers', v_tiers,
+    'run_streak', COALESCE(p.cg_run_streak,0), 'best_run_streak', COALESCE(p.cg_best_run_streak,0),
+    'best_run', COALESCE(p.cg_best_run,0), 'best_multiple_x100', COALESCE(p.cg_best_multiple_x100,0),
+    'best_heat_x100', COALESCE(p.cg_best_heat_x100,100), 'lifetime_net', COALESCE(p.cg_lifetime_net,0));
+END; $function$;
+
+-- Best-run leaderboard: rank by best CASH-OUT (what you banked), cross-tier; + best multiple.
+CREATE OR REPLACE FUNCTION public.get_climb_run_leaderboard(p_scope text DEFAULT 'friends'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  WITH pool AS (
+    SELECT pr.id, pr.cg_best_run, pr.cg_best_multiple_x100, pr.cg_run_streak
+    FROM public.profiles pr
+    WHERE pr.cg_best_run > 0 AND (
+         p_scope = 'global' OR pr.id = v_uid
+      OR (p_scope = 'friends' AND pr.id IN (SELECT friend_id FROM public.friendships WHERE user_id = v_uid))
+      OR (p_scope = 'group'   AND pr.id IN (SELECT user_id FROM public.group_members WHERE group_id = p_group)))
+  ),
+  ranked AS (SELECT *, row_number() OVER (ORDER BY cg_best_run DESC, cg_best_multiple_x100 DESC) AS rank
+             FROM pool ORDER BY cg_best_run DESC LIMIT 50)
+  SELECT jsonb_agg(jsonb_build_object('rank', rank, 'name', public._display_name(id),
+    'best_run', cg_best_run, 'best_multiple_x100', cg_best_multiple_x100, 'run_streak', cg_run_streak,
+    'is_me', id = v_uid) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
The biggest risk mode. Pick a tier → stake a buy-in → grow a run bankroll by solving efficiently (per-tier k, heat compounding) → cash out to bank it, or bust (lose the buy-in). Loans fund buy-ins; mastery unlocks higher tiers. DB applied to prod (PITR) + full rollback sim green; tier-select + Cash Out + result-modal frontend; E2E 19/19 + Playwright CG smoke (0 console errors). Spec: Notion 'Cash Game V2'. 🤖 Generated with [Claude Code](https://claude.com/claude-code)