### PR TITLE
chore: build-gated CI + app.d.ts typing (clean replacement for #353/#354)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build (gate) + lint/type-check (informational)
+    runs-on: ubuntu-latest
+    env:
+      # Build-time placeholders so vite build doesn't need real secrets in CI.
+      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || 'placeholder-anon-key' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Lint + type-check are INFORMATIONAL for now: the repo has ~100 files that
+      # predate `prettier --check` and a ~35-error svelte-check baseline (mixed
+      # Svelte 4/5 + JSDoc). They report status without failing the run; tighten to
+      # a hard gate once those are cleaned up.
+      - name: Lint (informational)
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Type-check (informational)
+        run: npm run check
+        continue-on-error: true
+
+      # Build is the hard gate — a broken build fails CI.
+      - name: Build
+        run: npm run build

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,10 +1,21 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
+// for information about these interfaces.
+import type { SupabaseClient, Session } from '@supabase/supabase-js';
+
 declare global {
 	namespace App {
-		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
+		interface Error {
+			message: string;
+		}
+		// Forward-looking: WordBank currently uses Supabase client-side (no hooks.server.ts).
+		// These are declared for when/if server-side auth via event.locals is added.
+		interface Locals {
+			supabase?: SupabaseClient;
+			session?: Session | null;
+		}
+		interface PageData {
+			session?: Session | null;
+		}
 		// interface PageState {}
 		// interface Platform {}
 	}


### PR DESCRIPTION
Clean replacements for the two closed agent PRs. **CI**: build is the hard gate; lint/type-check informational (continue-on-error) until the 102 prettier files + 35 svelte-check baseline are cleaned up — so it's green now instead of red-on-every-push. **app.d.ts**: App.Error + optional forward-looking Supabase Locals/PageData (no SSR auth wired today), no package-lock noise. Build ✓, check baseline unchanged (35). 🤖 Generated with [Claude Code](https://claude.com/claude-code)