### PR TITLE
V2 Phase 5: Blitz — the Speed-Run mode

### DIFF
--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -30,6 +30,8 @@
     N:'⠝',O:'⠕',P:'⠏',Q:'⠟',R:'⠗',S:'⠎',T:'⠞',U:'⠥',V:'⠧',W:'⠺',X:'⠭',Y:'⠽',Z:'⠵'
   };
 
+  // Blitz spends TIME, not Cash — every reveal is a flat −3s.
+  $: isBlitzKb = $gameStore.gameMode === 'blitz';
   // Effective per-letter prices after active discount / vowel_vision (server matches this):
   // daily uses the shared modifier.
   $: effCosts = (() => {
@@ -58,8 +60,10 @@
   $: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
 
   // 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
+  //    Blitz pays in TIME, not Cash, so letters are never gated by bankroll there.
   $: disabledKeys = Object.keys(letterCosts).filter((letter: string) =>
-        (effCosts[letter] ?? 0) > $gameStore.bankroll || incorrectLetters.includes(letter));
+        isBlitzKb ? incorrectLetters.includes(letter)
+                  : ((effCosts[letter] ?? 0) > $gameStore.bankroll || incorrectLetters.includes(letter)));
 
   /**
    * 🔹 Letter click logic for both guess mode and purchase mode.
@@ -173,7 +177,7 @@
       >
         <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
-        <div class="price">${effCosts[letter] ?? 0}</div>
+        <div class="price" class:time={isBlitzKb}>{isBlitzKb ? "−3s" : "$" + (effCosts[letter] ?? 0)}</div>
       </button>
     {/each}
   </div>
@@ -198,7 +202,7 @@
       >
         <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
-        <div class="price">${effCosts[letter] ?? 0}</div>
+        <div class="price" class:time={isBlitzKb}>{isBlitzKb ? "−3s" : "$" + (effCosts[letter] ?? 0)}</div>
       </button>
     {/each}
   </div>
@@ -223,7 +227,7 @@
       >
         <span class="braille">{BRAILLE[letter]}</span>
         <div class="letter">{letter}</div>
-        <div class="price">${effCosts[letter] ?? 0}</div>
+        <div class="price" class:time={isBlitzKb}>{isBlitzKb ? "−3s" : "$" + (effCosts[letter] ?? 0)}</div>
       </button>
     {/each}
 
@@ -357,6 +361,7 @@
     color: rgba(251, 191, 36, 0.55);
     font-variant-numeric: tabular-nums;
   }
+  .price.time { color: rgba(253, 224, 71, 0.75); font-weight: 700; }
 
   /* ---------------------------
      Key State Styles

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -8,6 +8,7 @@ import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter
 import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
 import { climbStart, cashgameStart, cashgameCashout, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, climbDoubleOrNothing, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
 import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchFold as matchFoldRpc, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
+import { blitzStart, blitzBuyLetter, blitzSubmitGuess, blitzSkip, blitzEnd } from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -46,6 +47,7 @@ import { track } from '$lib/analytics.js';
  *   makeupDate?: string | null,
  *   dailyResult?: any,
  *   climbInfo?: any,
+ *   blitzInfo?: any,
  *   matchInfo?: any,
  *   cashToast?: { amount:number, label:string } | null,
  *   dailyLive?: { remaining:number, mult:number, winnings:number } | null
@@ -91,6 +93,7 @@ export const gameStore = writable(/** @type {GameState} */ ({
   challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
   makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
   climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
+  blitzInfo: null, // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state } (blitz mode)
   matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
   cashToast: null, // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
   dailyLive: null, // { remaining, mult, winnings } — live Daily V2 HUD (Prize left → what you'd bank)
@@ -579,6 +582,89 @@ export async function climbPowerup(id) {
   }
 }
 
+/* ===== Blitz (timed speed run) ===== */
+/** @param {any} resp */
+function reconcileBlitzBoard(resp) {
+  if (!resp) return;
+  const prev = get(gameStore);
+  const blitz = resp.blitz || {};
+  const ended = blitz.state === 'ended';
+  if (ended) {
+    gameStore.update(s => ({ ...s, gameMode: 'blitz', gameState: 'lost', blitzInfo: blitz }));
+    fx('bust');
+    return;
+  }
+  gameStore.set(/** @type {GameState} */ ({
+    ...prev, ...boardToState(resp, prev),
+    gameMode: 'blitz',
+    gameState: 'default',
+    modifier: null,
+    blitzInfo: blitz
+  }));
+  playMoveCue(prev, resp);
+}
+
+/** Buy in at a tier and start a timed run. @param {string} tier @returns {Promise<any>} */
+export async function startBlitz(tier) {
+  try {
+    track('blitz_start', { tier });
+    const resp = await blitzStart(tier);
+    if (!resp?.ok) return resp || { ok: false };
+    reconcileBlitzBoard(resp);
+    return resp;
+  } catch (err) {
+    console.error('❌ Error starting Blitz:', err instanceof Error ? err.message : String(err));
+    return { ok: false };
+  }
+}
+
+/** @param {GameState} state */
+async function confirmPurchaseBlitz(state) {
+  const purchase = state.selectedPurchase;
+  if (!purchase || dailyInFlight) return;
+  dailyInFlight = true;
+  try {
+    let resp = null;
+    if (purchase.type === 'letter') resp = await blitzBuyLetter(purchase.value ?? '');
+    if (resp) reconcileBlitzBoard(resp);
+    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+  } finally { dailyInFlight = false; }
+}
+
+/** @param {GameState} state */
+async function submitGuessBlitz(state) {
+  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+  /** @type {Record<string, string>} */
+  const guess = {};
+  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
+  if (Object.keys(guess).length === 0) return;
+  dailyInFlight = true;
+  try {
+    const resp = await blitzSubmitGuess(guess);
+    if (resp) reconcileBlitzBoard(resp);
+  } finally { dailyInFlight = false; }
+}
+
+/** Skip the current Blitz puzzle (combo resets, −3s). */
+export async function blitzSkipPuzzle() {
+  if (dailyInFlight) return;
+  dailyInFlight = true;
+  try { const resp = await blitzSkip(); if (resp) reconcileBlitzBoard(resp); }
+  finally { dailyInFlight = false; }
+}
+
+/** End the run when the clock hits 0 → bank winnings, show the result. */
+export async function endBlitz() {
+  try {
+    const resp = await blitzEnd();
+    reconcileBlitzBoard(resp);
+    return resp?.blitz ?? null;
+  } catch (err) {
+    console.error('❌ Error ending Blitz:', err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
 /* ===== Challenge Builder match play (pack of puzzles vs friends/group) ===== */
 /** @type {string|null} */
 let activeMatchId = null;
@@ -854,6 +940,7 @@ export function confirmPurchase() {
   else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
   else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
   else if (current.gameMode === 'climb') confirmPurchaseClimb(current);
+  else if (current.gameMode === 'blitz') confirmPurchaseBlitz(current);
   else if (current.gameMode === 'match') confirmPurchaseMatch(current);
 }
 /* ================================
@@ -956,6 +1043,7 @@ export function submitGuess() {
   else if (current.gameMode === 'challenge') submitGuessChallenge(current);
   else if (current.gameMode === 'makeup') submitGuessMakeup(current);
   else if (current.gameMode === 'climb') submitGuessClimb(current);
+  else if (current.gameMode === 'blitz') submitGuessBlitz(current);
   else if (current.gameMode === 'match') submitGuessMatch(current);
 }
 /* ================================

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -473,6 +473,44 @@ export async function getCashgameMeta() {
   if (error) { console.error('❌ get_cashgame_meta:', error); return null; }
   return data;
 }
+
+/* ===== Blitz (timed speed run) ===== */
+/** @param {string} tier @returns {Promise<any>} */
+export async function blitzStart(tier) {
+  const { data, error } = await supabase.rpc('blitz_start', { p_tier: tier });
+  if (error || !data) { if (error) console.error('❌ blitz_start:', error); return { ok: false }; }
+  return data;
+}
+/** @param {string} letter @returns {Promise<any>} */
+export async function blitzBuyLetter(letter) {
+  const { data, error } = await supabase.rpc('blitz_buy_letter', { p_letter: letter });
+  if (error) { console.error('❌ blitz_buy_letter:', error); return null; }
+  return data;
+}
+/** @param {Record<string,string>} guess @returns {Promise<any>} */
+export async function blitzSubmitGuess(guess) {
+  const { data, error } = await supabase.rpc('blitz_submit_guess', { p_guess: guess });
+  if (error) { console.error('❌ blitz_submit_guess:', error); return null; }
+  return data;
+}
+/** @returns {Promise<any>} */
+export async function blitzSkip() {
+  const { data, error } = await supabase.rpc('blitz_skip');
+  if (error) { console.error('❌ blitz_skip:', error); return null; }
+  return data;
+}
+/** End the run (clock hit 0). @returns {Promise<any>} */
+export async function blitzEnd() {
+  const { data, error } = await supabase.rpc('blitz_end');
+  if (error || !data) { if (error) console.error('❌ blitz_end:', error); return { blitz: { state: 'ended' } }; }
+  return data;
+}
+/** Tier-select meta + Blitz stats. @returns {Promise<any>} */
+export async function getBlitzMeta() {
+  const { data, error } = await supabase.rpc('get_blitz_meta');
+  if (error) { console.error('❌ get_blitz_meta:', error); return null; }
+  return data;
+}
 /** @param {string} letter @returns {Promise<any>} */
 export async function climbBuyLetter(letter) {
   const { data, error } = await supabase.rpc('climb_buy_letter', { p_letter: letter });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,11 +6,11 @@
   import { tweened } from 'svelte/motion';
   import { cubicOut } from 'svelte/easing';
 
-  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, startCashGame, cashOutClimb, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
+  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, startCashGame, cashOutClimb, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startBlitz, endBlitz, blitzSkipPuzzle, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
   import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, getMatchDebuffs, getMatchOpponents, declineMatch } from '$lib/stores/statsStore.js';
   import { CATEGORIES } from '$lib/categories.js';
   import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getDailyModifier, deleteMyAccount, getMyAvatar, getCashgameMeta } from '$lib/stores/statsStore.js';
+  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getDailyModifier, deleteMyAccount, getMyAvatar, getCashgameMeta, getBlitzMeta } from '$lib/stores/statsStore.js';
   import Avatar from '$lib/components/Avatar.svelte';
   import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
   import { track } from '$lib/analytics.js';
@@ -236,8 +236,8 @@
       fetchMakeupGame().then((ok) => { if (!ok) showMainMenu = true; });
     } else if (gameMode === 'climb') {
       fetchClimbGame().then((ok) => { if (!ok) showMainMenu = true; });
-    } else if (gameMode === 'match') {
-      // Matches aren't deep-link restorable (need the active id) — return to the menu.
+    } else if (gameMode === 'match' || gameMode === 'blitz') {
+      // Matches (need the active id) + Blitz (a live timed run) aren't deep-link restorable.
       localStorage.setItem('gameMode', 'daily');
       showMainMenu = true;
     } else {
@@ -333,10 +333,34 @@
   }
   $: isClimb = $gameStore.gameMode === 'climb';
   $: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
+  // ⚡ Blitz — the live client clock counts down to blitzInfo.remaining_ms (server-authoritative);
+  // each action resyncs it. At 0 we call endBlitz() once.
+  $: isBlitz = $gameStore.gameMode === 'blitz';
+  $: blitz = $gameStore.blitzInfo; // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state }
+  let blitzClockMs = 0;
+  /** @type {ReturnType<typeof setInterval>|undefined} */
+  let blitzTimer;
+  let blitzEnding = false;
+  // Resync the local clock whenever the server sends a fresh remaining_ms.
+  $: if (isBlitz && blitz && blitz.state !== 'ended' && blitz.remaining_ms != null) {
+    blitzClockMs = blitz.remaining_ms;
+  }
+  $: if (isBlitz && blitz && blitz.state !== 'ended') {
+    if (!blitzTimer) {
+      blitzEnding = false;
+      blitzTimer = setInterval(() => {
+        blitzClockMs = Math.max(0, blitzClockMs - 100);
+        if (blitzClockMs <= 0 && !blitzEnding) { blitzEnding = true; clearInterval(blitzTimer); blitzTimer = undefined; endBlitz(); }
+      }, 100);
+    }
+  } else if (blitzTimer) { clearInterval(blitzTimer); blitzTimer = undefined; }
+  onDestroy(() => { if (blitzTimer) clearInterval(blitzTimer); });
+  $: blitzSec = Math.ceil(blitzClockMs / 1000);
   // 🏷️ Which mode you're in — a consistent pill under the wordmark on every game screen.
   $: modeLabel = ({
     daily:     { emoji: '📅', name: 'Daily' },
     climb:     { emoji: '🎰', name: 'Cash Game' },
+    blitz:     { emoji: '⚡', name: 'Blitz' },
     makeup:    { emoji: '📅', name: 'Make-up' },
     match:     { emoji: '⚔️', name: 'Challenge' },
     challenge: { emoji: '⚔️', name: 'Challenge' }
@@ -1166,6 +1190,36 @@
     const res = await cashOutClimb();
     cgBusy = false;
     if (res?.ok) { cashoutResult = res; showResultModal = true; refreshBank(); }
+  }
+
+  // ===== ⚡ Blitz — tier select + timed run =====
+  let showBlitzTier = false;
+  /** @type {any} */
+  let bzMeta = null;
+  let bzBusy = false;
+  /** @type {any} */
+  let blitzResult = null; // { solved, winnings, buy_in, net, best_combo, tier }
+  async function handleMenuBlitz() {
+    if (!get(user)?.id) return;
+    localStorage.setItem('gameMode', 'blitz');
+    bzMeta = await getBlitzMeta();
+    showBlitzTier = true;
+  }
+  /** @param {string} tier */
+  async function pickBlitzTier(tier) {
+    if (bzBusy) return;
+    bzBusy = true;
+    const res = await startBlitz(tier);
+    bzBusy = false;
+    if (res?.ok) {
+      hasInitialized = true; showMainMenu = false; showBlitzTier = false; blitzResult = null;
+    } else if (res?.reason === 'insufficient') {
+      if (confirm(`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`)) { showBlitzTier = false; goto('/bank'); }
+    }
+  }
+  // When the run ends (clock → 0), surface the result modal.
+  $: if (isBlitz && blitz && blitz.state === 'ended' && !blitzResult) {
+    blitzResult = blitz; showResultModal = true; refreshBank();
   }
 
   // ===== Challenge Builder (configurable packs vs friends/groups) =====
@@ -2021,10 +2075,9 @@
             <span class="mc-title">Cash Game</span>
             {#if climbInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
           </button>
-          <button class="menu-card" style="--i: 2" on:click={() => { blitzSoon = true; fx('tap'); setTimeout(() => blitzSoon = false, 2500); }}>
-            <span class="mc-title">Blitz</span><span class="mc-stat">Soon</span>
+          <button class="menu-card" style="--i: 2" on:click={handleMenuBlitz}>
+            <span class="mc-title">⚡ Blitz</span><span class="mc-stat">Beat the clock</span>
           </button>
-          {#if blitzSoon}<p class="pm-soon-note">⚡ Solo Blitz is coming soon!</p>{/if}
         </div>
 
       {:else if menuView === 'community'}
@@ -2112,6 +2165,32 @@
           </div>
           {#if (cgMeta?.best_run ?? 0) > 0}
             <p class="tier-stats">Best run <b>${(cgMeta.best_run).toLocaleString()}</b> · best multiple <b>{((cgMeta.best_multiple_x100 ?? 0)/100).toFixed(1)}×</b> · run streak <b>{cgMeta.run_streak ?? 0}</b></p>
+          {/if}
+        </div>
+      </div>
+    {/if}
+
+    <!-- ⚡ Blitz: tier select (timed run) -->
+    {#if showBlitzTier}
+      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a Blitz tier">
+        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showBlitzTier = false}></button>
+        <div class="modal-content main-menu-modal tier-modal">
+          <button class="close-btn" on:click={() => showBlitzTier = false}>❌</button>
+          <h2>⚡ Blitz</h2>
+          <p class="cat-sub">Beat the clock. 45s to start — reveal costs 3s, a wrong guess costs 5s, each solve adds 8s + a combo-boosted payout. Bank whatever you win.</p>
+          <div class="tier-grid tier-grid-3">
+            {#each (bzMeta?.tiers ?? []) as t}
+              <button class="tier-tile" disabled={bzBusy || !t.affordable}
+                on:click={() => pickBlitzTier(t.tier)}>
+                <span class="tt-label">{t.label}</span>
+                <span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
+                <span class="tt-meta">~${t.base}/solve × combo</span>
+                {#if !t.affordable}<span class="tt-lock">Need ${t.buy_in.toLocaleString()}</span>{/if}
+              </button>
+            {/each}
+          </div>
+          {#if (bzMeta?.best_run ?? 0) > 0}
+            <p class="tier-stats">Best run <b>{bzMeta.best_run}</b> solved · best combo <b>×{((bzMeta.best_combo_x100 ?? 100)/100).toFixed(2)}</b> · biggest payout <b>${(bzMeta.best_payout ?? 0).toLocaleString()}</b></p>
           {/if}
         </div>
       </div>
@@ -2364,7 +2443,18 @@
 
     <!-- 💰 Bankroll — top of every mode. Challenge ante now lives in the bounty hero below. -->
     {#if $gameStore.currentPhrase && $gameStore.gameMode}
-      {#if !matchBlitz}
+      {#if isBlitz && blitz && blitz.state !== 'ended'}
+        <!-- ⚡ Blitz HUD: big countdown clock + combo + live winnings -->
+        <div class="blitz-hud">
+          <div class="bz-clock" class:danger={blitzSec <= 10}>⏱️ {blitzSec}<span class="bz-clock-s">s</span></div>
+          <div class="bz-row">
+            <span class="bz-stat"><b class="bz-combo">×{((blitz.combo ?? 100)/100).toFixed(2)}</b><small>combo</small></span>
+            <span class="bz-stat"><b class="bz-win">${Math.round(blitz.winnings ?? 0).toLocaleString()}</b><small>winnings</small></span>
+            <span class="bz-stat"><b>{blitz.solved ?? 0}</b><small>solved</small></span>
+          </div>
+          <button class="bz-skip" on:click={() => { fx('tap'); blitzSkipPuzzle(); }}>Skip (−3s, combo resets)</button>
+        </div>
+      {:else if !matchBlitz}
         {@const isDailyLike = $gameStore.gameMode === 'daily' || isMakeup}
         <button class="top-bank solo" class:pop-up={bankFlash === 'up'} class:pop-down={bankFlash === 'down'} title={isDailyLike ? 'Prize remaining — spend it, keep the rest' : 'Your Cash'} on:click={openBankModal}>
           {#if isMatch}<span class="tb-wallet-cap">💰 Wallet</span>{:else if isDailyLike}<span class="tb-wallet-cap">🏆 Prize</span>{/if}
@@ -2647,6 +2737,21 @@
               <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Leave</button>
               <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; handleMenuClimb(); }}>New Run</button>
             </div>
+          {:else if isBlitz && blitzResult}
+            <!-- ⚡ Blitz: time's up -->
+            {@const br = blitzResult}
+            <h2 class="win-h">⚡ Time!</h2>
+            <p class="result-sub">{br.solved ?? 0} solved · best combo ×{((br.best_combo ?? 100)/100).toFixed(2)}</p>
+            <div class="win-math">
+              <div class="wm-row"><span>Winnings</span><b>${(br.winnings ?? 0).toLocaleString()}</b></div>
+              <div class="wm-row"><span>− Buy-in</span><b class="neg">−${(br.buy_in ?? 0).toLocaleString()}</b></div>
+              <div class="wm-row total"><span>Net</span><b class="profit">{(br.net ?? 0) >= 0 ? '+' : '−'}${Math.abs(br.net ?? 0).toLocaleString()}</b></div>
+            </div>
+            <p class="win-twist">{(br.net ?? 0) >= 0 ? '🔥 You beat the clock — banked to your Cash.' : 'Whiffed the bet — the Daily always refills your Cash.'}</p>
+            <div class="result-actions">
+              <button class="share-btn" on:click={() => { blitzResult = null; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Done</button>
+              <button class="next-puzzle-button" on:click={() => { blitzResult = null; showResultModal = false; hasTriggeredModal = false; handleMenuBlitz(); }}>New Run</button>
+            </div>
           {:else if isMatch}
             <!-- Challenge match: finished the whole pack -->
             <div class="result-medal">⚔️</div>
@@ -2834,6 +2939,20 @@
   .tt-lock { font-size: 0.66rem; color: #fca5a5; margin-top: 2px; }
   .tier-stats { text-align: center; font-size: 0.78rem; color: var(--text-muted); margin: 0; }
   .tier-stats b { color: var(--brand-2); }
+  .tier-grid-3 { grid-template-columns: repeat(3, 1fr); }
+  /* ⚡ Blitz HUD */
+  .blitz-hud { display: flex; flex-direction: column; align-items: center; gap: 6px; width: 100%; max-width: 360px; margin: 0 auto 12px; }
+  .bz-clock { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.6rem; line-height: 1; color: #fde047; font-variant-numeric: tabular-nums; }
+  .bz-clock-s { font-size: 1.1rem; color: var(--text-faint); margin-left: 2px; }
+  .bz-clock.danger { color: #fb7185; animation: pressurePulse 1s ease-in-out infinite; }
+  .bz-row { display: flex; gap: 10px; }
+  .bz-stat { display: flex; flex-direction: column; align-items: center; gap: 0; padding: 5px 14px; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); }
+  .bz-stat b { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--text); }
+  .bz-stat small { font-size: 0.58rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-faint); }
+  .bz-combo { color: #fbbf24 !important; }
+  .bz-win { color: #6ee7b7 !important; }
+  .bz-skip { padding: 0.4rem 0.9rem; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--text-muted); font-weight: 700; font-size: 0.74rem; cursor: pointer; }
+  .bz-skip:hover { border-color: #fb7185; color: #fca5a5; }
   .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
   .arcade-earn {
     font-family: var(--font-display); font-weight: 700; font-size: 0.95rem;

--- a/supabase-blitz-v2.sql
+++ b/supabase-blitz-v2.sql
@@ -1,0 +1,273 @@
+-- V2 Phase 5: Blitz — the Speed-Run mode (new mode).
+--
+-- The time-twin of Cash Game: buy in, then race a live clock. Revealing letters costs
+-- SECONDS (not Cash), solving adds seconds + a base_tier×combo Cash payout, and a combo
+-- snowballs. Clock hits 0 → bank the winnings; net = winnings − buy-in.
+--
+-- Anti-cheat clock: the clock is server-authoritative via `ends_at` (an absolute timestamp).
+-- Remaining = ends_at − now() on the SERVER; every action shifts ends_at by its ±seconds.
+-- The client can't fake time — it only renders a countdown to ends_at. Once now() ≥ ends_at
+-- the run auto-settles on the next action / board fetch.
+-- Spec: Notion "Blitz". PITR point logged before apply.
+
+BEGIN;
+
+-- Run state (one active run per user).
+CREATE TABLE IF NOT EXISTS public.blitz_runs (
+  user_id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  tier text NOT NULL,
+  buy_in bigint NOT NULL,
+  ends_at timestamptz NOT NULL,
+  combo_x100 int NOT NULL DEFAULT 100,
+  solved int NOT NULL DEFAULT 0,
+  winnings bigint NOT NULL DEFAULT 0,
+  puzzle_id uuid,
+  revealed_positions int[] NOT NULL DEFAULT '{}',
+  incorrect_letters text[] NOT NULL DEFAULT '{}',
+  state text NOT NULL DEFAULT 'active',
+  started_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.blitz_runs ENABLE ROW LEVEL SECURITY;
+
+-- Blitz stats.
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bz_best_run int DEFAULT 0;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bz_best_combo_x100 int DEFAULT 100;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bz_best_payout bigint DEFAULT 0;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bz_lifetime_net bigint DEFAULT 0;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bz_runs int DEFAULT 0;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS bz_highest_tier text;
+
+-- Clock + combo constants (seconds).
+--   START 45 · reveal −3 · wrong −5 · solve +8 · skip −3 · combo +0.25 cap ×5.
+
+-- Tier config: buy-in + base reward per solve (× combo). No difficulty change; only money scales.
+CREATE OR REPLACE FUNCTION public._blitz_tier(p_tier text)
+ RETURNS jsonb LANGUAGE sql IMMUTABLE
+AS $function$
+  SELECT CASE lower(p_tier)
+    WHEN 'bronze' THEN jsonb_build_object('buy_in', 500,   'base', 40,  'label', '🥉 Bronze', 'order', 1)
+    WHEN 'silver' THEN jsonb_build_object('buy_in', 2000,  'base', 160, 'label', '🥈 Silver', 'order', 2)
+    WHEN 'gold'   THEN jsonb_build_object('buy_in', 10000, 'base', 800, 'label', '🥇 Gold',   'order', 3)
+    ELSE NULL END;
+$function$;
+
+-- Board: phrase display + the live Blitz HUD (remaining_ms, combo, winnings…).
+CREATE OR REPLACE FUNCTION public._blitz_board(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE r public.blitz_runs; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_tier JSONB; v_rem int; v_board JSONB;
+BEGIN
+  SELECT * INTO r FROM public.blitz_runs WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_tier := public._blitz_tier(r.tier);
+  v_rem := GREATEST(0, (EXTRACT(epoch FROM (r.ends_at - now())) * 1000)::int);
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  v_board := public._daily_board(v_phrase, 'active', 0, 99, r.revealed_positions, r.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('blitz', jsonb_build_object(
+    'remaining_ms', v_rem, 'combo', r.combo_x100, 'solved', r.solved, 'winnings', r.winnings,
+    'tier', r.tier, 'buy_in', r.buy_in, 'base', (v_tier->>'base')::int, 'tier_label', v_tier->>'label',
+    'state', 'active'));
+END; $function$;
+
+-- Settle: bank winnings, record stats, end the run. Returns the result payload.
+CREATE OR REPLACE FUNCTION public._blitz_settle(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE r public.blitz_runs; v_net bigint; v_tier_order int; v_cur_order int;
+BEGIN
+  SELECT * INTO r FROM public.blitz_runs WHERE user_id = p_uid FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('blitz', jsonb_build_object('state','ended','ok',false)); END IF;
+  v_net := r.winnings - r.buy_in;
+  IF r.winnings > 0 THEN PERFORM public._bank_credit(p_uid, r.winnings, 'blitz_payout'); END IF;
+  -- highest tier reached (order the tiers)
+  v_tier_order := COALESCE((public._blitz_tier(r.tier)->>'order')::int, 0);
+  v_cur_order  := COALESCE((public._blitz_tier((SELECT bz_highest_tier FROM public.profiles WHERE id = p_uid))->>'order')::int, 0);
+  UPDATE public.profiles SET
+    bz_best_run = GREATEST(COALESCE(bz_best_run,0), r.solved),
+    bz_best_combo_x100 = GREATEST(COALESCE(bz_best_combo_x100,100), r.combo_x100),
+    bz_best_payout = GREATEST(COALESCE(bz_best_payout,0), r.winnings),
+    bz_lifetime_net = COALESCE(bz_lifetime_net,0) + v_net,
+    bz_runs = COALESCE(bz_runs,0) + 1,
+    bz_highest_tier = CASE WHEN v_tier_order > v_cur_order THEN r.tier ELSE bz_highest_tier END
+    WHERE id = p_uid;
+  DELETE FROM public.blitz_runs WHERE user_id = p_uid;
+  RETURN jsonb_build_object('blitz', jsonb_build_object('state','ended','ok',true,
+    'solved', r.solved, 'winnings', r.winnings, 'buy_in', r.buy_in, 'net', v_net,
+    'best_combo', r.combo_x100, 'tier', r.tier));
+END; $function$;
+
+-- Start a run: debit buy-in, seed the 45s clock.
+CREATE OR REPLACE FUNCTION public.blitz_start(p_tier text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_tier JSONB; v_buy BIGINT; v_bank BIGINT; v_pid UUID; v_t text := lower(COALESCE(p_tier,''));
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'blitz_start: not authenticated'; END IF;
+  v_tier := public._blitz_tier(v_t);
+  IF v_tier IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'bad_tier'); END IF;
+  IF EXISTS (SELECT 1 FROM public.blitz_runs WHERE user_id = v_uid) THEN RETURN jsonb_build_object('ok', false, 'reason', 'run_active'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_buy := (v_tier->>'buy_in')::bigint;
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = v_uid;
+  IF v_bank < v_buy THEN RETURN jsonb_build_object('ok', false, 'reason', 'insufficient', 'buy_in', v_buy, 'bank', v_bank); END IF;
+  v_pid := public._pick_casual(v_uid, null, null, 0);
+  IF v_pid IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_puzzles'); END IF;
+  PERFORM public._bank_credit(v_uid, -v_buy, 'blitz_buyin');
+  INSERT INTO public.blitz_runs(user_id, tier, buy_in, ends_at, puzzle_id)
+    VALUES (v_uid, v_t, v_buy, now() + interval '45 seconds', v_pid);
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._blitz_board(v_uid) || jsonb_build_object('ok', true);
+END; $function$;
+
+-- Resolve after a move: a solved phrase pays base×combo, ticks combo, adds 8s, next puzzle.
+CREATE OR REPLACE FUNCTION public._blitz_resolve(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE r public.blitz_runs; v_phrase TEXT; v_won BOOLEAN; v_base INT; v_payout INT; v_pid UUID;
+BEGIN
+  SELECT * INTO r FROM public.blitz_runs WHERE user_id = p_uid FOR UPDATE;
+  IF NOT FOUND THEN RETURN public._blitz_settle(p_uid); END IF;
+  IF now() >= r.ends_at THEN RETURN public._blitz_settle(p_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions)));
+  IF NOT v_won THEN RETURN public._blitz_board(p_uid); END IF;
+  v_base := (public._blitz_tier(r.tier)->>'base')::int;
+  v_payout := (round(v_base * r.combo_x100 / 100.0 / 10.0) * 10)::int;   -- $10-clean
+  v_pid := public._pick_casual(p_uid, null, r.puzzle_id, 0);
+  UPDATE public.blitz_runs SET
+    winnings = r.winnings + v_payout,
+    combo_x100 = LEAST(500, r.combo_x100 + 25),
+    solved = r.solved + 1,
+    ends_at = r.ends_at + interval '8 seconds',
+    puzzle_id = COALESCE(v_pid, r.puzzle_id),
+    revealed_positions = '{}', incorrect_letters = '{}'
+    WHERE user_id = p_uid;
+  IF v_pid IS NOT NULL THEN PERFORM public._mark_seen(p_uid, v_pid); END IF;
+  RETURN public._blitz_board(p_uid);
+END; $function$;
+
+-- Reveal a letter → −3s.
+CREATE OR REPLACE FUNCTION public.blitz_buy_letter(p_letter text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); r public.blitz_runs; v_phrase TEXT; v_letter TEXT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'blitz_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter);
+  IF public.letter_cost(v_letter) IS NULL THEN RAISE EXCEPTION 'blitz_buy_letter: invalid letter'; END IF;
+  SELECT * INTO r FROM public.blitz_runs WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'blitz_buy_letter: no run'; END IF;
+  IF now() >= r.ends_at THEN RETURN public._blitz_settle(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  IF v_letter = ANY(r.incorrect_letters) THEN RETURN public._blitz_board(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ r.revealed_positions THEN RETURN public._blitz_board(v_uid); END IF;
+  IF v_positions IS NULL THEN r.incorrect_letters := array_append(r.incorrect_letters, v_letter);
+  ELSE r.revealed_positions := ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.blitz_runs SET revealed_positions = r.revealed_positions, incorrect_letters = r.incorrect_letters,
+    ends_at = r.ends_at - interval '3 seconds' WHERE user_id = v_uid;
+  RETURN public._blitz_resolve(v_uid);
+END; $function$;
+
+-- Submit a guess → wrong costs 5s; correct solves.
+CREATE OR REPLACE FUNCTION public.blitz_submit_guess(p_guess jsonb)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); r public.blitz_runs; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}'; v_all BOOLEAN := true; pos INT; v_ch TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'blitz_submit_guess: not authenticated'; END IF;
+  SELECT * INTO r FROM public.blitz_runs WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'blitz_submit_guess: no run'; END IF;
+  IF now() >= r.ends_at THEN RETURN public._blitz_settle(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = r.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(r.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._blitz_board(v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    UPDATE public.blitz_runs SET revealed_positions = ARRAY(SELECT DISTINCT unnest(r.revealed_positions || v_correct) ORDER BY 1) WHERE user_id = v_uid;
+    RETURN public._blitz_resolve(v_uid);
+  ELSE
+    UPDATE public.blitz_runs SET ends_at = r.ends_at - interval '5 seconds' WHERE user_id = v_uid;
+    IF now() >= (r.ends_at - interval '5 seconds') THEN RETURN public._blitz_settle(v_uid); END IF;
+    RETURN public._blitz_board(v_uid);
+  END IF;
+END; $function$;
+
+-- Skip → new puzzle, combo resets ×1.0, −3s.
+CREATE OR REPLACE FUNCTION public.blitz_skip()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); r public.blitz_runs; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'blitz_skip: not authenticated'; END IF;
+  SELECT * INTO r FROM public.blitz_runs WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'blitz_skip: no run'; END IF;
+  IF now() >= r.ends_at THEN RETURN public._blitz_settle(v_uid); END IF;
+  v_pid := public._pick_casual(v_uid, null, r.puzzle_id, 0);
+  IF v_pid IS NULL THEN RETURN public._blitz_board(v_uid); END IF;
+  UPDATE public.blitz_runs SET puzzle_id = v_pid, revealed_positions = '{}', incorrect_letters = '{}',
+    combo_x100 = 100, ends_at = r.ends_at - interval '3 seconds' WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._blitz_board(v_uid);
+END; $function$;
+
+-- Client calls this when its countdown reaches 0 (server re-validates via ends_at).
+CREATE OR REPLACE FUNCTION public.blitz_end()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid();
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'blitz_end: not authenticated'; END IF;
+  RETURN public._blitz_settle(v_uid);
+END; $function$;
+
+-- Tier-select meta (affordability + stats).
+CREATE OR REPLACE FUNCTION public.get_blitz_meta()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); p public.profiles; v_tiers jsonb := '[]'::jsonb; t text; cfg jsonb;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  FOREACH t IN ARRAY ARRAY['bronze','silver','gold'] LOOP
+    cfg := public._blitz_tier(t);
+    v_tiers := v_tiers || jsonb_build_array(cfg || jsonb_build_object('tier', t, 'affordable', COALESCE(p.bank,0) >= (cfg->>'buy_in')::bigint));
+  END LOOP;
+  RETURN jsonb_build_object('bank', COALESCE(p.bank,0), 'loan', COALESCE(p.loan,0), 'tiers', v_tiers,
+    'best_run', COALESCE(p.bz_best_run,0), 'best_combo_x100', COALESCE(p.bz_best_combo_x100,100),
+    'best_payout', COALESCE(p.bz_best_payout,0), 'lifetime_net', COALESCE(p.bz_lifetime_net,0),
+    'runs', COALESCE(p.bz_runs,0), 'highest_tier', p.bz_highest_tier);
+END; $function$;
+
+-- Leaderboard: most solved in a run (best_run), then best combo.
+CREATE OR REPLACE FUNCTION public.get_blitz_leaderboard(p_scope text DEFAULT 'friends'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  WITH pool AS (
+    SELECT pr.id, pr.bz_best_run, pr.bz_best_combo_x100, pr.bz_best_payout
+    FROM public.profiles pr
+    WHERE pr.bz_best_run > 0 AND (
+         p_scope = 'global' OR pr.id = v_uid
+      OR (p_scope = 'friends' AND pr.id IN (SELECT friend_id FROM public.friendships WHERE user_id = v_uid))
+      OR (p_scope = 'group'   AND pr.id IN (SELECT user_id FROM public.group_members WHERE group_id = p_group)))
+  ),
+  ranked AS (SELECT *, row_number() OVER (ORDER BY bz_best_run DESC, bz_best_combo_x100 DESC) AS rank
+             FROM pool ORDER BY bz_best_run DESC LIMIT 50)
+  SELECT jsonb_agg(jsonb_build_object('rank', rank, 'name', public._display_name(id),
+    'best_run', bz_best_run, 'best_combo_x100', bz_best_combo_x100, 'best_payout', bz_best_payout,
+    'is_me', id = v_uid) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
The timed speed mode. Buy in → race a 45s clock (reveal −3s, wrong −5s, solve +8s + base×combo payout, combo ×1→×5) → clock hits 0 → bank winnings. **Server-authoritative clock (absolute ends_at timestamp) for anti-cheat.** New blitz_runs table + full RPC set; tier select + live countdown HUD + result modal. DB applied to prod (PITR) + full sim (incl. clock-expiry auto-settle); E2E 19/19 + Blitz smoke (0 console errors). Spec: Notion 'Blitz'. 🤖 Generated with [Claude Code](https://claude.com/claude-code)