### PR TITLE
chore: prettier format + 0 svelte-check errors + promote CI gates (fixes a live Daily HUD NaN)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build (gate) + lint/type-check (informational)
+    name: Format + type-check + build (gates); eslint (informational)
     runs-on: ubuntu-latest
     env:
       # Build-time placeholders so vite build doesn't need real secrets in CI.
@@ -21,24 +21,25 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
-          cache: "npm"
+          node-version: '22.x'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
-      # Lint + type-check are INFORMATIONAL for now: the repo has ~100 files that
-      # predate `prettier --check` and a ~35-error svelte-check baseline (mixed
-      # Svelte 4/5 + JSDoc). They report status without failing the run; tighten to
-      # a hard gate once those are cleaned up.
-      - name: Lint (informational)
-        run: npm run lint
-        continue-on-error: true
+      # HARD GATES — all clean as of the format/type-fix pass.
+      - name: Format check (prettier)
+        run: npx prettier --check .
 
-      - name: Type-check (informational)
+      - name: Type-check (svelte-check)
         run: npm run check
+
+      # INFORMATIONAL — eslint still flags ~183 unused-CSS selectors (risky to strip
+      # blindly — Svelte can't see dynamically-applied classes) + some unused vars.
+      # Reports without blocking; promote to a gate once the dead CSS is cleaned up.
+      - name: Lint (eslint, informational)
+        run: npx eslint .
         continue-on-error: true
 
-      # Build is the hard gate — a broken build fails CI.
       - name: Build
         run: npm run build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "CodeGPT.apiKey": "CodeGPT Plus Beta"
+	"CodeGPT.apiKey": "CodeGPT Plus Beta"
 }

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,13 +1,13 @@
 {
-  "appId": "com.wordbank.app",
-  "appName": "WordBank",
-  "webDir": "www",
-  "appendUserAgent": "WordBankApp",
-  "server": {
-    "url": "https://wordbanksvelte.vercel.app",
-    "cleartext": false
-  },
-  "ios": {
-    "contentInset": "always"
-  }
+	"appId": "com.wordbank.app",
+	"appName": "WordBank",
+	"webDir": "www",
+	"appendUserAgent": "WordBankApp",
+	"server": {
+		"url": "https://wordbanksvelte.vercel.app",
+		"cleartext": false
+	},
+	"ios": {
+		"contentInset": "always"
+	}
 }

--- a/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,14 +1,14 @@
 {
-  "images": [
-    {
-      "idiom": "universal",
-      "size": "1024x1024",
-      "filename": "AppIcon-512@2x.png",
-      "platform": "ios"
-    }
-  ],
-  "info": {
-    "author": "xcode",
-    "version": 1
-  }
+	"images": [
+		{
+			"idiom": "universal",
+			"size": "1024x1024",
+			"filename": "AppIcon-512@2x.png",
+			"platform": "ios"
+		}
+	],
+	"info": {
+		"author": "xcode",
+		"version": 1
+	}
 }

--- a/ios/App/App/Assets.xcassets/Contents.json
+++ b/ios/App/App/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
-  }
+	"info": {
+		"version": 1,
+		"author": "xcode"
+	}
 }

--- a/ios/App/App/Assets.xcassets/Splash.imageset/Contents.json
+++ b/ios/App/App/Assets.xcassets/Splash.imageset/Contents.json
@@ -1,56 +1,56 @@
 {
-  "images": [
-    {
-      "idiom": "universal",
-      "filename": "Default@1x~universal~anyany.png",
-      "scale": "1x"
-    },
-    {
-      "idiom": "universal",
-      "filename": "Default@2x~universal~anyany.png",
-      "scale": "2x"
-    },
-    {
-      "idiom": "universal",
-      "filename": "Default@3x~universal~anyany.png",
-      "scale": "3x"
-    },
-    {
-      "appearances": [
-        {
-          "appearance": "luminosity",
-          "value": "dark"
-        }
-      ],
-      "idiom": "universal",
-      "scale": "1x",
-      "filename": "Default@1x~universal~anyany-dark.png"
-    },
-    {
-      "appearances": [
-        {
-          "appearance": "luminosity",
-          "value": "dark"
-        }
-      ],
-      "idiom": "universal",
-      "scale": "2x",
-      "filename": "Default@2x~universal~anyany-dark.png"
-    },
-    {
-      "appearances": [
-        {
-          "appearance": "luminosity",
-          "value": "dark"
-        }
-      ],
-      "idiom": "universal",
-      "scale": "3x",
-      "filename": "Default@3x~universal~anyany-dark.png"
-    }
-  ],
-  "info": {
-    "version": 1,
-    "author": "xcode"
-  }
+	"images": [
+		{
+			"idiom": "universal",
+			"filename": "Default@1x~universal~anyany.png",
+			"scale": "1x"
+		},
+		{
+			"idiom": "universal",
+			"filename": "Default@2x~universal~anyany.png",
+			"scale": "2x"
+		},
+		{
+			"idiom": "universal",
+			"filename": "Default@3x~universal~anyany.png",
+			"scale": "3x"
+		},
+		{
+			"appearances": [
+				{
+					"appearance": "luminosity",
+					"value": "dark"
+				}
+			],
+			"idiom": "universal",
+			"scale": "1x",
+			"filename": "Default@1x~universal~anyany-dark.png"
+		},
+		{
+			"appearances": [
+				{
+					"appearance": "luminosity",
+					"value": "dark"
+				}
+			],
+			"idiom": "universal",
+			"scale": "2x",
+			"filename": "Default@2x~universal~anyany-dark.png"
+		},
+		{
+			"appearances": [
+				{
+					"appearance": "luminosity",
+					"value": "dark"
+				}
+			],
+			"idiom": "universal",
+			"scale": "3x",
+			"filename": "Default@3x~universal~anyany-dark.png"
+		}
+	],
+	"info": {
+		"version": 1,
+		"author": "xcode"
+	}
 }

--- a/scripts/apple-secret.mjs
+++ b/scripts/apple-secret.mjs
@@ -19,19 +19,21 @@ import fs from 'node:fs';
 
 const { TEAM_ID, KEY_ID, CLIENT_ID, KEY_PATH } = process.env;
 if (!TEAM_ID || !KEY_ID || !CLIENT_ID || !KEY_PATH) {
-  console.error('Missing env. Need TEAM_ID, KEY_ID, CLIENT_ID, KEY_PATH. See the header of this file.');
-  process.exit(1);
+	console.error(
+		'Missing env. Need TEAM_ID, KEY_ID, CLIENT_ID, KEY_PATH. See the header of this file.'
+	);
+	process.exit(1);
 }
 
 const b64url = (buf) => Buffer.from(buf).toString('base64url');
 const now = Math.floor(Date.now() / 1000);
 const header = { alg: 'ES256', kid: KEY_ID };
 const payload = {
-  iss: TEAM_ID,
-  iat: now,
-  exp: now + 60 * 60 * 24 * 180, // ~6 months (Apple's max)
-  aud: 'https://appleid.apple.com',
-  sub: CLIENT_ID
+	iss: TEAM_ID,
+	iat: now,
+	exp: now + 60 * 60 * 24 * 180, // ~6 months (Apple's max)
+	aud: 'https://appleid.apple.com',
+	sub: CLIENT_ID
 };
 
 const signingInput = `${b64url(JSON.stringify(header))}.${b64url(JSON.stringify(payload))}`;
@@ -39,4 +41,6 @@ const key = crypto.createPrivateKey(fs.readFileSync(KEY_PATH));
 const sig = crypto.sign('sha256', Buffer.from(signingInput), { key, dsaEncoding: 'ieee-p1363' });
 
 console.log(`${signingInput}.${b64url(sig)}`);
-console.error('\n↑ Paste this into Supabase → Auth → Providers → Apple → "Secret Key (for OAuth)". Expires in ~6 months.');
+console.error(
+	'\n↑ Paste this into Supabase → Auth → Providers → Apple → "Secret Key (for OAuth)". Expires in ~6 months.'
+);

--- a/scripts/bg-options.mjs
+++ b/scripts/bg-options.mjs
@@ -2,20 +2,30 @@
 import { chromium } from 'playwright';
 
 const COIN = 'file:///Users/admin/wordbankmaster/static/logo-coin.png';
-const WM   = 'file:///Users/admin/wordbankmaster/static/wordmark-slogan.png';
+const WM = 'file:///Users/admin/wordbankmaster/static/wordmark-slogan.png';
 
 // Subtle SVG noise texture (data URI) for "textured" options
-const noise = (op) => `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='${op}'/%3E%3C/svg%3E")`;
+const noise = (op) =>
+	`url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='${op}'/%3E%3C/svg%3E")`;
 
 const variants = [
-  { name: '1 · Current Navy',     bg: `#0a0e14` },
-  { name: '2 · Onyx + Gold Glow', bg: `radial-gradient(120% 80% at 50% 0%, rgba(251,191,36,0.12), rgba(0,0,0,0) 55%), #0b0b0d` },
-  { name: '3 · Charcoal Gold',    bg: `radial-gradient(130% 90% at 50% 18%, #211a10, #0d0b08 70%)` },
-  { name: '4 · Espresso',         bg: `linear-gradient(180deg, #241a10, #100a06)` },
-  { name: '5 · Casino Felt',      bg: `radial-gradient(130% 90% at 50% 20%, #11402b, #06170f 72%)` },
-  { name: '6 · Burgundy Luxe',    bg: `radial-gradient(130% 90% at 50% 18%, #2a0f17, #0c0609 72%)` },
-  { name: '7 · Carbon Texture',   bg: `${noise(0.5)}, radial-gradient(130% 90% at 50% 12%, #181818, #090909 75%)` },
-  { name: '8 · Gold Spotlight',   bg: `radial-gradient(60% 38% at 50% 30%, rgba(251,191,36,0.22), rgba(0,0,0,0) 60%), #070707` },
+	{ name: '1 · Current Navy', bg: `#0a0e14` },
+	{
+		name: '2 · Onyx + Gold Glow',
+		bg: `radial-gradient(120% 80% at 50% 0%, rgba(251,191,36,0.12), rgba(0,0,0,0) 55%), #0b0b0d`
+	},
+	{ name: '3 · Charcoal Gold', bg: `radial-gradient(130% 90% at 50% 18%, #211a10, #0d0b08 70%)` },
+	{ name: '4 · Espresso', bg: `linear-gradient(180deg, #241a10, #100a06)` },
+	{ name: '5 · Casino Felt', bg: `radial-gradient(130% 90% at 50% 20%, #11402b, #06170f 72%)` },
+	{ name: '6 · Burgundy Luxe', bg: `radial-gradient(130% 90% at 50% 18%, #2a0f17, #0c0609 72%)` },
+	{
+		name: '7 · Carbon Texture',
+		bg: `${noise(0.5)}, radial-gradient(130% 90% at 50% 12%, #181818, #090909 75%)`
+	},
+	{
+		name: '8 · Gold Spotlight',
+		bg: `radial-gradient(60% 38% at 50% 30%, rgba(251,191,36,0.22), rgba(0,0,0,0) 60%), #070707`
+	}
 ];
 
 const page = (bg) => `<!doctype html><html><head><meta charset=utf8><style>
@@ -50,9 +60,9 @@ const b = await chromium.launch();
 const ctx = await b.newContext({ viewport: { width: 390, height: 844 }, deviceScaleFactor: 2 });
 const p = await ctx.newPage();
 for (let i = 0; i < variants.length; i++) {
-  await p.setContent(page(variants[i].bg), { waitUntil: 'networkidle' });
-  await p.waitForTimeout(250);
-  await p.screenshot({ path: `/tmp/bg-${i}.png` });
+	await p.setContent(page(variants[i].bg), { waitUntil: 'networkidle' });
+	await p.waitForTimeout(250);
+	await p.screenshot({ path: `/tmp/bg-${i}.png` });
 }
 await b.close();
-console.log('done', variants.map(v => v.name).join(' | '));
+console.log('done', variants.map((v) => v.name).join(' | '));

--- a/scripts/knockout.cjs
+++ b/scripts/knockout.cjs
@@ -9,54 +9,64 @@ const { PNG } = require('pngjs');
 const clamp = (v) => Math.max(0, Math.min(255, Math.round(v)));
 
 function decode(src) {
-  const buf = fs.readFileSync(src);
-  if (src.endsWith('.png')) {
-    const p = PNG.sync.read(buf);
-    return { width: p.width, height: p.height, data: p.data };
-  }
-  const j = jpeg.decode(buf, { maxMemoryUsageInMB: 512 });
-  return { width: j.width, height: j.height, data: j.data };
+	const buf = fs.readFileSync(src);
+	if (src.endsWith('.png')) {
+		const p = PNG.sync.read(buf);
+		return { width: p.width, height: p.height, data: p.data };
+	}
+	const j = jpeg.decode(buf, { maxMemoryUsageInMB: 512 });
+	return { width: j.width, height: j.height, data: j.data };
 }
 
 /**
  * @param {string} src @param {string} dst @param {'white'|'black'|'keep'} bg
  */
 function build(src, dst, bg) {
-  const { width, height, data } = decode(src);
-  const alpha = new Uint8Array(width * height);
-  let minX = width, minY = height, maxX = -1, maxY = -1;
-  for (let y = 0; y < height; y++) {
-    for (let x = 0; x < width; x++) {
-      const i = y * width + x;
-      const r = data[i * 4], g = data[i * 4 + 1], b = data[i * 4 + 2];
-      let a;
-      if (bg === 'white') a = clamp((255 - Math.min(r, g, b) - 20) * 16);
-      else if (bg === 'black') a = clamp((Math.max(r, g, b) - 12) * 3);
-      else a = data[i * 4 + 3]; // keep existing alpha
-      alpha[i] = a;
-      if (a > 24) {
-        if (x < minX) minX = x; if (x > maxX) maxX = x;
-        if (y < minY) minY = y; if (y > maxY) maxY = y;
-      }
-    }
-  }
-  const pad = Math.round(Math.max(width, height) * 0.02);
-  minX = Math.max(0, minX - pad); minY = Math.max(0, minY - pad);
-  maxX = Math.min(width - 1, maxX + pad); maxY = Math.min(height - 1, maxY + pad);
-  const w = maxX - minX + 1, h = maxY - minY + 1;
-  const out = new PNG({ width: w, height: h });
-  for (let y = 0; y < h; y++) {
-    for (let x = 0; x < w; x++) {
-      const si = ((y + minY) * width + (x + minX)) * 4;
-      const di = (y * w + x) * 4;
-      out.data[di] = data[si];
-      out.data[di + 1] = data[si + 1];
-      out.data[di + 2] = data[si + 2];
-      out.data[di + 3] = alpha[(y + minY) * width + (x + minX)];
-    }
-  }
-  fs.writeFileSync(dst, PNG.sync.write(out));
-  console.log(`wrote ${dst} (${w}x${h}, from ${width}x${height})`);
+	const { width, height, data } = decode(src);
+	const alpha = new Uint8Array(width * height);
+	let minX = width,
+		minY = height,
+		maxX = -1,
+		maxY = -1;
+	for (let y = 0; y < height; y++) {
+		for (let x = 0; x < width; x++) {
+			const i = y * width + x;
+			const r = data[i * 4],
+				g = data[i * 4 + 1],
+				b = data[i * 4 + 2];
+			let a;
+			if (bg === 'white') a = clamp((255 - Math.min(r, g, b) - 20) * 16);
+			else if (bg === 'black') a = clamp((Math.max(r, g, b) - 12) * 3);
+			else a = data[i * 4 + 3]; // keep existing alpha
+			alpha[i] = a;
+			if (a > 24) {
+				if (x < minX) minX = x;
+				if (x > maxX) maxX = x;
+				if (y < minY) minY = y;
+				if (y > maxY) maxY = y;
+			}
+		}
+	}
+	const pad = Math.round(Math.max(width, height) * 0.02);
+	minX = Math.max(0, minX - pad);
+	minY = Math.max(0, minY - pad);
+	maxX = Math.min(width - 1, maxX + pad);
+	maxY = Math.min(height - 1, maxY + pad);
+	const w = maxX - minX + 1,
+		h = maxY - minY + 1;
+	const out = new PNG({ width: w, height: h });
+	for (let y = 0; y < h; y++) {
+		for (let x = 0; x < w; x++) {
+			const si = ((y + minY) * width + (x + minX)) * 4;
+			const di = (y * w + x) * 4;
+			out.data[di] = data[si];
+			out.data[di + 1] = data[si + 1];
+			out.data[di + 2] = data[si + 2];
+			out.data[di + 3] = alpha[(y + minY) * width + (x + minX)];
+		}
+	}
+	fs.writeFileSync(dst, PNG.sync.write(out));
+	console.log(`wrote ${dst} (${w}x${h}, from ${width}x${height})`);
 }
 
 // Coin mark — lossless PNG source, knock out the white backing.

--- a/scripts/make-ios-assets.cjs
+++ b/scripts/make-ios-assets.cjs
@@ -10,46 +10,60 @@ const src = PNG.sync.read(fs.readFileSync(SRC));
 
 /** Render the logo centered on a SIZE×SIZE opaque dark canvas, logo at `pad` of the canvas. */
 function compose(size, pad) {
-  const out = new PNG({ width: size, height: size });
-  for (let i = 0; i < out.data.length; i += 4) {
-    out.data[i] = BG[0]; out.data[i + 1] = BG[1]; out.data[i + 2] = BG[2]; out.data[i + 3] = 255;
-  }
-  const maxDim = size * pad;
-  const scale = Math.min(maxDim / src.width, maxDim / src.height);
-  const w = Math.round(src.width * scale);
-  const h = Math.round(src.height * scale);
-  const ox = Math.round((size - w) / 2);
-  const oy = Math.round((size - h) / 2);
-  // Area-average downscale (premultiplied) for a clean, non-aliased logo.
-  for (let y = 0; y < h; y++) {
-    const sy0 = Math.floor(y / scale), sy1 = Math.min(src.height, Math.floor((y + 1) / scale) + 1);
-    for (let x = 0; x < w; x++) {
-      const sx0 = Math.floor(x / scale), sx1 = Math.min(src.width, Math.floor((x + 1) / scale) + 1);
-      let r = 0, g = 0, b = 0, a = 0, n = 0;
-      for (let sy = sy0; sy < sy1; sy++) {
-        for (let sx = sx0; sx < sx1; sx++) {
-          const si = (sy * src.width + sx) * 4;
-          const al = src.data[si + 3] / 255;
-          r += src.data[si] * al; g += src.data[si + 1] * al; b += src.data[si + 2] * al;
-          a += al; n++;
-        }
-      }
-      if (n === 0) continue;
-      const af = a / n;                         // mean coverage
-      const dr = af > 0 ? r / a : 0, dg = af > 0 ? g / a : 0, db = af > 0 ? b / a : 0;
-      const di = ((oy + y) * size + (ox + x)) * 4;
-      out.data[di]     = Math.round(dr * af + BG[0] * (1 - af));
-      out.data[di + 1] = Math.round(dg * af + BG[1] * (1 - af));
-      out.data[di + 2] = Math.round(db * af + BG[2] * (1 - af));
-      out.data[di + 3] = 255;
-    }
-  }
-  return PNG.sync.write(out);
+	const out = new PNG({ width: size, height: size });
+	for (let i = 0; i < out.data.length; i += 4) {
+		out.data[i] = BG[0];
+		out.data[i + 1] = BG[1];
+		out.data[i + 2] = BG[2];
+		out.data[i + 3] = 255;
+	}
+	const maxDim = size * pad;
+	const scale = Math.min(maxDim / src.width, maxDim / src.height);
+	const w = Math.round(src.width * scale);
+	const h = Math.round(src.height * scale);
+	const ox = Math.round((size - w) / 2);
+	const oy = Math.round((size - h) / 2);
+	// Area-average downscale (premultiplied) for a clean, non-aliased logo.
+	for (let y = 0; y < h; y++) {
+		const sy0 = Math.floor(y / scale),
+			sy1 = Math.min(src.height, Math.floor((y + 1) / scale) + 1);
+		for (let x = 0; x < w; x++) {
+			const sx0 = Math.floor(x / scale),
+				sx1 = Math.min(src.width, Math.floor((x + 1) / scale) + 1);
+			let r = 0,
+				g = 0,
+				b = 0,
+				a = 0,
+				n = 0;
+			for (let sy = sy0; sy < sy1; sy++) {
+				for (let sx = sx0; sx < sx1; sx++) {
+					const si = (sy * src.width + sx) * 4;
+					const al = src.data[si + 3] / 255;
+					r += src.data[si] * al;
+					g += src.data[si + 1] * al;
+					b += src.data[si + 2] * al;
+					a += al;
+					n++;
+				}
+			}
+			if (n === 0) continue;
+			const af = a / n; // mean coverage
+			const dr = af > 0 ? r / a : 0,
+				dg = af > 0 ? g / a : 0,
+				db = af > 0 ? b / a : 0;
+			const di = ((oy + y) * size + (ox + x)) * 4;
+			out.data[di] = Math.round(dr * af + BG[0] * (1 - af));
+			out.data[di + 1] = Math.round(dg * af + BG[1] * (1 - af));
+			out.data[di + 2] = Math.round(db * af + BG[2] * (1 - af));
+			out.data[di + 3] = 255;
+		}
+	}
+	return PNG.sync.write(out);
 }
 
 fs.mkdirSync('assets', { recursive: true });
-fs.writeFileSync('assets/icon.png', compose(1024, 0.72));            // app icon
-const splash = compose(2732, 0.30);                                  // launch screen
+fs.writeFileSync('assets/icon.png', compose(1024, 0.72)); // app icon
+const splash = compose(2732, 0.3); // launch screen
 fs.writeFileSync('assets/splash.png', splash);
 fs.writeFileSync('assets/splash-dark.png', splash);
 console.log('wrote assets/icon.png (1024), assets/splash.png + splash-dark.png (2732)');

--- a/scripts/makeup-test.mjs
+++ b/scripts/makeup-test.mjs
@@ -10,45 +10,121 @@ const c = await b.newContext({ viewport: { width: 430, height: 932 }, deviceScal
 const p = await c.newPage();
 const w = (ms) => p.waitForTimeout(ms);
 async function gates() {
-  const sk = p.getByRole('button', { name: /skip for now/i }); if (await sk.count()) { await sk.first().click().catch(()=>{}); await w(500); }
-  const st = p.getByRole('button', { name: /^skip$/i }); if (await st.count()) { await st.first().click().catch(()=>{}); await w(400); }
+	const sk = p.getByRole('button', { name: /skip for now/i });
+	if (await sk.count()) {
+		await sk
+			.first()
+			.click()
+			.catch(() => {});
+		await w(500);
+	}
+	const st = p.getByRole('button', { name: /^skip$/i });
+	if (await st.count()) {
+		await st
+			.first()
+			.click()
+			.catch(() => {});
+		await w(400);
+	}
 }
-await p.goto(BASE, { waitUntil: 'networkidle' }); await w(1000);
+await p.goto(BASE, { waitUntil: 'networkidle' });
+await w(1000);
 if (PHASE === 'setup') {
-  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await w(300);
-  await p.locator('input').first().fill(ACC.email); await p.fill('input[type=password]', ACC.pass);
-  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(()=>{}); await w(3500);
-  const claim = p.locator('input.claim-input');
-  if (await claim.count()) { await claim.fill(ACC.user); await p.locator('button.claim-btn').click().catch(()=>{}); await w(1800); }
-  await gates(); console.log('SETUP_DONE');
+	await p
+		.getByRole('button', { name: /^sign up$/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await w(300);
+	await p.locator('input').first().fill(ACC.email);
+	await p.fill('input[type=password]', ACC.pass);
+	await p
+		.getByRole('button', { name: /^sign up$/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await w(3500);
+	const claim = p.locator('input.claim-input');
+	if (await claim.count()) {
+		await claim.fill(ACC.user);
+		await p
+			.locator('button.claim-btn')
+			.click()
+			.catch(() => {});
+		await w(1800);
+	}
+	await gates();
+	console.log('SETUP_DONE');
 }
 if (PHASE === 'play') {
-  if (await p.locator('input[type=password]').count()) {
-    await p.locator('input').first().fill(ACC.user); await p.fill('input[type=password]', ACC.pass);
-    await p.getByRole('button', { name: /log in/i }).first().click(); await w(3000);
-  }
-  await gates();
-  // bankroll shown on the menu top chip
-  const menuBank = await p.locator('text=/\\$[0-9,]+/').first().innerText().catch(()=>'?');
-  console.log('menu bankroll:', menuBank);
-  await p.goto(`${BASE}/streak`, { waitUntil: 'networkidle' }); await w(1500);
-  await p.screenshot({ path: 'screenshots/mk-01-calendar.png' });
-  // tap day 22 (a makeable past day → "The Ice Age")
-  await p.locator('.cell.playable', { has: p.locator('.cell-day', { hasText: /^22$/ }) }).first().click().catch(async () => {
-    await p.locator('.cell.playable').first().click().catch(()=>{});
-  });
-  await w(2800);
-  await p.screenshot({ path: 'screenshots/mk-02-board.png' });
-  const clue = await p.locator('.puzzle-clue').innerText().catch(()=>'(no clue)');
-  const boardBank = await p.locator('text=/\\$[0-9,]+/').first().innerText().catch(()=>'?');
-  console.log('makeup clue:', clue);
-  console.log('makeup board bankroll:', boardBank);
-  // solve
-  await p.getByRole('button', { name: /^solve$/i }).first().click().catch(async()=>{await p.keyboard.press(' ');}); await w(700);
-  for (const ch of ANSWER) { await p.keyboard.press(ch); await w(70); }
-  await w(400);
-  await p.getByRole('button', { name: /^submit$/i }).first().click().catch(async()=>{await p.keyboard.press('Enter');}); await w(2600);
-  await p.screenshot({ path: 'screenshots/mk-03-result.png' });
-  console.log('PLAY_DONE');
+	if (await p.locator('input[type=password]').count()) {
+		await p.locator('input').first().fill(ACC.user);
+		await p.fill('input[type=password]', ACC.pass);
+		await p
+			.getByRole('button', { name: /log in/i })
+			.first()
+			.click();
+		await w(3000);
+	}
+	await gates();
+	// bankroll shown on the menu top chip
+	const menuBank = await p
+		.locator('text=/\\$[0-9,]+/')
+		.first()
+		.innerText()
+		.catch(() => '?');
+	console.log('menu bankroll:', menuBank);
+	await p.goto(`${BASE}/streak`, { waitUntil: 'networkidle' });
+	await w(1500);
+	await p.screenshot({ path: 'screenshots/mk-01-calendar.png' });
+	// tap day 22 (a makeable past day → "The Ice Age")
+	await p
+		.locator('.cell.playable', { has: p.locator('.cell-day', { hasText: /^22$/ }) })
+		.first()
+		.click()
+		.catch(async () => {
+			await p
+				.locator('.cell.playable')
+				.first()
+				.click()
+				.catch(() => {});
+		});
+	await w(2800);
+	await p.screenshot({ path: 'screenshots/mk-02-board.png' });
+	const clue = await p
+		.locator('.puzzle-clue')
+		.innerText()
+		.catch(() => '(no clue)');
+	const boardBank = await p
+		.locator('text=/\\$[0-9,]+/')
+		.first()
+		.innerText()
+		.catch(() => '?');
+	console.log('makeup clue:', clue);
+	console.log('makeup board bankroll:', boardBank);
+	// solve
+	await p
+		.getByRole('button', { name: /^solve$/i })
+		.first()
+		.click()
+		.catch(async () => {
+			await p.keyboard.press(' ');
+		});
+	await w(700);
+	for (const ch of ANSWER) {
+		await p.keyboard.press(ch);
+		await w(70);
+	}
+	await w(400);
+	await p
+		.getByRole('button', { name: /^submit$/i })
+		.first()
+		.click()
+		.catch(async () => {
+			await p.keyboard.press('Enter');
+		});
+	await w(2600);
+	await p.screenshot({ path: 'screenshots/mk-03-result.png' });
+	console.log('PLAY_DONE');
 }
 await b.close();

--- a/scripts/measure.mjs
+++ b/scripts/measure.mjs
@@ -9,62 +9,99 @@ const PASS = process.env.PW_PASS || 'TestPass123!';
 mkdirSync('screenshots', { recursive: true });
 
 const viewports = [
-  { tag: 'mobile', width: 390, height: 844 },
-  { tag: 'desktop', width: 1440, height: 900 },
+	{ tag: 'mobile', width: 390, height: 844 },
+	{ tag: 'desktop', width: 1440, height: 900 }
 ];
 
 async function login(page) {
-  await page.goto(BASE, { waitUntil: 'networkidle' });
-  await page.waitForTimeout(900);
-  if (await page.locator('input[type=password]').count()) {
-    await page.fill('input[type=email]', EMAIL).catch(() => {});
-    await page.fill('input[type=password]', PASS).catch(() => {});
-    await page.getByRole('button', { name: /log in/i }).first().click().catch(() => {});
-    await page.waitForTimeout(2600);
-    if (await page.locator('input[type=password]').count()) {
-      await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
-      await page.waitForTimeout(300);
-      await page.fill('input[type=email]', EMAIL).catch(() => {});
-      await page.fill('input[type=password]', PASS).catch(() => {});
-      await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
-      await page.waitForTimeout(2600);
-    }
-  }
+	await page.goto(BASE, { waitUntil: 'networkidle' });
+	await page.waitForTimeout(900);
+	if (await page.locator('input[type=password]').count()) {
+		await page.fill('input[type=email]', EMAIL).catch(() => {});
+		await page.fill('input[type=password]', PASS).catch(() => {});
+		await page
+			.getByRole('button', { name: /log in/i })
+			.first()
+			.click()
+			.catch(() => {});
+		await page.waitForTimeout(2600);
+		if (await page.locator('input[type=password]').count()) {
+			await page
+				.getByRole('button', { name: /^sign up$/i })
+				.first()
+				.click()
+				.catch(() => {});
+			await page.waitForTimeout(300);
+			await page.fill('input[type=email]', EMAIL).catch(() => {});
+			await page.fill('input[type=password]', PASS).catch(() => {});
+			await page
+				.getByRole('button', { name: /^sign up$/i })
+				.first()
+				.click()
+				.catch(() => {});
+			await page.waitForTimeout(2600);
+		}
+	}
 }
 
 async function boxes(page, vh) {
-  const sel = { keyboard: '.keyboard-container', buttons: '.main-button-wrapper', wager: '.wager-ui', solve: '.guess-phrase-button' };
-  const out = {};
-  for (const [k, s] of Object.entries(sel)) {
-    const el = page.locator(s).first();
-    if (await el.count()) {
-      const b = await el.boundingBox();
-      if (b) out[k] = { top: Math.round(b.y), bottom: Math.round(b.y + b.height), h: Math.round(b.height), gapBelow: Math.round(vh - (b.y + b.height)) };
-    }
-  }
-  return out;
+	const sel = {
+		keyboard: '.keyboard-container',
+		buttons: '.main-button-wrapper',
+		wager: '.wager-ui',
+		solve: '.guess-phrase-button'
+	};
+	const out = {};
+	for (const [k, s] of Object.entries(sel)) {
+		const el = page.locator(s).first();
+		if (await el.count()) {
+			const b = await el.boundingBox();
+			if (b)
+				out[k] = {
+					top: Math.round(b.y),
+					bottom: Math.round(b.y + b.height),
+					h: Math.round(b.height),
+					gapBelow: Math.round(vh - (b.y + b.height))
+				};
+		}
+	}
+	return out;
 }
 
 for (const vp of viewports) {
-  const browser = await chromium.launch();
-  const ctx = await browser.newContext({ viewport: { width: vp.width, height: vp.height }, deviceScaleFactor: 1 });
-  const page = await ctx.newPage();
-  await login(page);
+	const browser = await chromium.launch();
+	const ctx = await browser.newContext({
+		viewport: { width: vp.width, height: vp.height },
+		deviceScaleFactor: 1
+	});
+	const page = await ctx.newPage();
+	await login(page);
 
-  // Daily
-  await page.getByRole('button', { name: /daily/i }).first().click().catch(() => {});
-  await page.waitForTimeout(2600);
-  await page.screenshot({ path: `screenshots/fix-${vp.tag}-daily.png` });
-  console.log(`\n[${vp.tag} ${vp.width}x${vp.height}] daily:`, JSON.stringify(await boxes(page, vp.height)));
+	// Daily
+	await page
+		.getByRole('button', { name: /daily/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await page.waitForTimeout(2600);
+	await page.screenshot({ path: `screenshots/fix-${vp.tag}-daily.png` });
+	console.log(
+		`\n[${vp.tag} ${vp.width}x${vp.height}] daily:`,
+		JSON.stringify(await boxes(page, vp.height))
+	);
 
-  // Arcade gauntlet — start today's run from the menu (server-authoritative, no wager)
-  await page.goto(BASE, { waitUntil: 'networkidle' });
-  await page.waitForTimeout(1000);
-  await page.getByRole('button', { name: /arcade/i }).first().click().catch(() => {});
-  await page.waitForTimeout(3000);
-  await page.screenshot({ path: `screenshots/fix-${vp.tag}-arcade.png` });
-  console.log(`[${vp.tag}] arcade:`, JSON.stringify(await boxes(page, vp.height)));
+	// Arcade gauntlet — start today's run from the menu (server-authoritative, no wager)
+	await page.goto(BASE, { waitUntil: 'networkidle' });
+	await page.waitForTimeout(1000);
+	await page
+		.getByRole('button', { name: /arcade/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await page.waitForTimeout(3000);
+	await page.screenshot({ path: `screenshots/fix-${vp.tag}-arcade.png` });
+	console.log(`[${vp.tag}] arcade:`, JSON.stringify(await boxes(page, vp.height)));
 
-  await browser.close();
+	await browser.close();
 }
 console.log('\ndone');

--- a/scripts/qa-e2e.mjs
+++ b/scripts/qa-e2e.mjs
@@ -7,135 +7,258 @@ const BASE = process.env.BASE || 'http://localhost:5174';
 const PASS = 'TestPass123!';
 const EMAIL = process.env.QA_EMAIL || `qa${Date.now()}@example.com`;
 const UNAME = 'qa' + String(Date.now()).slice(-7);
-const DAILY = (process.env.DAILY_ANSWER || 'The Northern Lights').toUpperCase().replace(/[^A-Z]/g, '');
+const DAILY = (process.env.DAILY_ANSWER || 'The Northern Lights')
+	.toUpperCase()
+	.replace(/[^A-Z]/g, '');
 mkdirSync('screenshots', { recursive: true });
 
 const results = [];
-const ok = (n, m = '') => { results.push({ n, pass: true, m }); console.log(`  ✅ ${n}${m ? ' — ' + m : ''}`); };
-const bad = (n, m = '') => { results.push({ n, pass: false, m }); console.log(`  ❌ ${n}${m ? ' — ' + m : ''}`); };
+const ok = (n, m = '') => {
+	results.push({ n, pass: true, m });
+	console.log(`  ✅ ${n}${m ? ' — ' + m : ''}`);
+};
+const bad = (n, m = '') => {
+	results.push({ n, pass: false, m });
+	console.log(`  ❌ ${n}${m ? ' — ' + m : ''}`);
+};
 
 const browser = await chromium.launch();
-const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const ctx = await browser.newContext({
+	viewport: { width: 430, height: 932 },
+	deviceScaleFactor: 2
+});
 const page = await ctx.newPage();
 
 // collect console errors + page errors per current label
 let label = 'boot';
 const errors = [];
-page.on('console', (m) => { if (m.type() === 'error') errors.push({ where: label, text: m.text().slice(0, 200) }); });
-page.on('pageerror', (e) => errors.push({ where: label, text: 'pageerror: ' + String(e).slice(0, 200) }));
+page.on('console', (m) => {
+	if (m.type() === 'error') errors.push({ where: label, text: m.text().slice(0, 200) });
+});
+page.on('pageerror', (e) =>
+	errors.push({ where: label, text: 'pageerror: ' + String(e).slice(0, 200) })
+);
 
 const wait = (ms) => page.waitForTimeout(ms);
 const shot = (n) => page.screenshot({ path: `screenshots/qa-${n}.png` }).catch(() => {});
 
 try {
-  // ---------- 1. Signup ----------
-  label = 'signup';
-  await page.goto(BASE, { waitUntil: 'networkidle' }); await wait(1200);
-  if (!(await page.locator('input[type=password]').count())) { bad('signup', 'no auth form'); }
-  else {
-    // toggle to sign-up
-    await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
-    await wait(400);
-    await page.fill('input[type=email]', EMAIL);
-    await page.fill('input[type=password]', PASS);
-    await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
-    await wait(3500);
-    (await page.locator('input[type=password]').count()) === 0 ? ok('signup', EMAIL) : bad('signup', 'still on auth form');
-  }
+	// ---------- 1. Signup ----------
+	label = 'signup';
+	await page.goto(BASE, { waitUntil: 'networkidle' });
+	await wait(1200);
+	if (!(await page.locator('input[type=password]').count())) {
+		bad('signup', 'no auth form');
+	} else {
+		// toggle to sign-up
+		await page
+			.getByRole('button', { name: /^sign up$/i })
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(400);
+		await page.fill('input[type=email]', EMAIL);
+		await page.fill('input[type=password]', PASS);
+		await page
+			.getByRole('button', { name: /^sign up$/i })
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(3500);
+		(await page.locator('input[type=password]').count()) === 0
+			? ok('signup', EMAIL)
+			: bad('signup', 'still on auth form');
+	}
 
-  // ---------- 2. Username gate ----------
-  label = 'username-gate';
-  await wait(600);
-  const claim = page.locator('input.claim-input');
-  if (await claim.count()) {
-    await claim.fill(UNAME);
-    await page.locator('button.claim-btn').click().catch(() => {});
-    await wait(1800);
-    (await claim.count()) === 0 ? ok('username-gate', '@' + UNAME) : bad('username-gate', 'gate did not clear');
-  } else bad('username-gate', 'no username prompt appeared');
+	// ---------- 2. Username gate ----------
+	label = 'username-gate';
+	await wait(600);
+	const claim = page.locator('input.claim-input');
+	if (await claim.count()) {
+		await claim.fill(UNAME);
+		await page
+			.locator('button.claim-btn')
+			.click()
+			.catch(() => {});
+		await wait(1800);
+		(await claim.count()) === 0
+			? ok('username-gate', '@' + UNAME)
+			: bad('username-gate', 'gate did not clear');
+	} else bad('username-gate', 'no username prompt appeared');
 
-  // ---------- 3. PIN gate (skip) ----------
-  label = 'pin-gate';
-  const skipPin = page.getByRole('button', { name: /skip for now/i });
-  if (await skipPin.count()) { await skipPin.first().click().catch(() => {}); await wait(900); ok('pin-gate', 'skipped'); }
-  else ok('pin-gate', 'no PIN prompt (ok)');
+	// ---------- 3. PIN gate (skip) ----------
+	label = 'pin-gate';
+	const skipPin = page.getByRole('button', { name: /skip for now/i });
+	if (await skipPin.count()) {
+		await skipPin
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(900);
+		ok('pin-gate', 'skipped');
+	} else ok('pin-gate', 'no PIN prompt (ok)');
 
-  // dismiss tutorial
-  const skipTut = page.getByRole('button', { name: /^skip$/i });
-  if (await skipTut.count()) { await skipTut.first().click().catch(() => {}); await wait(700); }
-  await wait(600); await shot('01-menu');
-  (await page.locator('.menu-card').count()) > 0 ? ok('reach-menu') : bad('reach-menu', 'no menu cards');
+	// dismiss tutorial
+	const skipTut = page.getByRole('button', { name: /^skip$/i });
+	if (await skipTut.count()) {
+		await skipTut
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(700);
+	}
+	await wait(600);
+	await shot('01-menu');
+	(await page.locator('.menu-card').count()) > 0
+		? ok('reach-menu')
+		: bad('reach-menu', 'no menu cards');
 
-  // ---------- 4. Page sweep (console-error / hang detection) ----------
-  const pages = ['/history', '/activity', '/leaderboard', '/groups', '/profile', '/badges', '/bank', '/streak', '/friends', '/shop'];
-  for (const path of pages) {
-    label = path;
-    const before = errors.length;
-    try {
-      await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle', timeout: 12000 });
-      await wait(1200);
-      const newErrs = errors.length - before;
-      const bodyLen = (await page.locator('body').innerText().catch(() => '')).length;
-      if (newErrs > 0) bad(`page ${path}`, `${newErrs} console error(s)`);
-      else if (bodyLen < 5) bad(`page ${path}`, 'empty render');
-      else ok(`page ${path}`);
-    } catch (e) {
-      bad(`page ${path}`, (e.message || '').includes('Timeout') ? 'HANG / networkidle timeout (possible loop)' : e.message.slice(0, 80));
-    }
-  }
+	// ---------- 4. Page sweep (console-error / hang detection) ----------
+	const pages = [
+		'/history',
+		'/activity',
+		'/leaderboard',
+		'/groups',
+		'/profile',
+		'/badges',
+		'/bank',
+		'/streak',
+		'/friends',
+		'/shop'
+	];
+	for (const path of pages) {
+		label = path;
+		const before = errors.length;
+		try {
+			await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle', timeout: 12000 });
+			await wait(1200);
+			const newErrs = errors.length - before;
+			const bodyLen = (
+				await page
+					.locator('body')
+					.innerText()
+					.catch(() => '')
+			).length;
+			if (newErrs > 0) bad(`page ${path}`, `${newErrs} console error(s)`);
+			else if (bodyLen < 5) bad(`page ${path}`, 'empty render');
+			else ok(`page ${path}`);
+		} catch (e) {
+			bad(
+				`page ${path}`,
+				(e.message || '').includes('Timeout')
+					? 'HANG / networkidle timeout (possible loop)'
+					: e.message.slice(0, 80)
+			);
+		}
+	}
 
-  // ---------- 5. Play the Daily to a solve ----------
-  label = 'daily';
-  await page.goto(BASE, { waitUntil: 'networkidle' }); await wait(1500);
-  // PIN should NOT reappear after skipping (regression guard for the persist-skip fix)
-  if (await page.getByText(/create your pin/i).count()) bad('pin-skip-persists', 'PIN re-nagged after skip + reload');
-  else ok('pin-skip-persists');
-  const sk2 = page.getByRole('button', { name: /skip for now/i });
-  if (await sk2.count()) { await sk2.first().click().catch(() => {}); await wait(700); }
-  const st2 = page.getByRole('button', { name: /^skip$/i });
-  if (await st2.count()) { await st2.first().click().catch(() => {}); await wait(600); }
-  await page.getByRole('button', { name: /play now/i }).first().click().catch(() => {});
-  await wait(700);
-  await page.getByRole('button', { name: /daily/i }).first().click().catch(() => {});
-  await wait(2800);
-  // Pre-game "How to win" objective card (first entry per mode) — dismiss to reach the board.
-  const objGo = page.getByRole('button', { name: /let’s go|let's go/i });
-  if (await objGo.count()) { await objGo.first().click().catch(() => {}); await wait(600); ok('objective-card', 'shown + dismissed'); }
-  await shot('02-daily-board');
-  if (!(await page.getByRole('button', { name: /^solve$/i }).count())) { bad('daily-open', 'no Solve button — board did not load'); }
-  else {
-    ok('daily-open');
-    await page.getByRole('button', { name: /^solve$/i }).first().click().catch(() => {}); // enter guess mode
-    await wait(700);
-    for (const ch of DAILY) { await page.keyboard.press(ch); await wait(70); }
-    await wait(500); await shot('03-daily-filled');
-    await page.getByRole('button', { name: /^submit$/i }).first().click().catch(() => {});
-    // the redesigned Daily plays a slot-machine reveal before the SOLVED! banner — wait it out
-    await page.getByText(/solved!|profit/i).first().waitFor({ timeout: 9000 }).catch(() => {});
-    await shot('04-daily-result');
-    const won = await page.getByText(/solved!|profit/i).count();
-    won > 0 ? ok('daily-solve', 'win banner shown') : bad('daily-solve', 'no win banner after submit');
-  }
+	// ---------- 5. Play the Daily to a solve ----------
+	label = 'daily';
+	await page.goto(BASE, { waitUntil: 'networkidle' });
+	await wait(1500);
+	// PIN should NOT reappear after skipping (regression guard for the persist-skip fix)
+	if (await page.getByText(/create your pin/i).count())
+		bad('pin-skip-persists', 'PIN re-nagged after skip + reload');
+	else ok('pin-skip-persists');
+	const sk2 = page.getByRole('button', { name: /skip for now/i });
+	if (await sk2.count()) {
+		await sk2
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(700);
+	}
+	const st2 = page.getByRole('button', { name: /^skip$/i });
+	if (await st2.count()) {
+		await st2
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(600);
+	}
+	await page
+		.getByRole('button', { name: /play now/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(700);
+	await page
+		.getByRole('button', { name: /daily/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(2800);
+	// Pre-game "How to win" objective card (first entry per mode) — dismiss to reach the board.
+	const objGo = page.getByRole('button', { name: /let’s go|let's go/i });
+	if (await objGo.count()) {
+		await objGo
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(600);
+		ok('objective-card', 'shown + dismissed');
+	}
+	await shot('02-daily-board');
+	if (!(await page.getByRole('button', { name: /^solve$/i }).count())) {
+		bad('daily-open', 'no Solve button — board did not load');
+	} else {
+		ok('daily-open');
+		await page
+			.getByRole('button', { name: /^solve$/i })
+			.first()
+			.click()
+			.catch(() => {}); // enter guess mode
+		await wait(700);
+		for (const ch of DAILY) {
+			await page.keyboard.press(ch);
+			await wait(70);
+		}
+		await wait(500);
+		await shot('03-daily-filled');
+		await page
+			.getByRole('button', { name: /^submit$/i })
+			.first()
+			.click()
+			.catch(() => {});
+		// the redesigned Daily plays a slot-machine reveal before the SOLVED! banner — wait it out
+		await page
+			.getByText(/solved!|profit/i)
+			.first()
+			.waitFor({ timeout: 9000 })
+			.catch(() => {});
+		await shot('04-daily-result');
+		const won = await page.getByText(/solved!|profit/i).count();
+		won > 0
+			? ok('daily-solve', 'win banner shown')
+			: bad('daily-solve', 'no win banner after submit');
+	}
 
-  // ---------- 6. Verify it landed in History ----------
-  label = 'history-verify';
-  // close result modal first
-  await page.keyboard.press('Escape').catch(() => {});
-  await page.goto(`${BASE}/history`, { waitUntil: 'networkidle' }); await wait(1600);
-  const items = await page.locator('.item').count();
-  items > 0 ? ok('history-verify', `${items} row(s)`) : bad('history-verify', 'history empty after a solve');
-  await shot('05-history');
-
+	// ---------- 6. Verify it landed in History ----------
+	label = 'history-verify';
+	// close result modal first
+	await page.keyboard.press('Escape').catch(() => {});
+	await page.goto(`${BASE}/history`, { waitUntil: 'networkidle' });
+	await wait(1600);
+	const items = await page.locator('.item').count();
+	items > 0
+		? ok('history-verify', `${items} row(s)`)
+		: bad('history-verify', 'history empty after a solve');
+	await shot('05-history');
 } catch (e) {
-  bad('fatal', e.message);
+	bad('fatal', e.message);
 } finally {
-  await browser.close();
+	await browser.close();
 }
 
 console.log('\n──────── QA SUMMARY ────────');
 const fails = results.filter((r) => !r.pass);
 for (const r of results) console.log(`${r.pass ? '✅' : '❌'} ${r.n}${r.m ? ' — ' + r.m : ''}`);
-if (errors.length) { console.log('\nConsole errors:'); for (const e of errors.slice(0, 20)) console.log(`  [${e.where}] ${e.text}`); }
-console.log(`\n${results.filter(r => r.pass).length}/${results.length} passed · ${fails.length} failed · ${errors.length} console errors`);
+if (errors.length) {
+	console.log('\nConsole errors:');
+	for (const e of errors.slice(0, 20)) console.log(`  [${e.where}] ${e.text}`);
+}
+console.log(
+	`\n${results.filter((r) => r.pass).length}/${results.length} passed · ${fails.length} failed · ${errors.length} console errors`
+);
 console.log('QA_EMAIL=' + EMAIL);
 process.exit(fails.length ? 1 : 0);

--- a/scripts/shoot-public.mjs
+++ b/scripts/shoot-public.mjs
@@ -5,14 +5,20 @@ const BASE = process.env.BASE || 'http://localhost:5174';
 const TAG = process.env.TAG || 'pub';
 mkdirSync('screenshots', { recursive: true });
 const browser = await chromium.launch();
-const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const ctx = await browser.newContext({
+	viewport: { width: 430, height: 932 },
+	deviceScaleFactor: 2
+});
 const page = await ctx.newPage();
-const routes = [['reset', '/reset-password'], ['leaderboard', '/leaderboard']];
+const routes = [
+	['reset', '/reset-password'],
+	['leaderboard', '/leaderboard']
+];
 for (const [name, path] of routes) {
-  await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle' });
-  await page.waitForTimeout(1500);
-  await page.screenshot({ path: `screenshots/${TAG}-${name}.png` });
-  console.log('shot', `${TAG}-${name}`);
+	await page.goto(`${BASE}${path}`, { waitUntil: 'networkidle' });
+	await page.waitForTimeout(1500);
+	await page.screenshot({ path: `screenshots/${TAG}-${name}.png` });
+	console.log('shot', `${TAG}-${name}`);
 }
 await browser.close();
 console.log('done');

--- a/scripts/shoot-stats.mjs
+++ b/scripts/shoot-stats.mjs
@@ -8,10 +8,18 @@ const PASS = process.env.PW_PASS || 'TestPass123!';
 mkdirSync('screenshots', { recursive: true });
 
 const browser = await chromium.launch();
-const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const ctx = await browser.newContext({
+	viewport: { width: 430, height: 932 },
+	deviceScaleFactor: 2
+});
 const page = await ctx.newPage();
-page.on('console', (m) => { if (m.type() === 'error') console.log('  [err]', m.text().slice(0, 140)); });
-const shot = async (n) => { await page.screenshot({ path: `screenshots/stats-${n}.png` }); console.log('shot', n); };
+page.on('console', (m) => {
+	if (m.type() === 'error') console.log('  [err]', m.text().slice(0, 140));
+});
+const shot = async (n) => {
+	await page.screenshot({ path: `screenshots/stats-${n}.png` });
+	console.log('shot', n);
+};
 const wait = (ms) => page.waitForTimeout(ms);
 
 await page.goto(BASE, { waitUntil: 'networkidle' });
@@ -19,44 +27,100 @@ await wait(1200);
 
 // login
 if (await page.locator('input[type=password]').count()) {
-  await page.locator('input').first().fill(EMAIL).catch(() => {});
-  await page.fill('input[type=password]', PASS).catch(() => {});
-  await page.getByRole('button', { name: /log in/i }).first().click().catch(() => {});
-  await wait(3000);
+	await page
+		.locator('input')
+		.first()
+		.fill(EMAIL)
+		.catch(() => {});
+	await page.fill('input[type=password]', PASS).catch(() => {});
+	await page
+		.getByRole('button', { name: /log in/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(3000);
 }
 // skip PIN set if shown
 const skip = page.getByRole('button', { name: /skip for now/i });
-if (await skip.count()) { await skip.first().click().catch(() => {}); await wait(800); }
+if (await skip.count()) {
+	await skip
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(800);
+}
 await wait(1000);
 await shot('00-menu');
 
 // Progress submenu (to show new cards)
 const prog = page.getByRole('button', { name: /progress/i });
-if (await prog.count()) { await prog.first().click().catch(() => {}); await wait(600); await shot('01-progress-menu'); }
+if (await prog.count()) {
+	await prog
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(600);
+	await shot('01-progress-menu');
+}
 
 // History
-await page.goto(`${BASE}/history`, { waitUntil: 'networkidle' }); await wait(1800); await shot('02-history');
+await page.goto(`${BASE}/history`, { waitUntil: 'networkidle' });
+await wait(1800);
+await shot('02-history');
 // expand a solo (daily) row
-await page.locator('.item-main').first().click().catch(() => {}); await wait(700); await shot('03-history-expanded');
+await page
+	.locator('.item-main')
+	.first()
+	.click()
+	.catch(() => {});
+await wait(700);
+await shot('03-history-expanded');
 // filter to Versus
 const versus = page.getByRole('button', { name: /versus/i });
-if (await versus.count()) { await versus.first().click().catch(() => {}); await wait(1200); await shot('04-history-versus'); }
+if (await versus.count()) {
+	await versus
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(1200);
+	await shot('04-history-versus');
+}
 
 // Activity
-await page.goto(`${BASE}/activity`, { waitUntil: 'networkidle' }); await wait(1800); await shot('05-activity');
+await page.goto(`${BASE}/activity`, { waitUntil: 'networkidle' });
+await wait(1800);
+await shot('05-activity');
 
 // Public profile + head-to-head
-await page.goto(`${BASE}/u/edithpink`, { waitUntil: 'networkidle' }); await wait(1800); await shot('06-profile-h2h');
+await page.goto(`${BASE}/u/edithpink`, { waitUntil: 'networkidle' });
+await wait(1800);
+await shot('06-profile-h2h');
 
 // Groups → open group → Compete tab
-await page.goto(`${BASE}/groups`, { waitUntil: 'networkidle' }); await wait(1600); await shot('07-groups-list');
-await page.locator('.g-card, .group-card, [class*=card]').first().click().catch(() => {});
-await wait(1400); await shot('08-group-wealth');
+await page.goto(`${BASE}/groups`, { waitUntil: 'networkidle' });
+await wait(1600);
+await shot('07-groups-list');
+await page
+	.locator('.g-card, .group-card, [class*=card]')
+	.first()
+	.click()
+	.catch(() => {});
+await wait(1400);
+await shot('08-group-wealth');
 const compete = page.getByRole('button', { name: /compete/i });
-if (await compete.count()) { await compete.first().click().catch(() => {}); await wait(1400); await shot('09-group-compete'); }
+if (await compete.count()) {
+	await compete
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(1400);
+	await shot('09-group-compete');
+}
 
 // Leaderboard (clickable names)
-await page.goto(`${BASE}/leaderboard`, { waitUntil: 'networkidle' }); await wait(1800); await shot('10-leaderboard');
+await page.goto(`${BASE}/leaderboard`, { waitUntil: 'networkidle' });
+await wait(1800);
+await shot('10-leaderboard');
 
 await browser.close();
 console.log('done');

--- a/scripts/shoot.mjs
+++ b/scripts/shoot.mjs
@@ -9,48 +9,89 @@ const TAG = process.env.TAG || 'base';
 mkdirSync('screenshots', { recursive: true });
 
 const browser = await chromium.launch();
-const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const ctx = await browser.newContext({
+	viewport: { width: 430, height: 932 },
+	deviceScaleFactor: 2
+});
 const page = await ctx.newPage();
-page.on('console', (m) => { if (m.type() === 'error') console.log('  [console.error]', m.text().slice(0, 160)); });
-const shot = async (name) => { await page.screenshot({ path: `screenshots/${TAG}-${name}.png` }); console.log('shot', `${TAG}-${name}`); };
+page.on('console', (m) => {
+	if (m.type() === 'error') console.log('  [console.error]', m.text().slice(0, 160));
+});
+const shot = async (name) => {
+	await page.screenshot({ path: `screenshots/${TAG}-${name}.png` });
+	console.log('shot', `${TAG}-${name}`);
+};
 const wait = (ms) => page.waitForTimeout(ms);
 
 await page.goto(BASE, { waitUntil: 'networkidle' });
 await wait(1000);
 if (await page.locator('input[type=password]').count()) {
-  await shot('01-login');
-  await page.locator('input').first().fill(EMAIL).catch(() => {});
-  await page.fill('input[type=password]', PASS).catch(() => {});
-  await page.getByRole('button', { name: /log in/i }).first().click().catch(() => {});
-  await wait(2800);
-  // If login failed (e.g. fresh DB / deleted test user), sign up instead.
-  if (await page.locator('input[type=password]').count()) {
-    await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); // toggle link
-    await wait(300);
-    await page.locator('input').first().fill(EMAIL).catch(() => {});
-    await page.fill('input[type=password]', PASS).catch(() => {});
-    await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); // submit
-    await wait(2800);
-  }
+	await shot('01-login');
+	await page
+		.locator('input')
+		.first()
+		.fill(EMAIL)
+		.catch(() => {});
+	await page.fill('input[type=password]', PASS).catch(() => {});
+	await page
+		.getByRole('button', { name: /log in/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(2800);
+	// If login failed (e.g. fresh DB / deleted test user), sign up instead.
+	if (await page.locator('input[type=password]').count()) {
+		await page
+			.getByRole('button', { name: /^sign up$/i })
+			.first()
+			.click()
+			.catch(() => {}); // toggle link
+		await wait(300);
+		await page
+			.locator('input')
+			.first()
+			.fill(EMAIL)
+			.catch(() => {});
+		await page.fill('input[type=password]', PASS).catch(() => {});
+		await page
+			.getByRole('button', { name: /^sign up$/i })
+			.first()
+			.click()
+			.catch(() => {}); // submit
+		await wait(2800);
+	}
 }
 await wait(800);
 await shot('02-menu');
 
 // Daily board
-await page.getByRole('button', { name: /daily puzzle/i }).click().catch((e) => console.log('daily click', e.message));
+await page
+	.getByRole('button', { name: /daily puzzle/i })
+	.click()
+	.catch((e) => console.log('daily click', e.message));
 await wait(2500);
 await shot('03-daily-board');
 
 // Buy a letter: tap E, then confirm
-await page.locator('.key:has(.letter:text-is("E"))').first().click({ force: true }).catch((e) => console.log('key E', e.message));
+await page
+	.locator('.key:has(.letter:text-is("E"))')
+	.first()
+	.click({ force: true })
+	.catch((e) => console.log('key E', e.message));
 await wait(600);
 await shot('04-letter-pending');
-await page.getByRole('button', { name: /^confirm$/i }).click({ force: true }).catch((e) => console.log('confirm', e.message));
+await page
+	.getByRole('button', { name: /^confirm$/i })
+	.click({ force: true })
+	.catch((e) => console.log('confirm', e.message));
 await wait(1800);
 await shot('05-after-letter');
 
 // Enter guess mode (Solve), screenshot
-await page.getByRole('button', { name: /^solve$/i }).click({ force: true }).catch(() => {});
+await page
+	.getByRole('button', { name: /^solve$/i })
+	.click({ force: true })
+	.catch(() => {});
 await wait(800);
 await shot('06-guess-mode');
 

--- a/scripts/vs-walkthrough.mjs
+++ b/scripts/vs-walkthrough.mjs
@@ -12,122 +12,246 @@ const B = { email: 'vsb@example.com', pass: 'TestPass123!', user: 'vsbob' };
 const log = (...a) => console.log('  ', ...a);
 
 const browser = await chromium.launch();
-const ctx = () => browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+const ctx = () =>
+	browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
 const wait = (p, ms) => p.waitForTimeout(ms);
 
 async function dismissGates(p) {
-  const sk = p.getByRole('button', { name: /skip for now/i });
-  if (await sk.count()) { await sk.first().click().catch(() => {}); await wait(p, 600); }
-  const st = p.getByRole('button', { name: /^skip$/i });
-  if (await st.count()) { await st.first().click().catch(() => {}); await wait(p, 500); }
+	const sk = p.getByRole('button', { name: /skip for now/i });
+	if (await sk.count()) {
+		await sk
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(p, 600);
+	}
+	const st = p.getByRole('button', { name: /^skip$/i });
+	if (await st.count()) {
+		await st
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(p, 500);
+	}
 }
 async function signup(p, acc) {
-  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(p, 1000);
-  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); await wait(p, 300);
-  await p.locator('input').first().fill(acc.email);
-  await p.fill('input[type=password]', acc.pass);
-  await p.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {}); await wait(p, 3500);
-  const claim = p.locator('input.claim-input');
-  if (await claim.count()) { await claim.fill(acc.user); await p.locator('button.claim-btn').click().catch(() => {}); await wait(p, 1800); }
-  await dismissGates(p);
+	await p.goto(BASE, { waitUntil: 'networkidle' });
+	await wait(p, 1000);
+	await p
+		.getByRole('button', { name: /^sign up$/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 300);
+	await p.locator('input').first().fill(acc.email);
+	await p.fill('input[type=password]', acc.pass);
+	await p
+		.getByRole('button', { name: /^sign up$/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 3500);
+	const claim = p.locator('input.claim-input');
+	if (await claim.count()) {
+		await claim.fill(acc.user);
+		await p
+			.locator('button.claim-btn')
+			.click()
+			.catch(() => {});
+		await wait(p, 1800);
+	}
+	await dismissGates(p);
 }
 async function login(p, acc) {
-  await p.goto(BASE, { waitUntil: 'networkidle' }); await wait(p, 1000);
-  if (await p.locator('input[type=password]').count()) {
-    await p.locator('input').first().fill(acc.user);
-    await p.fill('input[type=password]', acc.pass);
-    await p.getByRole('button', { name: /log in/i }).first().click(); await wait(p, 3000);
-  }
-  await dismissGates(p);
+	await p.goto(BASE, { waitUntil: 'networkidle' });
+	await wait(p, 1000);
+	if (await p.locator('input[type=password]').count()) {
+		await p.locator('input').first().fill(acc.user);
+		await p.fill('input[type=password]', acc.pass);
+		await p
+			.getByRole('button', { name: /log in/i })
+			.first()
+			.click();
+		await wait(p, 3000);
+	}
+	await dismissGates(p);
 }
 // buy `wrong` letters (not in the answer → pure spend, keeps all tiles editable), then solve.
 async function playSolve(p, answer, wrong) {
-  // Dismiss the pre-game "How to win" objective card (shown on every match entry).
-  const objGo = p.getByRole('button', { name: /let’s go|let's go/i });
-  if (await objGo.count()) { await objGo.first().click().catch(() => {}); await wait(p, 500); }
-  for (const L of wrong) { await p.keyboard.press(L); await wait(p, 250); await p.keyboard.press('Enter'); await wait(p, 900); }
-  // enter guess mode
-  await p.getByRole('button', { name: /^solve$/i }).first().click().catch(async () => { await p.keyboard.press(' '); });
-  await wait(p, 700);
-  for (const ch of answer) { await p.keyboard.press(ch); await wait(p, 60); }
-  await wait(p, 400);
-  await p.getByRole('button', { name: /^submit$/i }).first().click().catch(async () => { await p.keyboard.press('Enter'); });
-  await wait(p, 2500);
+	// Dismiss the pre-game "How to win" objective card (shown on every match entry).
+	const objGo = p.getByRole('button', { name: /let’s go|let's go/i });
+	if (await objGo.count()) {
+		await objGo
+			.first()
+			.click()
+			.catch(() => {});
+		await wait(p, 500);
+	}
+	for (const L of wrong) {
+		await p.keyboard.press(L);
+		await wait(p, 250);
+		await p.keyboard.press('Enter');
+		await wait(p, 900);
+	}
+	// enter guess mode
+	await p
+		.getByRole('button', { name: /^solve$/i })
+		.first()
+		.click()
+		.catch(async () => {
+			await p.keyboard.press(' ');
+		});
+	await wait(p, 700);
+	for (const ch of answer) {
+		await p.keyboard.press(ch);
+		await wait(p, 60);
+	}
+	await wait(p, 400);
+	await p
+		.getByRole('button', { name: /^submit$/i })
+		.first()
+		.click()
+		.catch(async () => {
+			await p.keyboard.press('Enter');
+		});
+	await wait(p, 2500);
 }
 // Community hub → Challenges tab (the inbox of your matches).
 async function openChallengeInbox(p) {
-  await p.locator('.menu-card').filter({ hasText: 'Community' }).first().click().catch(() => {}); await wait(p, 1200);
+	await p
+		.locator('.menu-card')
+		.filter({ hasText: 'Community' })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 1200);
 }
 // Community → Challenges → the New-Challenge builder modal.
 async function openNewChallenge(p) {
-  await openChallengeInbox(p);
-  await p.getByRole('button', { name: /New Challenge/i }).first().click().catch(() => {}); await wait(p, 1000);
+	await openChallengeInbox(p);
+	await p
+		.getByRole('button', { name: /New Challenge/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 1000);
 }
 
 // ──────────────────────────────────────────────────────────────
 if (PHASE === 'setup') {
-  const ca = await ctx(); const pa = await ca.newPage(); await signup(pa, A); log('A signed up', A.user);
-  const cb = await ctx(); const pb = await cb.newPage(); await signup(pb, B); log('B signed up', B.user);
-  console.log('SETUP_DONE');
+	const ca = await ctx();
+	const pa = await ca.newPage();
+	await signup(pa, A);
+	log('A signed up', A.user);
+	const cb = await ctx();
+	const pb = await cb.newPage();
+	await signup(pb, B);
+	log('B signed up', B.user);
+	console.log('SETUP_DONE');
 }
 
 if (PHASE === 'create') {
-  const c = await ctx(); const p = await c.newPage(); await login(p, A);
-  await openNewChallenge(p);
-  await p.locator('input.ch-input').first().fill(B.user); await wait(p, 800);
-  // pack size 1
-  await p.locator('select.ch-input').first().selectOption('1').catch(() => {});
-  // wager 500
-  await p.locator('input[type=number].ch-input').first().fill('500').catch(() => {});
-  await wait(p, 400);
-  await p.getByRole('button', { name: /send challenge/i }).first().click().catch(() => {});
-  await wait(p, 2500);
-  await p.screenshot({ path: 'screenshots/vs-01-created.png' });
-  console.log('CREATE_DONE');
+	const c = await ctx();
+	const p = await c.newPage();
+	await login(p, A);
+	await openNewChallenge(p);
+	await p.locator('input.ch-input').first().fill(B.user);
+	await wait(p, 800);
+	// pack size 1
+	await p
+		.locator('select.ch-input')
+		.first()
+		.selectOption('1')
+		.catch(() => {});
+	// wager 500
+	await p
+		.locator('input[type=number].ch-input')
+		.first()
+		.fill('500')
+		.catch(() => {});
+	await wait(p, 400);
+	await p
+		.getByRole('button', { name: /send challenge/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 2500);
+	await p.screenshot({ path: 'screenshots/vs-01-created.png' });
+	console.log('CREATE_DONE');
 }
 
 if (PHASE === 'play') {
-  // wrong letters not in the answer
-  const pool = 'QZXJKVWBYG'.split('').filter((L) => !ANSWER.includes(L));
-  // B accepts + plays (spends more → loses)
-  const cb = await ctx(); const pb = await cb.newPage(); await login(pb, B);
-  await openChallengeInbox(pb);
-  await pb.getByRole('button', { name: /^play$/i }).first().click().catch(() => {}); await wait(pb, 2600);
-  await pb.screenshot({ path: 'screenshots/vs-02-B-board.png' });
-  await playSolve(pb, ANSWER, pool.slice(0, 4)); // B buys 4 wrong letters
-  await pb.screenshot({ path: 'screenshots/vs-03-B-after.png' });
-  log('B played');
-  // A plays (spends less → wins)
-  const ca = await ctx(); const pa = await ca.newPage(); await login(pa, A);
-  await openChallengeInbox(pa);
-  await pa.getByRole('button', { name: /^(play|resume)$/i }).first().click().catch(() => {}); await wait(pa, 2600);
-  await playSolve(pa, ANSWER, pool.slice(0, 1)); // A buys 1 wrong letter
-  await pa.screenshot({ path: 'screenshots/vs-04-A-result.png' });
-  log('A played');
-  console.log('PLAY_DONE');
+	// wrong letters not in the answer
+	const pool = 'QZXJKVWBYG'.split('').filter((L) => !ANSWER.includes(L));
+	// B accepts + plays (spends more → loses)
+	const cb = await ctx();
+	const pb = await cb.newPage();
+	await login(pb, B);
+	await openChallengeInbox(pb);
+	await pb
+		.getByRole('button', { name: /^play$/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(pb, 2600);
+	await pb.screenshot({ path: 'screenshots/vs-02-B-board.png' });
+	await playSolve(pb, ANSWER, pool.slice(0, 4)); // B buys 4 wrong letters
+	await pb.screenshot({ path: 'screenshots/vs-03-B-after.png' });
+	log('B played');
+	// A plays (spends less → wins)
+	const ca = await ctx();
+	const pa = await ca.newPage();
+	await login(pa, A);
+	await openChallengeInbox(pa);
+	await pa
+		.getByRole('button', { name: /^(play|resume)$/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(pa, 2600);
+	await playSolve(pa, ANSWER, pool.slice(0, 1)); // A buys 1 wrong letter
+	await pa.screenshot({ path: 'screenshots/vs-04-A-result.png' });
+	log('A played');
+	console.log('PLAY_DONE');
 }
 
 if (PHASE === 'results') {
-  const c = await ctx(); const p = await c.newPage(); await login(p, A);
-  // 1) view results from the challenge inbox
-  await openChallengeInbox(p);
-  await p.screenshot({ path: 'screenshots/vs-05-inbox.png' });
-  await p.getByRole('button', { name: /results/i }).first().click().catch(() => {}); await wait(p, 1800);
-  await p.screenshot({ path: 'screenshots/vs-06-results-modal.png' });
-  // 2) History (Profile → History tab)
-  await p.goto(`${BASE}/history`, { waitUntil: 'networkidle' }); await wait(p, 1600);
-  await p.screenshot({ path: 'screenshots/vs-07-history.png' });
-  // 3) Profile stats
-  await p.goto(`${BASE}/profile`, { waitUntil: 'networkidle' }); await wait(p, 1500);
-  await p.screenshot({ path: 'screenshots/vs-08-profile.png' });
-  // 4) Leaderboard challenges
-  await p.goto(`${BASE}/leaderboard?board=challenges`, { waitUntil: 'networkidle' }); await wait(p, 1600);
-  await p.getByRole('button', { name: /challenges/i }).first().click().catch(() => {}); await wait(p, 1200);
-  await p.screenshot({ path: 'screenshots/vs-09-leaderboard.png' });
-  // 5) Activity
-  await p.goto(`${BASE}/activity`, { waitUntil: 'networkidle' }); await wait(p, 1600);
-  await p.screenshot({ path: 'screenshots/vs-10-activity.png' });
-  console.log('RESULTS_DONE');
+	const c = await ctx();
+	const p = await c.newPage();
+	await login(p, A);
+	// 1) view results from the challenge inbox
+	await openChallengeInbox(p);
+	await p.screenshot({ path: 'screenshots/vs-05-inbox.png' });
+	await p
+		.getByRole('button', { name: /results/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 1800);
+	await p.screenshot({ path: 'screenshots/vs-06-results-modal.png' });
+	// 2) History (Profile → History tab)
+	await p.goto(`${BASE}/history`, { waitUntil: 'networkidle' });
+	await wait(p, 1600);
+	await p.screenshot({ path: 'screenshots/vs-07-history.png' });
+	// 3) Profile stats
+	await p.goto(`${BASE}/profile`, { waitUntil: 'networkidle' });
+	await wait(p, 1500);
+	await p.screenshot({ path: 'screenshots/vs-08-profile.png' });
+	// 4) Leaderboard challenges
+	await p.goto(`${BASE}/leaderboard?board=challenges`, { waitUntil: 'networkidle' });
+	await wait(p, 1600);
+	await p
+		.getByRole('button', { name: /challenges/i })
+		.first()
+		.click()
+		.catch(() => {});
+	await wait(p, 1200);
+	await p.screenshot({ path: 'screenshots/vs-09-leaderboard.png' });
+	// 5) Activity
+	await p.goto(`${BASE}/activity`, { waitUntil: 'networkidle' });
+	await wait(p, 1600);
+	await p.screenshot({ path: 'screenshots/vs-10-activity.png' });
+	console.log('RESULTS_DONE');
 }
 
 await browser.close();

--- a/src/app.css
+++ b/src/app.css
@@ -5,245 +5,343 @@
 @import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-  /* Brand */
-  --brand-1: #fbbf24;          /* emerald */
-  --brand-2: #fde047;          /* lime */
-  --brand-grad: linear-gradient(135deg, #fbbf24 0%, #fde047 100%);
-  --gold: #fbbf24;             /* money accent */
-  --gold-2: #f59e0b;
-  --danger: #fb5a5a;
-  --info: #38bdf8;
+	/* Brand */
+	--brand-1: #fbbf24; /* emerald */
+	--brand-2: #fde047; /* lime */
+	--brand-grad: linear-gradient(135deg, #fbbf24 0%, #fde047 100%);
+	--gold: #fbbf24; /* money accent */
+	--gold-2: #f59e0b;
+	--danger: #fb5a5a;
+	--info: #38bdf8;
 
-  /* Surfaces (dark) */
-  --bg-0: #070b12;             /* page base */
-  --bg-1: #0c121d;
-  --surface: rgba(255, 255, 255, 0.045);
-  --surface-2: rgba(255, 255, 255, 0.08);
-  --surface-strong: rgba(20, 28, 42, 0.72);
-  --border: rgba(255, 255, 255, 0.09);
-  --border-strong: rgba(255, 255, 255, 0.16);
+	/* Surfaces (dark) */
+	--bg-0: #070b12; /* page base */
+	--bg-1: #0c121d;
+	--surface: rgba(255, 255, 255, 0.045);
+	--surface-2: rgba(255, 255, 255, 0.08);
+	--surface-strong: rgba(20, 28, 42, 0.72);
+	--border: rgba(255, 255, 255, 0.09);
+	--border-strong: rgba(255, 255, 255, 0.16);
 
-  /* Text */
-  --text: #eaf0f7;
-  --text-muted: #93a0b4;
-  --text-faint: #5d6b80;
+	/* Text */
+	--text: #eaf0f7;
+	--text-muted: #93a0b4;
+	--text-faint: #5d6b80;
 
-  /* Radii */
-  --r-sm: 10px;
-  --r-md: 14px;
-  --r-lg: 20px;
-  --r-xl: 28px;
-  --r-pill: 999px;
+	/* Radii */
+	--r-sm: 10px;
+	--r-md: 14px;
+	--r-lg: 20px;
+	--r-xl: 28px;
+	--r-pill: 999px;
 
-  /* Shadows / glow */
-  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
-  --shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.55);
-  --glow-brand: 0 0 0 1px rgba(253, 224, 71, 0.25), 0 8px 30px rgba(251, 191, 36, 0.28);
-  --glow-gold: 0 0 24px rgba(251, 191, 36, 0.35);
+	/* Shadows / glow */
+	--shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
+	--shadow-lg: 0 20px 50px rgba(0, 0, 0, 0.55);
+	--glow-brand: 0 0 0 1px rgba(253, 224, 71, 0.25), 0 8px 30px rgba(251, 191, 36, 0.28);
+	--glow-gold: 0 0 24px rgba(251, 191, 36, 0.35);
 
-  /* Type */
-  --font-display: 'Space Grotesk', system-ui, sans-serif;
-  --font-ui: 'Inter', system-ui, sans-serif;
+	/* Type */
+	--font-display: 'Space Grotesk', system-ui, sans-serif;
+	--font-ui: 'Inter', system-ui, sans-serif;
 
-  /* Motion */
-  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+	/* Motion */
+	--ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+	--ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-*, *::before, *::after { box-sizing: border-box; }
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
 
-html, body {
-  margin: 0;
-  padding: 0;
-  min-height: 100%;
+html,
+body {
+	margin: 0;
+	padding: 0;
+	min-height: 100%;
 }
 
 body {
-  font-family: var(--font-ui);
-  color: var(--text);
-  background-color: #070707;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
+	font-family: var(--font-ui);
+	color: var(--text);
+	background-color: #070707;
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
 }
 
 /* Gold spotlight glow (warm light pooling from the top, behind the hero) */
 body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: -2;
-  pointer-events: none;
-  background:
-    radial-gradient(62% 40% at 50% 26%, rgba(251, 191, 36, 0.20), rgba(0, 0, 0, 0) 60%),
-    radial-gradient(40% 26% at 50% 22%, rgba(255, 220, 140, 0.10), rgba(0, 0, 0, 0) 55%),
-    radial-gradient(80% 60% at 50% 120%, rgba(180, 140, 60, 0.07), rgba(0, 0, 0, 0) 60%);
-  animation: spotlightBreathe 12s ease-in-out infinite alternate;
+	content: '';
+	position: fixed;
+	inset: 0;
+	z-index: -2;
+	pointer-events: none;
+	background:
+		radial-gradient(62% 40% at 50% 26%, rgba(251, 191, 36, 0.2), rgba(0, 0, 0, 0) 60%),
+		radial-gradient(40% 26% at 50% 22%, rgba(255, 220, 140, 0.1), rgba(0, 0, 0, 0) 55%),
+		radial-gradient(80% 60% at 50% 120%, rgba(180, 140, 60, 0.07), rgba(0, 0, 0, 0) 60%);
+	animation: spotlightBreathe 12s ease-in-out infinite alternate;
 }
 @keyframes spotlightBreathe {
-  0%   { opacity: 0.85; }
-  100% { opacity: 1; }
+	0% {
+		opacity: 0.85;
+	}
+	100% {
+		opacity: 1;
+	}
 }
 
 /* Fine film grain for a premium, less-flat surface */
 body::after {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  opacity: 0.035;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+	content: '';
+	position: fixed;
+	inset: 0;
+	z-index: -1;
+	pointer-events: none;
+	opacity: 0.035;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
 }
 
-h1, h2, h3, h4 {
-  font-family: var(--font-display);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0;
+h1,
+h2,
+h3,
+h4 {
+	font-family: var(--font-display);
+	font-weight: 700;
+	letter-spacing: -0.02em;
+	margin: 0;
 }
 
-button { font-family: inherit; }
+button {
+	font-family: inherit;
+}
 
 /* Press = a brief GOLD flash, driven by a real click/tap (the layout toggles
    .gold-flash on click). Using click — not :active — means scrolling or brushing
    a button on a phone never lights it up; only a genuine activation does.
    Component rules (.menu-card, .key) layer a stronger version on top. */
 button.gold-flash {
-  outline: none;
-  border-color: #fde047;
-  background: linear-gradient(135deg, #fde047, #f59e0b);
-  color: #3a2a00;
-  box-shadow:
-    0 0 0 2px rgba(253, 224, 71, 1),
-    0 0 16px rgba(251, 191, 36, 0.95),
-    0 0 34px rgba(251, 191, 36, 0.7),
-    0 0 66px rgba(251, 191, 36, 0.42);
+	outline: none;
+	border-color: #fde047;
+	background: linear-gradient(135deg, #fde047, #f59e0b);
+	color: #3a2a00;
+	box-shadow:
+		0 0 0 2px rgba(253, 224, 71, 1),
+		0 0 16px rgba(251, 191, 36, 0.95),
+		0 0 34px rgba(251, 191, 36, 0.7),
+		0 0 66px rgba(251, 191, 36, 0.42);
 }
 /* Keyboard focus = the gold glow ring only (don't fill on tab-focus). */
 button:focus-visible {
-  outline: none;
-  border-color: #fde047;
-  box-shadow:
-    0 0 0 2px rgba(253, 224, 71, 0.9),
-    0 0 16px rgba(251, 191, 36, 0.7),
-    0 0 34px rgba(251, 191, 36, 0.45);
+	outline: none;
+	border-color: #fde047;
+	box-shadow:
+		0 0 0 2px rgba(253, 224, 71, 0.9),
+		0 0 16px rgba(251, 191, 36, 0.7),
+		0 0 34px rgba(251, 191, 36, 0.45);
 }
 
 /* Numbers that should feel like a readout (money, counters) */
-.tabular { font-variant-numeric: tabular-nums; font-feature-settings: 'tnum' 1; }
+.tabular {
+	font-variant-numeric: tabular-nums;
+	font-feature-settings: 'tnum' 1;
+}
 
 /* Reusable glass surface */
 .glass {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-lg);
-  backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--r-lg);
+	backdrop-filter: blur(14px) saturate(140%);
+	-webkit-backdrop-filter: blur(14px) saturate(140%);
 }
 
 /* Primary brand button */
 .btn-brand {
-  font-family: var(--font-display);
-  font-weight: 700;
-  letter-spacing: 0.01em;
-  color: #3a2a00;
-  background: var(--brand-grad);
-  border: none;
-  border-radius: var(--r-md);
-  padding: 14px 20px;
-  cursor: pointer;
-  box-shadow: var(--glow-brand);
-  transition: transform 0.15s var(--ease-spring), box-shadow 0.2s var(--ease-out), filter 0.2s;
+	font-family: var(--font-display);
+	font-weight: 700;
+	letter-spacing: 0.01em;
+	color: #3a2a00;
+	background: var(--brand-grad);
+	border: none;
+	border-radius: var(--r-md);
+	padding: 14px 20px;
+	cursor: pointer;
+	box-shadow: var(--glow-brand);
+	transition:
+		transform 0.15s var(--ease-spring),
+		box-shadow 0.2s var(--ease-out),
+		filter 0.2s;
 }
-.btn-brand:hover { transform: translateY(-2px); filter: brightness(1.05); }
-.btn-brand:active { transform: translateY(0) scale(0.98); }
-.btn-brand:disabled { opacity: 0.5; cursor: not-allowed; filter: grayscale(0.4); box-shadow: none; }
+.btn-brand:hover {
+	transform: translateY(-2px);
+	filter: brightness(1.05);
+}
+.btn-brand:active {
+	transform: translateY(0) scale(0.98);
+}
+.btn-brand:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+	filter: grayscale(0.4);
+	box-shadow: none;
+}
 
 /* Ghost / secondary button */
 .btn-ghost {
-  font-family: var(--font-ui);
-  font-weight: 600;
-  color: var(--text);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  padding: 13px 18px;
-  cursor: pointer;
-  transition: transform 0.15s var(--ease-spring), background 0.2s, border-color 0.2s;
+	font-family: var(--font-ui);
+	font-weight: 600;
+	color: var(--text);
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	padding: 13px 18px;
+	cursor: pointer;
+	transition:
+		transform 0.15s var(--ease-spring),
+		background 0.2s,
+		border-color 0.2s;
 }
-.btn-ghost:hover { background: var(--surface-2); border-color: var(--border-strong); transform: translateY(-1px); }
-.btn-ghost:active { transform: scale(0.98); }
+.btn-ghost:hover {
+	background: var(--surface-2);
+	border-color: var(--border-strong);
+	transform: translateY(-1px);
+}
+.btn-ghost:active {
+	transform: scale(0.98);
+}
 
 /* Inputs */
 .field {
-  width: 100%;
-  font-family: var(--font-ui);
-  font-size: 1rem;
-  color: var(--text);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border);
-  border-radius: var(--r-md);
-  padding: 14px 16px;
-  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+	width: 100%;
+	font-family: var(--font-ui);
+	font-size: 1rem;
+	color: var(--text);
+	background: rgba(255, 255, 255, 0.04);
+	border: 1px solid var(--border);
+	border-radius: var(--r-md);
+	padding: 14px 16px;
+	transition:
+		border-color 0.2s,
+		box-shadow 0.2s,
+		background 0.2s;
 }
-.field::placeholder { color: var(--text-faint); }
+.field::placeholder {
+	color: var(--text-faint);
+}
 .field:focus {
-  outline: none;
-  border-color: rgba(251, 191, 36, 0.6);
-  background: rgba(255, 255, 255, 0.06);
-  box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.15);
+	outline: none;
+	border-color: rgba(251, 191, 36, 0.6);
+	background: rgba(255, 255, 255, 0.06);
+	box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.15);
 }
 
 @keyframes wb-fade-up {
-  from { opacity: 0; transform: translateY(12px); }
-  to   { opacity: 1; transform: translateY(0); }
+	from {
+		opacity: 0;
+		transform: translateY(12px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
 }
-.fade-up { animation: wb-fade-up 0.5s var(--ease-out) both; }
+.fade-up {
+	animation: wb-fade-up 0.5s var(--ease-out) both;
+}
 
 /* Staggered children: set style="--i: n" on each child for a cascade */
-.stagger > * { animation: wb-fade-up 0.55s var(--ease-out) both; animation-delay: calc(var(--i, 0) * 70ms); }
+.stagger > * {
+	animation: wb-fade-up 0.55s var(--ease-out) both;
+	animation-delay: calc(var(--i, 0) * 70ms);
+}
 
 /* Pop / glow / shimmer / float — reusable epic accents */
 @keyframes wb-pop-in {
-  0%   { opacity: 0; transform: scale(0.8); }
-  60%  { transform: scale(1.06); }
-  100% { opacity: 1; transform: scale(1); }
+	0% {
+		opacity: 0;
+		transform: scale(0.8);
+	}
+	60% {
+		transform: scale(1.06);
+	}
+	100% {
+		opacity: 1;
+		transform: scale(1);
+	}
 }
-.pop-in { animation: wb-pop-in 0.5s var(--ease-spring) both; }
+.pop-in {
+	animation: wb-pop-in 0.5s var(--ease-spring) both;
+}
 
 @keyframes wb-glow-pulse {
-  0%, 100% { box-shadow: var(--glow-brand); }
-  50%      { box-shadow: 0 0 0 1px rgba(253, 224, 71,0.45), 0 10px 42px rgba(251, 191, 36,0.55); }
+	0%,
+	100% {
+		box-shadow: var(--glow-brand);
+	}
+	50% {
+		box-shadow:
+			0 0 0 1px rgba(253, 224, 71, 0.45),
+			0 10px 42px rgba(251, 191, 36, 0.55);
+	}
 }
 @keyframes wb-float {
-  0%, 100% { transform: translateY(0); }
-  50%      { transform: translateY(-5px); }
+	0%,
+	100% {
+		transform: translateY(0);
+	}
+	50% {
+		transform: translateY(-5px);
+	}
 }
-.float { animation: wb-float 4.5s ease-in-out infinite; }
+.float {
+	animation: wb-float 4.5s ease-in-out infinite;
+}
 
 /* Sweeping sheen for brand buttons / cards */
 @keyframes wb-sheen {
-  0%   { transform: translateX(-130%) skewX(-18deg); }
-  100% { transform: translateX(230%) skewX(-18deg); }
+	0% {
+		transform: translateX(-130%) skewX(-18deg);
+	}
+	100% {
+		transform: translateX(230%) skewX(-18deg);
+	}
 }
-.btn-brand, .sheen { position: relative; overflow: hidden; isolation: isolate; }
-.btn-brand::after, .sheen::after {
-  content: '';
-  position: absolute;
-  top: 0; bottom: 0; left: 0;
-  width: 40%;
-  background: linear-gradient(100deg, transparent, rgba(255,255,255,0.5), transparent);
-  transform: translateX(-130%) skewX(-18deg);
-  pointer-events: none;
+.btn-brand,
+.sheen {
+	position: relative;
+	overflow: hidden;
+	isolation: isolate;
 }
-.btn-brand:hover::after, .sheen:hover::after { animation: wb-sheen 0.85s var(--ease-out); }
+.btn-brand::after,
+.sheen::after {
+	content: '';
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+	width: 40%;
+	background: linear-gradient(100deg, transparent, rgba(255, 255, 255, 0.5), transparent);
+	transform: translateX(-130%) skewX(-18deg);
+	pointer-events: none;
+}
+.btn-brand:hover::after,
+.sheen:hover::after {
+	animation: wb-sheen 0.85s var(--ease-out);
+}
 
 /* Respect users who prefer less motion */
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.001ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.001ms !important;
-  }
-  body::before { animation: none !important; }
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.001ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.001ms !important;
+	}
+	body::before {
+		animation: none !important;
+	}
 }

--- a/src/app.html
+++ b/src/app.html
@@ -1,21 +1,21 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <link rel="icon" href="/logo-mark.png" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/manifest.webmanifest" />
-    <meta name="theme-color" content="#0a0e14" />
-    <!-- "Add to Home Screen" → opens full-screen like a real app -->
-    <meta name="mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-    <meta name="apple-mobile-web-app-title" content="WordBank" />
-    <title>WordBank Game</title>
-    %sveltekit.head%
-</head>
-<body>
-    <div style="display: contents">%sveltekit.body%</div>
-</body>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+		<link rel="icon" href="/logo-mark.png" />
+		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+		<link rel="manifest" href="/manifest.webmanifest" />
+		<meta name="theme-color" content="#0a0e14" />
+		<!-- "Add to Home Screen" → opens full-screen like a real app -->
+		<meta name="mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-status-bar-style" content="default" />
+		<meta name="apple-mobile-web-app-title" content="WordBank" />
+		<title>WordBank Game</title>
+		%sveltekit.head%
+	</head>
+	<body>
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
 </html>

--- a/src/canvas-confetti.d.ts
+++ b/src/canvas-confetti.d.ts
@@ -1,4 +1,4 @@
 declare module 'canvas-confetti' {
-  function confetti(options?: object): Promise<null>;
-  export default confetti;
+	function confetti(options?: object): Promise<null>;
+	export default confetti;
 }

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -5,21 +5,29 @@ import { supabase } from '$lib/supabaseClient';
 /** @type {string|null} */
 let _session = null;
 function sessionId() {
-  if (_session) return _session;
-  try { _session = crypto.randomUUID(); }
-  catch { _session = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`; }
-  return _session;
+	if (_session) return _session;
+	try {
+		_session = crypto.randomUUID();
+	} catch {
+		_session = `${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
+	}
+	return _session;
 }
 
 /** web | pwa | ios — so we can split traffic by surface. */
 function platform() {
-  if (typeof window === 'undefined') return 'ssr';
-  const ua = navigator.userAgent || '';
-  const cap = /** @type {any} */ (window).Capacitor;
-  if (/WordBankApp/i.test(ua) || (cap && (cap.isNativePlatform ? cap.isNativePlatform() : cap.isNative))) return 'ios';
-  const standalone = (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches)
-    || /** @type {any} */ (window.navigator).standalone === true;
-  return standalone ? 'pwa' : 'web';
+	if (typeof window === 'undefined') return 'ssr';
+	const ua = navigator.userAgent || '';
+	const cap = /** @type {any} */ (window).Capacitor;
+	if (
+		/WordBankApp/i.test(ua) ||
+		(cap && (cap.isNativePlatform ? cap.isNativePlatform() : cap.isNative))
+	)
+		return 'ios';
+	const standalone =
+		(window.matchMedia && window.matchMedia('(display-mode: standalone)').matches) ||
+		/** @type {any} */ (window.navigator).standalone === true;
+	return standalone ? 'pwa' : 'web';
 }
 
 /**
@@ -28,12 +36,19 @@ function platform() {
  * @param {Record<string, any>} [props]
  */
 export function track(name, props = {}) {
-  try {
-    supabase.rpc('log_event', {
-      p_name: name,
-      p_props: props ?? {},
-      p_session: sessionId(),
-      p_platform: platform()
-    }).then(() => {}, () => {}); // ignore success + failure
-  } catch { /* analytics must never break the app */ }
+	try {
+		supabase
+			.rpc('log_event', {
+				p_name: name,
+				p_props: props ?? {},
+				p_session: sessionId(),
+				p_platform: platform()
+			})
+			.then(
+				() => {},
+				() => {}
+			); // ignore success + failure
+	} catch {
+		/* analytics must never break the app */
+	}
 }

--- a/src/lib/avatar.js
+++ b/src/lib/avatar.js
@@ -6,165 +6,299 @@ import { avataaars } from '@dicebear/collection';
 
 /** A sensible starter look for brand-new players. */
 export const DEFAULT_AVATAR = {
-  skinColor: 'edb98a', top: 'shortFlat', hairColor: '4a312c',
-  eyes: 'default', eyebrows: 'default', mouth: 'smile',
-  clothing: 'shirtCrewNeck', clothesColor: '5199e4', clothingGraphic: 'bear',
-  accessories: 'none', accessoriesColor: '262e33', facialHair: 'none', hatColor: '262e33',
-  // premium FX — rendered by Avatar.svelte, not avataaars
-  fxShirt: 'none', frame: 'none', overlay: 'none', aura: 'none'
+	skinColor: 'edb98a',
+	top: 'shortFlat',
+	hairColor: '4a312c',
+	eyes: 'default',
+	eyebrows: 'default',
+	mouth: 'smile',
+	clothing: 'shirtCrewNeck',
+	clothesColor: '5199e4',
+	clothingGraphic: 'bear',
+	accessories: 'none',
+	accessoriesColor: '262e33',
+	facialHair: 'none',
+	hatColor: '262e33',
+	// premium FX — rendered by Avatar.svelte, not avataaars
+	fxShirt: 'none',
+	frame: 'none',
+	overlay: 'none',
+	aura: 'none'
 };
 
 const SKIN = ['ffdbb4', 'edb98a', 'fd9841', 'f8d25c', 'd08b5b', 'ae5d29', '614335'];
-const HAIR = ['2c1b18', '4a312c', '724133', 'a55728', 'b58143', 'c93305', 'd6b370', 'e8e1e1', 'ecdcbf', 'f59797'];
-const OUTFIT = ['262e33', '3c4f5c', '5199e4', '25557c', '65c9ff', '929598', 'a7ffc4', 'ff488e', 'ff5c5c', 'ffffb1', 'ffffff'];
+const HAIR = [
+	'2c1b18',
+	'4a312c',
+	'724133',
+	'a55728',
+	'b58143',
+	'c93305',
+	'd6b370',
+	'e8e1e1',
+	'ecdcbf',
+	'f59797'
+];
+const OUTFIT = [
+	'262e33',
+	'3c4f5c',
+	'5199e4',
+	'25557c',
+	'65c9ff',
+	'929598',
+	'a7ffc4',
+	'ff488e',
+	'ff5c5c',
+	'ffffb1',
+	'ffffff'
+];
 const NEON = ['262e33', '5199e4', 'ff488e', '7cff6b', 'ffe45c', 'c4b5fd', 'ff5c5c', 'ffffff'];
 const col = (/** @type {string[]} */ a) => a.map((value) => ({ value, label: '#' + value }));
 
 /** Ordered builder categories. `type:'color'` = swatches, `type:'style'` = thumbnails.
  *  Options with a `price` are paid (must be owned to equip). @type {any[]} */
 export const CATEGORIES = [
-  { key: 'skinColor', label: 'Skin', type: 'color', options: col(SKIN) },
-  { key: 'top', label: 'Hair & Hats', type: 'style', options: [
-    { value: 'none', label: 'Bald' }, { value: 'shortFlat', label: 'Short' }, { value: 'shortRound', label: 'Buzz' },
-    { value: 'shortWaved', label: 'Waved' }, { value: 'straight01', label: 'Straight' }, { value: 'bun', label: 'Bun' },
-    { value: 'shavedSides', label: 'Shaved Sides' }, { value: 'longButNotTooLong', label: 'Long' }, { value: 'sides', label: 'Sides' },
-    { value: 'theCaesar', label: 'Caesar' }, { value: 'hijab', label: 'Hijab' }, { value: 'turban', label: 'Turban' },
-    { value: 'curly', label: 'Curly', cosmeticId: 'av_top_curly', price: 300 },
-    { value: 'miaWallace', label: 'Long Bob', cosmeticId: 'av_top_miawallace', price: 400 },
-    { value: 'fro', label: 'Afro', cosmeticId: 'av_top_fro', price: 400 },
-    { value: 'dreads', label: 'Dreads', cosmeticId: 'av_top_dreads', price: 500 },
-    { value: 'bigHair', label: 'Big Hair', cosmeticId: 'av_top_bighair', price: 500 },
-    { value: 'frida', label: 'Frida', cosmeticId: 'av_top_frida', price: 600 },
-    { value: 'hat', label: 'Fedora', cosmeticId: 'av_top_hat', price: 600 },
-    { value: 'winterHat1', label: 'Beanie', cosmeticId: 'av_top_beanie', price: 400 },
-    { value: 'winterHat03', label: 'Bobble Hat', cosmeticId: 'av_top_bobble', price: 500 }
-  ] },
-  { key: 'hairColor', label: 'Hair Color', type: 'color', options: col(HAIR) },
-  { key: 'hatColor', label: 'Hat Color', type: 'color', options: col(OUTFIT) },
-  { key: 'eyes', label: 'Eyes', type: 'style', options: [
-    { value: 'default', label: 'Default' }, { value: 'happy', label: 'Happy' }, { value: 'wink', label: 'Wink' },
-    { value: 'squint', label: 'Squint' }, { value: 'side', label: 'Side' }, { value: 'surprised', label: 'Surprised' }, { value: 'hearts', label: 'Hearts' }
-  ] },
-  { key: 'eyebrows', label: 'Brows', type: 'style', options: [
-    { value: 'default', label: 'Default' }, { value: 'defaultNatural', label: 'Natural' }, { value: 'raisedExcited', label: 'Raised' },
-    { value: 'flatNatural', label: 'Flat' }, { value: 'sadConcerned', label: 'Sad' }, { value: 'angry', label: 'Angry' }
-  ] },
-  { key: 'mouth', label: 'Mouth', type: 'style', options: [
-    { value: 'smile', label: 'Smile' }, { value: 'default', label: 'Default' }, { value: 'twinkle', label: 'Twinkle' },
-    { value: 'serious', label: 'Serious' }, { value: 'eating', label: 'Eating' }, { value: 'tongue', label: 'Tongue' }
-  ] },
-  { key: 'facialHair', label: 'Beard', type: 'style', options: [
-    { value: 'none', label: 'None' },
-    { value: 'beardLight', label: 'Light Beard', cosmeticId: 'av_beard_light', price: 300 },
-    { value: 'beardMedium', label: 'Beard', cosmeticId: 'av_beard_medium', price: 400 },
-    { value: 'beardMajestic', label: 'Majestic', cosmeticId: 'av_beard_majestic', price: 700 },
-    { value: 'moustacheFancy', label: 'Fancy Stache', cosmeticId: 'av_must_fancy', price: 400 },
-    { value: 'moustacheMagnum', label: 'Magnum Stache', cosmeticId: 'av_must_magnum', price: 400 }
-  ] },
-  { key: 'clothing', label: 'Clothes', type: 'style', options: [
-    { value: 'shirtCrewNeck', label: 'Crew Tee' }, { value: 'shirtVNeck', label: 'V-Neck' }, { value: 'shirtScoopNeck', label: 'Scoop Tee' },
-    { value: 'hoodie', label: 'Hoodie', cosmeticId: 'av_cloth_hoodie', price: 400 },
-    { value: 'graphicShirt', label: 'Graphic Tee' },
-    { value: 'collarAndSweater', label: 'Collar & Sweater', cosmeticId: 'av_cloth_collar', price: 600 },
-    { value: 'overall', label: 'Overalls', cosmeticId: 'av_cloth_overall', price: 500 },
-    { value: 'blazerAndShirt', label: 'Blazer', cosmeticId: 'av_cloth_blazer', price: 800 },
-    { value: 'blazerAndSweater', label: 'Blazer & Sweater', cosmeticId: 'av_cloth_blazersw', price: 900 }
-  ] },
-  { key: 'clothesColor', label: 'Outfit Color', type: 'color', options: col(OUTFIT) },
-  { key: 'clothingGraphic', label: 'Shirt Design', type: 'style', hint: 'On the Graphic Tee', options: [
-    { value: 'bear', label: 'Bear' }, { value: 'diamond', label: 'Diamond' },
-    { value: 'skull', label: 'Skull', cosmeticId: 'av_gfx_skull', price: 200 },
-    { value: 'skullOutline', label: 'Skull 2', cosmeticId: 'av_gfx_skullo', price: 200 },
-    { value: 'bat', label: 'Bat', cosmeticId: 'av_gfx_bat', price: 200 },
-    { value: 'deer', label: 'Deer', cosmeticId: 'av_gfx_deer', price: 200 },
-    { value: 'pizza', label: 'Pizza', cosmeticId: 'av_gfx_pizza', price: 300 },
-    { value: 'hola', label: 'Hola', cosmeticId: 'av_gfx_hola', price: 200 },
-    { value: 'cumbia', label: 'Cumbia', cosmeticId: 'av_gfx_cumbia', price: 200 },
-    { value: 'resist', label: 'Resist', cosmeticId: 'av_gfx_resist', price: 300 }
-  ] },
-  { key: 'accessories', label: 'Glasses', type: 'style', options: [
-    { value: 'none', label: 'None' },
-    { value: 'round', label: 'Round', cosmeticId: 'av_acc_round', price: 300 },
-    { value: 'sunglasses', label: 'Sunglasses', cosmeticId: 'av_acc_sunglasses', price: 500 },
-    { value: 'wayfarers', label: 'Wayfarers', cosmeticId: 'av_acc_wayfarers', price: 500 },
-    { value: 'prescription01', label: 'Specs', cosmeticId: 'av_acc_specs', price: 300 },
-    { value: 'kurt', label: 'Kurt', cosmeticId: 'av_acc_kurt', price: 400 },
-    { value: 'eyepatch', label: 'Eyepatch', cosmeticId: 'av_acc_eyepatch', price: 700 }
-  ] },
-  { key: 'accessoriesColor', label: 'Glasses Color', type: 'color', options: col(NEON) },
-  // ── ✨ Premium FX (rendered by Avatar.svelte) ──
-  { key: 'fxShirt', label: '✨ Shirt FX', type: 'fx', options: [
-    { value: 'none', label: 'None' },
-    { value: 'holo', label: 'Holographic', cosmeticId: 'av_fxshirt_holo', price: 1500 }
-  ] },
-  { key: 'frame', label: '🖼️ Frame', type: 'fx', options: [
-    { value: 'none', label: 'None' },
-    { value: 'neon', label: 'Neon', cosmeticId: 'av_frame_neon', price: 1000 },
-    { value: 'gold', label: 'Gold', cosmeticId: 'av_frame_gold', price: 1200 },
-    { value: 'gem', label: 'Gem', cosmeticId: 'av_frame_gem', price: 2000 }
-  ] },
-  { key: 'overlay', label: '👑 Headpiece', type: 'fx', options: [
-    { value: 'none', label: 'None' },
-    { value: 'crown', label: 'Crown', cosmeticId: 'av_overlay_crown', price: 1500 },
-    { value: 'halo', label: 'Halo', cosmeticId: 'av_overlay_halo', price: 1000 },
-    { value: 'horns', label: 'Horns', cosmeticId: 'av_overlay_horns', price: 800 }
-  ] },
-  { key: 'aura', label: '🔆 Aura', type: 'fx', options: [
-    { value: 'none', label: 'None' },
-    { value: 'neon', label: 'Neon Glow', cosmeticId: 'av_aura_neon', price: 800 },
-    { value: 'gold', label: 'Gold Glow', cosmeticId: 'av_aura_gold', price: 1000 }
-  ] }
+	{ key: 'skinColor', label: 'Skin', type: 'color', options: col(SKIN) },
+	{
+		key: 'top',
+		label: 'Hair & Hats',
+		type: 'style',
+		options: [
+			{ value: 'none', label: 'Bald' },
+			{ value: 'shortFlat', label: 'Short' },
+			{ value: 'shortRound', label: 'Buzz' },
+			{ value: 'shortWaved', label: 'Waved' },
+			{ value: 'straight01', label: 'Straight' },
+			{ value: 'bun', label: 'Bun' },
+			{ value: 'shavedSides', label: 'Shaved Sides' },
+			{ value: 'longButNotTooLong', label: 'Long' },
+			{ value: 'sides', label: 'Sides' },
+			{ value: 'theCaesar', label: 'Caesar' },
+			{ value: 'hijab', label: 'Hijab' },
+			{ value: 'turban', label: 'Turban' },
+			{ value: 'curly', label: 'Curly', cosmeticId: 'av_top_curly', price: 300 },
+			{ value: 'miaWallace', label: 'Long Bob', cosmeticId: 'av_top_miawallace', price: 400 },
+			{ value: 'fro', label: 'Afro', cosmeticId: 'av_top_fro', price: 400 },
+			{ value: 'dreads', label: 'Dreads', cosmeticId: 'av_top_dreads', price: 500 },
+			{ value: 'bigHair', label: 'Big Hair', cosmeticId: 'av_top_bighair', price: 500 },
+			{ value: 'frida', label: 'Frida', cosmeticId: 'av_top_frida', price: 600 },
+			{ value: 'hat', label: 'Fedora', cosmeticId: 'av_top_hat', price: 600 },
+			{ value: 'winterHat1', label: 'Beanie', cosmeticId: 'av_top_beanie', price: 400 },
+			{ value: 'winterHat03', label: 'Bobble Hat', cosmeticId: 'av_top_bobble', price: 500 }
+		]
+	},
+	{ key: 'hairColor', label: 'Hair Color', type: 'color', options: col(HAIR) },
+	{ key: 'hatColor', label: 'Hat Color', type: 'color', options: col(OUTFIT) },
+	{
+		key: 'eyes',
+		label: 'Eyes',
+		type: 'style',
+		options: [
+			{ value: 'default', label: 'Default' },
+			{ value: 'happy', label: 'Happy' },
+			{ value: 'wink', label: 'Wink' },
+			{ value: 'squint', label: 'Squint' },
+			{ value: 'side', label: 'Side' },
+			{ value: 'surprised', label: 'Surprised' },
+			{ value: 'hearts', label: 'Hearts' }
+		]
+	},
+	{
+		key: 'eyebrows',
+		label: 'Brows',
+		type: 'style',
+		options: [
+			{ value: 'default', label: 'Default' },
+			{ value: 'defaultNatural', label: 'Natural' },
+			{ value: 'raisedExcited', label: 'Raised' },
+			{ value: 'flatNatural', label: 'Flat' },
+			{ value: 'sadConcerned', label: 'Sad' },
+			{ value: 'angry', label: 'Angry' }
+		]
+	},
+	{
+		key: 'mouth',
+		label: 'Mouth',
+		type: 'style',
+		options: [
+			{ value: 'smile', label: 'Smile' },
+			{ value: 'default', label: 'Default' },
+			{ value: 'twinkle', label: 'Twinkle' },
+			{ value: 'serious', label: 'Serious' },
+			{ value: 'eating', label: 'Eating' },
+			{ value: 'tongue', label: 'Tongue' }
+		]
+	},
+	{
+		key: 'facialHair',
+		label: 'Beard',
+		type: 'style',
+		options: [
+			{ value: 'none', label: 'None' },
+			{ value: 'beardLight', label: 'Light Beard', cosmeticId: 'av_beard_light', price: 300 },
+			{ value: 'beardMedium', label: 'Beard', cosmeticId: 'av_beard_medium', price: 400 },
+			{ value: 'beardMajestic', label: 'Majestic', cosmeticId: 'av_beard_majestic', price: 700 },
+			{ value: 'moustacheFancy', label: 'Fancy Stache', cosmeticId: 'av_must_fancy', price: 400 },
+			{ value: 'moustacheMagnum', label: 'Magnum Stache', cosmeticId: 'av_must_magnum', price: 400 }
+		]
+	},
+	{
+		key: 'clothing',
+		label: 'Clothes',
+		type: 'style',
+		options: [
+			{ value: 'shirtCrewNeck', label: 'Crew Tee' },
+			{ value: 'shirtVNeck', label: 'V-Neck' },
+			{ value: 'shirtScoopNeck', label: 'Scoop Tee' },
+			{ value: 'hoodie', label: 'Hoodie', cosmeticId: 'av_cloth_hoodie', price: 400 },
+			{ value: 'graphicShirt', label: 'Graphic Tee' },
+			{
+				value: 'collarAndSweater',
+				label: 'Collar & Sweater',
+				cosmeticId: 'av_cloth_collar',
+				price: 600
+			},
+			{ value: 'overall', label: 'Overalls', cosmeticId: 'av_cloth_overall', price: 500 },
+			{ value: 'blazerAndShirt', label: 'Blazer', cosmeticId: 'av_cloth_blazer', price: 800 },
+			{
+				value: 'blazerAndSweater',
+				label: 'Blazer & Sweater',
+				cosmeticId: 'av_cloth_blazersw',
+				price: 900
+			}
+		]
+	},
+	{ key: 'clothesColor', label: 'Outfit Color', type: 'color', options: col(OUTFIT) },
+	{
+		key: 'clothingGraphic',
+		label: 'Shirt Design',
+		type: 'style',
+		hint: 'On the Graphic Tee',
+		options: [
+			{ value: 'bear', label: 'Bear' },
+			{ value: 'diamond', label: 'Diamond' },
+			{ value: 'skull', label: 'Skull', cosmeticId: 'av_gfx_skull', price: 200 },
+			{ value: 'skullOutline', label: 'Skull 2', cosmeticId: 'av_gfx_skullo', price: 200 },
+			{ value: 'bat', label: 'Bat', cosmeticId: 'av_gfx_bat', price: 200 },
+			{ value: 'deer', label: 'Deer', cosmeticId: 'av_gfx_deer', price: 200 },
+			{ value: 'pizza', label: 'Pizza', cosmeticId: 'av_gfx_pizza', price: 300 },
+			{ value: 'hola', label: 'Hola', cosmeticId: 'av_gfx_hola', price: 200 },
+			{ value: 'cumbia', label: 'Cumbia', cosmeticId: 'av_gfx_cumbia', price: 200 },
+			{ value: 'resist', label: 'Resist', cosmeticId: 'av_gfx_resist', price: 300 }
+		]
+	},
+	{
+		key: 'accessories',
+		label: 'Glasses',
+		type: 'style',
+		options: [
+			{ value: 'none', label: 'None' },
+			{ value: 'round', label: 'Round', cosmeticId: 'av_acc_round', price: 300 },
+			{ value: 'sunglasses', label: 'Sunglasses', cosmeticId: 'av_acc_sunglasses', price: 500 },
+			{ value: 'wayfarers', label: 'Wayfarers', cosmeticId: 'av_acc_wayfarers', price: 500 },
+			{ value: 'prescription01', label: 'Specs', cosmeticId: 'av_acc_specs', price: 300 },
+			{ value: 'kurt', label: 'Kurt', cosmeticId: 'av_acc_kurt', price: 400 },
+			{ value: 'eyepatch', label: 'Eyepatch', cosmeticId: 'av_acc_eyepatch', price: 700 }
+		]
+	},
+	{ key: 'accessoriesColor', label: 'Glasses Color', type: 'color', options: col(NEON) },
+	// ── ✨ Premium FX (rendered by Avatar.svelte) ──
+	{
+		key: 'fxShirt',
+		label: '✨ Shirt FX',
+		type: 'fx',
+		options: [
+			{ value: 'none', label: 'None' },
+			{ value: 'holo', label: 'Holographic', cosmeticId: 'av_fxshirt_holo', price: 1500 }
+		]
+	},
+	{
+		key: 'frame',
+		label: '🖼️ Frame',
+		type: 'fx',
+		options: [
+			{ value: 'none', label: 'None' },
+			{ value: 'neon', label: 'Neon', cosmeticId: 'av_frame_neon', price: 1000 },
+			{ value: 'gold', label: 'Gold', cosmeticId: 'av_frame_gold', price: 1200 },
+			{ value: 'gem', label: 'Gem', cosmeticId: 'av_frame_gem', price: 2000 }
+		]
+	},
+	{
+		key: 'overlay',
+		label: '👑 Headpiece',
+		type: 'fx',
+		options: [
+			{ value: 'none', label: 'None' },
+			{ value: 'crown', label: 'Crown', cosmeticId: 'av_overlay_crown', price: 1500 },
+			{ value: 'halo', label: 'Halo', cosmeticId: 'av_overlay_halo', price: 1000 },
+			{ value: 'horns', label: 'Horns', cosmeticId: 'av_overlay_horns', price: 800 }
+		]
+	},
+	{
+		key: 'aura',
+		label: '🔆 Aura',
+		type: 'fx',
+		options: [
+			{ value: 'none', label: 'None' },
+			{ value: 'neon', label: 'Neon Glow', cosmeticId: 'av_aura_neon', price: 800 },
+			{ value: 'gold', label: 'Gold Glow', cosmeticId: 'av_aura_gold', price: 1000 }
+		]
+	}
 ];
 
 /** Map an avatar config to DiceBear avataaars options (forcing single values). @param {any} config */
 export function avataaarsOptions(config) {
-  const c = { ...DEFAULT_AVATAR, ...(config || {}) };
-  return {
-    seed: 'wb',
-    backgroundColor: ['transparent'],
-    skinColor: [c.skinColor],
-    top: c.top === 'none' ? [] : [c.top],
-    topProbability: c.top === 'none' ? 0 : 100,
-    hairColor: [c.hairColor],
-    hatColor: [c.hatColor],
-    eyes: [c.eyes],
-    eyebrows: [c.eyebrows],
-    mouth: [c.mouth],
-    facialHair: c.facialHair === 'none' ? [] : [c.facialHair],
-    facialHairProbability: c.facialHair === 'none' ? 0 : 100,
-    clothing: [c.clothing],
-    clothesColor: [c.clothesColor],
-    clothingGraphic: [c.clothingGraphic],
-    accessories: c.accessories === 'none' ? [] : [c.accessories],
-    accessoriesColor: [c.accessoriesColor],
-    accessoriesProbability: c.accessories === 'none' ? 0 : 100
-  };
+	const c = { ...DEFAULT_AVATAR, ...(config || {}) };
+	return {
+		seed: 'wb',
+		backgroundColor: ['transparent'],
+		skinColor: [c.skinColor],
+		top: c.top === 'none' ? [] : [c.top],
+		topProbability: c.top === 'none' ? 0 : 100,
+		hairColor: [c.hairColor],
+		hatColor: [c.hatColor],
+		eyes: [c.eyes],
+		eyebrows: [c.eyebrows],
+		mouth: [c.mouth],
+		facialHair: c.facialHair === 'none' ? [] : [c.facialHair],
+		facialHairProbability: c.facialHair === 'none' ? 0 : 100,
+		clothing: [c.clothing],
+		clothesColor: [c.clothesColor],
+		clothingGraphic: [c.clothingGraphic],
+		accessories: c.accessories === 'none' ? [] : [c.accessories],
+		accessoriesColor: [c.accessoriesColor],
+		accessoriesProbability: c.accessories === 'none' ? 0 : 100
+	};
 }
 
 /** Whether a config has any premium FX equipped. @param {any} config */
 export function hasFx(config) {
-  const c = config || {};
-  return (c.fxShirt && c.fxShirt !== 'none') || (c.frame && c.frame !== 'none') ||
-         (c.overlay && c.overlay !== 'none') || (c.aura && c.aura !== 'none');
+	const c = config || {};
+	return (
+		(c.fxShirt && c.fxShirt !== 'none') ||
+		(c.frame && c.frame !== 'none') ||
+		(c.overlay && c.overlay !== 'none') ||
+		(c.aura && c.aura !== 'none')
+	);
 }
 
 /** Render an avatar config to an SVG string. @param {any} config @param {any} [extra] extra DiceBear opts */
 export function renderAvatarSvg(config, extra = {}) {
-  return createAvatar(avataaars, { ...avataaarsOptions(config), ...extra }).toString();
+	return createAvatar(avataaars, { ...avataaarsOptions(config), ...extra }).toString();
 }
 
 /** PREMIUM FX: render the avatar with an animated holographic/iridescent shirt.
  *  Works by rendering the clothing in a sentinel colour, then swapping that fill
  *  for an animated multi-stop gradient. @param {any} config */
 export function renderHoloAvatar(config) {
-  const SENTINEL = '00fe01'; // an unlikely colour we can find + replace
-  let svg = renderAvatarSvg({ ...config, clothesColor: SENTINEL });
-  const defs =
-    '<defs><linearGradient id="wbHolo" gradientUnits="userSpaceOnUse" x1="40" y1="195" x2="240" y2="285" spreadMethod="reflect">' +
-    '<stop offset="0" stop-color="#ff5cf0"/><stop offset="0.3" stop-color="#5cd0ff"/>' +
-    '<stop offset="0.6" stop-color="#7cff6b"/><stop offset="1" stop-color="#ffe45c"/>' +
-    '<animateTransform attributeName="gradientTransform" type="translate" values="0 0;130 65;0 0" dur="3s" repeatCount="indefinite"/>' +
-    '</linearGradient></defs>';
-  svg = svg.replace('>', '>' + defs);
-  return svg.replace(new RegExp('#' + SENTINEL, 'gi'), 'url(#wbHolo)');
+	const SENTINEL = '00fe01'; // an unlikely colour we can find + replace
+	let svg = renderAvatarSvg({ ...config, clothesColor: SENTINEL });
+	const defs =
+		'<defs><linearGradient id="wbHolo" gradientUnits="userSpaceOnUse" x1="40" y1="195" x2="240" y2="285" spreadMethod="reflect">' +
+		'<stop offset="0" stop-color="#ff5cf0"/><stop offset="0.3" stop-color="#5cd0ff"/>' +
+		'<stop offset="0.6" stop-color="#7cff6b"/><stop offset="1" stop-color="#ffe45c"/>' +
+		'<animateTransform attributeName="gradientTransform" type="translate" values="0 0;130 65;0 0" dur="3s" repeatCount="indefinite"/>' +
+		'</linearGradient></defs>';
+	svg = svg.replace('>', '>' + defs);
+	return svg.replace(new RegExp('#' + SENTINEL, 'gi'), 'url(#wbHolo)');
 }

--- a/src/lib/avatarKit.js
+++ b/src/lib/avatarKit.js
@@ -15,48 +15,96 @@ export const KIT_READY = false;
 
 /** Slots in paint order, each with its placement {x,y,w,h} inside CANVAS. */
 export const SLOTS = [
-  { key: 'bottom', label: 'Bottoms', z: 0, place: { x: 0, y: 215, w: 300, h: 239 } },
-  { key: 'body', label: 'Outfit', z: 1, place: { x: 23, y: 105, w: 256, h: 187 } },
-  { key: 'head', label: 'Hair', z: 2, place: { x: 97, y: 17, w: 136, h: 104 } }
+	{ key: 'bottom', label: 'Bottoms', z: 0, place: { x: 0, y: 215, w: 300, h: 239 } },
+	{ key: 'body', label: 'Outfit', z: 1, place: { x: 23, y: 105, w: 256, h: 187 } },
+	{ key: 'head', label: 'Hair', z: 2, place: { x: 97, y: 17, w: 136, h: 104 } }
 ];
 
 /** Parts per slot. `price` = paid cosmetic (wired to the store when KIT_READY). */
 export const PARTS = /** @type {Record<string, any[]>} */ ({
-  head: [
-    { id: 'short-1', label: 'Short', file: 'short-1.svg' },
-    { id: 'short-2', label: 'Short 2', file: 'short-2.svg' },
-    { id: 'no-hair', label: 'Bald', file: 'no-hair.svg' },
-    { id: 'caesar', label: 'Caesar', file: 'caesar.svg' },
-    { id: 'wavy', label: 'Wavy', file: 'wavy.svg' },
-    { id: 'airy', label: 'Airy', file: 'airy.svg' },
-    { id: 'pony', label: 'Ponytail', file: 'pony.svg' },
-    { id: 'chongo', label: 'Bun', file: 'chongo.svg' },
-    { id: 'hijab-1', label: 'Hijab', file: 'hijab-1.svg' },
-    { id: 'turban-1', label: 'Turban', file: 'turban-1.svg' },
-    { id: 'curly', label: 'Curly', file: 'curly.svg', price: 300, cosmeticId: 'kit_head_curly' },
-    { id: 'afro', label: 'Afro', file: 'afro.svg', price: 400, cosmeticId: 'kit_head_afro' },
-    { id: 'long', label: 'Long', file: 'long.svg', price: 400, cosmeticId: 'kit_head_long' },
-    { id: 'rad', label: 'Rad', file: 'rad.svg', price: 400, cosmeticId: 'kit_head_rad' },
-    { id: 'top', label: 'Topknot', file: 'top.svg', price: 300, cosmeticId: 'kit_head_top' },
-    { id: 'short-beard', label: 'Beard', file: 'short-beard.svg', price: 500, cosmeticId: 'kit_head_beard' }
-  ],
-  body: [
-    { id: 'long-sleeve', label: 'Long Sleeve', file: 'long-sleeve.svg' },
-    { id: 'turtle-neck', label: 'Turtleneck', file: 'turtle-neck.svg' },
-    { id: 'hoodie', label: 'Hoodie', file: 'hoodie.svg', price: 400, cosmeticId: 'kit_body_hoodie' },
-    { id: 'jacket', label: 'Jacket', file: 'jacket.svg', price: 600, cosmeticId: 'kit_body_jacket' },
-    { id: 'jacket-2', label: 'Bomber', file: 'jacket-2.svg', price: 600, cosmeticId: 'kit_body_jacket2' },
-    { id: 'lab-coat', label: 'Lab Coat', file: 'lab-coat.svg', price: 700, cosmeticId: 'kit_body_labcoat' },
-    { id: 'trench-coat', label: 'Trench Coat', file: 'trench-coat.svg', price: 800, cosmeticId: 'kit_body_trench' }
-  ],
-  bottom: [
-    { id: 'skinny-jeans', label: 'Jeans', file: 'skinny-jeans.svg' },
-    { id: 'sweatpants', label: 'Sweatpants', file: 'sweatpants.svg' },
-    { id: 'shorts', label: 'Shorts', file: 'shorts.svg' },
-    { id: 'baggy-pants', label: 'Baggy Pants', file: 'baggy-pants.svg', price: 400, cosmeticId: 'kit_btm_baggy' },
-    { id: 'jogging', label: 'Joggers', file: 'jogging.svg', price: 400, cosmeticId: 'kit_btm_jogging' },
-    { id: 'skirt', label: 'Skirt', file: 'skirt.svg', price: 500, cosmeticId: 'kit_btm_skirt' }
-  ]
+	head: [
+		{ id: 'short-1', label: 'Short', file: 'short-1.svg' },
+		{ id: 'short-2', label: 'Short 2', file: 'short-2.svg' },
+		{ id: 'no-hair', label: 'Bald', file: 'no-hair.svg' },
+		{ id: 'caesar', label: 'Caesar', file: 'caesar.svg' },
+		{ id: 'wavy', label: 'Wavy', file: 'wavy.svg' },
+		{ id: 'airy', label: 'Airy', file: 'airy.svg' },
+		{ id: 'pony', label: 'Ponytail', file: 'pony.svg' },
+		{ id: 'chongo', label: 'Bun', file: 'chongo.svg' },
+		{ id: 'hijab-1', label: 'Hijab', file: 'hijab-1.svg' },
+		{ id: 'turban-1', label: 'Turban', file: 'turban-1.svg' },
+		{ id: 'curly', label: 'Curly', file: 'curly.svg', price: 300, cosmeticId: 'kit_head_curly' },
+		{ id: 'afro', label: 'Afro', file: 'afro.svg', price: 400, cosmeticId: 'kit_head_afro' },
+		{ id: 'long', label: 'Long', file: 'long.svg', price: 400, cosmeticId: 'kit_head_long' },
+		{ id: 'rad', label: 'Rad', file: 'rad.svg', price: 400, cosmeticId: 'kit_head_rad' },
+		{ id: 'top', label: 'Topknot', file: 'top.svg', price: 300, cosmeticId: 'kit_head_top' },
+		{
+			id: 'short-beard',
+			label: 'Beard',
+			file: 'short-beard.svg',
+			price: 500,
+			cosmeticId: 'kit_head_beard'
+		}
+	],
+	body: [
+		{ id: 'long-sleeve', label: 'Long Sleeve', file: 'long-sleeve.svg' },
+		{ id: 'turtle-neck', label: 'Turtleneck', file: 'turtle-neck.svg' },
+		{
+			id: 'hoodie',
+			label: 'Hoodie',
+			file: 'hoodie.svg',
+			price: 400,
+			cosmeticId: 'kit_body_hoodie'
+		},
+		{
+			id: 'jacket',
+			label: 'Jacket',
+			file: 'jacket.svg',
+			price: 600,
+			cosmeticId: 'kit_body_jacket'
+		},
+		{
+			id: 'jacket-2',
+			label: 'Bomber',
+			file: 'jacket-2.svg',
+			price: 600,
+			cosmeticId: 'kit_body_jacket2'
+		},
+		{
+			id: 'lab-coat',
+			label: 'Lab Coat',
+			file: 'lab-coat.svg',
+			price: 700,
+			cosmeticId: 'kit_body_labcoat'
+		},
+		{
+			id: 'trench-coat',
+			label: 'Trench Coat',
+			file: 'trench-coat.svg',
+			price: 800,
+			cosmeticId: 'kit_body_trench'
+		}
+	],
+	bottom: [
+		{ id: 'skinny-jeans', label: 'Jeans', file: 'skinny-jeans.svg' },
+		{ id: 'sweatpants', label: 'Sweatpants', file: 'sweatpants.svg' },
+		{ id: 'shorts', label: 'Shorts', file: 'shorts.svg' },
+		{
+			id: 'baggy-pants',
+			label: 'Baggy Pants',
+			file: 'baggy-pants.svg',
+			price: 400,
+			cosmeticId: 'kit_btm_baggy'
+		},
+		{
+			id: 'jogging',
+			label: 'Joggers',
+			file: 'jogging.svg',
+			price: 400,
+			cosmeticId: 'kit_btm_jogging'
+		},
+		{ id: 'skirt', label: 'Skirt', file: 'skirt.svg', price: 500, cosmeticId: 'kit_btm_skirt' }
+	]
 });
 
 /** A sensible starter look. */
@@ -64,6 +112,6 @@ export const DEFAULT_KIT = { head: 'short-1', body: 'long-sleeve', bottom: 'skin
 
 /** Resolve the SVG url for a slot's selected part. @param {string} slot @param {string} id */
 export function partFile(slot, id) {
-  const part = (PARTS[slot] || []).find((p) => p.id === id);
-  return part && part.file ? `/avatar/${slot}/${part.file}` : null;
+	const part = (PARTS[slot] || []).find((p) => p.id === id);
+	return part && part.file ? `/avatar/${slot}/${part.file}` : null;
 }

--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -2,42 +2,50 @@
 // Organized by the unified 5-bucket framework: Progression · Skill · Big-moment · Consistency · Social.
 /** @type {Record<string, { emoji: string, name: string, desc: string }>} */
 export const BADGES = {
-  // 🗓️ Daily
-  flawless:  { emoji: '🎯', name: 'Flawless',     desc: 'Solved a Daily with zero wrong letters' },
-  streak_7:  { emoji: '🔥', name: 'Week Warrior',  desc: '7-day Daily play streak' },
-  streak_30: { emoji: '👑', name: 'Iron Will',     desc: '30-day Daily play streak' },
-  week_complete:  { emoji: '🗓️', name: 'Perfect Week',  desc: 'Played every day of a calendar week' },
-  month_complete: { emoji: '📅', name: 'Perfect Month', desc: 'Played every day of a calendar month' },
+	// 🗓️ Daily
+	flawless: { emoji: '🎯', name: 'Flawless', desc: 'Solved a Daily with zero wrong letters' },
+	streak_7: { emoji: '🔥', name: 'Week Warrior', desc: '7-day Daily play streak' },
+	streak_30: { emoji: '👑', name: 'Iron Will', desc: '30-day Daily play streak' },
+	week_complete: { emoji: '🗓️', name: 'Perfect Week', desc: 'Played every day of a calendar week' },
+	month_complete: {
+		emoji: '📅',
+		name: 'Perfect Month',
+		desc: 'Played every day of a calendar month'
+	},
 
-  // 🎰 Cash Game
-  cg_bronze:      { emoji: '🥉', name: 'Bronze Runner',  desc: 'Cashed out a Bronze run' },
-  cg_silver:      { emoji: '🥈', name: 'Silver Runner',  desc: 'Cashed out a Silver run' },
-  cg_gold:        { emoji: '🥇', name: 'Gold Runner',    desc: 'Cashed out a Gold run' },
-  cg_run_5:       { emoji: '📈', name: 'On a Heater',    desc: '5 profitable cash-outs in a row' },
-  cg_multiple_10: { emoji: '🚀', name: 'Ten-Bagger',     desc: 'Cashed out 10× your buy-in' },
-  cg_heat_max:    { emoji: '🌋', name: 'Max Heat',       desc: 'Rode heat to the tier ceiling' },
-  cg_high_roller: { emoji: '💎', name: 'High Roller',    desc: 'A $25,000+ cash-out' },
-  gold_shark:     { emoji: '🦈', name: 'Gold Shark',     desc: 'Won a Gold Cash Game run — unlocks the 🦈 Gold Shark title' },
+	// 🎰 Cash Game
+	cg_bronze: { emoji: '🥉', name: 'Bronze Runner', desc: 'Cashed out a Bronze run' },
+	cg_silver: { emoji: '🥈', name: 'Silver Runner', desc: 'Cashed out a Silver run' },
+	cg_gold: { emoji: '🥇', name: 'Gold Runner', desc: 'Cashed out a Gold run' },
+	cg_run_5: { emoji: '📈', name: 'On a Heater', desc: '5 profitable cash-outs in a row' },
+	cg_multiple_10: { emoji: '🚀', name: 'Ten-Bagger', desc: 'Cashed out 10× your buy-in' },
+	cg_heat_max: { emoji: '🌋', name: 'Max Heat', desc: 'Rode heat to the tier ceiling' },
+	cg_high_roller: { emoji: '💎', name: 'High Roller', desc: 'A $25,000+ cash-out' },
+	gold_shark: {
+		emoji: '🦈',
+		name: 'Gold Shark',
+		desc: 'Won a Gold Cash Game run — unlocks the 🦈 Gold Shark title'
+	},
 
-  // ⚡ Blitz
-  bz_bronze:      { emoji: '🥉', name: 'Bronze Blitzer', desc: 'Played a Bronze Blitz run' },
-  bz_silver:      { emoji: '🥈', name: 'Silver Blitzer', desc: 'Played a Silver Blitz run' },
-  bz_gold:        { emoji: '🥇', name: 'Gold Blitzer',   desc: 'Played a Gold Blitz run' },
-  bz_speed_demon: { emoji: '😈', name: 'Speed Demon',    desc: 'Solved 10 in a single Blitz run' },
-  bz_combo_3:     { emoji: '🔗', name: 'Combo x3',       desc: 'Hit a ×3 combo in Blitz' },
-  bz_combo_5:     { emoji: '⚡', name: 'Combo x5',       desc: 'Maxed a ×5 combo in Blitz' },
-  bz_high_roller: { emoji: '💰', name: 'Big Blitz',      desc: 'A $5,000+ Blitz payout' },
+	// ⚡ Blitz
+	bz_bronze: { emoji: '🥉', name: 'Bronze Blitzer', desc: 'Played a Bronze Blitz run' },
+	bz_silver: { emoji: '🥈', name: 'Silver Blitzer', desc: 'Played a Silver Blitz run' },
+	bz_gold: { emoji: '🥇', name: 'Gold Blitzer', desc: 'Played a Gold Blitz run' },
+	bz_speed_demon: { emoji: '😈', name: 'Speed Demon', desc: 'Solved 10 in a single Blitz run' },
+	bz_combo_3: { emoji: '🔗', name: 'Combo x3', desc: 'Hit a ×3 combo in Blitz' },
+	bz_combo_5: { emoji: '⚡', name: 'Combo x5', desc: 'Maxed a ×5 combo in Blitz' },
+	bz_high_roller: { emoji: '💰', name: 'Big Blitz', desc: 'A $5,000+ Blitz payout' },
 
-  // ⚔️ Challenges
-  first_blood:  { emoji: '🩸', name: 'First Blood',   desc: 'Won your first challenge' },
-  gold_duelist: { emoji: '⚔️', name: 'Gold Duelist',  desc: 'Won a Gold challenge' },
-  hustler:      { emoji: '🤝', name: 'Hustler',       desc: 'Won 10 challenges' },
+	// ⚔️ Challenges
+	first_blood: { emoji: '🩸', name: 'First Blood', desc: 'Won your first challenge' },
+	gold_duelist: { emoji: '⚔️', name: 'Gold Duelist', desc: 'Won a Gold challenge' },
+	hustler: { emoji: '🤝', name: 'Hustler', desc: 'Won 10 challenges' },
 
-  // 💸 Economy
-  paid_in_full: { emoji: '🧾', name: 'Paid in Full',  desc: 'Cleared a loan from the Shark' },
+	// 💸 Economy
+	paid_in_full: { emoji: '🧾', name: 'Paid in Full', desc: 'Cleared a loan from the Shark' }
 };
 
 /** @param {string} id */
 export function badgeInfo(id) {
-  return BADGES[id] || { emoji: '🏅', name: id, desc: '' };
+	return BADGES[id] || { emoji: '🏅', name: id, desc: '' };
 }

--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -2,16 +2,16 @@
 // daily_puzzles.category (emoji included); used by the Challenge builder's picker.
 /** @type {{ value: string, label: string, emoji: string }[]} */
 export const CATEGORIES = [
-  { value: 'Movies & TV 🎬',        label: 'Movies & TV',       emoji: '🎬' },
-  { value: 'Music 🎵',             label: 'Music',             emoji: '🎵' },
-  { value: 'Famous People 🌟',     label: 'Famous People',     emoji: '🌟' },
-  { value: 'Food & Drink 🍔',      label: 'Food & Drink',      emoji: '🍔' },
-  { value: 'Places & Travel ✈️',   label: 'Places & Travel',   emoji: '✈️' },
-  { value: 'Sports 🏆',            label: 'Sports',            emoji: '🏆' },
-  { value: 'Phrases & Sayings 🗣️', label: 'Phrases & Sayings', emoji: '🗣️' },
-  { value: 'Science & Nature 🔬',  label: 'Science & Nature',  emoji: '🔬' },
-  { value: 'Books & Characters 📚', label: 'Books & Characters', emoji: '📚' },
-  { value: 'Video Games 🎮',       label: 'Video Games',       emoji: '🎮' },
-  { value: 'Brands & Logos 🏷️',    label: 'Brands & Logos',    emoji: '🏷️' },
-  { value: 'Tech & Internet 💻',   label: 'Tech & Internet',   emoji: '💻' }
+	{ value: 'Movies & TV 🎬', label: 'Movies & TV', emoji: '🎬' },
+	{ value: 'Music 🎵', label: 'Music', emoji: '🎵' },
+	{ value: 'Famous People 🌟', label: 'Famous People', emoji: '🌟' },
+	{ value: 'Food & Drink 🍔', label: 'Food & Drink', emoji: '🍔' },
+	{ value: 'Places & Travel ✈️', label: 'Places & Travel', emoji: '✈️' },
+	{ value: 'Sports 🏆', label: 'Sports', emoji: '🏆' },
+	{ value: 'Phrases & Sayings 🗣️', label: 'Phrases & Sayings', emoji: '🗣️' },
+	{ value: 'Science & Nature 🔬', label: 'Science & Nature', emoji: '🔬' },
+	{ value: 'Books & Characters 📚', label: 'Books & Characters', emoji: '📚' },
+	{ value: 'Video Games 🎮', label: 'Video Games', emoji: '🎮' },
+	{ value: 'Brands & Logos 🏷️', label: 'Brands & Logos', emoji: '🏷️' },
+	{ value: 'Tech & Internet 💻', label: 'Tech & Internet', emoji: '💻' }
 ];

--- a/src/lib/categoryBadges.js
+++ b/src/lib/categoryBadges.js
@@ -2,10 +2,10 @@
 
 /** Ascending tiers — a category badge levels up as you solve more in it. */
 export const CATEGORY_TIERS = [
-  { key: 'bronze',  name: 'Bronze',  medal: '🥉', at: 3 },
-  { key: 'silver',  name: 'Silver',  medal: '🥈', at: 10 },
-  { key: 'gold',    name: 'Gold',    medal: '🥇', at: 25 },
-  { key: 'diamond', name: 'Diamond', medal: '💎', at: 60 }
+	{ key: 'bronze', name: 'Bronze', medal: '🥉', at: 3 },
+	{ key: 'silver', name: 'Silver', medal: '🥈', at: 10 },
+	{ key: 'gold', name: 'Gold', medal: '🥇', at: 25 },
+	{ key: 'diamond', name: 'Diamond', medal: '💎', at: 60 }
 ];
 
 /**
@@ -13,27 +13,32 @@ export const CATEGORY_TIERS = [
  * @param {number} solves
  */
 export function categoryProgress(solves) {
-  let current = null;
-  for (const t of CATEGORY_TIERS) if (solves >= t.at) current = t;
-  const next = CATEGORY_TIERS.find((t) => solves < t.at) || null;
-  const prevAt = current ? current.at : 0;
-  const progress = next ? (solves - prevAt) / (next.at - prevAt) : 1;
-  return {
-    solves,
-    current,                    // {medal,name,at} or null (no tier yet)
-    next,                       // {medal,name,at} or null (maxed)
-    toNext: next ? next.at - solves : 0,
-    progress: Math.max(0, Math.min(1, progress))
-  };
+	let current = null;
+	for (const t of CATEGORY_TIERS) if (solves >= t.at) current = t;
+	const next = CATEGORY_TIERS.find((t) => solves < t.at) || null;
+	const prevAt = current ? current.at : 0;
+	const progress = next ? (solves - prevAt) / (next.at - prevAt) : 1;
+	return {
+		solves,
+		current, // {medal,name,at} or null (no tier yet)
+		next, // {medal,name,at} or null (maxed)
+		toNext: next ? next.at - solves : 0,
+		progress: Math.max(0, Math.min(1, progress))
+	};
 }
 
 /** Global "total puzzles solved" milestone achievements (any mode). */
 export const SOLVE_MILESTONES = [
-  { id: 'm10',  emoji: '🌱', name: 'Getting Started', at: 10,  desc: 'Solve 10 puzzles' },
-  { id: 'm50',  emoji: '✍️', name: 'Wordsmith',       at: 50,  desc: 'Solve 50 puzzles' },
-  { id: 'm150', emoji: '⚡', name: 'Phrase Fiend',     at: 150, desc: 'Solve 150 puzzles' },
-  { id: 'm500', emoji: '🧙', name: 'Word Wizard',      at: 500, desc: 'Solve 500 puzzles' }
+	{ id: 'm10', emoji: '🌱', name: 'Getting Started', at: 10, desc: 'Solve 10 puzzles' },
+	{ id: 'm50', emoji: '✍️', name: 'Wordsmith', at: 50, desc: 'Solve 50 puzzles' },
+	{ id: 'm150', emoji: '⚡', name: 'Phrase Fiend', at: 150, desc: 'Solve 150 puzzles' },
+	{ id: 'm500', emoji: '🧙', name: 'Word Wizard', at: 500, desc: 'Solve 500 puzzles' }
 ];
 
 /** A standalone achievement for earning Gold in every category. */
-export const COLLECTOR = { id: 'collector', emoji: '🏅', name: 'Collector', desc: 'Reach Gold in all 12 categories' };
+export const COLLECTOR = {
+	id: 'collector',
+	emoji: '🏅',
+	name: 'Collector',
+	desc: 'Reach Gold in all 12 categories'
+};

--- a/src/lib/components/ActivityPanel.svelte
+++ b/src/lib/components/ActivityPanel.svelte
@@ -1,106 +1,184 @@
 <script>
-  // Activity feed — you, your friends, your groups. Reused by the /activity route
-  // and the Community ▸ Activity tab.
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { getActivityFeed } from '$lib/stores/statsStore.js';
+	// Activity feed — you, your friends, your groups. Reused by the /activity route
+	// and the Community ▸ Activity tab.
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { getActivityFeed } from '$lib/stores/statsStore.js';
 
-  /** @type {any[]} */
-  let rows = $state([]);
-  let loading = $state(true);
-  let done = $state(false);
-  let offset = $state(0);
-  const PAGE = 30;
+	/** @type {any[]} */
+	let rows = $state([]);
+	let loading = $state(true);
+	let done = $state(false);
+	let offset = $state(0);
+	const PAGE = 30;
 
-  const ICON = {
-    daily_win: '📅', challenge: '⚔️', big_solve: '🎰', badge: '🏅', group_join: '👥'
-  };
-  const pretty = (/** @type {string} */ s) => (s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
-  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
+	/** @type {Record<string,string>} */
+	const ICON = {
+		daily_win: '📅',
+		challenge: '⚔️',
+		big_solve: '🎰',
+		badge: '🏅',
+		group_join: '👥'
+	};
+	const pretty = (/** @type {string} */ s) =>
+		(s || '').replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '');
+	const money = (/** @type {any} */ n) =>
+		(Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
 
-  /** relative time */
-  function ago(/** @type {string} */ t) {
-    const s = Math.max(1, Math.floor((Date.now() - new Date(t).getTime()) / 1000));
-    if (s < 60) return s + 's';
-    if (s < 3600) return Math.floor(s / 60) + 'm';
-    if (s < 86400) return Math.floor(s / 3600) + 'h';
-    if (s < 604800) return Math.floor(s / 86400) + 'd';
-    return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  }
+	/** relative time */
+	function ago(/** @type {string} */ t) {
+		const s = Math.max(1, Math.floor((Date.now() - new Date(t).getTime()) / 1000));
+		if (s < 60) return s + 's';
+		if (s < 3600) return Math.floor(s / 60) + 'm';
+		if (s < 86400) return Math.floor(s / 3600) + 'h';
+		if (s < 604800) return Math.floor(s / 86400) + 'd';
+		return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	}
 
-  /** @param {any} r */
-  function line(r) {
-    const m = r.meta || {};
-    switch (r.type) {
-      case 'daily_win': {
-        const extra = m.multiple_x100 ? ` (${mult(m.multiple_x100)})` : '';
-        return { verb: `won the Daily${extra}`, tag: m.net != null ? money(m.net) : '' };
-      }
-      case 'challenge':
-        return m.opponent_name
-          ? { verb: `beat @${m.opponent_name} in a challenge`, tag: '' }
-          : { verb: `won a group challenge${m.rank ? ` · #${m.rank}` : ''}`, tag: '' };
-      case 'big_solve':
-        return { verb: `pulled a ${mult(m.multiple_x100)} solve in the Cash Game`, tag: m.net != null ? money(m.net) : '' };
-      case 'badge':
-        return { verb: `earned the “${pretty(m.badge)}” badge`, tag: '' };
-      case 'group_join':
-        return { verb: `joined ${r.group_name || 'a group'}`, tag: '' };
-      default:
-        return { verb: 'did something', tag: '' };
-    }
-  }
+	/** @param {any} r */
+	function line(r) {
+		const m = r.meta || {};
+		switch (r.type) {
+			case 'daily_win': {
+				const extra = m.multiple_x100 ? ` (${mult(m.multiple_x100)})` : '';
+				return { verb: `won the Daily${extra}`, tag: m.net != null ? money(m.net) : '' };
+			}
+			case 'challenge':
+				return m.opponent_name
+					? { verb: `beat @${m.opponent_name} in a challenge`, tag: '' }
+					: { verb: `won a group challenge${m.rank ? ` · #${m.rank}` : ''}`, tag: '' };
+			case 'big_solve':
+				return {
+					verb: `pulled a ${mult(m.multiple_x100)} solve in the Cash Game`,
+					tag: m.net != null ? money(m.net) : ''
+				};
+			case 'badge':
+				return { verb: `earned the “${pretty(m.badge)}” badge`, tag: '' };
+			case 'group_join':
+				return { verb: `joined ${r.group_name || 'a group'}`, tag: '' };
+			default:
+				return { verb: 'did something', tag: '' };
+		}
+	}
 
-  async function load(reset = false) {
-    if (reset) { offset = 0; done = false; rows = []; }
-    loading = true;
-    const page = await getActivityFeed(PAGE, offset);
-    rows = reset ? page : [...rows, ...page];
-    offset += page.length;
-    if (page.length < PAGE) done = true;
-    loading = false;
-  }
+	async function load(reset = false) {
+		if (reset) {
+			offset = 0;
+			done = false;
+			rows = [];
+		}
+		loading = true;
+		const page = await getActivityFeed(PAGE, offset);
+		rows = reset ? page : [...rows, ...page];
+		offset += page.length;
+		if (page.length < PAGE) done = true;
+		loading = false;
+	}
 
-  onMount(() => load(true));
+	onMount(() => load(true));
 </script>
 
 {#if loading && rows.length === 0}
-  <p class="msg">Loading…</p>
+	<p class="msg">Loading…</p>
 {:else if rows.length === 0}
-  <p class="msg">Nothing yet. Add friends and play — wins, badges and challenges show up here.</p>
+	<p class="msg">Nothing yet. Add friends and play — wins, badges and challenges show up here.</p>
 {:else}
-  <ul class="feed">
-    {#each rows as r, i (r.type + r.actor_id + r.ts + i)}
-      {@const l = line(r)}
-      <li class="ev">
-        <span class="ev-ic">{ICON[r.type] || '•'}</span>
-        <span class="ev-body">
-          <button class="ev-actor" onclick={() => goto('/u/' + encodeURIComponent(r.actor_name || ''))}>@{r.actor_name || 'player'}</button>
-          <span class="ev-verb">{l.verb}</span>
-        </span>
-        {#if l.tag}<span class="ev-tag" class:neg={l.tag.startsWith('−')}>{l.tag}</span>{/if}
-        <span class="ev-time">{ago(r.ts)}</span>
-      </li>
-    {/each}
-  </ul>
-  {#if !done}
-    <button class="more" onclick={() => load(false)} disabled={loading}>{loading ? 'Loading…' : 'Load more'}</button>
-  {/if}
+	<ul class="feed">
+		{#each rows as r, i (r.type + r.actor_id + r.ts + i)}
+			{@const l = line(r)}
+			<li class="ev">
+				<span class="ev-ic">{ICON[r.type] || '•'}</span>
+				<span class="ev-body">
+					<button
+						class="ev-actor"
+						onclick={() => goto('/u/' + encodeURIComponent(r.actor_name || ''))}
+						>@{r.actor_name || 'player'}</button
+					>
+					<span class="ev-verb">{l.verb}</span>
+				</span>
+				{#if l.tag}<span class="ev-tag" class:neg={l.tag.startsWith('−')}>{l.tag}</span>{/if}
+				<span class="ev-time">{ago(r.ts)}</span>
+			</li>
+		{/each}
+	</ul>
+	{#if !done}
+		<button class="more" onclick={() => load(false)} disabled={loading}
+			>{loading ? 'Loading…' : 'Load more'}</button
+		>
+	{/if}
 {/if}
 
 <style>
-  .msg { color: var(--text-muted); text-align: center; padding: 28px 10px; }
-  .feed { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 7px; }
-  .ev { display: flex; align-items: center; gap: 11px; padding: 11px 13px; border: 1px solid var(--border);
-    border-radius: var(--r-md); background: var(--surface); }
-  .ev-ic { font-size: 1.2rem; flex: 0 0 auto; }
-  .ev-body { flex: 1; min-width: 0; font-size: 0.9rem; line-height: 1.35; text-align: left; }
-  .ev-actor { background: none; border: none; padding: 0; font: inherit; font-weight: 800; color: var(--gold); cursor: pointer; }
-  .ev-verb { color: var(--text); }
-  .ev-tag { flex: 0 0 auto; font-weight: 800; color: #7ee0a8; font-size: 0.85rem; font-variant-numeric: tabular-nums; }
-  .ev-tag.neg { color: #fb7185; }
-  .ev-time { flex: 0 0 auto; color: var(--text-faint); font-size: 0.72rem; }
-  .more { display: block; margin: 14px auto 0; padding: 9px 22px; border-radius: var(--r-pill);
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; cursor: pointer; }
+	.msg {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 28px 10px;
+	}
+	.feed {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+	}
+	.ev {
+		display: flex;
+		align-items: center;
+		gap: 11px;
+		padding: 11px 13px;
+		border: 1px solid var(--border);
+		border-radius: var(--r-md);
+		background: var(--surface);
+	}
+	.ev-ic {
+		font-size: 1.2rem;
+		flex: 0 0 auto;
+	}
+	.ev-body {
+		flex: 1;
+		min-width: 0;
+		font-size: 0.9rem;
+		line-height: 1.35;
+		text-align: left;
+	}
+	.ev-actor {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		font-weight: 800;
+		color: var(--gold);
+		cursor: pointer;
+	}
+	.ev-verb {
+		color: var(--text);
+	}
+	.ev-tag {
+		flex: 0 0 auto;
+		font-weight: 800;
+		color: #7ee0a8;
+		font-size: 0.85rem;
+		font-variant-numeric: tabular-nums;
+	}
+	.ev-tag.neg {
+		color: #fb7185;
+	}
+	.ev-time {
+		flex: 0 0 auto;
+		color: var(--text-faint);
+		font-size: 0.72rem;
+	}
+	.more {
+		display: block;
+		margin: 14px auto 0;
+		padding: 9px 22px;
+		border-radius: var(--r-pill);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		font-weight: 600;
+		cursor: pointer;
+	}
 </style>

--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -1,405 +1,489 @@
 <script>
-  import { supabase } from '$lib/supabaseClient';
-  import { user, userProfile } from '$lib/stores/userStore.js';
-  import { gameStore } from '$lib/stores/GameStore.js';
-  import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
-  import { track } from '$lib/analytics.js';
-  import { onMount } from 'svelte';
+	import { supabase } from '$lib/supabaseClient';
+	import { user, userProfile } from '$lib/stores/userStore.js';
+	import { gameStore } from '$lib/stores/GameStore.js';
+	import { saveGameToLocalStorage } from '$lib/stores/localGameUtils.js';
+	import { track } from '$lib/analytics.js';
+	import { onMount } from 'svelte';
 
-  let email = '';
-  let password = '';
-  let errorMsg = '';
-  let isLoading = false;
-  let isLogin = true;
-  let keepLoggedIn = true; // "keep me logged in" — false = sign out when the browser closes
+	let email = '';
+	let password = '';
+	let errorMsg = '';
+	let isLoading = false;
+	let isLogin = true;
+	let keepLoggedIn = true; // "keep me logged in" — false = sign out when the browser closes
 
-  // Inside the native (Capacitor) app, Google blocks OAuth in the embedded
-  // webview so it kicks out to Safari. Hide it there — native testers use
-  // email/password (stays in-app). On the web, Google shows normally.
-  let isNativeApp = false;
-  onMount(() => {
-    try {
-      const c = /** @type {any} */ (window).Capacitor;
-      isNativeApp = !!(c && (c.isNativePlatform ? c.isNativePlatform() : c.isNative))
-        || /WordBankApp/i.test(navigator.userAgent);
-    } catch { isNativeApp = false; }
+	// Inside the native (Capacitor) app, Google blocks OAuth in the embedded
+	// webview so it kicks out to Safari. Hide it there — native testers use
+	// email/password (stays in-app). On the web, Google shows normally.
+	let isNativeApp = false;
+	onMount(() => {
+		try {
+			const c = /** @type {any} */ (window).Capacitor;
+			isNativeApp =
+				!!(c && (c.isNativePlatform ? c.isNativePlatform() : c.isNative)) ||
+				/WordBankApp/i.test(navigator.userAgent);
+		} catch {
+			isNativeApp = false;
+		}
 
-    // Surface a failed OAuth/callback round-trip (set by /auth/callback).
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const ae = params.get('auth_error');
-      const detail = params.get('auth_detail');
-      if (ae) {
-        errorMsg = ae === 'exchange' || ae === 'nocode'
-          ? 'Sign-in didn’t complete — please try again, or use email & password.'
-          : ae === 'config'
-          ? 'Sign-in is temporarily unavailable. Please try again shortly.'
-          : `Google sign-in was cancelled or blocked: ${decodeURIComponent(ae)}`;
-        if (detail) errorMsg += ` (${decodeURIComponent(detail)})`;
-        track('oauth_callback_error', { reason: ae, detail: detail ? decodeURIComponent(detail) : '' });
-        // strip the param so it doesn't stick around on refresh
-        params.delete('auth_error');
-        params.delete('auth_detail');
-        const qs = params.toString();
-        window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
-      }
-    } catch { /* non-fatal */ }
-  });
+		// Surface a failed OAuth/callback round-trip (set by /auth/callback).
+		try {
+			const params = new URLSearchParams(window.location.search);
+			const ae = params.get('auth_error');
+			const detail = params.get('auth_detail');
+			if (ae) {
+				errorMsg =
+					ae === 'exchange' || ae === 'nocode'
+						? 'Sign-in didn’t complete — please try again, or use email & password.'
+						: ae === 'config'
+							? 'Sign-in is temporarily unavailable. Please try again shortly.'
+							: `Google sign-in was cancelled or blocked: ${decodeURIComponent(ae)}`;
+				if (detail) errorMsg += ` (${decodeURIComponent(detail)})`;
+				track('oauth_callback_error', {
+					reason: ae,
+					detail: detail ? decodeURIComponent(detail) : ''
+				});
+				// strip the param so it doesn't stick around on refresh
+				params.delete('auth_error');
+				params.delete('auth_detail');
+				const qs = params.toString();
+				window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
+			}
+		} catch {
+			/* non-fatal */
+		}
+	});
 
-  let showReset = false;
-  let resetEmail = '';
-  let resetMsg = '';
+	let showReset = false;
+	let resetEmail = '';
+	let resetMsg = '';
 
-  async function handleAuth() {
-    isLoading = true;
-    errorMsg = '';
+	async function handleAuth() {
+		isLoading = true;
+		errorMsg = '';
 
-    if (!email || !password) {
-      errorMsg = isLogin ? 'Enter your email or username and password.' : 'Email and password are required.';
-      isLoading = false;
-      return;
-    }
+		if (!email || !password) {
+			errorMsg = isLogin
+				? 'Enter your email or username and password.'
+				: 'Email and password are required.';
+			isLoading = false;
+			return;
+		}
 
-    try {
-      /** @type {any} */ let result;
-      if (isLogin) {
-        // Accept email OR username — resolve a username to its email first.
-        let loginEmail = email.trim();
-        if (!loginEmail.includes('@')) {
-          const { data: resolved } = await supabase.rpc('email_for_login', { p_identifier: loginEmail });
-          if (!resolved) { errorMsg = 'No account found with that username.'; isLoading = false; return; }
-          loginEmail = resolved;
-        }
-        result = await supabase.auth.signInWithPassword({ email: loginEmail, password });
-      } else {
-        result = await supabase.auth.signUp({ email, password });
-      }
-      const { data, error } = result;
+		try {
+			/** @type {any} */ let result;
+			if (isLogin) {
+				// Accept email OR username — resolve a username to its email first.
+				let loginEmail = email.trim();
+				if (!loginEmail.includes('@')) {
+					const { data: resolved } = await supabase.rpc('email_for_login', {
+						p_identifier: loginEmail
+					});
+					if (!resolved) {
+						errorMsg = 'No account found with that username.';
+						isLoading = false;
+						return;
+					}
+					loginEmail = resolved;
+				}
+				result = await supabase.auth.signInWithPassword({ email: loginEmail, password });
+			} else {
+				result = await supabase.auth.signUp({ email, password });
+			}
+			const { data, error } = result;
 
-      if (error || !data?.user?.id) {
-        errorMsg = error?.message || "Authentication failed.";
-        return;
-      }
+			if (error || !data?.user?.id) {
+				errorMsg = error?.message || 'Authentication failed.';
+				return;
+			}
 
-      // Remember-me: persist the choice; mark this browser session active so the
-      // layout can sign out on next cold open when "keep me logged in" is off.
-      try {
-        localStorage.setItem('wb_keep', keepLoggedIn ? '1' : '0');
-        sessionStorage.setItem('wb_sess', '1');
-      } catch { /* storage blocked — default to persistent */ }
+			// Remember-me: persist the choice; mark this browser session active so the
+			// layout can sign out on next cold open when "keep me logged in" is off.
+			try {
+				localStorage.setItem('wb_keep', keepLoggedIn ? '1' : '0');
+				sessionStorage.setItem('wb_sess', '1');
+			} catch {
+				/* storage blocked — default to persistent */
+			}
 
-      track(isLogin ? 'login' : 'signup', { platform: isNativeApp ? 'ios' : 'web' });
-      user.set(/** @type {{ id: string }} */ (data.user));
+			track(isLogin ? 'login' : 'signup', { platform: isNativeApp ? 'ios' : 'web' });
+			user.set(/** @type {{ id: string }} */ (data.user));
 
-      const profile = await loadUserProfile(data.user.id);
-      if (profile) {
-        window.location.href = '/';
-      }
+			const profile = await loadUserProfile(data.user.id);
+			if (profile) {
+				window.location.href = '/';
+			}
+		} catch (err) {
+			errorMsg = (err instanceof Error ? err.message : String(err)) || 'Unexpected error.';
+		} finally {
+			isLoading = false;
+		}
+	}
 
-    } catch (err) {
-      errorMsg = (err instanceof Error ? err.message : String(err)) || "Unexpected error.";
-    } finally {
-      isLoading = false;
-    }
-  }
+	async function handlePasswordReset() {
+		resetMsg = '';
 
-  async function handlePasswordReset() {
-  resetMsg = '';
+		if (!resetEmail) {
+			resetMsg = 'Please enter your email.';
+			return;
+		}
 
-  if (!resetEmail) {
-    resetMsg = 'Please enter your email.';
-    return;
-  }
+		// The reset email links straight to /reset-password with a one-time token_hash
+		// (cross-device, no code verifier). redirectTo is just the allow-listed landing
+		// page; the actual link is built by the Supabase email template, which must be:
+		//   {{ .SiteURL }}/reset-password?token_hash={{ .TokenHash }}&type=recovery
+		const redirectUrl = `${window.location.origin}/reset-password`;
 
-  // The reset email links straight to /reset-password with a one-time token_hash
-  // (cross-device, no code verifier). redirectTo is just the allow-listed landing
-  // page; the actual link is built by the Supabase email template, which must be:
-  //   {{ .SiteURL }}/reset-password?token_hash={{ .TokenHash }}&type=recovery
-  const redirectUrl = `${window.location.origin}/reset-password`;
+		const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
+			redirectTo: redirectUrl
+		});
 
-  const { error } = await supabase.auth.resetPasswordForEmail(resetEmail, {
-    redirectTo: redirectUrl
-  });
+		if (error) {
+			resetMsg = `❌ ${error.message}`;
+		} else {
+			resetMsg = '✅ Check your email to reset your password.';
+		}
+	}
 
-  if (error) {
-    resetMsg = `❌ ${error.message}`;
-  } else {
-    resetMsg = '✅ Check your email to reset your password.';
-  }
-}
+	/** @param {string} userId */
+	async function loadUserProfile(userId) {
+		const { data: profile, error } = await supabase
+			.from('profiles')
+			.select('*')
+			.eq('id', userId)
+			.single();
 
-  /** @param {string} userId */
-  async function loadUserProfile(userId) {
-    const { data: profile, error } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('id', userId)
-      .single();
+		if (error || !profile) {
+			errorMsg = error?.message || 'Profile not found.';
+			return null;
+		}
 
-    if (error || !profile) {
-      errorMsg = error?.message || "Profile not found.";
-      return null;
-    }
+		userProfile.set(profile);
+		gameStore.update((state) => ({
+			...state,
+			bankroll: profile.current_bankroll ?? 1000
+		}));
 
-    userProfile.set(profile);
-    gameStore.update(state => ({
-      ...state,
-      bankroll: profile.current_bankroll ?? 1000
-    }));
+		saveGameToLocalStorage();
+		return profile;
+	}
 
-    saveGameToLocalStorage();
-    return profile;
-  }
+	async function signInWithGoogle() {
+		errorMsg = '';
+		isLoading = true;
+		try {
+			const redirectUrl = `${window.location.origin}/auth/callback`;
+			const { error } = await supabase.auth.signInWithOAuth({
+				provider: 'google',
+				options: {
+					redirectTo: redirectUrl,
+					// Let the user pick which Google account (avoids silently reusing the wrong one).
+					queryParams: { prompt: 'select_account' }
+				}
+			});
+			if (error) {
+				// Surface failures instead of doing nothing (provider disabled, redirect not
+				// allow-listed, popup blocked, etc.).
+				errorMsg = `Google sign-in failed: ${error.message}`;
+				track('google_signin_error', { message: error.message });
+				isLoading = false;
+			}
+			// On success the browser navigates to Google — no further code runs here.
+		} catch (e) {
+			errorMsg = 'Google sign-in failed. Try again, or use email & password.';
+			isLoading = false;
+		}
+	}
 
-  async function signInWithGoogle() {
-    errorMsg = '';
-    isLoading = true;
-    try {
-      const redirectUrl = `${window.location.origin}/auth/callback`;
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: 'google',
-        options: {
-          redirectTo: redirectUrl,
-          // Let the user pick which Google account (avoids silently reusing the wrong one).
-          queryParams: { prompt: 'select_account' }
-        }
-      });
-      if (error) {
-        // Surface failures instead of doing nothing (provider disabled, redirect not
-        // allow-listed, popup blocked, etc.).
-        errorMsg = `Google sign-in failed: ${error.message}`;
-        track('google_signin_error', { message: error.message });
-        isLoading = false;
-      }
-      // On success the browser navigates to Google — no further code runs here.
-    } catch (e) {
-      errorMsg = 'Google sign-in failed. Try again, or use email & password.';
-      isLoading = false;
-    }
-  }
-
-  async function signInWithApple() {
-    errorMsg = '';
-    isLoading = true;
-    try {
-      const redirectUrl = `${window.location.origin}/auth/callback`;
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: 'apple',
-        options: { redirectTo: redirectUrl }
-      });
-      if (error) {
-        errorMsg = `Apple sign-in failed: ${error.message}`;
-        track('apple_signin_error', { message: error.message });
-        isLoading = false;
-      }
-    } catch (e) {
-      errorMsg = 'Apple sign-in failed. Try again, or use email & password.';
-      isLoading = false;
-    }
-  }
+	async function signInWithApple() {
+		errorMsg = '';
+		isLoading = true;
+		try {
+			const redirectUrl = `${window.location.origin}/auth/callback`;
+			const { error } = await supabase.auth.signInWithOAuth({
+				provider: 'apple',
+				options: { redirectTo: redirectUrl }
+			});
+			if (error) {
+				errorMsg = `Apple sign-in failed: ${error.message}`;
+				track('apple_signin_error', { message: error.message });
+				isLoading = false;
+			}
+		} catch (e) {
+			errorMsg = 'Apple sign-in failed. Try again, or use email & password.';
+			isLoading = false;
+		}
+	}
 </script>
 
 <div class="auth-screen">
-  <div class="auth-card glass fade-up">
-    <div class="brand">
-      <video class="mark" src="/coin.mp4" poster="/coin-poster.jpg" autoplay loop muted playsinline disablepictureinpicture></video>
-      <img class="wordmark" src="/wordmark-slogan.png" alt="WordBank — Spend Less. Think More." />
-    </div>
+	<div class="auth-card glass fade-up">
+		<div class="brand">
+			<video
+				class="mark"
+				src="/coin.mp4"
+				poster="/coin-poster.jpg"
+				autoplay
+				loop
+				muted
+				playsinline
+				disablepictureinpicture
+			></video>
+			<img class="wordmark" src="/wordmark-slogan.png" alt="WordBank — Spend Less. Think More." />
+		</div>
 
-    {#if showReset}
-      <h2 class="auth-title">Reset password</h2>
-    {:else if !isLogin}
-      <h2 class="auth-title">Create your account</h2>
-    {/if}
+		{#if showReset}
+			<h2 class="auth-title">Reset password</h2>
+		{:else if !isLogin}
+			<h2 class="auth-title">Create your account</h2>
+		{/if}
 
-    {#if showReset}
-      <input class="field" type="email" bind:value={resetEmail} placeholder="Your email" />
+		{#if showReset}
+			<input class="field" type="email" bind:value={resetEmail} placeholder="Your email" />
 
-      <button class="btn-brand full" on:click={handlePasswordReset} disabled={isLoading}>
-        {isLoading ? 'Sending…' : 'Send reset link'}
-      </button>
+			<button class="btn-brand full" on:click={handlePasswordReset} disabled={isLoading}>
+				{isLoading ? 'Sending…' : 'Send reset link'}
+			</button>
 
-      {#if resetMsg}
-        <p class="reset-msg">{resetMsg}</p>
-      {/if}
+			{#if resetMsg}
+				<p class="reset-msg">{resetMsg}</p>
+			{/if}
 
-      <p class="toggle-mode">
-        <button type="button" class="link" on:click={() => showReset = false}>
-          ← Back to login
-        </button>
-      </p>
+			<p class="toggle-mode">
+				<button type="button" class="link" on:click={() => (showReset = false)}>
+					← Back to login
+				</button>
+			</p>
+		{:else}
+			<input
+				class="field"
+				type={isLogin ? 'text' : 'email'}
+				bind:value={email}
+				placeholder={isLogin ? 'Email or username' : 'Email'}
+				autocapitalize="none"
+				autocorrect="off"
+				spellcheck="false"
+				autocomplete={isLogin ? 'username' : 'email'}
+			/>
+			<input
+				class="field"
+				type="password"
+				bind:value={password}
+				placeholder="Password"
+				autocomplete={isLogin ? 'current-password' : 'new-password'}
+			/>
 
-    {:else}
-      <input class="field" type={isLogin ? 'text' : 'email'} bind:value={email}
-        placeholder={isLogin ? 'Email or username' : 'Email'}
-        autocapitalize="none" autocorrect="off" spellcheck="false"
-        autocomplete={isLogin ? 'username' : 'email'} />
-      <input class="field" type="password" bind:value={password} placeholder="Password" autocomplete={isLogin ? 'current-password' : 'new-password'} />
+			{#if isLogin}
+				<label class="remember">
+					<input type="checkbox" bind:checked={keepLoggedIn} />
+					<span>Keep me logged in</span>
+				</label>
+			{/if}
 
-      {#if isLogin}
-        <label class="remember">
-          <input type="checkbox" bind:checked={keepLoggedIn} />
-          <span>Keep me logged in</span>
-        </label>
-      {/if}
+			<button class="btn-brand full" on:click={handleAuth} disabled={isLoading}>
+				{isLoading ? 'Loading…' : isLogin ? 'Log in' : 'Sign up'}
+			</button>
 
-      <button class="btn-brand full" on:click={handleAuth} disabled={isLoading}>
-        {isLoading ? 'Loading…' : (isLogin ? 'Log in' : 'Sign up')}
-      </button>
+			{#if !isNativeApp}
+				<div class="divider"><span>or</span></div>
 
-      {#if !isNativeApp}
-        <div class="divider"><span>or</span></div>
+				<button class="btn-ghost full google" on:click={signInWithGoogle}>
+					<img src="/googlelogo.png" alt="Google icon" class="google-icon" />
+					Continue with Google
+				</button>
 
-        <button class="btn-ghost full google" on:click={signInWithGoogle}>
-          <img src="/googlelogo.png" alt="Google icon" class="google-icon" />
-          Continue with Google
-        </button>
+				<button class="btn-ghost full apple" on:click={signInWithApple}>
+					<svg class="apple-icon" viewBox="0 0 384 512" aria-hidden="true"
+						><path
+							fill="currentColor"
+							d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"
+						/></svg
+					>
+					Continue with Apple
+				</button>
+			{/if}
 
-        <button class="btn-ghost full apple" on:click={signInWithApple}>
-          <svg class="apple-icon" viewBox="0 0 384 512" aria-hidden="true"><path fill="currentColor" d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg>
-          Continue with Apple
-        </button>
-      {/if}
+			{#if errorMsg}
+				<div class="error-text">{errorMsg}</div>
+			{/if}
 
-      {#if errorMsg}
-        <div class="error-text">{errorMsg}</div>
-      {/if}
+			<p class="toggle-mode">
+				<button type="button" class="link subtle" on:click={() => (showReset = true)}>
+					Forgot password?
+				</button>
+			</p>
 
-      <p class="toggle-mode">
-        <button type="button" class="link subtle" on:click={() => showReset = true}>
-          Forgot password?
-        </button>
-      </p>
-
-      <p class="toggle-mode">
-        {isLogin ? "Don't have an account?" : 'Already have an account?'}
-        <button type="button" class="link" on:click={() => isLogin = !isLogin}>
-          {isLogin ? 'Sign up' : 'Log in'}
-        </button>
-      </p>
-    {/if}
-  </div>
+			<p class="toggle-mode">
+				{isLogin ? "Don't have an account?" : 'Already have an account?'}
+				<button type="button" class="link" on:click={() => (isLogin = !isLogin)}>
+					{isLogin ? 'Sign up' : 'Log in'}
+				</button>
+			</p>
+		{/if}
+	</div>
 </div>
 
 <style>
-  .auth-screen {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    padding: 20px;
-  }
+	.auth-screen {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		min-height: 100vh;
+		padding: 20px;
+	}
 
-  .auth-card {
-    width: 100%;
-    max-width: 400px;
-    padding: 32px 28px 28px;
-    text-align: center;
-    box-shadow: var(--shadow-lg);
-  }
+	.auth-card {
+		width: 100%;
+		max-width: 400px;
+		padding: 32px 28px 28px;
+		text-align: center;
+		box-shadow: var(--shadow-lg);
+	}
 
-  .brand { margin-bottom: 22px; }
+	.brand {
+		margin-bottom: 22px;
+	}
 
-  .mark {
-    width: min(44vw, 160px);
-    aspect-ratio: 1;
-    height: auto;
-    object-fit: cover;
-    border-radius: 50%;
-    margin: 0 auto 6px;
-    display: block;
-    box-shadow: 0 0 24px rgba(251, 191, 36, 0.5), 0 8px 28px rgba(251, 191, 36, 0.35);
-  }
+	.mark {
+		width: min(44vw, 160px);
+		aspect-ratio: 1;
+		height: auto;
+		object-fit: cover;
+		border-radius: 50%;
+		margin: 0 auto 6px;
+		display: block;
+		box-shadow:
+			0 0 24px rgba(251, 191, 36, 0.5),
+			0 8px 28px rgba(251, 191, 36, 0.35);
+	}
 
-  .wordmark {
-    width: min(72vw, 270px);
-    height: auto;
-    margin: 2px auto 0;
-    display: block;
-    filter: drop-shadow(0 2px 14px rgba(0, 0, 0, 0.5));
-  }
+	.wordmark {
+		width: min(72vw, 270px);
+		height: auto;
+		margin: 2px auto 0;
+		display: block;
+		filter: drop-shadow(0 2px 14px rgba(0, 0, 0, 0.5));
+	}
 
-  .auth-title {
-    font-family: var(--font-display);
-    font-size: 1.15rem;
-    font-weight: 600;
-    color: var(--text);
-    margin: 0 0 18px;
-  }
+	.auth-title {
+		font-family: var(--font-display);
+		font-size: 1.15rem;
+		font-weight: 600;
+		color: var(--text);
+		margin: 0 0 18px;
+	}
 
-  .field { margin: 10px 0; text-align: left; }
+	.field {
+		margin: 10px 0;
+		text-align: left;
+	}
 
-  .remember {
-    display: flex; align-items: center; gap: 9px; margin: 4px 2px 2px; cursor: pointer;
-    font-size: 0.88rem; color: var(--text-muted); user-select: none;
-  }
-  .remember input { width: 17px; height: 17px; accent-color: #f59e0b; cursor: pointer; }
+	.remember {
+		display: flex;
+		align-items: center;
+		gap: 9px;
+		margin: 4px 2px 2px;
+		cursor: pointer;
+		font-size: 0.88rem;
+		color: var(--text-muted);
+		user-select: none;
+	}
+	.remember input {
+		width: 17px;
+		height: 17px;
+		accent-color: #f59e0b;
+		cursor: pointer;
+	}
 
-  .full { width: 100%; }
-  .btn-brand.full { margin-top: 6px; padding: 15px; font-size: 1.02rem; }
+	.full {
+		width: 100%;
+	}
+	.btn-brand.full {
+		margin-top: 6px;
+		padding: 15px;
+		font-size: 1.02rem;
+	}
 
-  .divider {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin: 20px 2px;
-    color: var(--text-faint);
-    font-size: 0.82rem;
-  }
-  .divider::before, .divider::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: var(--border);
-  }
+	.divider {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		margin: 20px 2px;
+		color: var(--text-faint);
+		font-size: 0.82rem;
+	}
+	.divider::before,
+	.divider::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: var(--border);
+	}
 
-  .google {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    width: 100%;
-  }
-  .google-icon { width: 18px; height: 18px; }
+	.google {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		width: 100%;
+	}
+	.google-icon {
+		width: 18px;
+		height: 18px;
+	}
 
-  .toggle-mode {
-    margin-top: 16px;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
+	.toggle-mode {
+		margin-top: 16px;
+		font-size: 0.9rem;
+		color: var(--text-muted);
+	}
 
-  /* Gold primary button (Log in / Sign up / reset) */
-  .btn-brand {
-    background: linear-gradient(135deg, #fde047, #f59e0b);
-    color: #3a2a00;
-    box-shadow: 0 4px 16px rgba(251, 191, 36, 0.3);
-  }
-  .apple {
-    display: flex; align-items: center; justify-content: center; gap: 10px; width: 100%;
-    margin-top: 10px;
-  }
-  .apple-icon { width: 17px; height: 17px; color: var(--text); }
+	/* Gold primary button (Log in / Sign up / reset) */
+	.btn-brand {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		box-shadow: 0 4px 16px rgba(251, 191, 36, 0.3);
+	}
+	.apple {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		width: 100%;
+		margin-top: 10px;
+	}
+	.apple-icon {
+		width: 17px;
+		height: 17px;
+		color: var(--text);
+	}
 
-  .link {
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    font-weight: 700;
-    color: #fbbf24;
-  }
-  .link:hover { text-decoration: underline; }
-  .link.subtle { color: var(--text-muted); font-weight: 500; }
+	.link {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		font-weight: 700;
+		color: #fbbf24;
+	}
+	.link:hover {
+		text-decoration: underline;
+	}
+	.link.subtle {
+		color: var(--text-muted);
+		font-weight: 500;
+	}
 
-  .error-text {
-    margin-top: 12px;
-    color: var(--danger);
-    font-size: 0.9rem;
-  }
+	.error-text {
+		margin-top: 12px;
+		color: var(--danger);
+		font-size: 0.9rem;
+	}
 
-  .reset-msg {
-    margin-top: 10px;
-    font-size: 0.9rem;
-    color: var(--text-muted);
-  }
+	.reset-msg {
+		margin-top: 10px;
+		font-size: 0.9rem;
+		color: var(--text-muted);
+	}
 </style>

--- a/src/lib/components/Avatar.svelte
+++ b/src/lib/components/Avatar.svelte
@@ -1,56 +1,146 @@
 <script>
-  import { renderAvatarSvg, renderHoloAvatar } from '$lib/avatar.js';
-  /** @type {any} */
-  export let config = null;
-  export let size = 64;
-  /** 'bust' = head + shoulders · 'head' = cropped head circle · 'full' = legacy figure */
-  export let mode = 'bust';
-  /** render premium FX (frame / aura / headpiece / holographic shirt) */
-  export let fx = false;
+	import { renderAvatarSvg, renderHoloAvatar } from '$lib/avatar.js';
+	/** @type {any} */
+	export let config = null;
+	export let size = 64;
+	/** 'bust' = head + shoulders · 'head' = cropped head circle · 'full' = legacy figure */
+	export let mode = 'bust';
+	/** render premium FX (frame / aura / headpiece / holographic shirt) */
+	export let fx = false;
 
-  $: c = config || {};
-  $: useHolo = fx && mode !== 'head' && c.fxShirt === 'holo';
-  $: coreSvg = mode === 'head'
-    ? renderAvatarSvg(config, { scale: 170, translateY: 18 })
-    : (useHolo ? renderHoloAvatar(config) : renderAvatarSvg(config));
-  $: frame = fx ? (c.frame || 'none') : 'none';
-  $: aura = fx ? (c.aura || 'none') : 'none';
-  $: overlay = fx ? (c.overlay || 'none') : 'none';
-  $: wrapped = frame !== 'none' || aura !== 'none' || overlay !== 'none';
+	$: c = config || {};
+	$: useHolo = fx && mode !== 'head' && c.fxShirt === 'holo';
+	$: coreSvg =
+		mode === 'head'
+			? renderAvatarSvg(config, { scale: 170, translateY: 18 })
+			: useHolo
+				? renderHoloAvatar(config)
+				: renderAvatarSvg(config);
+	$: frame = fx ? c.frame || 'none' : 'none';
+	$: aura = fx ? c.aura || 'none' : 'none';
+	$: overlay = fx ? c.overlay || 'none' : 'none';
+	$: wrapped = frame !== 'none' || aura !== 'none' || overlay !== 'none';
 </script>
 
 {#if wrapped}
-  <div class="wb-fx" style="--sz:{size}px" aria-hidden="true">
-    {#if aura !== 'none'}<div class="fx-aura aura-{aura}"></div>{/if}
-    {#if frame !== 'none'}<div class="fx-ring frame-{frame}"></div>{/if}
-    <div class="fx-core">{@html coreSvg}</div>
-    {#if overlay !== 'none'}<img class="fx-overlay" src="/avatar/fx/{overlay}.svg" alt="" />{/if}
-  </div>
+	<div class="wb-fx" style="--sz:{size}px" aria-hidden="true">
+		{#if aura !== 'none'}<div class="fx-aura aura-{aura}"></div>{/if}
+		{#if frame !== 'none'}<div class="fx-ring frame-{frame}"></div>{/if}
+		<div class="fx-core">{@html coreSvg}</div>
+		{#if overlay !== 'none'}<img class="fx-overlay" src="/avatar/fx/{overlay}.svg" alt="" />{/if}
+	</div>
 {:else}
-  <div class="wb-avatar" style="--sz:{size}px" aria-hidden="true">{@html coreSvg}</div>
+	<div class="wb-avatar" style="--sz:{size}px" aria-hidden="true">{@html coreSvg}</div>
 {/if}
 
 <style>
-  .wb-avatar {
-    width: var(--sz); height: var(--sz); border-radius: 50%; overflow: hidden; flex: none;
-    background: linear-gradient(135deg, #2a3344, #1b2230);
-    border: 2px solid var(--border, rgba(255,255,255,0.15));
-  }
-  .wb-avatar :global(svg), .fx-core :global(svg) { width: 100%; height: 100%; display: block; }
+	.wb-avatar {
+		width: var(--sz);
+		height: var(--sz);
+		border-radius: 50%;
+		overflow: hidden;
+		flex: none;
+		background: linear-gradient(135deg, #2a3344, #1b2230);
+		border: 2px solid var(--border, rgba(255, 255, 255, 0.15));
+	}
+	.wb-avatar :global(svg),
+	.fx-core :global(svg) {
+		width: 100%;
+		height: 100%;
+		display: block;
+	}
 
-  .wb-fx { position: relative; width: var(--sz); height: var(--sz); flex: none; }
-  .fx-core { position: absolute; inset: 0; z-index: 2; border-radius: 50%; overflow: hidden; background: #0b0f1a; }
-  .fx-aura { position: absolute; inset: -22%; border-radius: 50%; z-index: 0; filter: blur(10px); animation: fxpulse 2.6s ease-in-out infinite; }
-  .aura-neon { background: radial-gradient(circle, rgba(124,255,107,0.5), rgba(92,208,255,0.35) 45%, transparent 70%); }
-  .aura-gold { background: radial-gradient(circle, rgba(255,210,74,0.6), rgba(255,140,0,0.35) 45%, transparent 70%); }
-  .fx-ring { position: absolute; inset: -6%; border-radius: 50%; z-index: 1; animation: fxspin 4s linear infinite; }
-  .frame-neon { background: conic-gradient(from 0deg, #ff5cf0, #5cd0ff, #7cff6b, #ffe45c, #ff5cf0); box-shadow: 0 0 18px rgba(124,255,107,0.5); }
-  .frame-gold { background: conic-gradient(from 0deg, #fff0a8, #ffd24a, #d99100, #ffd24a, #fff0a8); box-shadow: 0 0 16px rgba(255,210,74,0.55); }
-  .frame-gem { background: conic-gradient(from 0deg, #c4b5fd, #5cd0ff, #ff88e0, #7cff6b, #c4b5fd); box-shadow: 0 0 20px rgba(196,181,253,0.6); }
-  .fx-overlay { position: absolute; z-index: 3; top: -10%; left: 50%; transform: translateX(-50%); width: 58%;
-    filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5)); animation: fxfloat 2.4s ease-in-out infinite; }
+	.wb-fx {
+		position: relative;
+		width: var(--sz);
+		height: var(--sz);
+		flex: none;
+	}
+	.fx-core {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		border-radius: 50%;
+		overflow: hidden;
+		background: #0b0f1a;
+	}
+	.fx-aura {
+		position: absolute;
+		inset: -22%;
+		border-radius: 50%;
+		z-index: 0;
+		filter: blur(10px);
+		animation: fxpulse 2.6s ease-in-out infinite;
+	}
+	.aura-neon {
+		background: radial-gradient(
+			circle,
+			rgba(124, 255, 107, 0.5),
+			rgba(92, 208, 255, 0.35) 45%,
+			transparent 70%
+		);
+	}
+	.aura-gold {
+		background: radial-gradient(
+			circle,
+			rgba(255, 210, 74, 0.6),
+			rgba(255, 140, 0, 0.35) 45%,
+			transparent 70%
+		);
+	}
+	.fx-ring {
+		position: absolute;
+		inset: -6%;
+		border-radius: 50%;
+		z-index: 1;
+		animation: fxspin 4s linear infinite;
+	}
+	.frame-neon {
+		background: conic-gradient(from 0deg, #ff5cf0, #5cd0ff, #7cff6b, #ffe45c, #ff5cf0);
+		box-shadow: 0 0 18px rgba(124, 255, 107, 0.5);
+	}
+	.frame-gold {
+		background: conic-gradient(from 0deg, #fff0a8, #ffd24a, #d99100, #ffd24a, #fff0a8);
+		box-shadow: 0 0 16px rgba(255, 210, 74, 0.55);
+	}
+	.frame-gem {
+		background: conic-gradient(from 0deg, #c4b5fd, #5cd0ff, #ff88e0, #7cff6b, #c4b5fd);
+		box-shadow: 0 0 20px rgba(196, 181, 253, 0.6);
+	}
+	.fx-overlay {
+		position: absolute;
+		z-index: 3;
+		top: -10%;
+		left: 50%;
+		transform: translateX(-50%);
+		width: 58%;
+		filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.5));
+		animation: fxfloat 2.4s ease-in-out infinite;
+	}
 
-  @keyframes fxspin { to { transform: rotate(360deg); } }
-  @keyframes fxpulse { 0%, 100% { opacity: 0.6; transform: scale(0.96); } 50% { opacity: 1; transform: scale(1.04); } }
-  @keyframes fxfloat { 0%, 100% { transform: translateX(-50%) translateY(0); } 50% { transform: translateX(-50%) translateY(-3px); } }
+	@keyframes fxspin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+	@keyframes fxpulse {
+		0%,
+		100% {
+			opacity: 0.6;
+			transform: scale(0.96);
+		}
+		50% {
+			opacity: 1;
+			transform: scale(1.04);
+		}
+	}
+	@keyframes fxfloat {
+		0%,
+		100% {
+			transform: translateX(-50%) translateY(0);
+		}
+		50% {
+			transform: translateX(-50%) translateY(-3px);
+		}
+	}
 </style>

--- a/src/lib/components/BadgesPanel.svelte
+++ b/src/lib/components/BadgesPanel.svelte
@@ -1,95 +1,200 @@
 <script>
-  import { onMount } from 'svelte';
-  import { getCategoryStats, getUserBadges } from '$lib/stores/statsStore.js';
-  import { CATEGORIES } from '$lib/categories.js';
-  import { categoryProgress, SOLVE_MILESTONES, COLLECTOR } from '$lib/categoryBadges.js';
-  import { BADGES, badgeInfo } from '$lib/badges.js';
+	import { onMount } from 'svelte';
+	import { getCategoryStats, getUserBadges } from '$lib/stores/statsStore.js';
+	import { CATEGORIES } from '$lib/categories.js';
+	import { categoryProgress, SOLVE_MILESTONES, COLLECTOR } from '$lib/categoryBadges.js';
+	import { BADGES, badgeInfo } from '$lib/badges.js';
 
-  /** @type {{category: string, solves: number}[]} */
-  let categoryStats = $state([]);
-  /** @type {string[]} */
-  let earnedBadges = $state([]);
-  let loaded = $state(false);
+	/** @type {{category: string, solves: number}[]} */
+	let categoryStats = $state([]);
+	/** @type {string[]} */
+	let earnedBadges = $state([]);
+	let loaded = $state(false);
 
-  onMount(async () => {
-    const [stats, earned] = await Promise.all([getCategoryStats(), getUserBadges()]);
-    categoryStats = stats;
-    earnedBadges = earned;
-    loaded = true;
-  });
+	onMount(async () => {
+		const [stats, earned] = await Promise.all([getCategoryStats(), getUserBadges()]);
+		categoryStats = stats;
+		earnedBadges = earned;
+		loaded = true;
+	});
 
-  let solvesByCat = $derived(Object.fromEntries(categoryStats.map((r) => [r.category, r.solves])));
-  let total = $derived(categoryStats.reduce((n, r) => n + (r.solves || 0), 0));
-  let rows = $derived(CATEGORIES.map((c) => ({ ...c, ...categoryProgress(solvesByCat[c.value] ?? 0) })));
-  let goldCount = $derived(rows.filter((r) => (r.solves ?? 0) >= 25).length);
-  let achievements = $derived([
-    ...Object.keys(BADGES).map((id) => ({ ...badgeInfo(id), earned: earnedBadges.includes(id) })),
-    ...SOLVE_MILESTONES.map((m) => ({ emoji: m.emoji, name: m.name, desc: m.desc, earned: total >= m.at })),
-    { emoji: COLLECTOR.emoji, name: COLLECTOR.name, desc: COLLECTOR.desc, earned: goldCount >= 12 }
-  ]);
+	let solvesByCat = $derived(Object.fromEntries(categoryStats.map((r) => [r.category, r.solves])));
+	let total = $derived(categoryStats.reduce((n, r) => n + (r.solves || 0), 0));
+	let rows = $derived(
+		CATEGORIES.map((c) => ({ ...c, ...categoryProgress(solvesByCat[c.value] ?? 0) }))
+	);
+	let goldCount = $derived(rows.filter((r) => (r.solves ?? 0) >= 25).length);
+	let achievements = $derived([
+		...Object.keys(BADGES).map((id) => ({ ...badgeInfo(id), earned: earnedBadges.includes(id) })),
+		...SOLVE_MILESTONES.map((m) => ({
+			emoji: m.emoji,
+			name: m.name,
+			desc: m.desc,
+			earned: total >= m.at
+		})),
+		{ emoji: COLLECTOR.emoji, name: COLLECTOR.name, desc: COLLECTOR.desc, earned: goldCount >= 12 }
+	]);
 </script>
 
 <div class="bp">
-  <p class="badges-total">{total} {total === 1 ? 'puzzle' : 'puzzles'} solved all-time</p>
+	<p class="badges-total">{total} {total === 1 ? 'puzzle' : 'puzzles'} solved all-time</p>
 
-  <p class="bm-section-title">Category Levels</p>
-  <div class="bm-cats">
-    {#each rows as r (r.value)}
-      <div class="bm-cat">
-        <span class="bm-cat-emoji">{r.emoji}</span>
-        <div class="bm-cat-body">
-          <div class="bm-cat-top">
-            <span class="bm-cat-name">{r.label}</span>
-            <span class="bm-cat-tier">{r.current ? r.current.medal + ' ' + r.current.name : '—'}</span>
-          </div>
-          <div class="bm-bar"><div class="bm-bar-fill" style="width:{Math.round(r.progress * 100)}%"></div></div>
-          <span class="bm-cat-sub">
-            {#if r.next}{r.toNext} more → {r.next.medal} {r.next.name}{:else}Maxed out 💎 · {r.solves} solved{/if}
-          </span>
-        </div>
-      </div>
-    {/each}
-  </div>
+	<p class="bm-section-title">Category Levels</p>
+	<div class="bm-cats">
+		{#each rows as r (r.value)}
+			<div class="bm-cat">
+				<span class="bm-cat-emoji">{r.emoji}</span>
+				<div class="bm-cat-body">
+					<div class="bm-cat-top">
+						<span class="bm-cat-name">{r.label}</span>
+						<span class="bm-cat-tier"
+							>{r.current ? r.current.medal + ' ' + r.current.name : '—'}</span
+						>
+					</div>
+					<div class="bm-bar">
+						<div class="bm-bar-fill" style="width:{Math.round(r.progress * 100)}%"></div>
+					</div>
+					<span class="bm-cat-sub">
+						{#if r.next}{r.toNext} more → {r.next.medal} {r.next.name}{:else}Maxed out 💎 · {r.solves}
+							solved{/if}
+					</span>
+				</div>
+			</div>
+		{/each}
+	</div>
 
-  <p class="bm-section-title">Achievements</p>
-  <div class="bm-ach-grid">
-    {#each achievements as a}
-      <div class="bm-ach {a.earned ? 'earned' : 'locked'}" title={a.desc}>
-        <span class="bm-ach-emoji">{a.emoji}</span>
-        <span class="bm-ach-name">{a.name}</span>
-        <span class="bm-ach-desc">{a.desc}</span>
-      </div>
-    {/each}
-  </div>
+	<p class="bm-section-title">Achievements</p>
+	<div class="bm-ach-grid">
+		{#each achievements as a}
+			<div class="bm-ach {a.earned ? 'earned' : 'locked'}" title={a.desc}>
+				<span class="bm-ach-emoji">{a.emoji}</span>
+				<span class="bm-ach-name">{a.name}</span>
+				<span class="bm-ach-desc">{a.desc}</span>
+			</div>
+		{/each}
+	</div>
 
-  {#if !loaded}<p class="bm-loading">Loading…</p>{/if}
+	{#if !loaded}<p class="bm-loading">Loading…</p>{/if}
 </div>
 
 <style>
-  .badges-total { font-size: 0.9rem; color: var(--text-muted); margin: 0 0 14px; text-align: center; }
-  .bm-section-title {
-    font-family: var(--font-display); font-weight: 700; font-size: 0.7rem; letter-spacing: 0.14em;
-    text-transform: uppercase; color: var(--brand-2, #fde047); text-align: left; margin: 22px 0 10px;
-  }
-  .bm-cats { display: flex; flex-direction: column; gap: 10px; }
-  .bm-cat { display: flex; align-items: center; gap: 12px; text-align: left; padding: 10px 12px;
-    border-radius: var(--r-md, 12px); background: var(--surface, rgba(255, 255, 255, 0.05)); border: 1px solid var(--border, rgba(255, 255, 255, 0.1)); }
-  .bm-cat-emoji { font-size: 1.5rem; line-height: 1; }
-  .bm-cat-body { flex: 1; min-width: 0; }
-  .bm-cat-top { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
-  .bm-cat-name { font-family: var(--font-display); font-weight: 600; font-size: 0.9rem; }
-  .bm-cat-tier { font-family: var(--font-display); font-weight: 700; font-size: 0.78rem; color: #fcd34d; white-space: nowrap; }
-  .bm-bar { height: 6px; border-radius: 999px; background: var(--border, rgba(255, 255, 255, 0.12)); margin: 6px 0 4px; overflow: hidden; }
-  .bm-bar-fill { height: 100%; border-radius: 999px; background: var(--brand-grad, linear-gradient(90deg, #fbbf24, #fde047)); transition: width 0.4s var(--ease-spring, ease); }
-  .bm-cat-sub { font-family: var(--font-ui); font-size: 0.72rem; color: var(--text-muted); }
+	.badges-total {
+		font-size: 0.9rem;
+		color: var(--text-muted);
+		margin: 0 0 14px;
+		text-align: center;
+	}
+	.bm-section-title {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.7rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--brand-2, #fde047);
+		text-align: left;
+		margin: 22px 0 10px;
+	}
+	.bm-cats {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+	.bm-cat {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		text-align: left;
+		padding: 10px 12px;
+		border-radius: var(--r-md, 12px);
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+	}
+	.bm-cat-emoji {
+		font-size: 1.5rem;
+		line-height: 1;
+	}
+	.bm-cat-body {
+		flex: 1;
+		min-width: 0;
+	}
+	.bm-cat-top {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 8px;
+	}
+	.bm-cat-name {
+		font-family: var(--font-display);
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.bm-cat-tier {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.78rem;
+		color: #fcd34d;
+		white-space: nowrap;
+	}
+	.bm-bar {
+		height: 6px;
+		border-radius: 999px;
+		background: var(--border, rgba(255, 255, 255, 0.12));
+		margin: 6px 0 4px;
+		overflow: hidden;
+	}
+	.bm-bar-fill {
+		height: 100%;
+		border-radius: 999px;
+		background: var(--brand-grad, linear-gradient(90deg, #fbbf24, #fde047));
+		transition: width 0.4s var(--ease-spring, ease);
+	}
+	.bm-cat-sub {
+		font-family: var(--font-ui);
+		font-size: 0.72rem;
+		color: var(--text-muted);
+	}
 
-  .bm-ach-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
-  .bm-ach { display: flex; flex-direction: column; align-items: center; gap: 3px; text-align: center; padding: 12px 8px;
-    border-radius: var(--r-md, 12px); background: var(--surface, rgba(255, 255, 255, 0.05)); border: 1px solid var(--border, rgba(255, 255, 255, 0.1)); }
-  .bm-ach.earned { border-color: rgba(253, 224, 71, 0.45); box-shadow: 0 0 14px rgba(251, 191, 36, 0.14); }
-  .bm-ach.locked { opacity: 0.45; filter: grayscale(0.7); }
-  .bm-ach-emoji { font-size: 1.5rem; line-height: 1; }
-  .bm-ach-name { font-family: var(--font-display); font-weight: 700; font-size: 0.78rem; }
-  .bm-ach-desc { font-family: var(--font-ui); font-size: 0.66rem; color: var(--text-muted); line-height: 1.2; }
-  .bm-loading { color: var(--text-muted); font-size: 0.85rem; }
+	.bm-ach-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 8px;
+	}
+	.bm-ach {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 3px;
+		text-align: center;
+		padding: 12px 8px;
+		border-radius: var(--r-md, 12px);
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+	}
+	.bm-ach.earned {
+		border-color: rgba(253, 224, 71, 0.45);
+		box-shadow: 0 0 14px rgba(251, 191, 36, 0.14);
+	}
+	.bm-ach.locked {
+		opacity: 0.45;
+		filter: grayscale(0.7);
+	}
+	.bm-ach-emoji {
+		font-size: 1.5rem;
+		line-height: 1;
+	}
+	.bm-ach-name {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.78rem;
+	}
+	.bm-ach-desc {
+		font-family: var(--font-ui);
+		font-size: 0.66rem;
+		color: var(--text-muted);
+		line-height: 1.2;
+	}
+	.bm-loading {
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
 </style>

--- a/src/lib/components/ConfirmModal.svelte
+++ b/src/lib/components/ConfirmModal.svelte
@@ -1,39 +1,113 @@
 <script>
-  import { confirmStore } from '$lib/confirm.js';
-  /** @param {boolean} v */
-  function done(v) {
-    const s = $confirmStore;
-    confirmStore.set(null);
-    s?.resolve(v);
-  }
+	import { confirmStore } from '$lib/confirm.js';
+	/** @param {boolean} v */
+	function done(v) {
+		const s = $confirmStore;
+		confirmStore.set(null);
+		s?.resolve(v);
+	}
 </script>
 
 {#if $confirmStore}
-  <div class="cm-overlay" role="dialog" aria-modal="true" aria-label={$confirmStore.title}>
-    <button type="button" class="cm-backdrop" aria-label={$confirmStore.cancelText} on:click={() => done(false)}></button>
-    <div class="cm-card" role="document">
-      <h3 class="cm-title">{$confirmStore.title}</h3>
-      {#if $confirmStore.message}<p class="cm-msg">{$confirmStore.message}</p>{/if}
-      <button class="cm-go" class:danger={$confirmStore.danger} on:click={() => done(true)}>{$confirmStore.confirmText}</button>
-      <button class="cm-cancel" on:click={() => done(false)}>{$confirmStore.cancelText}</button>
-    </div>
-  </div>
+	<div class="cm-overlay" role="dialog" aria-modal="true" aria-label={$confirmStore.title}>
+		<button
+			type="button"
+			class="cm-backdrop"
+			aria-label={$confirmStore.cancelText}
+			on:click={() => done(false)}
+		></button>
+		<div class="cm-card" role="document">
+			<h3 class="cm-title">{$confirmStore.title}</h3>
+			{#if $confirmStore.message}<p class="cm-msg">{$confirmStore.message}</p>{/if}
+			<button class="cm-go" class:danger={$confirmStore.danger} on:click={() => done(true)}
+				>{$confirmStore.confirmText}</button
+			>
+			<button class="cm-cancel" on:click={() => done(false)}>{$confirmStore.cancelText}</button>
+		</div>
+	</div>
 {/if}
 
 <style>
-  /* above every in-page modal (settings modal is 9999, PinConfirm is 100000) */
-  .cm-overlay { position: fixed; inset: 0; z-index: 100001; display: grid; place-items: center; padding: 20px; }
-  .cm-backdrop { position: absolute; inset: 0; background: rgba(4,8,14,0.72); backdrop-filter: blur(6px); border: none; cursor: pointer; }
-  .cm-card { position: relative; z-index: 1; width: 100%; max-width: 340px; padding: 22px; border-radius: 20px; text-align: center;
-    background: var(--surface-strong, rgba(20,26,38,0.96)); border: 1px solid var(--border-strong, rgba(255,255,255,0.16));
-    box-shadow: 0 24px 60px rgba(0,0,0,0.5); display: flex; flex-direction: column; gap: 10px;
-    animation: cmPop 0.22s cubic-bezier(0.34,1.56,0.64,1); }
-  @keyframes cmPop { from { transform: translateY(10px) scale(0.96); opacity: 0; } to { transform: none; opacity: 1; } }
-  .cm-title { font-family: var(--font-display); font-size: 1.2rem; margin: 0; color: var(--text); }
-  .cm-msg { font-size: 0.9rem; line-height: 1.5; color: var(--text-muted); margin: 0 0 4px; }
-  .cm-go { width: 100%; height: 48px; border-radius: 14px; border: none; cursor: pointer; font-weight: 800; font-size: 1rem; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b); }
-  .cm-go.danger { color: #fff; background: linear-gradient(135deg, #f87171, #dc2626); }
-  .cm-go:active { transform: scale(0.98); }
-  .cm-cancel { background: none; border: none; color: var(--text-muted); cursor: pointer; font-weight: 600; padding: 4px; font-size: 0.95rem; }
+	/* above every in-page modal (settings modal is 9999, PinConfirm is 100000) */
+	.cm-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 100001;
+		display: grid;
+		place-items: center;
+		padding: 20px;
+	}
+	.cm-backdrop {
+		position: absolute;
+		inset: 0;
+		background: rgba(4, 8, 14, 0.72);
+		backdrop-filter: blur(6px);
+		border: none;
+		cursor: pointer;
+	}
+	.cm-card {
+		position: relative;
+		z-index: 1;
+		width: 100%;
+		max-width: 340px;
+		padding: 22px;
+		border-radius: 20px;
+		text-align: center;
+		background: var(--surface-strong, rgba(20, 26, 38, 0.96));
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		animation: cmPop 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes cmPop {
+		from {
+			transform: translateY(10px) scale(0.96);
+			opacity: 0;
+		}
+		to {
+			transform: none;
+			opacity: 1;
+		}
+	}
+	.cm-title {
+		font-family: var(--font-display);
+		font-size: 1.2rem;
+		margin: 0;
+		color: var(--text);
+	}
+	.cm-msg {
+		font-size: 0.9rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		margin: 0 0 4px;
+	}
+	.cm-go {
+		width: 100%;
+		height: 48px;
+		border-radius: 14px;
+		border: none;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 1rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.cm-go.danger {
+		color: #fff;
+		background: linear-gradient(135deg, #f87171, #dc2626);
+	}
+	.cm-go:active {
+		transform: scale(0.98);
+	}
+	.cm-cancel {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-weight: 600;
+		padding: 4px;
+		font-size: 0.95rem;
+	}
 </style>

--- a/src/lib/components/FlipDigit.svelte
+++ b/src/lib/components/FlipDigit.svelte
@@ -1,59 +1,59 @@
 <script>
-  export let digit = 0;
+	export let digit = 0;
 
-  const digitHeight = 40;
-  let currentDigit = digit;
-  let reelStyle = `transform: translateY(-${digit * digitHeight}px);`;
+	const digitHeight = 40;
+	let currentDigit = digit;
+	let reelStyle = `transform: translateY(-${digit * digitHeight}px);`;
 
-  // 🔄 Trigger animation when digit changes
-  $: if (digit !== currentDigit) {
-    const fullReelHeight = 10 * digitHeight;
-    const animatedOffset = 2 * fullReelHeight + digit * digitHeight;
+	// 🔄 Trigger animation when digit changes
+	$: if (digit !== currentDigit) {
+		const fullReelHeight = 10 * digitHeight;
+		const animatedOffset = 2 * fullReelHeight + digit * digitHeight;
 
-    // 🎞️ Animate to simulate spinning reel
-    reelStyle = `
+		// 🎞️ Animate to simulate spinning reel
+		reelStyle = `
       transform: translateY(-${animatedOffset}px);
       transition: transform 0.8s cubic-bezier(0.68, -0.55, 0.265, 1.55);
     `;
 
-    // 🧼 Reset style for looped look after animation
-    setTimeout(() => {
-      currentDigit = digit;
-      reelStyle = `transform: translateY(-${digit * digitHeight}px); transition: none;`;
-    }, 800);
-  }
+		// 🧼 Reset style for looped look after animation
+		setTimeout(() => {
+			currentDigit = digit;
+			reelStyle = `transform: translateY(-${digit * digitHeight}px); transition: none;`;
+		}, 800);
+	}
 </script>
 
 <!-- 🎰 Slot Reel Display -->
 <div class="slot-container">
-  <div class="reel" style={reelStyle}>
-    {#each Array(20) as _, i}
-      <div class="slot-digit">{i % 10}</div>
-    {/each}
-  </div>
+	<div class="reel" style={reelStyle}>
+		{#each Array(20) as _, i}
+			<div class="slot-digit">{i % 10}</div>
+		{/each}
+	</div>
 </div>
 
 <style>
-  .slot-container {
-    overflow: hidden;
-    width: 22px;
-    height: 40px;
-  }
+	.slot-container {
+		overflow: hidden;
+		width: 22px;
+		height: 40px;
+	}
 
-  .reel {
-    display: flex;
-    flex-direction: column;
-  }
+	.reel {
+		display: flex;
+		flex-direction: column;
+	}
 
-  .slot-digit {
-    height: 40px;
-    line-height: 40px;
-    text-align: center;
-    font-size: 1.9rem;
-    font-family: 'Space Grotesk', system-ui, sans-serif;
-    font-weight: 700;
-    font-variant-numeric: tabular-nums;
-    color: #fcd34d;
-    text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
-  }
+	.slot-digit {
+		height: 40px;
+		line-height: 40px;
+		text-align: center;
+		font-size: 1.9rem;
+		font-family: 'Space Grotesk', system-ui, sans-serif;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		color: #fcd34d;
+		text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
+	}
 </style>

--- a/src/lib/components/FriendsPanel.svelte
+++ b/src/lib/components/FriendsPanel.svelte
@@ -1,192 +1,405 @@
 <script>
-  // Friends management — search/add, requests, your list. Reused by the /friends
-  // route and the Community ▸ People ▸ Friends tab.
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { searchUsers, addFriend, respondFriendRequest, removeFriend, listFriends, listFriendRequests } from '$lib/stores/statsStore.js';
-  import { requireConfirm } from '$lib/confirm.js';
-  import { fx } from '$lib/sound.js';
+	// Friends management — search/add, requests, your list. Reused by the /friends
+	// route and the Community ▸ People ▸ Friends tab.
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import {
+		searchUsers,
+		addFriend,
+		respondFriendRequest,
+		removeFriend,
+		listFriends,
+		listFriendRequests
+	} from '$lib/stores/statsStore.js';
+	import { requireConfirm } from '$lib/confirm.js';
+	import { fx } from '$lib/sound.js';
 
-  /** Optional: called to start a challenge with a friend (username). */
-  let { onChallenge = null } = $props();
+	/** Optional: called to start a challenge with a friend (username). */
+	let { onChallenge = null } = $props();
 
-  /** @type {{id?:string,username:string,name:string}[]} */
-  let friends = $state([]);
-  /** @type {{id?:string,username:string,name:string}[]} */
-  let incoming = $state([]);
-  /** @type {{id?:string,username:string,name:string}[]} */
-  let outgoing = $state([]);
-  let loading = $state(true);
-  let busy = $state('');
-  let msg = $state('');
+	/** @type {{id?:string,username:string,name:string}[]} */
+	let friends = $state([]);
+	/** @type {{id?:string,username:string,name:string}[]} */
+	let incoming = $state([]);
+	/** @type {{id?:string,username:string,name:string}[]} */
+	let outgoing = $state([]);
+	let loading = $state(true);
+	let busy = $state('');
+	let msg = $state('');
 
-  let query = $state('');
-  /** @type {{username:string,status:string,is_friend:boolean}[]} */
-  let results = $state([]);
-  let searching = $state(false);
+	let query = $state('');
+	/** @type {Array<{username:string,name?:string,status?:string,id?:string,is_friend:boolean}>} */
+	let results = $state([]);
+	let searching = $state(false);
 
-  async function load() {
-    const [f, r] = await Promise.all([listFriends(), listFriendRequests()]);
-    friends = f;
-    incoming = r.incoming ?? [];
-    outgoing = r.outgoing ?? [];
-  }
+	async function load() {
+		const [f, r] = await Promise.all([listFriends(), listFriendRequests()]);
+		friends = f;
+		incoming = r.incoming ?? [];
+		outgoing = r.outgoing ?? [];
+	}
 
-  onMount(async () => { try { await load(); } finally { loading = false; } });
+	onMount(async () => {
+		try {
+			await load();
+		} finally {
+			loading = false;
+		}
+	});
 
-  let timer;
-  $effect(() => {
-    const q = query.trim();
-    clearTimeout(timer);
-    if (q.length < 2) { results = []; searching = false; return; }
-    searching = true;
-    timer = setTimeout(async () => { results = await searchUsers(q); searching = false; }, 280);
-  });
+	/** @type {ReturnType<typeof setTimeout>|undefined} */
+	let timer;
+	$effect(() => {
+		const q = query.trim();
+		clearTimeout(timer);
+		if (q.length < 2) {
+			results = [];
+			searching = false;
+			return;
+		}
+		searching = true;
+		timer = setTimeout(async () => {
+			results = await searchUsers(q);
+			searching = false;
+		}, 280);
+	});
 
-  /** @param {string} username */
-  async function add(username) {
-    if (busy) return;
-    busy = username; msg = '';
-    const res = await addFriend(username);
-    busy = '';
-    if (res?.ok) {
-      fx('select');
-      msg = res.status === 'friends' ? `You're now friends with ${res.friend_name ?? username}!` : `Request sent to ${res.friend_name ?? username}.`;
-      query = '';     // clear the search box so the results list collapses
-      results = [];
-      await load();
-    } else {
-      msg = res?.reason === 'already_friends' ? 'Already friends.' : res?.reason === 'not_found' ? 'No player with that name.' : 'Could not send request.';
-    }
-  }
+	/** @param {string} username */
+	async function add(username) {
+		if (busy) return;
+		busy = username;
+		msg = '';
+		const res = await addFriend(username);
+		busy = '';
+		if (res?.ok) {
+			fx('select');
+			msg =
+				res.status === 'friends'
+					? `You're now friends with ${res.friend_name ?? username}!`
+					: `Request sent to ${res.friend_name ?? username}.`;
+			query = ''; // clear the search box so the results list collapses
+			results = [];
+			await load();
+		} else {
+			msg =
+				res?.reason === 'already_friends'
+					? 'Already friends.'
+					: res?.reason === 'not_found'
+						? 'No player with that name.'
+						: 'Could not send request.';
+		}
+	}
 
-  /** @param {any} u @param {boolean} accept */
-  async function respond(u, accept) {
-    if (busy) return;
-    busy = u.id;
-    const res = await respondFriendRequest(u.id, accept);
-    busy = '';
-    if (res?.ok) { fx(accept ? 'win' : 'tap'); await load(); }
-  }
+	/** @param {any} u @param {boolean} accept */
+	async function respond(u, accept) {
+		if (busy) return;
+		busy = u.id;
+		const res = await respondFriendRequest(u.id, accept);
+		busy = '';
+		if (res?.ok) {
+			fx(accept ? 'win' : 'tap');
+			await load();
+		}
+	}
 
-  /** @param {any} u */
-  async function unfriend(u) {
-    if (busy) return;
-    if (!(await requireConfirm({ title: 'Remove friend?', message: `Remove @${u.username || u.name} from your friends?`, confirmText: 'Remove', danger: true }))) return;
-    busy = u.id;
-    await removeFriend(u.id);
-    busy = '';
-    fx('tap'); await load();
-  }
+	/** @param {any} u */
+	async function unfriend(u) {
+		if (busy) return;
+		if (
+			!(await requireConfirm({
+				title: 'Remove friend?',
+				message: `Remove @${u.username || u.name} from your friends?`,
+				confirmText: 'Remove',
+				danger: true
+			}))
+		)
+			return;
+		busy = u.id;
+		await removeFriend(u.id);
+		busy = '';
+		fx('tap');
+		await load();
+	}
 
-  const label = (/** @type {any} */ u) => (u.username ? '@' + u.username : (u.name || 'Player'));
+	const label = (/** @type {any} */ u) => (u.username ? '@' + u.username : u.name || 'Player');
 </script>
 
 <div class="search-wrap">
-  <input class="search" type="text" placeholder="Search players by username…" bind:value={query} maxlength="20" autocomplete="off" />
-  {#if query.trim().length >= 2}
-    <div class="results">
-      {#if searching}
-        <p class="muted small pad">Searching…</p>
-      {:else if results.length === 0}
-        <p class="muted small pad">No players found.</p>
-      {:else}
-        {#each results as u}
-          <div class="row">
-            <span class="who">
-              {#if u.name && u.name !== u.username}<span class="rname">{u.name}</span>{/if}
-              <span class="uname">@{u.username}</span>
-            </span>
-            {#if u.status === 'friends'}<span class="tag friend">✓ Friend</span>
-            {:else if u.status === 'pending_out'}<span class="tag pending">Requested</span>
-            {:else if u.status === 'pending_in'}<button class="act accept" disabled={busy === u.id} onclick={() => respond(u, true)}>Accept</button>
-            {:else}<button class="act add" disabled={busy === u.username} onclick={() => add(u.username)}>+ Add</button>{/if}
-          </div>
-        {/each}
-      {/if}
-    </div>
-  {/if}
+	<input
+		class="search"
+		type="text"
+		placeholder="Search players by username…"
+		bind:value={query}
+		maxlength="20"
+		autocomplete="off"
+	/>
+	{#if query.trim().length >= 2}
+		<div class="results">
+			{#if searching}
+				<p class="muted small pad">Searching…</p>
+			{:else if results.length === 0}
+				<p class="muted small pad">No players found.</p>
+			{:else}
+				{#each results as u}
+					<div class="row">
+						<span class="who">
+							{#if u.name && u.name !== u.username}<span class="rname">{u.name}</span>{/if}
+							<span class="uname">@{u.username}</span>
+						</span>
+						{#if u.status === 'friends'}<span class="tag friend">✓ Friend</span>
+						{:else if u.status === 'pending_out'}<span class="tag pending">Requested</span>
+						{:else if u.status === 'pending_in'}<button
+								class="act accept"
+								disabled={busy === u.id}
+								onclick={() => respond(u, true)}>Accept</button
+							>
+						{:else}<button
+								class="act add"
+								disabled={busy === u.username}
+								onclick={() => add(u.username)}>+ Add</button
+							>{/if}
+					</div>
+				{/each}
+			{/if}
+		</div>
+	{/if}
 </div>
 
 {#if msg}<p class="msg">{msg}</p>{/if}
 
 {#if loading}
-  <p class="muted pad">Loading…</p>
+	<p class="muted pad">Loading…</p>
 {:else}
-  {#if incoming.length > 0}
-    <h2 class="sec">Requests <span class="count">{incoming.length}</span></h2>
-    <div class="list">
-      {#each incoming as u}
-        <div class="row card">
-          <span class="uname">{label(u)}</span>
-          <div class="row-acts">
-            <button class="act accept" disabled={busy === u.id} onclick={() => respond(u, true)}>Accept</button>
-            <button class="act decline" disabled={busy === u.id} onclick={() => respond(u, false)}>Decline</button>
-          </div>
-        </div>
-      {/each}
-    </div>
-  {/if}
+	{#if incoming.length > 0}
+		<h2 class="sec">Requests <span class="count">{incoming.length}</span></h2>
+		<div class="list">
+			{#each incoming as u}
+				<div class="row card">
+					<span class="uname">{label(u)}</span>
+					<div class="row-acts">
+						<button class="act accept" disabled={busy === u.id} onclick={() => respond(u, true)}
+							>Accept</button
+						>
+						<button class="act decline" disabled={busy === u.id} onclick={() => respond(u, false)}
+							>Decline</button
+						>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
 
-  <h2 class="sec">Your Friends <span class="count">{friends.length}</span></h2>
-  {#if friends.length === 0}
-    <p class="muted small pad">No friends yet — search above to add some.</p>
-  {:else}
-    <div class="list">
-      {#each friends as u}
-        <div class="row card">
-          <button class="uname namelink" onclick={() => goto('/u/' + encodeURIComponent(u.username || ''))}>{label(u)}</button>
-          <div class="row-acts">
-            {#if onChallenge}<button class="act challenge" onclick={() => onChallenge(u.username)} title="Challenge">⚔️</button>{/if}
-            <button class="act remove" disabled={busy === u.id} onclick={() => unfriend(u)} title="Remove friend">✕</button>
-          </div>
-        </div>
-      {/each}
-    </div>
-  {/if}
+	<h2 class="sec">Your Friends <span class="count">{friends.length}</span></h2>
+	{#if friends.length === 0}
+		<p class="muted small pad">No friends yet — search above to add some.</p>
+	{:else}
+		<div class="list">
+			{#each friends as u}
+				<div class="row card">
+					<button
+						class="uname namelink"
+						onclick={() => goto('/u/' + encodeURIComponent(u.username || ''))}>{label(u)}</button
+					>
+					<div class="row-acts">
+						{#if onChallenge}<button
+								class="act challenge"
+								onclick={() => onChallenge(u.username)}
+								title="Challenge">⚔️</button
+							>{/if}
+						<button
+							class="act remove"
+							disabled={busy === u.id}
+							onclick={() => unfriend(u)}
+							title="Remove friend">✕</button
+						>
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
 
-  {#if outgoing.length > 0}
-    <h2 class="sec muted-sec">Sent</h2>
-    <div class="list">
-      {#each outgoing as u}
-        <div class="row card dim"><span class="uname">{label(u)}</span><span class="tag pending">Pending</span></div>
-      {/each}
-    </div>
-  {/if}
+	{#if outgoing.length > 0}
+		<h2 class="sec muted-sec">Sent</h2>
+		<div class="list">
+			{#each outgoing as u}
+				<div class="row card dim">
+					<span class="uname">{label(u)}</span><span class="tag pending">Pending</span>
+				</div>
+			{/each}
+		</div>
+	{/if}
 {/if}
 
 <style>
-  .search-wrap { position: relative; }
-  .search { width: 100%; padding: 0.85rem 1rem; border-radius: 14px; font-size: 0.95rem; background: var(--surface); border: 1px solid var(--border); color: var(--text); }
-  .search:focus { outline: none; border-color: rgba(251,191,36,0.5); }
-  .results { margin-top: 0.5rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); overflow: hidden; }
-  .results .row { padding: 0.7rem 0.9rem; border-bottom: 1px solid var(--border); }
-  .results .row:last-child { border-bottom: none; }
-  .row { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; }
-  .card { padding: 0.8rem 0.9rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); }
-  .card.dim { opacity: 0.7; }
-  .list { display: flex; flex-direction: column; gap: 0.5rem; }
-  .who { display: flex; flex-direction: column; gap: 1px; min-width: 0; text-align: left; }
-  .rname { font-family: var(--font-display); font-weight: 700; font-size: 0.95rem; line-height: 1.1; }
-  .who .uname { font-weight: 600; font-size: 0.78rem; color: var(--text-muted); }
-  .uname { font-family: var(--font-display); font-weight: 700; font-size: 1rem; }
-  .namelink { background: none; border: none; padding: 0; color: var(--text); cursor: pointer; text-align: left; }
-  .namelink:hover { color: var(--brand-2); }
-  .row-acts { display: flex; gap: 0.4rem; }
-  .act { padding: 0.45rem 0.9rem; border-radius: 10px; cursor: pointer; font-weight: 800; font-size: 0.85rem; border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.06)); color: var(--text); }
-  .act:disabled { opacity: 0.5; cursor: default; }
-  .act.add, .act.accept { color: #3a2a00; border: none; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .act.decline { color: #f87171; border-color: rgba(248,113,113,0.4); }
-  .act.challenge { padding: 0.4rem 0.6rem; }
-  .act.remove { color: var(--text-faint); padding: 0.35rem 0.6rem; }
-  .tag { font-size: 0.78rem; font-weight: 800; padding: 0.3rem 0.7rem; border-radius: 999px; }
-  .tag.friend { color: var(--brand-2); background: rgba(253, 224, 71,0.12); border: 1px solid rgba(253, 224, 71,0.35); }
-  .tag.pending { color: #fbbf24; background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.3); }
-  .sec { font-family: var(--font-display); font-size: 1.05rem; margin: 1.6rem 0 0.6rem; display: flex; align-items: center; gap: 0.5rem; }
-  .muted-sec { color: var(--text-muted); font-size: 0.95rem; }
-  .count { font-size: 0.8rem; font-weight: 800; color: #fbbf24; background: rgba(251,191,36,0.12); border-radius: 999px; padding: 1px 9px; }
-  .msg { text-align: center; font-size: 0.88rem; color: var(--brand-2); margin: 0.8rem 0 0; }
-  .muted { color: var(--text-muted); }
-  .small { font-size: 0.85rem; }
-  .pad { padding: 1rem 0.2rem; text-align: center; }
+	.search-wrap {
+		position: relative;
+	}
+	.search {
+		width: 100%;
+		padding: 0.85rem 1rem;
+		border-radius: 14px;
+		font-size: 0.95rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.search:focus {
+		outline: none;
+		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.results {
+		margin-top: 0.5rem;
+		border: 1px solid var(--border);
+		border-radius: 14px;
+		background: var(--surface);
+		overflow: hidden;
+	}
+	.results .row {
+		padding: 0.7rem 0.9rem;
+		border-bottom: 1px solid var(--border);
+	}
+	.results .row:last-child {
+		border-bottom: none;
+	}
+	.row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem;
+	}
+	.card {
+		padding: 0.8rem 0.9rem;
+		border: 1px solid var(--border);
+		border-radius: 14px;
+		background: var(--surface);
+	}
+	.card.dim {
+		opacity: 0.7;
+	}
+	.list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.who {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		min-width: 0;
+		text-align: left;
+	}
+	.rname {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+		line-height: 1.1;
+	}
+	.who .uname {
+		font-weight: 600;
+		font-size: 0.78rem;
+		color: var(--text-muted);
+	}
+	.uname {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1rem;
+	}
+	.namelink {
+		background: none;
+		border: none;
+		padding: 0;
+		color: var(--text);
+		cursor: pointer;
+		text-align: left;
+	}
+	.namelink:hover {
+		color: var(--brand-2);
+	}
+	.row-acts {
+		display: flex;
+		gap: 0.4rem;
+	}
+	.act {
+		padding: 0.45rem 0.9rem;
+		border-radius: 10px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.85rem;
+		border: 1px solid var(--border);
+		background: var(--surface-2, rgba(255, 255, 255, 0.06));
+		color: var(--text);
+	}
+	.act:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.act.add,
+	.act.accept {
+		color: #3a2a00;
+		border: none;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.act.decline {
+		color: #f87171;
+		border-color: rgba(248, 113, 113, 0.4);
+	}
+	.act.challenge {
+		padding: 0.4rem 0.6rem;
+	}
+	.act.remove {
+		color: var(--text-faint);
+		padding: 0.35rem 0.6rem;
+	}
+	.tag {
+		font-size: 0.78rem;
+		font-weight: 800;
+		padding: 0.3rem 0.7rem;
+		border-radius: 999px;
+	}
+	.tag.friend {
+		color: var(--brand-2);
+		background: rgba(253, 224, 71, 0.12);
+		border: 1px solid rgba(253, 224, 71, 0.35);
+	}
+	.tag.pending {
+		color: #fbbf24;
+		background: rgba(251, 191, 36, 0.12);
+		border: 1px solid rgba(251, 191, 36, 0.3);
+	}
+	.sec {
+		font-family: var(--font-display);
+		font-size: 1.05rem;
+		margin: 1.6rem 0 0.6rem;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.muted-sec {
+		color: var(--text-muted);
+		font-size: 0.95rem;
+	}
+	.count {
+		font-size: 0.8rem;
+		font-weight: 800;
+		color: #fbbf24;
+		background: rgba(251, 191, 36, 0.12);
+		border-radius: 999px;
+		padding: 1px 9px;
+	}
+	.msg {
+		text-align: center;
+		font-size: 0.88rem;
+		color: var(--brand-2);
+		margin: 0.8rem 0 0;
+	}
+	.muted {
+		color: var(--text-muted);
+	}
+	.small {
+		font-size: 0.85rem;
+	}
+	.pad {
+		padding: 1rem 0.2rem;
+		text-align: center;
+	}
 </style>

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -1,271 +1,285 @@
 <script>
-  import { gameStore, confirmPurchase, submitGuess } from '$lib/stores/GameStore.js';
-  import { fx } from '$lib/sound.js';
+	import { gameStore, confirmPurchase, submitGuess } from '$lib/stores/GameStore.js';
+	import { fx } from '$lib/sound.js';
 
-  // 🧠 Reactive state (server-authoritative). v3: unlimited guesses, no Reveal button.
-  $: guessModeActive = $gameStore.gameState === 'guess_mode';
-  $: purchasePending = !!$gameStore.selectedPurchase;
-  $: gameOver = $gameStore.gameState === 'won' || $gameStore.gameState === 'lost';
-  $: buttonsDisabled = gameOver;
+	// 🧠 Reactive state (server-authoritative). v3: unlimited guesses, no Reveal button.
+	$: guessModeActive = $gameStore.gameState === 'guess_mode';
+	$: purchasePending = !!$gameStore.selectedPurchase;
+	$: gameOver = $gameStore.gameState === 'won' || $gameStore.gameState === 'lost';
+	$: buttonsDisabled = gameOver;
 
-  // ✅ Detect full phrase input
-  $: guessComplete = guessModeActive && (() => {
-    const phrase = $gameStore.currentPhrase;
-    for (let i = 0; i < phrase.length; i++) {
-      if (phrase[i] === ' ') continue;
-      if ($gameStore.purchasedLetters[i] === phrase[i]) continue;
-      if (!$gameStore.guessedLetters[i]) return false;
-    }
-    return true;
-  })();
+	// ✅ Detect full phrase input
+	$: guessComplete =
+		guessModeActive &&
+		(() => {
+			const phrase = $gameStore.currentPhrase;
+			for (let i = 0; i < phrase.length; i++) {
+				if (phrase[i] === ' ') continue;
+				if ($gameStore.purchasedLetters[i] === phrase[i]) continue;
+				if (!$gameStore.guessedLetters[i]) return false;
+			}
+			return true;
+		})();
 
-  // 🔁 Button display modes
-  $: dualButtonMode = purchasePending || (guessModeActive && guessComplete);
-  $: guessCancelOnlyMode = guessModeActive && !guessComplete;
+	// 🔁 Button display modes
+	$: dualButtonMode = purchasePending || (guessModeActive && guessComplete);
+	$: guessCancelOnlyMode = guessModeActive && !guessComplete;
 
-  // 🏷️ Main button label
-  $: buttonLabel = purchasePending
-    ? 'Confirm'
-    : guessModeActive
-      ? (guessComplete ? 'Submit' : 'Cancel')
-      : 'Solve';
+	// 🏷️ Main button label
+	$: buttonLabel = purchasePending
+		? 'Confirm'
+		: guessModeActive
+			? guessComplete
+				? 'Submit'
+				: 'Cancel'
+			: 'Solve';
 
-  // 🎨 Button classes
-  $: buttonClass = [
-    'guess-phrase-button',
-    guessModeActive && !guessComplete ? 'exit-mode' : '',
-    guessComplete ? 'guess-complete' : ''
-  ].join(' ');
+	// 🎨 Button classes
+	$: buttonClass = [
+		'guess-phrase-button',
+		guessModeActive && !guessComplete ? 'exit-mode' : '',
+		guessComplete ? 'guess-complete' : ''
+	].join(' ');
 
-  // 🎯 Main button logic
-  function handleMainButtonClick() {
-    fx('tap');
-    if (purchasePending) {
-      confirmPurchase();
-      return;
-    }
-    if (guessModeActive && guessComplete) {
-      submitGuess();
-      return;
-    }
-    // Enter guess mode — guesses are unlimited (v3).
-    gameStore.update(state => ({
-      ...state,
-      gameState: 'guess_mode',
-      selectedPurchase: null,
-      guessedLetters: {}
-    }));
-  }
+	// 🎯 Main button logic
+	function handleMainButtonClick() {
+		fx('tap');
+		if (purchasePending) {
+			confirmPurchase();
+			return;
+		}
+		if (guessModeActive && guessComplete) {
+			submitGuess();
+			return;
+		}
+		// Enter guess mode — guesses are unlimited (v3).
+		gameStore.update((state) => ({
+			...state,
+			gameState: 'guess_mode',
+			selectedPurchase: null,
+			guessedLetters: {}
+		}));
+	}
 </script>
 
 {#if $gameStore.message}
-  <div class="message-box">{$gameStore.message}</div>
+	<div class="message-box">{$gameStore.message}</div>
 {/if}
 
 <div class="main-button-wrapper">
-  <!-- Optional left accessory (e.g. Cash Game vault). Absolutely positioned so Solve stays centered. -->
-  <slot name="left" />
-  {#if dualButtonMode}
-    <div class="dual-button-container">
-      <button
-        class="cancel-button"
-        on:click={() => {
-          gameStore.update(state => ({
-            ...state,
-            guessedLetters: {},
-            selectedPurchase: null,
-            gameState: 'default'
-          }));
-        }}
-        disabled={buttonsDisabled}
-      >
-        Cancel
-      </button>
+	<!-- Optional left accessory (e.g. Cash Game vault). Absolutely positioned so Solve stays centered. -->
+	<slot name="left" />
+	{#if dualButtonMode}
+		<div class="dual-button-container">
+			<button
+				class="cancel-button"
+				on:click={() => {
+					gameStore.update((state) => ({
+						...state,
+						guessedLetters: {},
+						selectedPurchase: null,
+						gameState: 'default'
+					}));
+				}}
+				disabled={buttonsDisabled}
+			>
+				Cancel
+			</button>
 
-      <button
-        class="confirm-button"
-        on:click={handleMainButtonClick}
-        disabled={buttonsDisabled}
-      >
-        {purchasePending ? 'Confirm' : 'Submit'}
-      </button>
-    </div>
-
-  {:else if guessCancelOnlyMode}
-    <div class="solve-button-container">
-      <button
-        class="guess-phrase-button exit-mode"
-        on:click={() => {
-          gameStore.update(state => ({
-            ...state,
-            guessedLetters: {},
-            gameState: 'default'
-          }));
-        }}
-        disabled={buttonsDisabled}
-      >
-        Cancel
-      </button>
-    </div>
-
-  {:else}
-    <div class="solve-button-container">
-      <button
-        class={buttonClass}
-        on:click={handleMainButtonClick}
-        disabled={buttonsDisabled}
-      >
-        {buttonLabel}
-      </button>
-    </div>
-  {/if}
+			<button class="confirm-button" on:click={handleMainButtonClick} disabled={buttonsDisabled}>
+				{purchasePending ? 'Confirm' : 'Submit'}
+			</button>
+		</div>
+	{:else if guessCancelOnlyMode}
+		<div class="solve-button-container">
+			<button
+				class="guess-phrase-button exit-mode"
+				on:click={() => {
+					gameStore.update((state) => ({
+						...state,
+						guessedLetters: {},
+						gameState: 'default'
+					}));
+				}}
+				disabled={buttonsDisabled}
+			>
+				Cancel
+			</button>
+		</div>
+	{:else}
+		<div class="solve-button-container">
+			<button class={buttonClass} on:click={handleMainButtonClick} disabled={buttonsDisabled}>
+				{buttonLabel}
+			</button>
+		</div>
+	{/if}
 </div>
+
 <style>
-@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+	@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
 
-@keyframes solvePulse {
-  0%, 100% { box-shadow: var(--glow-brand); }
-  50% { box-shadow: 0 0 0 1px rgba(253, 224, 71, 0.4), 0 8px 36px rgba(251, 191, 36, 0.5); }
-}
+	@keyframes solvePulse {
+		0%,
+		100% {
+			box-shadow: var(--glow-brand);
+		}
+		50% {
+			box-shadow:
+				0 0 0 1px rgba(253, 224, 71, 0.4),
+				0 8px 36px rgba(251, 191, 36, 0.5);
+		}
+	}
 
-.message-box {
-  position: fixed;
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 232px);
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1002;
-  font-family: var(--font-ui);
-  font-weight: 600;
-  font-size: 0.85rem;
-  color: var(--text);
-  background: var(--surface-strong);
-  border: 1px solid var(--border-strong);
-  padding: 9px 16px;
-  border-radius: 999px;
-  box-shadow: var(--shadow-md);
-  backdrop-filter: blur(12px);
-  white-space: nowrap;
-}
+	.message-box {
+		position: fixed;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 232px);
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 1002;
+		font-family: var(--font-ui);
+		font-weight: 600;
+		font-size: 0.85rem;
+		color: var(--text);
+		background: var(--surface-strong);
+		border: 1px solid var(--border-strong);
+		padding: 9px 16px;
+		border-radius: 999px;
+		box-shadow: var(--shadow-md);
+		backdrop-filter: blur(12px);
+		white-space: nowrap;
+	}
 
-/* ---------------------------
+	/* ---------------------------
    Button Wrapper Layout
 --------------------------- */
-.main-button-wrapper {
-  position: fixed;
-  /* Sit above the keyboard, which is lifted by the safe-area inset — match it so
+	.main-button-wrapper {
+		position: fixed;
+		/* Sit above the keyboard, which is lifted by the safe-area inset — match it so
      the button never overlaps the top key row on phones with a home indicator. */
-  bottom: calc(env(safe-area-inset-bottom, 0px) + 188px);
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  z-index: 999;
-}
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 188px);
+		left: 50%;
+		transform: translateX(-50%);
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		z-index: 999;
+	}
 
-/* ---------------------------
+	/* ---------------------------
    Solve / Submit / Cancel Button
 --------------------------- */
-.solve-button-container,
-.dual-button-container {
-  width: 200px;
-  height: 46px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
+	.solve-button-container,
+	.dual-button-container {
+		width: 200px;
+		height: 46px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
 
-/* Solve Button */
-.guess-phrase-button {
-  width: 100%;
-  height: 100%;
-  font-family: var(--font-display);
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  background: var(--brand-grad);
-  color: #3a2a00;
-  border-radius: 14px;
-  border: none;
-  box-shadow: var(--glow-brand);
-  transition: transform 0.16s var(--ease-spring), filter 0.2s, box-shadow 0.2s;
-}
+	/* Solve Button */
+	.guess-phrase-button {
+		width: 100%;
+		height: 100%;
+		font-family: var(--font-display);
+		font-size: 18px;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		text-transform: uppercase;
+		background: var(--brand-grad);
+		color: #3a2a00;
+		border-radius: 14px;
+		border: none;
+		box-shadow: var(--glow-brand);
+		transition:
+			transform 0.16s var(--ease-spring),
+			filter 0.2s,
+			box-shadow 0.2s;
+	}
 
-.guess-phrase-button:hover {
-  transform: translateY(-2px);
-  filter: brightness(1.05);
-}
+	.guess-phrase-button:hover {
+		transform: translateY(-2px);
+		filter: brightness(1.05);
+	}
 
-.guess-phrase-button:active {
-  transform: scale(0.97);
-}
+	.guess-phrase-button:active {
+		transform: scale(0.97);
+	}
 
-.guess-phrase-button.guess-complete {
-  animation: solvePulse 1.1s infinite;
-}
+	.guess-phrase-button.guess-complete {
+		animation: solvePulse 1.1s infinite;
+	}
 
-.guess-phrase-button.exit-mode {
-  background: linear-gradient(135deg, #fb5a5a, #c81e1e);
-  color: #fff;
-  border: none;
-  box-shadow: 0 8px 24px rgba(200, 30, 30, 0.35);
-}
+	.guess-phrase-button.exit-mode {
+		background: linear-gradient(135deg, #fb5a5a, #c81e1e);
+		color: #fff;
+		border: none;
+		box-shadow: 0 8px 24px rgba(200, 30, 30, 0.35);
+	}
 
-.guess-phrase-button.exit-mode:active {
-  transform: scale(0.96);
-}
+	.guess-phrase-button.exit-mode:active {
+		transform: scale(0.96);
+	}
 
-/* ---------------------------
+	/* ---------------------------
    Confirm / Cancel Buttons
 --------------------------- */
-.dual-button-container {
-  gap: 10px;
-}
-.confirm-button,
-.cancel-button {
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 16px;
-  flex: 1;
-  height: 46px;
-  border-radius: 14px;
-  cursor: pointer;
-  transition: transform 0.16s var(--ease-spring), filter 0.2s;
-}
+	.dual-button-container {
+		gap: 10px;
+	}
+	.confirm-button,
+	.cancel-button {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 16px;
+		flex: 1;
+		height: 46px;
+		border-radius: 14px;
+		cursor: pointer;
+		transition:
+			transform 0.16s var(--ease-spring),
+			filter 0.2s;
+	}
 
-/* Confirm */
-.confirm-button {
-  background: var(--brand-grad);
-  color: #3a2a00;
-  border: none;
-  box-shadow: var(--glow-brand);
-  animation: solvePulse 1.1s infinite;
-}
-.confirm-button:hover {
-  filter: brightness(1.05);
-  transform: translateY(-2px);
-}
-.confirm-button:active { transform: scale(0.97); }
+	/* Confirm */
+	.confirm-button {
+		background: var(--brand-grad);
+		color: #3a2a00;
+		border: none;
+		box-shadow: var(--glow-brand);
+		animation: solvePulse 1.1s infinite;
+	}
+	.confirm-button:hover {
+		filter: brightness(1.05);
+		transform: translateY(-2px);
+	}
+	.confirm-button:active {
+		transform: scale(0.97);
+	}
 
-/* Cancel */
-.cancel-button {
-  background: var(--surface-2);
-  color: var(--text);
-  border: 1px solid var(--border-strong);
-}
-.cancel-button:hover { transform: translateY(-1px); background: rgba(251, 90, 90, 0.16); border-color: rgba(251, 90, 90, 0.4); }
-.cancel-button:active { transform: scale(0.97); }
-.guess-phrase-button:disabled,
-.confirm-button:disabled,
-.cancel-button:disabled {
-  opacity: 0.4;
-  filter: grayscale(100%);
-  cursor: not-allowed;
-  box-shadow: none;
-  background: #888 !important;
-  color: #eee;
-  border: 2px solid #666;
-}
-
+	/* Cancel */
+	.cancel-button {
+		background: var(--surface-2);
+		color: var(--text);
+		border: 1px solid var(--border-strong);
+	}
+	.cancel-button:hover {
+		transform: translateY(-1px);
+		background: rgba(251, 90, 90, 0.16);
+		border-color: rgba(251, 90, 90, 0.4);
+	}
+	.cancel-button:active {
+		transform: scale(0.97);
+	}
+	.guess-phrase-button:disabled,
+	.confirm-button:disabled,
+	.cancel-button:disabled {
+		opacity: 0.4;
+		filter: grayscale(100%);
+		cursor: not-allowed;
+		box-shadow: none;
+		background: #888 !important;
+		color: #eee;
+		border: 2px solid #666;
+	}
 </style>

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -1,355 +1,897 @@
 <script>
-  // Groups — list, create, and the per-group detail (wealth/compete, members,
-  // add-friends, chat). Reused by the /groups route and Community ▸ People ▸ Groups.
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { getMyGroups, getGroup, createGroup, leaveGroup, addGroupMember, removeGroupMember, renameGroup, listFriends, getGroupMessages, sendGroupMessage, getGroupStandings } from '$lib/stores/statsStore.js';
-  import { requireConfirm } from '$lib/confirm.js';
-  import { supabase } from '$lib/supabaseClient.js';
+	// Groups — list, create, and the per-group detail (wealth/compete, members,
+	// add-friends, chat). Reused by the /groups route and Community ▸ People ▸ Groups.
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import {
+		getMyGroups,
+		getGroup,
+		createGroup,
+		leaveGroup,
+		addGroupMember,
+		removeGroupMember,
+		renameGroup,
+		listFriends,
+		getGroupMessages,
+		sendGroupMessage,
+		getGroupStandings
+	} from '$lib/stores/statsStore.js';
+	import { requireConfirm } from '$lib/confirm.js';
+	import { supabase } from '$lib/supabaseClient.js';
 
-  /** Optional: list-view back button (e.g. the route's "← Menu"). Hidden if absent.
-   *  Optional title: shown only on the list view (the route shows it; in Community
-   *  the tab already says "Groups"). */
-  let { onExit = null, title = '' } = $props();
+	/** Optional: list-view back button (e.g. the route's "← Menu"). Hidden if absent.
+	 *  Optional title: shown only on the list view (the route shows it; in Community
+	 *  the tab already says "Groups"). */
+	let { onExit = null, title = '' } = $props();
 
-  /** @type {any[]} */
-  let groups = $state([]);
-  /** @type {any|null} */
-  let open = $state(null);
-  let loading = $state(true);
-  let busy = $state(false);
-  let newName = $state('');
-  let msg = $state('');
+	/** @type {any[]} */
+	let groups = $state([]);
+	/** @type {any|null} */
+	let open = $state(null);
+	let loading = $state(true);
+	let busy = $state(false);
+	let newName = $state('');
+	let msg = $state('');
 
-  let renaming = $state(false);
-  let renameInput = $state('');
+	let renaming = $state(false);
+	let renameInput = $state('');
 
-  let gtab = $state('wealth');
-  /** @type {any|null} */
-  let standings = $state(null);
-  let standingsLoading = $state(false);
+	let gtab = $state('wealth');
+	/** @type {any|null} */
+	let standings = $state(null);
+	let standingsLoading = $state(false);
 
-  async function switchTab(/** @type {string} */ t) {
-    gtab = t;
-    if (t === 'compete' && !standings && open) {
-      standingsLoading = true;
-      standings = await getGroupStandings(open.id);
-      standingsLoading = false;
-    }
-  }
+	async function switchTab(/** @type {string} */ t) {
+		gtab = t;
+		if (t === 'compete' && !standings && open) {
+			standingsLoading = true;
+			standings = await getGroupStandings(open.id);
+			standingsLoading = false;
+		}
+	}
 
-  /** @type {{username:string,name:string}[]} */
-  let friends = $state([]);
-  let showAdd = $state(false);
-  let addMsg = $state('');
+	/** @type {{username:string,name:string}[]} */
+	let friends = $state([]);
+	let showAdd = $state(false);
+	let addMsg = $state('');
 
-  let availableFriends = $derived(
-    open ? friends.filter((f) => !open.members.some((/** @type {any} */ m) => (m.username ?? '').toLowerCase() === (f.username ?? '').toLowerCase())) : []
-  );
+	let availableFriends = $derived(
+		open
+			? friends.filter(
+					(f) =>
+						!open.members.some(
+							(/** @type {any} */ m) =>
+								(m.username ?? '').toLowerCase() === (f.username ?? '').toLowerCase()
+						)
+				)
+			: []
+	);
 
-  /** @type {any[]} */
-  let messages = $state([]);
-  let chatInput = $state('');
-  let chatBusy = $state(false);
-  /** @type {HTMLElement|undefined} */
-  let chatScroll = $state();
+	/** @type {any[]} */
+	let messages = $state([]);
+	let chatInput = $state('');
+	let chatBusy = $state(false);
+	/** @type {HTMLElement|undefined} */
+	let chatScroll = $state();
 
-  $effect(() => {
-    const g = open;
-    if (!g?.id) { messages = []; return; }
-    let alive = true;
-    const reload = async () => { const m = await getGroupMessages(g.id); if (alive && open?.id === g.id) messages = m; };
-    reload();
-    const channel = supabase
-      .channel(`group:${g.id}`)
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'group_messages', filter: `group_id=eq.${g.id}` }, reload)
-      .subscribe();
-    const iv = setInterval(reload, 30000);
-    return () => { alive = false; clearInterval(iv); supabase.removeChannel(channel); };
-  });
-  $effect(() => { messages; if (chatScroll) chatScroll.scrollTop = chatScroll.scrollHeight; });
+	$effect(() => {
+		const g = open;
+		if (!g?.id) {
+			messages = [];
+			return;
+		}
+		let alive = true;
+		const reload = async () => {
+			const m = await getGroupMessages(g.id);
+			if (alive && open?.id === g.id) messages = m;
+		};
+		reload();
+		const channel = supabase
+			.channel(`group:${g.id}`)
+			.on(
+				'postgres_changes',
+				{
+					event: 'INSERT',
+					schema: 'public',
+					table: 'group_messages',
+					filter: `group_id=eq.${g.id}`
+				},
+				reload
+			)
+			.subscribe();
+		const iv = setInterval(reload, 30000);
+		return () => {
+			alive = false;
+			clearInterval(iv);
+			supabase.removeChannel(channel);
+		};
+	});
+	$effect(() => {
+		messages;
+		if (chatScroll) chatScroll.scrollTop = chatScroll.scrollHeight;
+	});
 
-  async function sendMessage() {
-    const body = chatInput.trim();
-    if (!body || chatBusy || !open) return;
-    chatBusy = true;
-    const res = await sendGroupMessage(open.id, body);
-    chatBusy = false;
-    if (res.ok) { chatInput = ''; messages = await getGroupMessages(open.id); }
-  }
+	async function sendMessage() {
+		const body = chatInput.trim();
+		if (!body || chatBusy || !open) return;
+		chatBusy = true;
+		const res = await sendGroupMessage(open.id, body);
+		chatBusy = false;
+		if (res.ok) {
+			chatInput = '';
+			messages = await getGroupMessages(open.id);
+		}
+	}
 
-  async function refresh() { groups = await getMyGroups(); }
-  onMount(async () => { try { await refresh(); } finally { loading = false; } });
+	async function refresh() {
+		groups = await getMyGroups();
+	}
+	onMount(async () => {
+		try {
+			await refresh();
+		} finally {
+			loading = false;
+		}
+	});
 
-  const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
 
-  async function create() {
-    const name = newName.trim();
-    if (!name || busy) return;
-    busy = true; msg = '';
-    const res = await createGroup(name);
-    busy = false;
-    if (res.ok) { newName = ''; await refresh(); await openGroup(res.group); }
-    else { msg = res.reason === 'name' ? 'Name must be 2–24 characters.' : 'Could not create group.'; }
-  }
+	async function create() {
+		const name = newName.trim();
+		if (!name || busy) return;
+		busy = true;
+		msg = '';
+		const res = await createGroup(name);
+		busy = false;
+		if (res.ok) {
+			newName = '';
+			await refresh();
+			await openGroup(res.group);
+		} else {
+			msg = res.reason === 'name' ? 'Name must be 2–24 characters.' : 'Could not create group.';
+		}
+	}
 
-  /** @param {any} g */
-  async function openGroup(g) {
-    open = g; renaming = false; showAdd = false; addMsg = '';
-    gtab = 'wealth'; standings = null;
-    if (!friends.length) friends = await listFriends();
-  }
-  /** @param {string} id */
-  async function view(id) { await openGroup(await getGroup(id)); }
-  function backToList() { open = null; renaming = false; showAdd = false; gtab = 'wealth'; standings = null; }
+	/** @param {any} g */
+	async function openGroup(g) {
+		open = g;
+		renaming = false;
+		showAdd = false;
+		addMsg = '';
+		gtab = 'wealth';
+		standings = null;
+		if (!friends.length) friends = await listFriends();
+	}
+	/** @param {string} id */
+	async function view(id) {
+		await openGroup(await getGroup(id));
+	}
+	function backToList() {
+		open = null;
+		renaming = false;
+		showAdd = false;
+		gtab = 'wealth';
+		standings = null;
+	}
 
-  async function leave() {
-    if (!open || busy) return;
-    if (!(await requireConfirm({ title: 'Leave group?', message: `Leave "${open.name}"? You can be re-added by a member.`, confirmText: 'Leave', danger: true }))) return;
-    busy = true;
-    await leaveGroup(open.id);
-    busy = false;
-    backToList(); await refresh();
-  }
+	async function leave() {
+		if (!open || busy) return;
+		if (
+			!(await requireConfirm({
+				title: 'Leave group?',
+				message: `Leave "${open.name}"? You can be re-added by a member.`,
+				confirmText: 'Leave',
+				danger: true
+			}))
+		)
+			return;
+		busy = true;
+		await leaveGroup(open.id);
+		busy = false;
+		backToList();
+		await refresh();
+	}
 
-  function startRename() { renameInput = open.name; renaming = true; }
-  async function saveRename() {
-    const name = renameInput.trim();
-    if (!name || busy) return;
-    busy = true;
-    const res = await renameGroup(open.id, name);
-    busy = false;
-    if (res.ok) { open = res.group; renaming = false; await refresh(); }
-  }
+	function startRename() {
+		renameInput = open.name;
+		renaming = true;
+	}
+	async function saveRename() {
+		const name = renameInput.trim();
+		if (!name || busy) return;
+		busy = true;
+		const res = await renameGroup(open.id, name);
+		busy = false;
+		if (res.ok) {
+			open = res.group;
+			renaming = false;
+			await refresh();
+		}
+	}
 
-  /** @param {string} username */
-  async function addMember(username) {
-    if (busy) return;
-    busy = true; addMsg = '';
-    const res = await addGroupMember(open.id, username);
-    busy = false;
-    if (res.ok) { open = res.group; await refresh(); }
-    else { addMsg = res.reason === 'not_friend' ? 'You can only add friends.' : res.reason === 'already_member' ? 'Already in the group.' : 'Could not add.'; }
-  }
-  /** @param {string} username */
-  async function removeMember(username) {
-    if (busy) return;
-    if (!(await requireConfirm({ title: 'Remove member?', message: `Remove @${username} from "${open.name}"?`, confirmText: 'Remove', danger: true }))) return;
-    busy = true;
-    const res = await removeGroupMember(open.id, username);
-    busy = false;
-    if (res.ok) { open = res.group; await refresh(); }
-  }
+	/** @param {string} username */
+	async function addMember(username) {
+		if (busy) return;
+		busy = true;
+		addMsg = '';
+		const res = await addGroupMember(open.id, username);
+		busy = false;
+		if (res.ok) {
+			open = res.group;
+			await refresh();
+		} else {
+			addMsg =
+				res.reason === 'not_friend'
+					? 'You can only add friends.'
+					: res.reason === 'already_member'
+						? 'Already in the group.'
+						: 'Could not add.';
+		}
+	}
+	/** @param {string} username */
+	async function removeMember(username) {
+		if (busy) return;
+		if (
+			!(await requireConfirm({
+				title: 'Remove member?',
+				message: `Remove @${username} from "${open.name}"?`,
+				confirmText: 'Remove',
+				danger: true
+			}))
+		)
+			return;
+		busy = true;
+		const res = await removeGroupMember(open.id, username);
+		busy = false;
+		if (res.ok) {
+			open = res.group;
+			await refresh();
+		}
+	}
 </script>
 
 <div class="groups-panel">
-  {#if open}
-    <button class="back-btn" onclick={backToList}>← Groups</button>
-    <div class="g-head">
-      {#if renaming}
-        <input class="rename-input" bind:value={renameInput} maxlength="24" onkeydown={(e) => { if (e.key === 'Enter') saveRename(); }} />
-        <button class="g-btn sm" onclick={saveRename} disabled={busy}>Save</button>
-      {:else}
-        <h1>{open.name}</h1>
-        {#if open.is_owner}<button class="rename-btn" onclick={startRename} title="Rename group">✏️</button>{/if}
-      {/if}
-    </div>
-    <p class="sub">{open.members.length} member{open.members.length === 1 ? '' : 's'}</p>
+	{#if open}
+		<button class="back-btn" onclick={backToList}>← Groups</button>
+		<div class="g-head">
+			{#if renaming}
+				<input
+					class="rename-input"
+					bind:value={renameInput}
+					maxlength="24"
+					onkeydown={(e) => {
+						if (e.key === 'Enter') saveRename();
+					}}
+				/>
+				<button class="g-btn sm" onclick={saveRename} disabled={busy}>Save</button>
+			{:else}
+				<h1>{open.name}</h1>
+				{#if open.is_owner}<button class="rename-btn" onclick={startRename} title="Rename group"
+						>✏️</button
+					>{/if}
+			{/if}
+		</div>
+		<p class="sub">{open.members.length} member{open.members.length === 1 ? '' : 's'}</p>
 
-    <div class="g-tabs">
-      <button class="g-tab" class:active={gtab === 'wealth'} onclick={() => switchTab('wealth')}>💰 Wealth</button>
-      <button class="g-tab" class:active={gtab === 'compete'} onclick={() => switchTab('compete')}>⚔️ Compete</button>
-    </div>
+		<div class="g-tabs">
+			<button class="g-tab" class:active={gtab === 'wealth'} onclick={() => switchTab('wealth')}
+				>💰 Wealth</button
+			>
+			<button class="g-tab" class:active={gtab === 'compete'} onclick={() => switchTab('compete')}
+				>⚔️ Compete</button
+			>
+		</div>
 
-    {#if gtab === 'wealth'}
-    <div class="table-wrap">
-      <table>
-        <thead><tr><th>#</th><th>Player</th><th>Net Worth</th><th>Cash</th>{#if open.is_owner}<th></th>{/if}</tr></thead>
-        <tbody>
-          {#each open.members as m}
-            <tr class={m.is_me ? 'me-row' : ((m.rank ?? 0) <= 3 ? 'top-three' : '')}>
-              <td class="rank">{#if m.rank === 1}🥇{:else if m.rank === 2}🥈{:else if m.rank === 3}🥉{:else}{m.rank}{/if}</td>
-              <td class="name">{#if m.is_me}<span style={m.color ? `color:${m.color}` : ''}>You</span>{:else}<button class="m-link" style={m.color ? `color:${m.color}` : ''} onclick={() => m.username && goto('/u/' + encodeURIComponent(m.username))}>{m.name}</button>{/if}{#if m.is_owner}<span class="owner-tag">owner</span>{/if}{#if m.title}<span class="nw-title">{m.title}</span>{/if}</td>
-              <td class="score-cell" class:neg={(m.net_worth ?? 0) < 0}>{fmt(m.net_worth)}</td>
-              <td>{fmt(m.cash)}</td>
-              {#if open.is_owner}<td class="rm-cell">{#if !m.is_owner}<button class="rm-btn" onclick={() => removeMember(m.username)} disabled={busy} title="Remove">✕</button>{/if}</td>{/if}
-            </tr>
-          {/each}
-        </tbody>
-      </table>
-    </div>
-    {:else}
-      {#if standingsLoading}
-        <p class="msg">Loading…</p>
-      {:else if !standings || standings.total_matches === 0}
-        <p class="compete-empty">No group challenges yet. Start one from <button class="link" onclick={() => goto('/')}>the menu</button> — pick this group as the opponent.</p>
-      {:else}
-        <p class="compete-sub">{standings.total_matches} group challenge{standings.total_matches === 1 ? '' : 's'} played</p>
-        <div class="table-wrap">
-          <table>
-            <thead><tr><th>#</th><th>Player</th><th>W</th><th>Played</th><th>Win %</th></tr></thead>
-            <tbody>
-              {#each standings.members as m, i}
-                <tr class={m.is_me ? 'me-row' : (i < 3 && m.wins > 0 ? 'top-three' : '')}>
-                  <td class="rank">{#if i === 0 && m.wins > 0}🏆{:else}{i + 1}{/if}</td>
-                  <td class="name">{m.is_me ? 'You' : m.name}</td>
-                  <td class="score-cell">{m.wins}</td>
-                  <td>{m.played}</td>
-                  <td class="dim">{m.win_pct}%</td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
-        </div>
-        {#if (standings.recent ?? []).length}
-          <div class="recent-h">Recent matches</div>
-          <div class="recent">
-            {#each standings.recent as r}
-              <div class="recent-row">
-                <span class="r-win">🏆 @{r.winner}</span>
-                <span class="r-meta">{r.players} players · {r.pack_size} puzzle{r.pack_size === 1 ? '' : 's'}{#if Number(r.wager) > 0} · ${Number(r.wager).toLocaleString()}{/if}</span>
-              </div>
-            {/each}
-          </div>
-        {/if}
-      {/if}
-    {/if}
+		{#if gtab === 'wealth'}
+			<div class="table-wrap">
+				<table>
+					<thead
+						><tr
+							><th>#</th><th>Player</th><th>Net Worth</th><th>Cash</th>{#if open.is_owner}<th
+								></th>{/if}</tr
+						></thead
+					>
+					<tbody>
+						{#each open.members as m}
+							<tr class={m.is_me ? 'me-row' : (m.rank ?? 0) <= 3 ? 'top-three' : ''}>
+								<td class="rank"
+									>{#if m.rank === 1}🥇{:else if m.rank === 2}🥈{:else if m.rank === 3}🥉{:else}{m.rank}{/if}</td
+								>
+								<td class="name"
+									>{#if m.is_me}<span style={m.color ? `color:${m.color}` : ''}>You</span
+										>{:else}<button
+											class="m-link"
+											style={m.color ? `color:${m.color}` : ''}
+											onclick={() => m.username && goto('/u/' + encodeURIComponent(m.username))}
+											>{m.name}</button
+										>{/if}{#if m.is_owner}<span class="owner-tag">owner</span
+										>{/if}{#if m.title}<span class="nw-title">{m.title}</span>{/if}</td
+								>
+								<td class="score-cell" class:neg={(m.net_worth ?? 0) < 0}>{fmt(m.net_worth)}</td>
+								<td>{fmt(m.cash)}</td>
+								{#if open.is_owner}<td class="rm-cell"
+										>{#if !m.is_owner}<button
+												class="rm-btn"
+												onclick={() => removeMember(m.username)}
+												disabled={busy}
+												title="Remove">✕</button
+											>{/if}</td
+									>{/if}
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{:else if standingsLoading}
+			<p class="msg">Loading…</p>
+		{:else if !standings || standings.total_matches === 0}
+			<p class="compete-empty">
+				No group challenges yet. Start one from <button class="link" onclick={() => goto('/')}
+					>the menu</button
+				> — pick this group as the opponent.
+			</p>
+		{:else}
+			<p class="compete-sub">
+				{standings.total_matches} group challenge{standings.total_matches === 1 ? '' : 's'} played
+			</p>
+			<div class="table-wrap">
+				<table>
+					<thead><tr><th>#</th><th>Player</th><th>W</th><th>Played</th><th>Win %</th></tr></thead>
+					<tbody>
+						{#each standings.members as m, i}
+							<tr class={m.is_me ? 'me-row' : i < 3 && m.wins > 0 ? 'top-three' : ''}>
+								<td class="rank"
+									>{#if i === 0 && m.wins > 0}🏆{:else}{i + 1}{/if}</td
+								>
+								<td class="name">{m.is_me ? 'You' : m.name}</td>
+								<td class="score-cell">{m.wins}</td>
+								<td>{m.played}</td>
+								<td class="dim">{m.win_pct}%</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+			{#if (standings.recent ?? []).length}
+				<div class="recent-h">Recent matches</div>
+				<div class="recent">
+					{#each standings.recent as r}
+						<div class="recent-row">
+							<span class="r-win">🏆 @{r.winner}</span>
+							<span class="r-meta"
+								>{r.players} players · {r.pack_size} puzzle{r.pack_size === 1
+									? ''
+									: 's'}{#if Number(r.wager) > 0}
+									· ${Number(r.wager).toLocaleString()}{/if}</span
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		{/if}
 
-    <button class="add-toggle" onclick={() => { showAdd = !showAdd; addMsg = ''; }}>{showAdd ? '×' : '＋'} Add friends</button>
-    {#if showAdd}
-      <div class="add-panel">
-        {#if availableFriends.length}
-          {#each availableFriends as f}
-            <div class="add-row"><span class="uname">@{f.username}</span><button class="g-btn sm" onclick={() => addMember(f.username)} disabled={busy}>Add</button></div>
-          {/each}
-        {:else if friends.length === 0}
-          <p class="add-empty">No friends yet — add some in <button class="link" onclick={() => goto('/friends')}>Friends</button>.</p>
-        {:else}
-          <p class="add-empty">All your friends are already in this group.</p>
-        {/if}
-        {#if addMsg}<p class="msg">{addMsg}</p>{/if}
-      </div>
-    {/if}
+		<button
+			class="add-toggle"
+			onclick={() => {
+				showAdd = !showAdd;
+				addMsg = '';
+			}}>{showAdd ? '×' : '＋'} Add friends</button
+		>
+		{#if showAdd}
+			<div class="add-panel">
+				{#if availableFriends.length}
+					{#each availableFriends as f}
+						<div class="add-row">
+							<span class="uname">@{f.username}</span><button
+								class="g-btn sm"
+								onclick={() => addMember(f.username)}
+								disabled={busy}>Add</button
+							>
+						</div>
+					{/each}
+				{:else if friends.length === 0}
+					<p class="add-empty">
+						No friends yet — add some in <button class="link" onclick={() => goto('/friends')}
+							>Friends</button
+						>.
+					</p>
+				{:else}
+					<p class="add-empty">All your friends are already in this group.</p>
+				{/if}
+				{#if addMsg}<p class="msg">{addMsg}</p>{/if}
+			</div>
+		{/if}
 
-    <div class="chat">
-      <h2 class="chat-title">💬 Chat</h2>
-      <div class="chat-msgs" bind:this={chatScroll}>
-        {#if messages.length}
-          {#each messages as m}
-            <div class="cmsg" class:mine={m.is_me}>{#if !m.is_me}<span class="cm-name">{m.name}</span>{/if}<span class="cm-body">{m.body}</span></div>
-          {/each}
-        {:else}
-          <p class="chat-empty">No messages yet — say hi 👋</p>
-        {/if}
-      </div>
-      <div class="g-row chat-input-row">
-        <input class="g-input" placeholder="Message…" bind:value={chatInput} maxlength="500" onkeydown={(e) => { if (e.key === 'Enter') sendMessage(); }} />
-        <button class="g-btn" onclick={sendMessage} disabled={chatBusy || !chatInput.trim()}>Send</button>
-      </div>
-    </div>
+		<div class="chat">
+			<h2 class="chat-title">💬 Chat</h2>
+			<div class="chat-msgs" bind:this={chatScroll}>
+				{#if messages.length}
+					{#each messages as m}
+						<div class="cmsg" class:mine={m.is_me}>
+							{#if !m.is_me}<span class="cm-name">{m.name}</span>{/if}<span class="cm-body"
+								>{m.body}</span
+							>
+						</div>
+					{/each}
+				{:else}
+					<p class="chat-empty">No messages yet — say hi 👋</p>
+				{/if}
+			</div>
+			<div class="g-row chat-input-row">
+				<input
+					class="g-input"
+					placeholder="Message…"
+					bind:value={chatInput}
+					maxlength="500"
+					onkeydown={(e) => {
+						if (e.key === 'Enter') sendMessage();
+					}}
+				/>
+				<button class="g-btn" onclick={sendMessage} disabled={chatBusy || !chatInput.trim()}
+					>Send</button
+				>
+			</div>
+		</div>
 
-    <button class="leave-btn" onclick={leave} disabled={busy}>Leave group</button>
-  {:else}
-    {#if onExit}<button class="back-btn" onclick={onExit}>← Menu</button>{/if}
-    {#if title}<h1>{title}</h1>{/if}
+		<button class="leave-btn" onclick={leave} disabled={busy}>Leave group</button>
+	{:else}
+		{#if onExit}<button class="back-btn" onclick={onExit}>← Menu</button>{/if}
+		{#if title}<h1>{title}</h1>{/if}
 
-    {#if loading}
-      <p class="loading">Loading…</p>
-    {:else}
-      {#if groups.length}
-        <div class="g-list">
-          {#each groups as g}
-            <button class="g-card" onclick={() => view(g.id)}>
-              <div class="gc-body"><span class="gc-name">{g.name}</span><span class="gc-meta">{g.members} member{g.members === 1 ? '' : 's'}</span></div>
-              <span class="gc-arrow">→</span>
-            </button>
-          {/each}
-        </div>
-      {:else}
-        <p class="empty">No groups yet — create one and add your friends.</p>
-      {/if}
+		{#if loading}
+			<p class="loading">Loading…</p>
+		{:else}
+			{#if groups.length}
+				<div class="g-list">
+					{#each groups as g}
+						<button class="g-card" onclick={() => view(g.id)}>
+							<div class="gc-body">
+								<span class="gc-name">{g.name}</span><span class="gc-meta"
+									>{g.members} member{g.members === 1 ? '' : 's'}</span
+								>
+							</div>
+							<span class="gc-arrow">→</span>
+						</button>
+					{/each}
+				</div>
+			{:else}
+				<p class="empty">No groups yet — create one and add your friends.</p>
+			{/if}
 
-      <div class="g-forms">
-        <div class="g-row">
-          <input class="g-input" placeholder="New group name" bind:value={newName} maxlength="24" onkeydown={(e) => { if (e.key === 'Enter') create(); }} />
-          <button class="g-btn" onclick={create} disabled={busy}>Create</button>
-        </div>
-        {#if msg}<p class="msg">{msg}</p>{/if}
-      </div>
-    {/if}
-  {/if}
+			<div class="g-forms">
+				<div class="g-row">
+					<input
+						class="g-input"
+						placeholder="New group name"
+						bind:value={newName}
+						maxlength="24"
+						onkeydown={(e) => {
+							if (e.key === 'Enter') create();
+						}}
+					/>
+					<button class="g-btn" onclick={create} disabled={busy}>Create</button>
+				</div>
+				{#if msg}<p class="msg">{msg}</p>{/if}
+			</div>
+		{/if}
+	{/if}
 </div>
 
 <style>
-  .groups-panel { width: 100%; }
-  .back-btn { display: inline-block; margin-bottom: 1rem; padding: 0.55rem 1.1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
-  h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0; }
-  .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1rem; }
-  .sub.top { margin-top: 0; }
-  .g-tabs { display: flex; gap: 8px; margin: 0 0 14px; }
-  .g-tab { flex: 1; padding: 9px 0; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); color: var(--text-muted); font-weight: 700; font-size: 0.88rem; cursor: pointer; }
-  .g-tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
-  .compete-sub { color: var(--text-faint); font-size: 0.8rem; margin: 0 0 10px; }
-  .compete-empty { color: var(--text-muted); text-align: center; padding: 24px 10px; font-size: 0.9rem; }
-  .dim { color: var(--text-faint); }
-  .recent-h { color: var(--text-faint); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; margin: 18px 0 8px; }
-  .recent { display: flex; flex-direction: column; gap: 6px; }
-  .recent-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 9px 11px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; }
-  .r-win { font-weight: 700; color: var(--gold); font-size: 0.86rem; }
-  .r-meta { color: var(--text-faint); font-size: 0.74rem; text-align: right; }
-  .loading, .empty { color: var(--text-muted); padding: 1.5rem 0; text-align: center; }
-  .g-head { display: flex; align-items: center; gap: 0.6rem; }
-  .rename-btn { background: none; border: none; cursor: pointer; font-size: 1rem; opacity: 0.7; }
-  .rename-btn:hover { opacity: 1; }
-  .rename-input { flex: 1; min-width: 0; padding: 0.5rem 0.8rem; border-radius: 12px; border: 1px solid rgba(251,191,36,0.5); background: var(--surface); color: var(--text); font-size: 1.1rem; font-family: var(--font-display); font-weight: 700; }
-  .g-list { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1.2rem; }
-  .g-card { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; padding: 0.9rem 1rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; cursor: pointer; text-align: left; }
-  .g-card:hover { border-color: rgba(253, 224, 71,0.4); }
-  .gc-body { display: flex; flex-direction: column; gap: 2px; }
-  .gc-name { font-family: var(--font-display); font-weight: 700; font-size: 1rem; color: var(--text); }
-  .gc-meta { font-size: 0.78rem; color: var(--text-faint); }
-  .gc-arrow { color: var(--text-faint); }
-  .g-forms { display: flex; flex-direction: column; gap: 0.5rem; }
-  .g-row { display: flex; gap: 0.5rem; }
-  .g-input { flex: 1; min-width: 0; padding: 0.6rem 0.9rem; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; }
-  .g-btn { padding: 0.6rem 1.2rem; border: none; border-radius: 12px; cursor: pointer; font-weight: 700; color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .g-btn.sm { padding: 0.45rem 0.9rem; font-size: 0.85rem; }
-  .g-btn:disabled { opacity: 0.5; }
-  .msg { text-align: center; color: #f87171; font-size: 0.85rem; margin: 0.3rem 0 0; }
-  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; }
-  table { width: 100%; border-collapse: collapse; }
-  th { font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-faint); padding: 0.7rem 0.6rem; text-align: left; border-bottom: 1px solid var(--border); }
-  td { padding: 0.7rem 0.6rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; }
-  tr:last-child td { border-bottom: none; }
-  td.rank { width: 36px; }
-  td.name { font-weight: 600; }
-  .m-link { background: none; border: none; padding: 0; font: inherit; font-weight: 600; color: var(--text); cursor: pointer; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.2); text-underline-offset: 2px; }
-  .m-link:hover { text-decoration-color: var(--gold); }
-  td.score-cell { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); }
-  td.score-cell.neg { color: #fb7185; }
-  tr.me-row { background: rgba(56,189,248,0.1); }
-  tr.me-row td.name { color: #7dd3fc; }
-  .owner-tag { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em; color: #fbbf24; background: rgba(251,191,36,0.12); border-radius: 999px; padding: 1px 6px; margin-left: 0.4rem; }
-  .nw-title { font-size: 0.7rem; color: var(--text-faint); margin-left: 0.4rem; white-space: nowrap; }
-  .rm-cell { width: 30px; text-align: right; }
-  .rm-btn { background: none; border: none; color: var(--text-faint); cursor: pointer; font-size: 0.85rem; padding: 2px 4px; }
-  .rm-btn:hover { color: #fb7185; }
-  .add-toggle { margin-top: 0.9rem; width: 100%; padding: 0.7rem; border: 1px dashed var(--border-strong, rgba(255,255,255,0.18)); border-radius: 12px; background: transparent; color: var(--brand-2); cursor: pointer; font-weight: 700; font-size: 0.9rem; }
-  .add-panel { margin-top: 0.5rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); overflow: hidden; }
-  .add-row { display: flex; align-items: center; justify-content: space-between; padding: 0.6rem 0.9rem; border-bottom: 1px solid var(--border); }
-  .add-row:last-child { border-bottom: none; }
-  .add-empty { color: var(--text-muted); font-size: 0.85rem; padding: 0.9rem; text-align: center; }
-  .link { background: none; border: none; color: var(--brand-2); cursor: pointer; text-decoration: underline; font-size: inherit; }
-  .uname { font-family: var(--font-display); font-weight: 700; font-size: 0.95rem; }
-  .leave-btn { margin-top: 1.2rem; padding: 0.6rem 1.2rem; border: 1px solid rgba(251,113,133,0.4); border-radius: 12px; background: transparent; color: #fb7185; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
-  .leave-btn:disabled { opacity: 0.5; }
-  .chat { margin-top: 1.6rem; }
-  .chat-title { font-family: var(--font-display); font-size: 1.05rem; margin: 0 0 0.6rem; }
-  .chat-msgs { display: flex; flex-direction: column; gap: 6px; height: 260px; overflow-y: auto; padding: 0.8rem; border-radius: 14px; border: 1px solid var(--border); background: var(--surface); }
-  .chat-empty { color: var(--text-faint); font-size: 0.85rem; text-align: center; margin: auto; }
-  .cmsg { max-width: 80%; align-self: flex-start; display: flex; flex-direction: column; gap: 1px; padding: 0.45rem 0.7rem; border-radius: 12px; background: var(--surface-2, rgba(255,255,255,0.05)); border: 1px solid var(--border); }
-  .cmsg.mine { align-self: flex-end; background: rgba(253, 224, 71,0.12); border-color: rgba(253, 224, 71,0.3); }
-  .cm-name { font-size: 0.66rem; font-weight: 700; color: var(--brand-2); }
-  .cm-body { font-size: 0.88rem; color: var(--text); word-break: break-word; }
-  .chat-input-row { margin-top: 0.6rem; }
+	.groups-panel {
+		width: 100%;
+	}
+	.back-btn {
+		display: inline-block;
+		margin-bottom: 1rem;
+		padding: 0.55rem 1.1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.7rem;
+		margin: 0;
+	}
+	.sub {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin: 0.2rem 0 1rem;
+	}
+	.sub.top {
+		margin-top: 0;
+	}
+	.g-tabs {
+		display: flex;
+		gap: 8px;
+		margin: 0 0 14px;
+	}
+	.g-tab {
+		flex: 1;
+		padding: 9px 0;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text-muted);
+		font-weight: 700;
+		font-size: 0.88rem;
+		cursor: pointer;
+	}
+	.g-tab.active {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		border-color: transparent;
+	}
+	.compete-sub {
+		color: var(--text-faint);
+		font-size: 0.8rem;
+		margin: 0 0 10px;
+	}
+	.compete-empty {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 24px 10px;
+		font-size: 0.9rem;
+	}
+	.dim {
+		color: var(--text-faint);
+	}
+	.recent-h {
+		color: var(--text-faint);
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		margin: 18px 0 8px;
+	}
+	.recent {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.recent-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+		padding: 9px 11px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 10px;
+	}
+	.r-win {
+		font-weight: 700;
+		color: var(--gold);
+		font-size: 0.86rem;
+	}
+	.r-meta {
+		color: var(--text-faint);
+		font-size: 0.74rem;
+		text-align: right;
+	}
+	.loading,
+	.empty {
+		color: var(--text-muted);
+		padding: 1.5rem 0;
+		text-align: center;
+	}
+	.g-head {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+	}
+	.rename-btn {
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 1rem;
+		opacity: 0.7;
+	}
+	.rename-btn:hover {
+		opacity: 1;
+	}
+	.rename-input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.5rem 0.8rem;
+		border-radius: 12px;
+		border: 1px solid rgba(251, 191, 36, 0.5);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 1.1rem;
+		font-family: var(--font-display);
+		font-weight: 700;
+	}
+	.g-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1.2rem;
+	}
+	.g-card {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem;
+		padding: 0.9rem 1rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 14px;
+		cursor: pointer;
+		text-align: left;
+	}
+	.g-card:hover {
+		border-color: rgba(253, 224, 71, 0.4);
+	}
+	.gc-body {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+	.gc-name {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1rem;
+		color: var(--text);
+	}
+	.gc-meta {
+		font-size: 0.78rem;
+		color: var(--text-faint);
+	}
+	.gc-arrow {
+		color: var(--text-faint);
+	}
+	.g-forms {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.g-row {
+		display: flex;
+		gap: 0.5rem;
+	}
+	.g-input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.6rem 0.9rem;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.95rem;
+	}
+	.g-btn {
+		padding: 0.6rem 1.2rem;
+		border: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 700;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.g-btn.sm {
+		padding: 0.45rem 0.9rem;
+		font-size: 0.85rem;
+	}
+	.g-btn:disabled {
+		opacity: 0.5;
+	}
+	.msg {
+		text-align: center;
+		color: #f87171;
+		font-size: 0.85rem;
+		margin: 0.3rem 0 0;
+	}
+	.table-wrap {
+		overflow-x: auto;
+		border: 1px solid var(--border);
+		border-radius: 14px;
+	}
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+	th {
+		font-size: 0.65rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-faint);
+		padding: 0.7rem 0.6rem;
+		text-align: left;
+		border-bottom: 1px solid var(--border);
+	}
+	td {
+		padding: 0.7rem 0.6rem;
+		border-bottom: 1px solid var(--border);
+		font-size: 0.9rem;
+	}
+	tr:last-child td {
+		border-bottom: none;
+	}
+	td.rank {
+		width: 36px;
+	}
+	td.name {
+		font-weight: 600;
+	}
+	.m-link {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		font-weight: 600;
+		color: var(--text);
+		cursor: pointer;
+		text-decoration: underline;
+		text-decoration-color: rgba(255, 255, 255, 0.2);
+		text-underline-offset: 2px;
+	}
+	.m-link:hover {
+		text-decoration-color: var(--gold);
+	}
+	td.score-cell {
+		font-family: var(--font-display);
+		font-weight: 700;
+		color: var(--brand-2);
+	}
+	td.score-cell.neg {
+		color: #fb7185;
+	}
+	tr.me-row {
+		background: rgba(56, 189, 248, 0.1);
+	}
+	tr.me-row td.name {
+		color: #7dd3fc;
+	}
+	.owner-tag {
+		font-size: 0.62rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: #fbbf24;
+		background: rgba(251, 191, 36, 0.12);
+		border-radius: 999px;
+		padding: 1px 6px;
+		margin-left: 0.4rem;
+	}
+	.nw-title {
+		font-size: 0.7rem;
+		color: var(--text-faint);
+		margin-left: 0.4rem;
+		white-space: nowrap;
+	}
+	.rm-cell {
+		width: 30px;
+		text-align: right;
+	}
+	.rm-btn {
+		background: none;
+		border: none;
+		color: var(--text-faint);
+		cursor: pointer;
+		font-size: 0.85rem;
+		padding: 2px 4px;
+	}
+	.rm-btn:hover {
+		color: #fb7185;
+	}
+	.add-toggle {
+		margin-top: 0.9rem;
+		width: 100%;
+		padding: 0.7rem;
+		border: 1px dashed var(--border-strong, rgba(255, 255, 255, 0.18));
+		border-radius: 12px;
+		background: transparent;
+		color: var(--brand-2);
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 0.9rem;
+	}
+	.add-panel {
+		margin-top: 0.5rem;
+		border: 1px solid var(--border);
+		border-radius: 14px;
+		background: var(--surface);
+		overflow: hidden;
+	}
+	.add-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 0.6rem 0.9rem;
+		border-bottom: 1px solid var(--border);
+	}
+	.add-row:last-child {
+		border-bottom: none;
+	}
+	.add-empty {
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		padding: 0.9rem;
+		text-align: center;
+	}
+	.link {
+		background: none;
+		border: none;
+		color: var(--brand-2);
+		cursor: pointer;
+		text-decoration: underline;
+		font-size: inherit;
+	}
+	.uname {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+	}
+	.leave-btn {
+		margin-top: 1.2rem;
+		padding: 0.6rem 1.2rem;
+		border: 1px solid rgba(251, 113, 133, 0.4);
+		border-radius: 12px;
+		background: transparent;
+		color: #fb7185;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.85rem;
+	}
+	.leave-btn:disabled {
+		opacity: 0.5;
+	}
+	.chat {
+		margin-top: 1.6rem;
+	}
+	.chat-title {
+		font-family: var(--font-display);
+		font-size: 1.05rem;
+		margin: 0 0 0.6rem;
+	}
+	.chat-msgs {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		height: 260px;
+		overflow-y: auto;
+		padding: 0.8rem;
+		border-radius: 14px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.chat-empty {
+		color: var(--text-faint);
+		font-size: 0.85rem;
+		text-align: center;
+		margin: auto;
+	}
+	.cmsg {
+		max-width: 80%;
+		align-self: flex-start;
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		padding: 0.45rem 0.7rem;
+		border-radius: 12px;
+		background: var(--surface-2, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+	}
+	.cmsg.mine {
+		align-self: flex-end;
+		background: rgba(253, 224, 71, 0.12);
+		border-color: rgba(253, 224, 71, 0.3);
+	}
+	.cm-name {
+		font-size: 0.66rem;
+		font-weight: 700;
+		color: var(--brand-2);
+	}
+	.cm-body {
+		font-size: 0.88rem;
+		color: var(--text);
+		word-break: break-word;
+	}
+	.chat-input-row {
+		margin-top: 0.6rem;
+	}
 </style>

--- a/src/lib/components/HistoryList.svelte
+++ b/src/lib/components/HistoryList.svelte
@@ -1,198 +1,402 @@
 <script>
-  import { onMount } from 'svelte';
-  import { getHistory, getMatchDetail } from '$lib/stores/statsStore.js';
-  import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
-  import { track } from '$lib/analytics.js';
+	import { onMount } from 'svelte';
+	import { getHistory, getMatchDetail } from '$lib/stores/statsStore.js';
+	import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
+	import { track } from '$lib/analytics.js';
 
-  /** @type {'all'|'daily'|'climb'|'challenge'} */
-  let mode = $state('all');
-  /** @type {'all'|'won'|'lost'|'tie'} */
-  let result = $state('all');
-  /** @type {'recent'|'net'|'multiple'} */
-  let sort = $state('recent');
+	/** @type {'all'|'daily'|'climb'|'challenge'} */
+	let mode = $state('all');
+	/** @type {'all'|'won'|'lost'|'tie'} */
+	let result = $state('all');
+	/** @type {'recent'|'net'|'multiple'} */
+	let sort = $state('recent');
 
-  /** @type {any[]} */
-  let rows = $state([]);
-  let loading = $state(true);
-  let error = $state('');
-  let offset = $state(0);
-  let done = $state(false);
-  const PAGE = 30;
+	/** @type {any[]} */
+	let rows = $state([]);
+	let loading = $state(true);
+	let error = $state('');
+	let offset = $state(0);
+	let done = $state(false);
+	const PAGE = 30;
 
-  let openRow = $state('');
-  /** @type {any} */
-  let detail = $state(null);
+	let openRow = $state('');
+	/** @type {any} */
+	let detail = $state(null);
 
-  const MODES = [
-    { k: 'all', label: 'All' }, { k: 'daily', label: '📅 Daily' },
-    { k: 'climb', label: '🎰 Cash Game' },
-    { k: 'challenge', label: '⚔️ Versus' }
-  ];
-  const icon = (/** @type {string} */ m) =>
-    m === 'daily' ? '📅' : m === 'makeup' ? '🗓️' : m === 'climb' ? '🎰' : m === 'challenge' ? '⚔️' : '🎮';
-  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
-  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
-  const when = (/** @type {string} */ t) => new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	const MODES = [
+		{ k: 'all', label: 'All' },
+		{ k: 'daily', label: '📅 Daily' },
+		{ k: 'climb', label: '🎰 Cash Game' },
+		{ k: 'challenge', label: '⚔️ Versus' }
+	];
+	const icon = (/** @type {string} */ m) =>
+		m === 'daily'
+			? '📅'
+			: m === 'makeup'
+				? '🗓️'
+				: m === 'climb'
+					? '🎰'
+					: m === 'challenge'
+						? '⚔️'
+						: '🎮';
+	const money = (/** @type {any} */ n) =>
+		(Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
+	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '');
+	const when = (/** @type {string} */ t) =>
+		new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 
-  /** @param {any} r */
-  const title = (r) =>
-    r.game_mode === 'challenge'
-      ? (r.opponent_name ? '@' + r.opponent_name : r.group_name || 'Challenge')
-      : (r.category || 'Puzzle');
+	/** @param {any} r */
+	const title = (r) =>
+		r.game_mode === 'challenge'
+			? r.opponent_name
+				? '@' + r.opponent_name
+				: r.group_name || 'Challenge'
+			: r.category || 'Puzzle';
 
-  async function load(reset = false) {
-    if (reset) { offset = 0; done = false; rows = []; }
-    loading = true; error = '';
-    try {
-      const page = await getHistory({
-        mode: mode === 'all' ? null : mode,
-        result: result === 'all' ? null : result,
-        sort, limit: PAGE, offset
-      });
-      rows = reset ? page : [...rows, ...page];
-      offset += page.length;
-      if (page.length < PAGE) done = true;
-    } catch (e) {
-      error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
-    } finally { loading = false; }
-  }
+	async function load(reset = false) {
+		if (reset) {
+			offset = 0;
+			done = false;
+			rows = [];
+		}
+		loading = true;
+		error = '';
+		try {
+			const page = await getHistory({
+				mode: mode === 'all' ? null : mode,
+				result: result === 'all' ? null : result,
+				sort,
+				limit: PAGE,
+				offset
+			});
+			rows = reset ? page : [...rows, ...page];
+			offset += page.length;
+			if (page.length < PAGE) done = true;
+		} catch (e) {
+			error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
+		} finally {
+			loading = false;
+		}
+	}
 
-  /** @param {any} r */
-  async function openDetail(r) {
-    if (r.game_mode === 'challenge' && r.match_id) {
-      detail = { loading: true };
-      const d = await getMatchDetail(r.match_id);
-      detail = d || null;
-      if (!d) error = 'Could not load that challenge.';
-    } else {
-      openRow = openRow === r.id ? '' : r.id;
-    }
-  }
+	/** @param {any} r */
+	async function openDetail(r) {
+		if (r.game_mode === 'challenge' && r.match_id) {
+			detail = { loading: true };
+			const d = await getMatchDetail(r.match_id);
+			detail = d || null;
+			if (!d) error = 'Could not load that challenge.';
+		} else {
+			openRow = openRow === r.id ? '' : r.id;
+		}
+	}
 
-  onMount(() => { track('history_view'); load(true); });
-  function setMode(/** @type {any} */ k) { mode = k; load(true); }
-  function setResult(/** @type {any} */ k) { result = k; load(true); }
+	onMount(() => {
+		track('history_view');
+		load(true);
+	});
+	function setMode(/** @type {any} */ k) {
+		mode = k;
+		load(true);
+	}
+	function setResult(/** @type {any} */ k) {
+		result = k;
+		load(true);
+	}
 </script>
 
 <div class="hl">
-  <div class="chips">
-    {#each MODES as m}
-      <button class="chip" class:active={mode === m.k} onclick={() => setMode(m.k)}>{m.label}</button>
-    {/each}
-  </div>
+	<div class="chips">
+		{#each MODES as m}
+			<button class="chip" class:active={mode === m.k} onclick={() => setMode(m.k)}
+				>{m.label}</button
+			>
+		{/each}
+	</div>
 
-  <div class="row2">
-    <div class="seg">
-      {#each [['all','All'],['won','Won'],['lost','Lost'],['tie','Tie']] as [k, l]}
-        <button class="seg-btn" class:active={result === k} onclick={() => setResult(k)}>{l}</button>
-      {/each}
-    </div>
-    <select class="sort" bind:value={sort} onchange={() => load(true)}>
-      <option value="recent">Newest</option>
-      <option value="net">Biggest net</option>
-      <option value="multiple">Highest ×</option>
-    </select>
-  </div>
+	<div class="row2">
+		<div class="seg">
+			{#each [['all', 'All'], ['won', 'Won'], ['lost', 'Lost'], ['tie', 'Tie']] as [k, l]}
+				<button class="seg-btn" class:active={result === k} onclick={() => setResult(k)}>{l}</button
+				>
+			{/each}
+		</div>
+		<select class="sort" bind:value={sort} onchange={() => load(true)}>
+			<option value="recent">Newest</option>
+			<option value="net">Biggest net</option>
+			<option value="multiple">Highest ×</option>
+		</select>
+	</div>
 
-  {#if error}<p class="msg err">{error}</p>{/if}
+	{#if error}<p class="msg err">{error}</p>{/if}
 
-  {#if loading && rows.length === 0}
-    <p class="msg">Loading…</p>
-  {:else if rows.length === 0}
-    <p class="msg">No games yet. Play a round and it’ll show up here.</p>
-  {:else}
-    <ul class="list">
-      {#each rows as r (r.id)}
-        <li class="item" class:open={openRow === r.id}>
-          <button class="item-main" onclick={() => openDetail(r)}>
-            <span class="ic">{icon(r.game_mode)}</span>
-            <span class="mid">
-              <span class="ttl">{title(r)}</span>
-              <span class="sub">
-                {#if r.game_mode === 'challenge'}
-                  {r.outcome === 'won' ? 'Won' : r.outcome === 'tie' ? 'Tied' : 'Lost'}
-                  {#if r.rank && r.field_size}· #{r.rank}/{r.field_size}{/if}
-                  {#if r.solved_count != null}· solved {r.solved_count}/{r.puzzle_count}{/if}
-                {:else}
-                  {r.outcome === 'won' ? 'Solved' : r.outcome === 'lost' ? 'Missed' : (r.outcome || '')}
-                  {#if r.spent != null}· spent ${r.spent}{/if}
-                {/if}
-              </span>
-            </span>
-            <span class="right">
-              {#if r.game_mode === 'challenge' && r.net == null}
-                <span class="oc {r.outcome}">{r.outcome === 'won' ? 'WON' : r.outcome === 'tie' ? 'TIE' : 'LOST'}</span>
-                {#if Number(r.pot) > 0}<span class="mult">${Number(r.pot).toLocaleString()} pot</span>{/if}
-              {:else}
-                {#if r.net != null}<span class="net" class:neg={Number(r.net) < 0}>{money(r.net)}</span>{/if}
-                {#if mult(r.multiple_x100)}<span class="mult">{mult(r.multiple_x100)}</span>{/if}
-              {/if}
-              <span class="date">{when(r.played_at)}</span>
-            </span>
-          </button>
-          {#if openRow === r.id && r.game_mode !== 'challenge'}
-            <div class="detail-inline">
-              {#if r.puzzle_phrase}<div class="answer">“{r.puzzle_phrase}”</div>{/if}
-              <div class="kv">
-                {#if r.earned != null}<span>Bounty <b>${r.earned}</b></span>{/if}
-                {#if r.spent != null}<span>Spent <b>${r.spent}</b></span>{/if}
-                {#if r.net != null}<span>Net <b class:neg={Number(r.net) < 0}>{money(r.net)}</b></span>{/if}
-                {#if mult(r.multiple_x100)}<span>Multiple <b>{mult(r.multiple_x100)}</b></span>{/if}
-              </div>
-            </div>
-          {/if}
-        </li>
-      {/each}
-    </ul>
+	{#if loading && rows.length === 0}
+		<p class="msg">Loading…</p>
+	{:else if rows.length === 0}
+		<p class="msg">No games yet. Play a round and it’ll show up here.</p>
+	{:else}
+		<ul class="list">
+			{#each rows as r (r.id)}
+				<li class="item" class:open={openRow === r.id}>
+					<button class="item-main" onclick={() => openDetail(r)}>
+						<span class="ic">{icon(r.game_mode)}</span>
+						<span class="mid">
+							<span class="ttl">{title(r)}</span>
+							<span class="sub">
+								{#if r.game_mode === 'challenge'}
+									{r.outcome === 'won' ? 'Won' : r.outcome === 'tie' ? 'Tied' : 'Lost'}
+									{#if r.rank && r.field_size}· #{r.rank}/{r.field_size}{/if}
+									{#if r.solved_count != null}· solved {r.solved_count}/{r.puzzle_count}{/if}
+								{:else}
+									{r.outcome === 'won'
+										? 'Solved'
+										: r.outcome === 'lost'
+											? 'Missed'
+											: r.outcome || ''}
+									{#if r.spent != null}· spent ${r.spent}{/if}
+								{/if}
+							</span>
+						</span>
+						<span class="right">
+							{#if r.game_mode === 'challenge' && r.net == null}
+								<span class="oc {r.outcome}"
+									>{r.outcome === 'won' ? 'WON' : r.outcome === 'tie' ? 'TIE' : 'LOST'}</span
+								>
+								{#if Number(r.pot) > 0}<span class="mult"
+										>${Number(r.pot).toLocaleString()} pot</span
+									>{/if}
+							{:else}
+								{#if r.net != null}<span class="net" class:neg={Number(r.net) < 0}
+										>{money(r.net)}</span
+									>{/if}
+								{#if mult(r.multiple_x100)}<span class="mult">{mult(r.multiple_x100)}</span>{/if}
+							{/if}
+							<span class="date">{when(r.played_at)}</span>
+						</span>
+					</button>
+					{#if openRow === r.id && r.game_mode !== 'challenge'}
+						<div class="detail-inline">
+							{#if r.puzzle_phrase}<div class="answer">“{r.puzzle_phrase}”</div>{/if}
+							<div class="kv">
+								{#if r.earned != null}<span>Bounty <b>${r.earned}</b></span>{/if}
+								{#if r.spent != null}<span>Spent <b>${r.spent}</b></span>{/if}
+								{#if r.net != null}<span
+										>Net <b class:neg={Number(r.net) < 0}>{money(r.net)}</b></span
+									>{/if}
+								{#if mult(r.multiple_x100)}<span>Multiple <b>{mult(r.multiple_x100)}</b></span>{/if}
+							</div>
+						</div>
+					{/if}
+				</li>
+			{/each}
+		</ul>
 
-    {#if !done}
-      <button class="more" onclick={() => load(false)} disabled={loading}>
-        {loading ? 'Loading…' : 'Load more'}
-      </button>
-    {/if}
-  {/if}
+		{#if !done}
+			<button class="more" onclick={() => load(false)} disabled={loading}>
+				{loading ? 'Loading…' : 'Load more'}
+			</button>
+		{/if}
+	{/if}
 </div>
 
-<MatchDetailModal {detail} on:close={() => detail = null} />
+<MatchDetailModal {detail} on:close={() => (detail = null)} />
 
 <style>
-  .chips { display: flex; gap: 8px; overflow-x: auto; padding-bottom: 6px; margin-bottom: 10px; }
-  .chip { flex: 0 0 auto; padding: 7px 13px; border-radius: var(--r-pill); border: 1px solid var(--border);
-    background: var(--surface); color: var(--text-muted); font-weight: 600; font-size: 0.84rem; cursor: pointer; }
-  .chip.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
+	.chips {
+		display: flex;
+		gap: 8px;
+		overflow-x: auto;
+		padding-bottom: 6px;
+		margin-bottom: 10px;
+	}
+	.chip {
+		flex: 0 0 auto;
+		padding: 7px 13px;
+		border-radius: var(--r-pill);
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text-muted);
+		font-weight: 600;
+		font-size: 0.84rem;
+		cursor: pointer;
+	}
+	.chip.active {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		border-color: transparent;
+	}
 
-  .row2 { display: flex; gap: 10px; align-items: center; margin-bottom: 14px; }
-  .seg { display: flex; flex: 1; background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md); overflow: hidden; }
-  .seg-btn { flex: 1; padding: 8px 0; background: none; border: none; color: var(--text-muted); font-size: 0.82rem; font-weight: 600; cursor: pointer; }
-  .seg-btn.active { background: var(--surface-2); color: var(--gold); }
-  .sort { background: var(--surface); border: 1px solid var(--border); color: var(--text); border-radius: var(--r-md); padding: 8px 10px; font-size: 0.82rem; }
+	.row2 {
+		display: flex;
+		gap: 10px;
+		align-items: center;
+		margin-bottom: 14px;
+	}
+	.seg {
+		display: flex;
+		flex: 1;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--r-md);
+		overflow: hidden;
+	}
+	.seg-btn {
+		flex: 1;
+		padding: 8px 0;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.82rem;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.seg-btn.active {
+		background: var(--surface-2);
+		color: var(--gold);
+	}
+	.sort {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		border-radius: var(--r-md);
+		padding: 8px 10px;
+		font-size: 0.82rem;
+	}
 
-  .list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
-  .item { border: 1px solid var(--border); border-radius: var(--r-md); background: var(--surface); overflow: hidden; }
-  .item.open { border-color: rgba(251,191,36,0.4); }
-  .item-main { width: 100%; display: flex; align-items: center; gap: 11px; padding: 12px 13px; background: none; border: none; cursor: pointer; text-align: left; }
-  .ic { font-size: 1.3rem; flex: 0 0 auto; }
-  .mid { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
-  .ttl { color: var(--text); font-weight: 700; font-size: 0.95rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .sub { color: var(--text-faint); font-size: 0.76rem; }
-  .right { display: flex; flex-direction: column; align-items: flex-end; gap: 1px; flex: 0 0 auto; }
-  .net { color: #7ee0a8; font-weight: 800; font-size: 0.95rem; font-variant-numeric: tabular-nums; }
-  .net.neg, b.neg { color: #fb7185; }
-  .mult { color: var(--gold); font-size: 0.74rem; font-weight: 700; }
-  .date { color: var(--text-faint); font-size: 0.7rem; }
-  .oc { font-size: 0.68rem; font-weight: 800; letter-spacing: 0.04em; padding: 2px 7px; border-radius: 6px; }
-  .oc.won { background: rgba(126,224,168,0.18); color: #7ee0a8; }
-  .oc.lost { background: rgba(251,113,133,0.18); color: #fb7185; }
-  .oc.tie { background: var(--surface-2); color: var(--text-muted); }
+	.list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	.item {
+		border: 1px solid var(--border);
+		border-radius: var(--r-md);
+		background: var(--surface);
+		overflow: hidden;
+	}
+	.item.open {
+		border-color: rgba(251, 191, 36, 0.4);
+	}
+	.item-main {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		gap: 11px;
+		padding: 12px 13px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		text-align: left;
+	}
+	.ic {
+		font-size: 1.3rem;
+		flex: 0 0 auto;
+	}
+	.mid {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+		flex: 1;
+	}
+	.ttl {
+		color: var(--text);
+		font-weight: 700;
+		font-size: 0.95rem;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+	.sub {
+		color: var(--text-faint);
+		font-size: 0.76rem;
+	}
+	.right {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 1px;
+		flex: 0 0 auto;
+	}
+	.net {
+		color: #7ee0a8;
+		font-weight: 800;
+		font-size: 0.95rem;
+		font-variant-numeric: tabular-nums;
+	}
+	.net.neg,
+	b.neg {
+		color: #fb7185;
+	}
+	.mult {
+		color: var(--gold);
+		font-size: 0.74rem;
+		font-weight: 700;
+	}
+	.date {
+		color: var(--text-faint);
+		font-size: 0.7rem;
+	}
+	.oc {
+		font-size: 0.68rem;
+		font-weight: 800;
+		letter-spacing: 0.04em;
+		padding: 2px 7px;
+		border-radius: 6px;
+	}
+	.oc.won {
+		background: rgba(126, 224, 168, 0.18);
+		color: #7ee0a8;
+	}
+	.oc.lost {
+		background: rgba(251, 113, 133, 0.18);
+		color: #fb7185;
+	}
+	.oc.tie {
+		background: var(--surface-2);
+		color: var(--text-muted);
+	}
 
-  .detail-inline { padding: 0 13px 13px 49px; }
-  .answer { color: var(--gold); font-weight: 700; margin: 0 0 8px; }
-  .kv { display: flex; flex-wrap: wrap; gap: 6px 16px; color: var(--text-muted); font-size: 0.8rem; }
-  .kv b { color: var(--text); }
+	.detail-inline {
+		padding: 0 13px 13px 49px;
+	}
+	.answer {
+		color: var(--gold);
+		font-weight: 700;
+		margin: 0 0 8px;
+	}
+	.kv {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px 16px;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+	.kv b {
+		color: var(--text);
+	}
 
-  .more { display: block; margin: 14px auto 0; padding: 9px 22px; border-radius: var(--r-pill);
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; cursor: pointer; }
+	.more {
+		display: block;
+		margin: 14px auto 0;
+		padding: 9px 22px;
+		border-radius: var(--r-pill);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		font-weight: 600;
+		cursor: pointer;
+	}
 
-  .msg { color: var(--text-muted); text-align: center; padding: 24px 0; }
-  .msg.err { color: #fb7185; }
+	.msg {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 24px 0;
+	}
+	.msg.err {
+		color: #fb7185;
+	}
 </style>

--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -1,113 +1,211 @@
 <script>
-  // 🎒 My Bag — everything you currently own that you bought/earned, grouped by type:
-  // Power-ups (incl. Bounty Boosts), Sabotage, and Extras (titles + name colors).
-  // Power-ups are spent in-game; cosmetics are equipped from the Store/Profile.
-  import { onMount } from 'svelte';
-  import { getPowerups, getShop } from '$lib/stores/statsStore.js';
+	// 🎒 My Bag — everything you currently own that you bought/earned, grouped by type:
+	// Power-ups (incl. Bounty Boosts), Sabotage, and Extras (titles + name colors).
+	// Power-ups are spent in-game; cosmetics are equipped from the Store/Profile.
+	import { onMount } from 'svelte';
+	import { getPowerups, getShop } from '$lib/stores/statsStore.js';
 
-  /** When set, the empty "+" slots link here (e.g. the Store). */
-  export let addHref = '';
+	/** When set, the empty "+" slots link here (e.g. the Store). */
+	export let addHref = '';
 
-  /** @type {any[]} */ let pups = [];
-  /** @type {any[]} */ let cosmetics = [];
-  let loading = true;
+	/** @type {any[]} */ let pups = [];
+	/** @type {any[]} */ let cosmetics = [];
+	let loading = true;
 
-  /** @type {Record<string,{icon:string,desc:string}>} */
-  const META = {
-    bounty_boost:  { icon: '💥', desc: 'Adds ×0.5 to your Daily bounty' },
-    jackpot_boost: { icon: '💎', desc: 'Adds ×1.0 to your Daily bounty' },
-    free_reveal:   { icon: '🔍', desc: 'Reveal the most useful letter' },
-    free_vowel:    { icon: '🅰️', desc: 'Reveal one vowel free' },
-    half_off:      { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
-    vowel_vision:  { icon: '👁️', desc: 'Reveal every vowel' },
-    reveal_word:   { icon: '📖', desc: 'Reveal a whole word' },
-    extra_hint:    { icon: '💡', desc: 'First letter of each word' },
-    last_letters:  { icon: '🔚', desc: 'Last letter of each word' },
-    sabotage_tax:  { icon: '💸', desc: "An opponent's letters cost +50%" },
-    sabotage_fog:  { icon: '🌫️', desc: "Hide an opponent's clue" },
-    sabotage_toll: { icon: '🚧', desc: "An opponent's next letter costs 3×" },
-    sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
-    sabotage_lock: { icon: '🔒', desc: 'Wipe a letter an opponent revealed' }
-  };
-  const GROUPS = [
-    { key: 'powerups', title: '⚡ Power-ups', note: 'Use in the Daily, Cash Game, or a challenge.' },
-    { key: 'sabotage', title: '😈 Sabotage', note: 'Hit an opponent in a challenge.' },
-    { key: 'extras',   title: '✨ Extras',   note: 'Titles & name colors for your profile.' }
-  ];
+	/** @type {Record<string,{icon:string,desc:string}>} */
+	const META = {
+		bounty_boost: { icon: '💥', desc: 'Adds ×0.5 to your Daily bounty' },
+		jackpot_boost: { icon: '💎', desc: 'Adds ×1.0 to your Daily bounty' },
+		free_reveal: { icon: '🔍', desc: 'Reveal the most useful letter' },
+		free_vowel: { icon: '🅰️', desc: 'Reveal one vowel free' },
+		half_off: { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
+		vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
+		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
+		extra_hint: { icon: '💡', desc: 'First letter of each word' },
+		last_letters: { icon: '🔚', desc: 'Last letter of each word' },
+		sabotage_tax: { icon: '💸', desc: "An opponent's letters cost +50%" },
+		sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" },
+		sabotage_toll: { icon: '🚧', desc: "An opponent's next letter costs 3×" },
+		sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
+		sabotage_lock: { icon: '🔒', desc: 'Wipe a letter an opponent revealed' }
+	};
+	const GROUPS = [
+		{
+			key: 'powerups',
+			title: '⚡ Power-ups',
+			note: 'Use in the Daily, Cash Game, or a challenge.'
+		},
+		{ key: 'sabotage', title: '😈 Sabotage', note: 'Hit an opponent in a challenge.' },
+		{ key: 'extras', title: '✨ Extras', note: 'Titles & name colors for your profile.' }
+	];
 
-  onMount(async () => {
-    try { pups = (await getPowerups()).items ?? []; } catch { /* non-fatal */ }
-    try { cosmetics = (await getShop()).items ?? []; } catch { /* non-fatal */ }
-    loading = false;
-  });
+	onMount(async () => {
+		try {
+			pups = (await getPowerups()).items ?? [];
+		} catch {
+			/* non-fatal */
+		}
+		try {
+			cosmetics = (await getShop()).items ?? [];
+		} catch {
+			/* non-fatal */
+		}
+		loading = false;
+	});
 
-  $: ownedPups = pups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0);
-  $: ownedCos = cosmetics.filter((/** @type {any} */ i) => i.owned && (i.kind === 'title' || i.kind === 'color'));
-  $: totalCount = ownedPups.reduce((/** @type {number} */ s, /** @type {any} */ i) => s + (i.owned ?? 0), 0) + ownedCos.length;
-  /** @param {string} key */
-  function itemsFor(key) {
-    if (key === 'powerups') return ownedPups.filter((/** @type {any} */ i) => i.kind === 'climb' || i.kind === 'daily');
-    if (key === 'sabotage') return ownedPups.filter((/** @type {any} */ i) => i.kind === 'sabotage');
-    return ownedCos;
-  }
+	$: ownedPups = pups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0);
+	$: ownedCos = cosmetics.filter(
+		(/** @type {any} */ i) => i.owned && (i.kind === 'title' || i.kind === 'color')
+	);
+	$: totalCount =
+		ownedPups.reduce((/** @type {number} */ s, /** @type {any} */ i) => s + (i.owned ?? 0), 0) +
+		ownedCos.length;
+	/** @param {string} key */
+	function itemsFor(key) {
+		if (key === 'powerups')
+			return ownedPups.filter((/** @type {any} */ i) => i.kind === 'climb' || i.kind === 'daily');
+		if (key === 'sabotage')
+			return ownedPups.filter((/** @type {any} */ i) => i.kind === 'sabotage');
+		return ownedCos;
+	}
 </script>
 
 <div class="inv">
-  {#if loading}
-    <p class="inv-msg">Loading…</p>
-  {:else if totalCount === 0}
-    <div class="inv-slots">
-      {#each Array(6) as _, i}
-        {#if addHref}<a class="inv-slot" href={addHref} aria-label="Get items in the Store">+</a>
-        {:else}<span class="inv-slot">+</span>{/if}
-      {/each}
-    </div>
-  {:else}
-    <p class="inv-total">{totalCount} item{totalCount === 1 ? '' : 's'} in your vault</p>
-    {#each GROUPS as g}
-      {@const list = itemsFor(g.key)}
-      {#if list.length}
-        <div class="inv-h">{g.title}</div>
-        <p class="inv-note">{g.note}</p>
-        <div class="inv-grid">
-          {#each list as it}
-            <div class="inv-card">
-              {#if it.kind === 'title' || it.kind === 'color'}
-                <span class="inv-ic">{it.kind === 'color' ? '🎨' : '👑'}</span>
-                {#if it.equipped}<span class="inv-badge">✓</span>{/if}
-                <span class="inv-name" style={it.kind === 'color' && it.value ? `color:${it.value}` : ''}>{it.label}</span>
-                <span class="inv-desc">{it.equipped ? 'Equipped' : (it.kind === 'color' ? 'Name color' : 'Profile title')}</span>
-              {:else}
-                <span class="inv-ic">{META[it.id]?.icon ?? '✨'}</span>
-                <span class="inv-badge">×{it.owned}</span>
-                <span class="inv-name">{it.name}</span>
-                <span class="inv-desc">{META[it.id]?.desc ?? ''}</span>
-              {/if}
-            </div>
-          {/each}
-        </div>
-      {/if}
-    {/each}
-  {/if}
+	{#if loading}
+		<p class="inv-msg">Loading…</p>
+	{:else if totalCount === 0}
+		<div class="inv-slots">
+			{#each Array(6) as _, i}
+				{#if addHref}<a class="inv-slot" href={addHref} aria-label="Get items in the Store">+</a>
+				{:else}<span class="inv-slot">+</span>{/if}
+			{/each}
+		</div>
+	{:else}
+		<p class="inv-total">{totalCount} item{totalCount === 1 ? '' : 's'} in your vault</p>
+		{#each GROUPS as g}
+			{@const list = itemsFor(g.key)}
+			{#if list.length}
+				<div class="inv-h">{g.title}</div>
+				<p class="inv-note">{g.note}</p>
+				<div class="inv-grid">
+					{#each list as it}
+						<div class="inv-card">
+							{#if it.kind === 'title' || it.kind === 'color'}
+								<span class="inv-ic">{it.kind === 'color' ? '🎨' : '👑'}</span>
+								{#if it.equipped}<span class="inv-badge">✓</span>{/if}
+								<span
+									class="inv-name"
+									style={it.kind === 'color' && it.value ? `color:${it.value}` : ''}
+									>{it.label}</span
+								>
+								<span class="inv-desc"
+									>{it.equipped
+										? 'Equipped'
+										: it.kind === 'color'
+											? 'Name color'
+											: 'Profile title'}</span
+								>
+							{:else}
+								<span class="inv-ic">{META[it.id]?.icon ?? '✨'}</span>
+								<span class="inv-badge">×{it.owned}</span>
+								<span class="inv-name">{it.name}</span>
+								<span class="inv-desc">{META[it.id]?.desc ?? ''}</span>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			{/if}
+		{/each}
+	{/if}
 </div>
 
 <style>
-  .inv { width: 100%; }
-  .inv-msg { color: var(--text-muted); font-size: 0.9rem; text-align: center; padding: 1.2rem 0.5rem; }
-  .inv-total { font-size: 0.8rem; color: var(--text-faint); margin: 0 0 0.6rem; }
-  .inv-h { font-family: var(--font-display); font-size: 0.92rem; font-weight: 700; margin: 1.1rem 0 0.1rem; text-align: left; }
-  .inv-note { font-size: 0.74rem; color: var(--text-faint); margin: 0 0 0.6rem; }
-  .inv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-  .inv-slots { display: flex; flex-wrap: wrap; gap: 7px; }
-  .inv-slot { width: 42px; height: 42px; border-radius: 10px; display: grid; place-items: center; font-size: 1.1rem;
-    border: 1.5px dashed var(--border-strong, rgba(255,255,255,0.16)); background: rgba(255,255,255,0.02);
-    color: var(--text-faint); text-decoration: none; }
-  a.inv-slot:hover { border-color: var(--brand-2); color: var(--brand-2); }
-  .inv-card { position: relative; display: flex; flex-direction: column; align-items: center; text-align: center; gap: 3px;
-    padding: 0.9rem 0.5rem; border-radius: 14px; background: var(--surface); border: 1px solid var(--border); }
-  .inv-ic { font-size: 1.7rem; line-height: 1; }
-  .inv-badge { position: absolute; top: 7px; right: 9px; font-family: 'Orbitron', var(--font-display); font-weight: 800;
-    font-size: 0.78rem; color: #fde047; }
-  .inv-name { font-family: var(--font-display); font-weight: 700; font-size: 0.86rem; color: var(--text); }
-  .inv-desc { font-size: 0.72rem; line-height: 1.3; color: var(--text-muted); }
+	.inv {
+		width: 100%;
+	}
+	.inv-msg {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		text-align: center;
+		padding: 1.2rem 0.5rem;
+	}
+	.inv-total {
+		font-size: 0.8rem;
+		color: var(--text-faint);
+		margin: 0 0 0.6rem;
+	}
+	.inv-h {
+		font-family: var(--font-display);
+		font-size: 0.92rem;
+		font-weight: 700;
+		margin: 1.1rem 0 0.1rem;
+		text-align: left;
+	}
+	.inv-note {
+		font-size: 0.74rem;
+		color: var(--text-faint);
+		margin: 0 0 0.6rem;
+	}
+	.inv-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 8px;
+	}
+	.inv-slots {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 7px;
+	}
+	.inv-slot {
+		width: 42px;
+		height: 42px;
+		border-radius: 10px;
+		display: grid;
+		place-items: center;
+		font-size: 1.1rem;
+		border: 1.5px dashed var(--border-strong, rgba(255, 255, 255, 0.16));
+		background: rgba(255, 255, 255, 0.02);
+		color: var(--text-faint);
+		text-decoration: none;
+	}
+	a.inv-slot:hover {
+		border-color: var(--brand-2);
+		color: var(--brand-2);
+	}
+	.inv-card {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: 3px;
+		padding: 0.9rem 0.5rem;
+		border-radius: 14px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+	}
+	.inv-ic {
+		font-size: 1.7rem;
+		line-height: 1;
+	}
+	.inv-badge {
+		position: absolute;
+		top: 7px;
+		right: 9px;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 0.78rem;
+		color: #fde047;
+	}
+	.inv-name {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.86rem;
+		color: var(--text);
+	}
+	.inv-desc {
+		font-size: 0.72rem;
+		line-height: 1.3;
+		color: var(--text-muted);
+	}
 </style>

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -1,415 +1,519 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { get } from 'svelte/store';
-  import {
-    gameStore,
-    selectLetter,
-    inputGuessLetter,
-    confirmPurchase,
-    submitGuess,
-    deleteGuessLetter,
-    enterGuessMode
-  } from '$lib/stores/GameStore.js';
-  import { fx } from '$lib/sound.js';
+	import { onMount } from 'svelte';
+	import { get } from 'svelte/store';
+	import {
+		gameStore,
+		selectLetter,
+		inputGuessLetter,
+		confirmPurchase,
+		submitGuess,
+		deleteGuessLetter,
+		enterGuessMode
+	} from '$lib/stores/GameStore.js';
+	import { fx } from '$lib/sound.js';
 
-  type LetterCosts = Record<string, number>;
-  // Mirror of server public.letter_cost() (economy v3.2: −25%, cheapest $20).
-  const letterCosts: LetterCosts = {
-    Q: 20, W: 40, E: 100, R: 90, T: 90, Y: 50, U: 60, I: 80, O: 70, P: 60,
-    A: 100, S: 90, D: 60, F: 50, G: 50, H: 50, J: 20, K: 40, L: 60,
-    Z: 30, X: 30, C: 60, V: 40, B: 50, N: 80, M: 50
-  };
+	type LetterCosts = Record<string, number>;
+	// Mirror of server public.letter_cost() (economy v3.2: −25%, cheapest $20).
+	const letterCosts: LetterCosts = {
+		Q: 20,
+		W: 40,
+		E: 100,
+		R: 90,
+		T: 90,
+		Y: 50,
+		U: 60,
+		I: 80,
+		O: 70,
+		P: 60,
+		A: 100,
+		S: 90,
+		D: 60,
+		F: 50,
+		G: 50,
+		H: 50,
+		J: 20,
+		K: 40,
+		L: 60,
+		Z: 30,
+		X: 30,
+		C: 60,
+		V: 40,
+		B: 50,
+		N: 80,
+		M: 50
+	};
 
-  const row1: string[] = ['Q','W','E','R','T','Y','U','I','O','P'];
-  const row2: string[] = ['A','S','D','F','G','H','J','K','L'];
-  const row3: string[] = ['Z','X','C','V','B','N','M'];
+	const row1: string[] = ['Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'];
+	const row2: string[] = ['A', 'S', 'D', 'F', 'G', 'H', 'J', 'K', 'L'];
+	const row3: string[] = ['Z', 'X', 'C', 'V', 'B', 'N', 'M'];
 
-  // Braille (Unicode patterns) for each letter — the tactile dots on ATM-style keys.
-  const BRAILLE: Record<string, string> = {
-    A:'⠁',B:'⠃',C:'⠉',D:'⠙',E:'⠑',F:'⠋',G:'⠛',H:'⠓',I:'⠊',J:'⠚',K:'⠅',L:'⠇',M:'⠍',
-    N:'⠝',O:'⠕',P:'⠏',Q:'⠟',R:'⠗',S:'⠎',T:'⠞',U:'⠥',V:'⠧',W:'⠺',X:'⠭',Y:'⠽',Z:'⠵'
-  };
+	// Braille (Unicode patterns) for each letter — the tactile dots on ATM-style keys.
+	const BRAILLE: Record<string, string> = {
+		A: '⠁',
+		B: '⠃',
+		C: '⠉',
+		D: '⠙',
+		E: '⠑',
+		F: '⠋',
+		G: '⠛',
+		H: '⠓',
+		I: '⠊',
+		J: '⠚',
+		K: '⠅',
+		L: '⠇',
+		M: '⠍',
+		N: '⠝',
+		O: '⠕',
+		P: '⠏',
+		Q: '⠟',
+		R: '⠗',
+		S: '⠎',
+		T: '⠞',
+		U: '⠥',
+		V: '⠧',
+		W: '⠺',
+		X: '⠭',
+		Y: '⠽',
+		Z: '⠵'
+	};
 
-  // Blitz spends TIME, not Cash — every reveal is a flat −3s.
-  $: isBlitzKb = $gameStore.gameMode === 'blitz';
-  // Effective per-letter prices after active discount / vowel_vision (server matches this):
-  // daily uses the shared modifier.
-  $: effCosts = (() => {
-    let discount = false, vowelHalf = false;
-    if ($gameStore.gameMode === 'daily') {
-      const m = $gameStore.modifier;
-      discount = m === 'discount'; vowelHalf = m === 'vowel_vision';
-    }
-    const out: Record<string, number> = {};
-    for (const k of Object.keys(letterCosts)) {
-      let c = letterCosts[k];
-      if (discount) c = Math.ceil(c * 0.75);
-      if (vowelHalf && 'AEIOU'.includes(k)) c = Math.ceil(c * 0.5);
-      out[k] = c;
-    }
-    return out;
-  })();
+	// Blitz spends TIME, not Cash — every reveal is a flat −3s.
+	$: isBlitzKb = $gameStore.gameMode === 'blitz';
+	// Effective per-letter prices after active discount / vowel_vision (server matches this):
+	// daily uses the shared modifier.
+	$: effCosts = (() => {
+		let discount = false,
+			vowelHalf = false;
+		if ($gameStore.gameMode === 'daily') {
+			const m = $gameStore.modifier;
+			discount = m === 'discount';
+			vowelHalf = m === 'vowel_vision';
+		}
+		const out: Record<string, number> = {};
+		for (const k of Object.keys(letterCosts)) {
+			let c = letterCosts[k];
+			if (discount) c = Math.ceil(c * 0.75);
+			if (vowelHalf && 'AEIOU'.includes(k)) c = Math.ceil(c * 0.5);
+			out[k] = c;
+		}
+		return out;
+	})();
 
-  type SelectedPurchase = { type: string; value?: string } | null;
-  type LockedLetters = Record<string, unknown>;
-  let selectedPurchase: SelectedPurchase = null;
-  let lockedLetters: LockedLetters = {};
-  let incorrectLetters: string[] = [];
-  $: selectedPurchase = $gameStore.selectedPurchase as SelectedPurchase;
-  $: lockedLetters = ($gameStore.lockedLetters || {}) as LockedLetters;
-  $: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
+	type SelectedPurchase = { type: string; value?: string } | null;
+	type LockedLetters = Record<string, unknown>;
+	let selectedPurchase: SelectedPurchase = null;
+	let lockedLetters: LockedLetters = {};
+	let incorrectLetters: string[] = [];
+	$: selectedPurchase = $gameStore.selectedPurchase as SelectedPurchase;
+	$: lockedLetters = ($gameStore.lockedLetters || {}) as LockedLetters;
+	$: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
 
-  // 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
-  //    Blitz pays in TIME, not Cash, so letters are never gated by bankroll there.
-  $: disabledKeys = Object.keys(letterCosts).filter((letter: string) =>
-        isBlitzKb ? incorrectLetters.includes(letter)
-                  : ((effCosts[letter] ?? 0) > $gameStore.bankroll || incorrectLetters.includes(letter)));
+	// 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
+	//    Blitz pays in TIME, not Cash, so letters are never gated by bankroll there.
+	$: disabledKeys = Object.keys(letterCosts).filter((letter: string) =>
+		isBlitzKb
+			? incorrectLetters.includes(letter)
+			: (effCosts[letter] ?? 0) > $gameStore.bankroll || incorrectLetters.includes(letter)
+	);
 
-  /**
-   * 🔹 Letter click logic for both guess mode and purchase mode.
-   */
-  function handleLetterClick(letter: string): void {
-    fx('select');
-    if ($gameStore.gameState === 'guess_mode') {
-      inputGuessLetter(letter);
-    } else {
-      selectLetter(letter);
-    }
-  }
+	/**
+	 * 🔹 Letter click logic for both guess mode and purchase mode.
+	 */
+	function handleLetterClick(letter: string): void {
+		fx('select');
+		if ($gameStore.gameState === 'guess_mode') {
+			inputGuessLetter(letter);
+		} else {
+			selectLetter(letter);
+		}
+	}
 
-  /**
-   * 🔹 Global key handling: letters, Enter (submit), ESC (cancel), Backspace, Space.
-   */
-  function handleKeyDown(event: KeyboardEvent): void {
-    // Don't hijack typing in a text field (chat, username, search, wager…).
-    // Without this the game eats every keystroke — preventDefault stops the
-    // character and blur() closes the field, so e.g. chat won't accept input.
-    const el = document.activeElement as HTMLElement | null;
-    if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
+	/**
+	 * 🔹 Global key handling: letters, Enter (submit), ESC (cancel), Backspace, Space.
+	 */
+	function handleKeyDown(event: KeyboardEvent): void {
+		// Don't hijack typing in a text field (chat, username, search, wager…).
+		// Without this the game eats every keystroke — preventDefault stops the
+		// character and blur() closes the field, so e.g. chat won't accept input.
+		const el = document.activeElement as HTMLElement | null;
+		if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
 
-    const state = get(gameStore);
-    const gameOver = state.gameState === 'won' || state.gameState === 'lost';
-    const key = event.key.toUpperCase();
+		const state = get(gameStore);
+		const gameOver = state.gameState === 'won' || state.gameState === 'lost';
+		const key = event.key.toUpperCase();
 
-    // ESC – Cancel: exit guess mode, clear purchase, hide wager
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      if (state.gameState === 'guess_mode') {
-        enterGuessMode();
-      } else if (state.selectedPurchase) {
-        gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-      }
-      const active = document.activeElement;
-      if (active && active instanceof HTMLElement) active.blur();
-      return;
-    }
+		// ESC – Cancel: exit guess mode, clear purchase, hide wager
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			if (state.gameState === 'guess_mode') {
+				enterGuessMode();
+			} else if (state.selectedPurchase) {
+				gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+			}
+			const active = document.activeElement;
+			if (active && active instanceof HTMLElement) active.blur();
+			return;
+		}
 
-    if (gameOver) return; // Don't handle letters/Enter when game is over
+		if (gameOver) return; // Don't handle letters/Enter when game is over
 
-    // Enter – Submit guess, confirm purchase, or enter guess mode
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      if (state.selectedPurchase) {
-        confirmPurchase();
-      } else if (state.gameState === 'guess_mode') {
-        submitGuess();
-      } else if (!state.selectedPurchase && state.gameState !== 'guess_mode') {
-        gameStore.update(s => ({ ...s, gameState: 'guess_mode', selectedPurchase: null, guessedLetters: {} }));
-      }
-      const active = document.activeElement;
-      if (active && active instanceof HTMLElement) active.blur();
-      return;
-    }
+		// Enter – Submit guess, confirm purchase, or enter guess mode
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			if (state.selectedPurchase) {
+				confirmPurchase();
+			} else if (state.gameState === 'guess_mode') {
+				submitGuess();
+			} else if (!state.selectedPurchase && state.gameState !== 'guess_mode') {
+				gameStore.update((s) => ({
+					...s,
+					gameState: 'guess_mode',
+					selectedPurchase: null,
+					guessedLetters: {}
+				}));
+			}
+			const active = document.activeElement;
+			if (active && active instanceof HTMLElement) active.blur();
+			return;
+		}
 
-    // Backspace / Delete – Remove last guess letter
-    if (event.key === 'Backspace' || event.key === 'Delete') {
-      if (state.gameState === 'guess_mode') {
-        event.preventDefault();
-        deleteGuessLetter();
-      }
-      return;
-    }
+		// Backspace / Delete – Remove last guess letter
+		if (event.key === 'Backspace' || event.key === 'Delete') {
+			if (state.gameState === 'guess_mode') {
+				event.preventDefault();
+				deleteGuessLetter();
+			}
+			return;
+		}
 
-    // Space – Toggle guess mode
-    if (event.key === ' ' || event.code === 'Space') {
-      event.preventDefault();
-      enterGuessMode();
-      const active = document.activeElement;
-      if (active && active instanceof HTMLElement) active.blur();
-      return;
-    }
+		// Space – Toggle guess mode
+		if (event.key === ' ' || event.code === 'Space') {
+			event.preventDefault();
+			enterGuessMode();
+			const active = document.activeElement;
+			if (active && active instanceof HTMLElement) active.blur();
+			return;
+		}
 
-    // A–Z – Select letter (purchase or guess)
-    if (/^[A-Z]$/.test(key)) {
-      event.preventDefault();
-      fx('select');
-      if (state.gameState === 'guess_mode') {
-        inputGuessLetter(key);
-      } else {
-        selectLetter(key);
-      }
-      const active = document.activeElement;
-      if (active && active instanceof HTMLElement) active.blur();
-    }
-  }
+		// A–Z – Select letter (purchase or guess)
+		if (/^[A-Z]$/.test(key)) {
+			event.preventDefault();
+			fx('select');
+			if (state.gameState === 'guess_mode') {
+				inputGuessLetter(key);
+			} else {
+				selectLetter(key);
+			}
+			const active = document.activeElement;
+			if (active && active instanceof HTMLElement) active.blur();
+		}
+	}
 
-  onMount(() => {
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  });
+	onMount(() => {
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	});
 </script>
 
 <!-- Keyboard layout rendering -->
 <div class="keyboard-container">
-  <!-- Row 1: Q - P -->
-  <div class="keyboard-row">
-    {#each row1 as letter}
-      <button
-      tabindex="-1"
-      class="key 
+	<!-- Row 1: Q - P -->
+	<div class="keyboard-row">
+		{#each row1 as letter}
+			<button
+				tabindex="-1"
+				class="key
       {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode' ? 'disabled' : ''} 
-      {(selectedPurchase?.type === 'letter' && 
-        selectedPurchase.value === letter && 
-        $gameStore.gameState === 'purchase_pending') ? 'pending' : ''}
+      {selectedPurchase?.type === 'letter' &&
+				selectedPurchase.value === letter &&
+				$gameStore.gameState === 'purchase_pending'
+					? 'pending'
+					: ''}
       {lockedLetters[letter] ? 'purchased' : ''}
       {incorrectLetters.includes(letter) ? 'incorrect' : ''}"
-        on:click={() => handleLetterClick(letter)}
-      >
-        <span class="braille">{BRAILLE[letter]}</span>
-        <div class="letter">{letter}</div>
-        <div class="price" class:time={isBlitzKb}>{isBlitzKb ? "−3s" : "$" + (effCosts[letter] ?? 0)}</div>
-      </button>
-    {/each}
-  </div>
+				on:click={() => handleLetterClick(letter)}
+			>
+				<span class="braille">{BRAILLE[letter]}</span>
+				<div class="letter">{letter}</div>
+				<div class="price" class:time={isBlitzKb}>
+					{isBlitzKb ? '−3s' : '$' + (effCosts[letter] ?? 0)}
+				</div>
+			</button>
+		{/each}
+	</div>
 
-  <!-- Row 2: A - L -->
-  <div class="keyboard-row">
-    {#each row2 as letter}
-      <button
-      tabindex="-1"
-        class="key {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode' ? 'disabled' : ''} 
-                { selectedPurchase?.type === 'letter' &&
-                  selectedPurchase.value === letter &&
-                  $gameStore.gameState === 'purchase_pending'
-                    ? 'pending'
-                    : lockedLetters[letter]
-                      ? 'purchased'
-                      : incorrectLetters.includes(letter)
-                        ? 'incorrect'
-                        : ''
-                }"
-        on:click={() => handleLetterClick(letter)}
-      >
-        <span class="braille">{BRAILLE[letter]}</span>
-        <div class="letter">{letter}</div>
-        <div class="price" class:time={isBlitzKb}>{isBlitzKb ? "−3s" : "$" + (effCosts[letter] ?? 0)}</div>
-      </button>
-    {/each}
-  </div>
+	<!-- Row 2: A - L -->
+	<div class="keyboard-row">
+		{#each row2 as letter}
+			<button
+				tabindex="-1"
+				class="key {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode'
+					? 'disabled'
+					: ''} 
+                {selectedPurchase?.type === 'letter' &&
+				selectedPurchase.value === letter &&
+				$gameStore.gameState === 'purchase_pending'
+					? 'pending'
+					: lockedLetters[letter]
+						? 'purchased'
+						: incorrectLetters.includes(letter)
+							? 'incorrect'
+							: ''}"
+				on:click={() => handleLetterClick(letter)}
+			>
+				<span class="braille">{BRAILLE[letter]}</span>
+				<div class="letter">{letter}</div>
+				<div class="price" class:time={isBlitzKb}>
+					{isBlitzKb ? '−3s' : '$' + (effCosts[letter] ?? 0)}
+				</div>
+			</button>
+		{/each}
+	</div>
 
-  <!-- Row 3: Z - M (Plus Delete Button in Guess Mode) -->
-  <div class="keyboard-row">
-    {#each row3 as letter}
-      <button
-      tabindex="-1"
-        class="key {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode' ? 'disabled' : ''} 
-                { selectedPurchase?.type === 'letter' &&
-                  selectedPurchase.value === letter &&
-                  $gameStore.gameState === 'purchase_pending'
-                    ? 'pending'
-                    : lockedLetters[letter]
-                      ? 'purchased'
-                      : incorrectLetters.includes(letter)
-                        ? 'incorrect'
-                        : ''
-                }"
-        on:click={() => handleLetterClick(letter)}
-      >
-        <span class="braille">{BRAILLE[letter]}</span>
-        <div class="letter">{letter}</div>
-        <div class="price" class:time={isBlitzKb}>{isBlitzKb ? "−3s" : "$" + (effCosts[letter] ?? 0)}</div>
-      </button>
-    {/each}
+	<!-- Row 3: Z - M (Plus Delete Button in Guess Mode) -->
+	<div class="keyboard-row">
+		{#each row3 as letter}
+			<button
+				tabindex="-1"
+				class="key {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode'
+					? 'disabled'
+					: ''} 
+                {selectedPurchase?.type === 'letter' &&
+				selectedPurchase.value === letter &&
+				$gameStore.gameState === 'purchase_pending'
+					? 'pending'
+					: lockedLetters[letter]
+						? 'purchased'
+						: incorrectLetters.includes(letter)
+							? 'incorrect'
+							: ''}"
+				on:click={() => handleLetterClick(letter)}
+			>
+				<span class="braille">{BRAILLE[letter]}</span>
+				<div class="letter">{letter}</div>
+				<div class="price" class:time={isBlitzKb}>
+					{isBlitzKb ? '−3s' : '$' + (effCosts[letter] ?? 0)}
+				</div>
+			</button>
+		{/each}
 
-    {#if $gameStore.gameState === 'guess_mode'}
-      <button
-      tabindex="-1"
-      class="key delete" on:click={deleteGuessLetter}>
-        <div class="letter">⌫</div>
-      </button>
-    {/if}
-  </div>
+		{#if $gameStore.gameState === 'guess_mode'}
+			<button tabindex="-1" class="key delete" on:click={deleteGuessLetter}>
+				<div class="letter">⌫</div>
+			</button>
+		{/if}
+	</div>
 </div>
 
 <style>
-  /* ---------------------------
+	/* ---------------------------
      Keyboard Container & Layout
   --------------------------- */
-  .keyboard-container {
-    position: fixed;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 9px); /* lifted off the bottom edge */
-    left: 50%;
-    transform: translateX(-50%);
-    width: 100%;
-    max-width: 600px;
-    box-shadow: none !important;
-    background: transparent !important;
-    padding: 6px 8px; /* side padding so edge keys never clip */
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-    z-index: 1000;
-  }
-  .keyboard-row {
-    display: flex;
-    justify-content: center;
-    gap: 5px;
-    flex-wrap: nowrap;
-  }
-  :global(body) {
-    padding-bottom: 176px; /* Space for the lifted keyboard */
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+	.keyboard-container {
+		position: fixed;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 9px); /* lifted off the bottom edge */
+		left: 50%;
+		transform: translateX(-50%);
+		width: 100%;
+		max-width: 600px;
+		box-shadow: none !important;
+		background: transparent !important;
+		padding: 6px 8px; /* side padding so edge keys never clip */
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+		z-index: 1000;
+	}
+	.keyboard-row {
+		display: flex;
+		justify-content: center;
+		gap: 5px;
+		flex-wrap: nowrap;
+	}
+	:global(body) {
+		padding-bottom: 176px; /* Space for the lifted keyboard */
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
 
-  /* ---------------------------
+	/* ---------------------------
      Key Styles — silver ATM keys
   --------------------------- */
-  .key {
-    flex: 1 1 0;
-    min-width: 0;
-    height: 47px;
-    border: 1px solid rgba(251, 191, 36, 0.32);
-    background: linear-gradient(160deg, #1c1f28, #0c0e13);
-    color: #f4e7c6;
-    border-radius: 8px;
-    cursor: pointer;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 1px;
-    padding: 2px;
-    position: relative;
-    box-sizing: border-box;
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.06),
-      inset 0 0 10px rgba(251, 191, 36, 0.06),
-      0 2px 0 rgba(0, 0, 0, 0.6),
-      0 4px 8px rgba(0, 0, 0, 0.5);
-    transition: transform 0.1s var(--ease-spring), box-shadow 0.12s, border-color 0.15s;
-  }
-  .key:hover:not(.purchased):not(.incorrect):not(.disabled) {
-    border-color: rgba(251, 191, 36, 0.6);
-    box-shadow: inset 0 0 14px rgba(251, 191, 36, 0.12), 0 2px 0 rgba(0,0,0,0.6), 0 4px 10px rgba(0,0,0,0.5);
-    transform: translateY(-1px);
-  }
-  .key:active,
-  .key:focus-visible {
-    transform: translateY(1px) scale(0.97);
-    border-color: #fde047 !important;
-    outline: none;
-    box-shadow:
-      0 0 0 2px rgba(253, 224, 71, 1),
-      0 0 16px rgba(251, 191, 36, 0.95),
-      0 0 34px rgba(251, 191, 36, 0.65) !important;
-  }
+	.key {
+		flex: 1 1 0;
+		min-width: 0;
+		height: 47px;
+		border: 1px solid rgba(251, 191, 36, 0.32);
+		background: linear-gradient(160deg, #1c1f28, #0c0e13);
+		color: #f4e7c6;
+		border-radius: 8px;
+		cursor: pointer;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 1px;
+		padding: 2px;
+		position: relative;
+		box-sizing: border-box;
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.06),
+			inset 0 0 10px rgba(251, 191, 36, 0.06),
+			0 2px 0 rgba(0, 0, 0, 0.6),
+			0 4px 8px rgba(0, 0, 0, 0.5);
+		transition:
+			transform 0.1s var(--ease-spring),
+			box-shadow 0.12s,
+			border-color 0.15s;
+	}
+	.key:hover:not(.purchased):not(.incorrect):not(.disabled) {
+		border-color: rgba(251, 191, 36, 0.6);
+		box-shadow:
+			inset 0 0 14px rgba(251, 191, 36, 0.12),
+			0 2px 0 rgba(0, 0, 0, 0.6),
+			0 4px 10px rgba(0, 0, 0, 0.5);
+		transform: translateY(-1px);
+	}
+	.key:active,
+	.key:focus-visible {
+		transform: translateY(1px) scale(0.97);
+		border-color: #fde047 !important;
+		outline: none;
+		box-shadow:
+			0 0 0 2px rgba(253, 224, 71, 1),
+			0 0 16px rgba(251, 191, 36, 0.95),
+			0 0 34px rgba(251, 191, 36, 0.65) !important;
+	}
 
-  /* braille pips, top-left of each key */
-  .braille {
-    position: absolute;
-    top: 3px;
-    left: 5px;
-    font-size: 8px;
-    line-height: 1;
-    color: rgba(251, 191, 36, 0.4);
-  }
+	/* braille pips, top-left of each key */
+	.braille {
+		position: absolute;
+		top: 3px;
+		left: 5px;
+		font-size: 8px;
+		line-height: 1;
+		color: rgba(251, 191, 36, 0.4);
+	}
 
-  /* Delete: gold-accent futuristic key (guess mode), wider so it can't be missed */
-  .key.delete {
-    flex: 1.5 1 0;
-    background: linear-gradient(160deg, #2c2410, #16110a) !important;
-    color: #fde047 !important;
-    border-color: rgba(251, 191, 36, 0.6) !important;
-    box-shadow:
-      inset 0 0 12px rgba(251, 191, 36, 0.18),
-      0 2px 0 rgba(0, 0, 0, 0.6),
-      0 4px 8px rgba(0, 0, 0, 0.5) !important;
-  }
-  .key.delete .letter { font-size: 19px; color: #fde047; }
-  @keyframes blink {
-  0% { opacity: 1; }
-  50% { opacity: 0; }
-  100% { opacity: 1; }
-}
+	/* Delete: gold-accent futuristic key (guess mode), wider so it can't be missed */
+	.key.delete {
+		flex: 1.5 1 0;
+		background: linear-gradient(160deg, #2c2410, #16110a) !important;
+		color: #fde047 !important;
+		border-color: rgba(251, 191, 36, 0.6) !important;
+		box-shadow:
+			inset 0 0 12px rgba(251, 191, 36, 0.18),
+			0 2px 0 rgba(0, 0, 0, 0.6),
+			0 4px 8px rgba(0, 0, 0, 0.5) !important;
+	}
+	.key.delete .letter {
+		font-size: 19px;
+		color: #fde047;
+	}
+	@keyframes blink {
+		0% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 
-  /* ---------------------------
+	/* ---------------------------
      Letter & Price Styling
   --------------------------- */
-  .letter {
-    line-height: 1;
-    font-family: 'Orbitron', var(--font-display);
-    font-weight: 700;
-    font-size: 15px;
-    letter-spacing: 0.02em;
-    color: inherit; /* so purchased/incorrect state colors on .key apply */
-  }
-  .price {
-    line-height: 1;
-    font-size: 8.5px;
-    color: rgba(251, 191, 36, 0.55);
-    font-variant-numeric: tabular-nums;
-  }
-  .price.time { color: rgba(253, 224, 71, 0.75); font-weight: 700; }
+	.letter {
+		line-height: 1;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 700;
+		font-size: 15px;
+		letter-spacing: 0.02em;
+		color: inherit; /* so purchased/incorrect state colors on .key apply */
+	}
+	.price {
+		line-height: 1;
+		font-size: 8.5px;
+		color: rgba(251, 191, 36, 0.55);
+		font-variant-numeric: tabular-nums;
+	}
+	.price.time {
+		color: rgba(253, 224, 71, 0.75);
+		font-weight: 700;
+	}
 
-  /* ---------------------------
+	/* ---------------------------
      Key State Styles
   --------------------------- */
-  .purchased {
-    background: linear-gradient(135deg, rgba(251, 191, 36, 0.30), rgba(253, 224, 71, 0.18)) !important;
-    color: var(--brand-2) !important;
-    border-color: rgba(253, 224, 71, 0.4) !important;
-    cursor: default;
-    pointer-events: none;
-  }
-  .purchased .price { color: rgba(253, 224, 71, 0.65); }
-  .pending {
-    background: var(--brand-grad) !important;
-    color: #3a2a00 !important;
-    border-color: transparent !important;
-    box-shadow: var(--glow-brand);
-    animation: keyPulse 1s infinite;
-  }
-  .pending .price { color: rgba(6, 33, 15, 0.7); }
-  @keyframes keyPulse { 0%, 100% { filter: brightness(1); } 50% { filter: brightness(1.12); } }
-  .incorrect {
-    background: rgba(255, 255, 255, 0.02) !important;
-    color: var(--text-faint) !important;
-    border-color: var(--border) !important;
-    cursor: default;
-    opacity: 0.5;
-    pointer-events: none;
-  }
+	.purchased {
+		background: linear-gradient(
+			135deg,
+			rgba(251, 191, 36, 0.3),
+			rgba(253, 224, 71, 0.18)
+		) !important;
+		color: var(--brand-2) !important;
+		border-color: rgba(253, 224, 71, 0.4) !important;
+		cursor: default;
+		pointer-events: none;
+	}
+	.purchased .price {
+		color: rgba(253, 224, 71, 0.65);
+	}
+	.pending {
+		background: var(--brand-grad) !important;
+		color: #3a2a00 !important;
+		border-color: transparent !important;
+		box-shadow: var(--glow-brand);
+		animation: keyPulse 1s infinite;
+	}
+	.pending .price {
+		color: rgba(6, 33, 15, 0.7);
+	}
+	@keyframes keyPulse {
+		0%,
+		100% {
+			filter: brightness(1);
+		}
+		50% {
+			filter: brightness(1.12);
+		}
+	}
+	.incorrect {
+		background: rgba(255, 255, 255, 0.02) !important;
+		color: var(--text-faint) !important;
+		border-color: var(--border) !important;
+		cursor: default;
+		opacity: 0.5;
+		pointer-events: none;
+	}
 
-  /* Blinking animation for pending keys */
-  @keyframes blink {
-    0% { opacity: 1; }
-    50% { opacity: 0.5; }
-    100% { opacity: 1; }
-  }
+	/* Blinking animation for pending keys */
+	@keyframes blink {
+		0% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.5;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 
-  /* Unaffordable letters: dim, not blurred */
-  .key.disabled {
-    opacity: 0.4;
-    pointer-events: none;
-    transition: opacity 0.3s ease;
-  }
+	/* Unaffordable letters: dim, not blurred */
+	.key.disabled {
+		opacity: 0.4;
+		pointer-events: none;
+		transition: opacity 0.3s ease;
+	}
 
-  /* In guess mode, all letters are tappable */
-  :global(body.guess-mode) .key.incorrect,
-  :global(body.guess-mode) .key.disabled {
-    opacity: 1 !important;
-    pointer-events: all;
-  }
+	/* In guess mode, all letters are tappable */
+	:global(body.guess-mode) .key.incorrect,
+	:global(body.guess-mode) .key.disabled {
+		opacity: 1 !important;
+		pointer-events: all;
+	}
 </style>

--- a/src/lib/components/KitAvatar.svelte
+++ b/src/lib/components/KitAvatar.svelte
@@ -1,25 +1,41 @@
 <script>
-  import { SLOTS, PARTS, CANVAS, DEFAULT_KIT } from '$lib/avatarKit.js';
-  /** @type {any} */ export let config = null;   // { slot: partId }
-  export let size = 200;                         // width in px (height from CANVAS ratio)
+	import { SLOTS, PARTS, CANVAS, DEFAULT_KIT } from '$lib/avatarKit.js';
+	/** @type {any} */ export let config = null; // { slot: partId }
+	export let size = 200; // width in px (height from CANVAS ratio)
 
-  $: sel = { ...DEFAULT_KIT, ...(config || {}) };
-  $: ordered = [...SLOTS].sort((a, b) => a.z - b.z);
-  /** @param {string} slot */
-  function fileFor(slot) {
-    const part = (PARTS[slot] || []).find((p) => p.id === sel[slot]);
-    return part && part.file ? `/avatar/${slot}/${part.file}` : null;
-  }
+	$: sel = { ...DEFAULT_KIT, ...(config || {}) };
+	$: ordered = [...SLOTS].sort((a, b) => a.z - b.z);
+	/** @param {string} slot */
+	function fileFor(slot) {
+		const part = (PARTS[slot] || []).find((p) => p.id === sel[slot]);
+		return part && part.file ? `/avatar/${slot}/${part.file}` : null;
+	}
 </script>
 
-<svg class="kit" viewBox="0 0 {CANVAS.w} {CANVAS.h}" style="width:{size}px;" xmlns="http://www.w3.org/2000/svg">
-  {#each ordered as s (s.key)}
-    {#if fileFor(s.key)}
-      <image href={fileFor(s.key)} x={s.place.x} y={s.place.y} width={s.place.w} height={s.place.h} />
-    {/if}
-  {/each}
+<svg
+	class="kit"
+	viewBox="0 0 {CANVAS.w} {CANVAS.h}"
+	style="width:{size}px;"
+	xmlns="http://www.w3.org/2000/svg"
+>
+	{#each ordered as s (s.key)}
+		{#if fileFor(s.key)}
+			<image
+				href={fileFor(s.key)}
+				x={s.place.x}
+				y={s.place.y}
+				width={s.place.w}
+				height={s.place.h}
+			/>
+		{/if}
+	{/each}
 </svg>
 
 <style>
-  .kit { display: block; height: auto; flex: none; overflow: visible; }
+	.kit {
+		display: block;
+		height: auto;
+		flex: none;
+		overflow: visible;
+	}
 </style>

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -1,152 +1,335 @@
 <script>
-  // Today's Daily leaderboard. Sort by any column (name / cash / score / streaks);
-  // scope dropdown: Everyone · Friends · a specific group.
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { getDailyBoard, getMyGroups } from '$lib/stores/statsStore.js';
+	// Today's Daily leaderboard. Sort by any column (name / cash / score / streaks);
+	// scope dropdown: Everyone · Friends · a specific group.
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { getDailyBoard, getMyGroups } from '$lib/stores/statsStore.js';
 
-  /** scope: 'global' (Everyone) | 'friends' | a group id */
-  let scope = $state('global');
-  /** @type {any[]} */
-  let rows = $state([]);
-  /** @type {any[]} */
-  let groups = $state([]);
-  let loading = $state(true);
-  let error = $state('');
+	/** scope: 'global' (Everyone) | 'friends' | a group id */
+	let scope = $state('global');
+	/** @type {any[]} */
+	let rows = $state([]);
+	/** @type {any[]} */
+	let groups = $state([]);
+	let loading = $state(true);
+	let error = $state('');
 
-  // Sortable columns (client-side). Default: by place, best → worst. Tap # again to
-  // flip and bring LAST place to the top.
-  /** @typedef {'place'|'name'|'net_worth'|'score'|'efficiency'|'play_streak'|'win_streak'} SortKey */
-  let sortKey = $state(/** @type {SortKey} */ ('place'));
-  let sortDir = $state(/** @type {'asc'|'desc'} */ ('asc'));
-  /** @param {SortKey} k */
-  function setSort(k) {
-    if (sortKey === k) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
-    else { sortKey = k; sortDir = (k === 'name' || k === 'place') ? 'asc' : 'desc'; }
-  }
-  /** @param {SortKey} k */
-  const arrow = (k) => sortKey === k ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
-  // Canonical place = rank by today's score (played first, high → low). Stays fixed
-  // no matter how the list is sorted, so the # column always shows the real place.
-  let ranked = $derived.by(() =>
-    [...rows]
-      .sort((a, b) => (b.score ?? -Infinity) - (a.score ?? -Infinity) || String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' }))
-      .map((r, i) => ({ ...r, _place: i + 1 }))
-  );
-  let sortedRows = $derived.by(() => {
-    const dir = sortDir === 'asc' ? 1 : -1;
-    return [...ranked].sort((a, b) => {
-      if (sortKey === 'place') return dir * (a._place - b._place);
-      if (sortKey === 'name') return dir * String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' });
-      const nullLast = sortKey === 'score' || sortKey === 'efficiency';
-      const av = nullLast ? (a[sortKey] ?? -Infinity) : Number(a[sortKey] ?? 0);
-      const bv = nullLast ? (b[sortKey] ?? -Infinity) : Number(b[sortKey] ?? 0);
-      return dir * (av - bv) || (a._place - b._place);
-    });
-  });
+	// Sortable columns (client-side). Default: by place, best → worst. Tap # again to
+	// flip and bring LAST place to the top.
+	/** @typedef {'place'|'name'|'net_worth'|'score'|'efficiency'|'play_streak'|'win_streak'} SortKey */
+	let sortKey = $state(/** @type {SortKey} */ ('place'));
+	let sortDir = $state(/** @type {'asc'|'desc'} */ ('asc'));
+	/** @param {SortKey} k */
+	function setSort(k) {
+		if (sortKey === k) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+		else {
+			sortKey = k;
+			sortDir = k === 'name' || k === 'place' ? 'asc' : 'desc';
+		}
+	}
+	/** @param {SortKey} k */
+	const arrow = (k) => (sortKey === k ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '');
+	// Canonical place = rank by today's score (played first, high → low). Stays fixed
+	// no matter how the list is sorted, so the # column always shows the real place.
+	let ranked = $derived.by(() =>
+		[...rows]
+			.sort(
+				(a, b) =>
+					(b.score ?? -Infinity) - (a.score ?? -Infinity) ||
+					String(a.name || '').localeCompare(String(b.name || ''), undefined, {
+						sensitivity: 'base'
+					})
+			)
+			.map((r, i) => ({ ...r, _place: i + 1 }))
+	);
+	let sortedRows = $derived.by(() => {
+		const dir = sortDir === 'asc' ? 1 : -1;
+		return [...ranked].sort((a, b) => {
+			if (sortKey === 'place') return dir * (a._place - b._place);
+			if (sortKey === 'name')
+				return (
+					dir *
+					String(a.name || '').localeCompare(String(b.name || ''), undefined, {
+						sensitivity: 'base'
+					})
+				);
+			const nullLast = sortKey === 'score' || sortKey === 'efficiency';
+			const av = nullLast ? (a[sortKey] ?? -Infinity) : Number(a[sortKey] ?? 0);
+			const bv = nullLast ? (b[sortKey] ?? -Infinity) : Number(b[sortKey] ?? 0);
+			return dir * (av - bv) || a._place - b._place;
+		});
+	});
 
-  const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
+	const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
 
-  async function load() {
-    loading = true; error = '';
-    try {
-      const isGroup = scope !== 'global' && scope !== 'friends';
-      rows = await getDailyBoard(isGroup ? 'group' : scope, isGroup ? scope : null);
-    } catch (e) {
-      error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
-    } finally { loading = false; }
-  }
+	async function load() {
+		loading = true;
+		error = '';
+		try {
+			const isGroup = scope !== 'global' && scope !== 'friends';
+			rows = await getDailyBoard(isGroup ? 'group' : scope, isGroup ? scope : null);
+		} catch (e) {
+			error = (e instanceof Error ? e.message : String(e)) || 'Failed to load';
+		} finally {
+			loading = false;
+		}
+	}
 
-  onMount(async () => { groups = await getMyGroups(); await load(); });
-  $effect(() => { scope; load(); });
+	onMount(async () => {
+		groups = await getMyGroups();
+		await load();
+	});
+	$effect(() => {
+		scope;
+		load();
+	});
 
-  /** @param {number} rank */
-  const medal = (rank) => rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : String(rank);
+	/** @param {number} rank */
+	const medal = (rank) =>
+		rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : String(rank);
 </script>
 
 <!-- Scope: Everyone · Friends · a specific group -->
 <div class="filters">
-  <select class="filter-select" bind:value={scope}>
-    <option value="global">🌍 Everyone</option>
-    <option value="friends">👋 Friends</option>
-    {#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
-  </select>
+	<select class="filter-select" bind:value={scope}>
+		<option value="global">🌍 Everyone</option>
+		<option value="friends">👋 Friends</option>
+		{#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
+	</select>
 </div>
 
 <p class="caption">Today's Daily — same puzzle for everyone. Tap a column to sort.</p>
 
 {#if loading}
-  <p class="muted">Loading…</p>
+	<p class="muted">Loading…</p>
 {:else if error}
-  <p class="error">{error}</p>
+	<p class="error">{error}</p>
 {:else if rows.length === 0}
-  <p class="muted">Nobody here yet — add friends or play today's Daily!</p>
+	<p class="muted">Nobody here yet — add friends or play today's Daily!</p>
 {:else}
-  <div class="table-wrap">
-    <table>
-      <thead>
-        <tr>
-          <th><button class="sort" class:on={sortKey === 'place'} onclick={() => setSort('place')}>#{arrow('place')}</button></th>
-          <th><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}>Player{arrow('name')}</button></th>
-          <th class="num"><button class="sort" class:on={sortKey === 'net_worth'} onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button></th>
-          <th class="num"><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}>Bounty Earned{arrow('score')}</button></th>
-          <th class="num"><button class="sort" class:on={sortKey === 'efficiency'} onclick={() => setSort('efficiency')} title="Efficiency — value kept of the puzzle's base bounty (same for everyone; pure spend-less skill)">⚡ Eff{arrow('efficiency')}</button></th>
-          <th class="num"><button class="sort" class:on={sortKey === 'play_streak'} onclick={() => setSort('play_streak')}>🔥{arrow('play_streak')}</button></th>
-          <th class="num"><button class="sort" class:on={sortKey === 'win_streak'} onclick={() => setSort('win_streak')}>🏆{arrow('win_streak')}</button></th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each sortedRows as r, i}
-          <tr class={r.is_me ? 'me' : (r._place <= 3 ? 'top' : '')}>
-            <td class="rank">{medal(r._place)}</td>
-            <td class="name">
-              {#if r.is_me}
-                <button class="name-link" onclick={() => goto('/profile')} style={r.color ? `color:${r.color}` : ''}>You</button>
-              {:else}
-                <button class="name-link" onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))} style={r.color ? `color:${r.color}` : ''}>{r.name || 'Player'}</button>
-              {/if}
-              {#if r.title}<span class="title">{r.title}</span>{/if}
-            </td>
-            <td class="metric">{fmt(r.net_worth)}</td>
-            <td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
-            <td class="metric eff">{r.efficiency != null ? r.efficiency + '%' : '—'}</td>
-            <td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>
-            <td class="metric small">{r.win_streak > 0 ? '🏆' + r.win_streak : '—'}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
+	<div class="table-wrap">
+		<table>
+			<thead>
+				<tr>
+					<th
+						><button class="sort" class:on={sortKey === 'place'} onclick={() => setSort('place')}
+							>#{arrow('place')}</button
+						></th
+					>
+					<th
+						><button class="sort" class:on={sortKey === 'name'} onclick={() => setSort('name')}
+							>Player{arrow('name')}</button
+						></th
+					>
+					<th class="num"
+						><button
+							class="sort"
+							class:on={sortKey === 'net_worth'}
+							onclick={() => setSort('net_worth')}>💰 Cash{arrow('net_worth')}</button
+						></th
+					>
+					<th class="num"
+						><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}
+							>Bounty Earned{arrow('score')}</button
+						></th
+					>
+					<th class="num"
+						><button
+							class="sort"
+							class:on={sortKey === 'efficiency'}
+							onclick={() => setSort('efficiency')}
+							title="Efficiency — value kept of the puzzle's base bounty (same for everyone; pure spend-less skill)"
+							>⚡ Eff{arrow('efficiency')}</button
+						></th
+					>
+					<th class="num"
+						><button
+							class="sort"
+							class:on={sortKey === 'play_streak'}
+							onclick={() => setSort('play_streak')}>🔥{arrow('play_streak')}</button
+						></th
+					>
+					<th class="num"
+						><button
+							class="sort"
+							class:on={sortKey === 'win_streak'}
+							onclick={() => setSort('win_streak')}>🏆{arrow('win_streak')}</button
+						></th
+					>
+				</tr>
+			</thead>
+			<tbody>
+				{#each sortedRows as r, i}
+					<tr class={r.is_me ? 'me' : r._place <= 3 ? 'top' : ''}>
+						<td class="rank">{medal(r._place)}</td>
+						<td class="name">
+							{#if r.is_me}
+								<button
+									class="name-link"
+									onclick={() => goto('/profile')}
+									style={r.color ? `color:${r.color}` : ''}>You</button
+								>
+							{:else}
+								<button
+									class="name-link"
+									onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))}
+									style={r.color ? `color:${r.color}` : ''}>{r.name || 'Player'}</button
+								>
+							{/if}
+							{#if r.title}<span class="title">{r.title}</span>{/if}
+						</td>
+						<td class="metric">{fmt(r.net_worth)}</td>
+						<td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
+						<td class="metric eff">{r.efficiency != null ? r.efficiency + '%' : '—'}</td>
+						<td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>
+						<td class="metric small">{r.win_streak > 0 ? '🏆' + r.win_streak : '—'}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
 {/if}
 
 <p class="hint">Same puzzle for everyone today. Spend less, score more.</p>
 
 <style>
-  .filters { display: flex; gap: 0.5rem; justify-content: center; align-items: center; flex-wrap: wrap; margin-bottom: 0.5rem; }
-  .filter-select { padding: 0.55rem 1rem; border-radius: 10px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; font-weight: 600; }
-  .caption { color: var(--text-faint); font-size: 0.8rem; margin: 0.2rem 0 1rem; text-align: center; }
-  .muted { color: var(--text-muted); padding: 2rem 0; text-align: center; }
-  .error { color: #fb7185; text-align: center; }
-  .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 14px; }
-  table { width: 100%; border-collapse: collapse; }
-  th { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-faint); padding: 0.6rem 0.45rem; text-align: left; border-bottom: 1px solid var(--border); }
-  td { padding: 0.6rem 0.45rem; border-bottom: 1px solid var(--border); font-size: 0.9rem; text-align: left; }
-  tr:last-child td { border-bottom: none; }
-  td.rank { width: 30px; padding-left: 0.5rem; }
-  td.name { font-weight: 600; }
-  .name-link { background: none; border: none; padding: 0; font: inherit; color: inherit; cursor: pointer; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.2); text-underline-offset: 2px; }
-  .name-link:hover { text-decoration-color: var(--gold); }
-  td.metric { font-family: var(--font-display); font-weight: 700; color: var(--text); text-align: right; white-space: nowrap; }
-  td.metric.gold { color: var(--brand-2); }
-  td.metric.eff { color: #6ee7b7; font-size: 0.85rem; }
-  td.metric.small { font-weight: 700; font-size: 0.82rem; color: var(--text-muted); }
-  th.num { text-align: right; }
-  th button.sort { background: none; border: none; padding: 0; margin: 0; cursor: pointer; font: inherit;
-    color: inherit; text-transform: inherit; letter-spacing: inherit; white-space: nowrap; }
-  th button.sort:hover { color: var(--text-muted); }
-  th button.sort.on { color: var(--brand-2); }
-  tr.me { background: rgba(56,189,248,0.1); }
-  tr.me td.name { color: #7dd3fc; }
-  .title { font-size: 0.68rem; color: var(--text-faint); margin-left: 0.35rem; white-space: nowrap; }
-  .hint { margin-top: 1.2rem; font-size: 0.76rem; color: var(--text-faint); line-height: 1.5; text-align: center; }
+	.filters {
+		display: flex;
+		gap: 0.5rem;
+		justify-content: center;
+		align-items: center;
+		flex-wrap: wrap;
+		margin-bottom: 0.5rem;
+	}
+	.filter-select {
+		padding: 0.55rem 1rem;
+		border-radius: 10px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.95rem;
+		font-weight: 600;
+	}
+	.caption {
+		color: var(--text-faint);
+		font-size: 0.8rem;
+		margin: 0.2rem 0 1rem;
+		text-align: center;
+	}
+	.muted {
+		color: var(--text-muted);
+		padding: 2rem 0;
+		text-align: center;
+	}
+	.error {
+		color: #fb7185;
+		text-align: center;
+	}
+	.table-wrap {
+		overflow-x: auto;
+		border: 1px solid var(--border);
+		border-radius: 14px;
+	}
+	table {
+		width: 100%;
+		border-collapse: collapse;
+	}
+	th {
+		font-size: 0.62rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-faint);
+		padding: 0.6rem 0.45rem;
+		text-align: left;
+		border-bottom: 1px solid var(--border);
+	}
+	td {
+		padding: 0.6rem 0.45rem;
+		border-bottom: 1px solid var(--border);
+		font-size: 0.9rem;
+		text-align: left;
+	}
+	tr:last-child td {
+		border-bottom: none;
+	}
+	td.rank {
+		width: 30px;
+		padding-left: 0.5rem;
+	}
+	td.name {
+		font-weight: 600;
+	}
+	.name-link {
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		color: inherit;
+		cursor: pointer;
+		text-decoration: underline;
+		text-decoration-color: rgba(255, 255, 255, 0.2);
+		text-underline-offset: 2px;
+	}
+	.name-link:hover {
+		text-decoration-color: var(--gold);
+	}
+	td.metric {
+		font-family: var(--font-display);
+		font-weight: 700;
+		color: var(--text);
+		text-align: right;
+		white-space: nowrap;
+	}
+	td.metric.gold {
+		color: var(--brand-2);
+	}
+	td.metric.eff {
+		color: #6ee7b7;
+		font-size: 0.85rem;
+	}
+	td.metric.small {
+		font-weight: 700;
+		font-size: 0.82rem;
+		color: var(--text-muted);
+	}
+	th.num {
+		text-align: right;
+	}
+	th button.sort {
+		background: none;
+		border: none;
+		padding: 0;
+		margin: 0;
+		cursor: pointer;
+		font: inherit;
+		color: inherit;
+		text-transform: inherit;
+		letter-spacing: inherit;
+		white-space: nowrap;
+	}
+	th button.sort:hover {
+		color: var(--text-muted);
+	}
+	th button.sort.on {
+		color: var(--brand-2);
+	}
+	tr.me {
+		background: rgba(56, 189, 248, 0.1);
+	}
+	tr.me td.name {
+		color: #7dd3fc;
+	}
+	.title {
+		font-size: 0.68rem;
+		color: var(--text-faint);
+		margin-left: 0.35rem;
+		white-space: nowrap;
+	}
+	.hint {
+		margin-top: 1.2rem;
+		font-size: 0.76rem;
+		color: var(--text-faint);
+		line-height: 1.5;
+		text-align: center;
+	}
 </style>

--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -1,137 +1,295 @@
 <script>
-  import { createEventDispatcher } from 'svelte';
+	import { createEventDispatcher } from 'svelte';
 
-  /** @type {any} */
-  export let detail = null; // get_match_detail() result, or { loading:true }
+	/** @type {any} */
+	export let detail = null; // get_match_detail() result, or { loading:true }
 
-  const dispatch = createEventDispatcher();
-  const close = () => dispatch('close');
+	const dispatch = createEventDispatcher();
+	const close = () => dispatch('close');
 
-  $: parts = detail?.participants ?? [];
-  $: m = detail?.match;
-  $: opp = parts.find((/** @type {any} */ p) => !p.is_me);
-  $: me = parts.find((/** @type {any} */ p) => p.is_me);
-  $: noSolve = parts.length > 0 && parts.every((/** @type {any} */ p) => (p.solved ?? 0) === 0);
-  $: title = detail?.group_name || (opp ? '@' + (opp.name || 'player') : 'Challenge');
-  $: wagered = Number(m?.wager) > 0;
-  const rankIcon = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
-  const money = (/** @type {any} */ n) => (Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
-  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '';
-  const ordinal = (/** @type {number} */ n) => { const s = ['th', 'st', 'nd', 'rd'], v = n % 100; return n + (s[(v - 20) % 10] || s[v] || s[0]); };
-  const dollars = (/** @type {any} */ n) => '$' + Number(n ?? 0).toLocaleString();
+	$: parts = detail?.participants ?? [];
+	$: m = detail?.match;
+	$: opp = parts.find((/** @type {any} */ p) => !p.is_me);
+	$: me = parts.find((/** @type {any} */ p) => p.is_me);
+	$: noSolve = parts.length > 0 && parts.every((/** @type {any} */ p) => (p.solved ?? 0) === 0);
+	$: title = detail?.group_name || (opp ? '@' + (opp.name || 'player') : 'Challenge');
+	$: wagered = Number(m?.wager) > 0;
+	const rankIcon = (/** @type {number} */ r) =>
+		r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
+	const money = (/** @type {any} */ n) =>
+		(Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
+	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '');
+	const ordinal = (/** @type {number} */ n) => {
+		const s = ['th', 'st', 'nd', 'rd'],
+			v = n % 100;
+		return n + (s[(v - 20) % 10] || s[v] || s[0]);
+	};
+	const dollars = (/** @type {any} */ n) => '$' + Number(n ?? 0).toLocaleString();
 
-  // The spend "tie-back": frame the outcome in the universal metric — who solved
-  // for the least. Works for 1v1 and groups, wagered or friendly.
-  $: field = parts.length;
-  $: winner = parts.find((/** @type {any} */ p) => Number(p.rank) === 1);
-  $: iWon = me && Number(me.rank) === 1;
-  $: tieback = (() => {
-    if (!me || noSolve || m?.status !== 'settled') return '';
-    const myS = dollars(me.spent);
-    if (field === 2 && opp) {
-      const oS = dollars(opp.spent), on = '@' + (opp.name || 'opponent');
-      if (iWon) return me.solved ? `You solved for ${myS} — beat ${on}'s ${oS}.` : `You took it — ${on} didn't solve.`;
-      if (Number(opp.rank) === 1) return opp.solved ? `${on} solved for ${oS} — you spent ${myS}.` : `You spent ${myS}.`;
-      return `You spent ${myS}.`;
-    }
-    if (iWon) return `You solved for ${myS} — cheapest of ${field}.`;
-    if (winner) return `Winner @${winner.name || 'player'} solved for ${dollars(winner.spent)} — you placed ${ordinal(Number(me.rank))} (${myS}).`;
-    return `You placed ${ordinal(Number(me.rank))} — you spent ${myS}.`;
-  })();
+	// The spend "tie-back": frame the outcome in the universal metric — who solved
+	// for the least. Works for 1v1 and groups, wagered or friendly.
+	$: field = parts.length;
+	$: winner = parts.find((/** @type {any} */ p) => Number(p.rank) === 1);
+	$: iWon = me && Number(me.rank) === 1;
+	$: tieback = (() => {
+		if (!me || noSolve || m?.status !== 'settled') return '';
+		const myS = dollars(me.spent);
+		if (field === 2 && opp) {
+			const oS = dollars(opp.spent),
+				on = '@' + (opp.name || 'opponent');
+			if (iWon)
+				return me.solved
+					? `You solved for ${myS} — beat ${on}'s ${oS}.`
+					: `You took it — ${on} didn't solve.`;
+			if (Number(opp.rank) === 1)
+				return opp.solved ? `${on} solved for ${oS} — you spent ${myS}.` : `You spent ${myS}.`;
+			return `You spent ${myS}.`;
+		}
+		if (iWon) return `You solved for ${myS} — cheapest of ${field}.`;
+		if (winner)
+			return `Winner @${winner.name || 'player'} solved for ${dollars(winner.spent)} — you placed ${ordinal(Number(me.rank))} (${myS}).`;
+		return `You placed ${ordinal(Number(me.rank))} — you spent ${myS}.`;
+	})();
 </script>
 
 {#if detail}
-  <div class="md-overlay" role="button" tabindex="0"
-       on:click={close} on:keydown={(e) => { if (e.key === 'Escape') close(); }}>
-    <div class="md" role="dialog" tabindex="0" on:click|stopPropagation on:keydown={() => {}}>
-      <button class="md-x" on:click={close}>✕</button>
-      {#if detail.loading}
-        <p class="md-msg">Loading…</p>
-      {:else}
-        <h2 class="md-title">{noSolve ? '🤝' : '⚔️'} {title}</h2>
-        <p class="md-sub">
-          {m?.pack_size} puzzle{m?.pack_size === 1 ? '' : 's'}
-          · {m?.payout === 'podium' ? 'podium 3·2·1' : 'winner-take-all'}
-          {#if wagered}· ${Number(m.wager).toLocaleString()} buy-in{:else}· friendly{/if}
-          {#if m?.status !== 'settled'}· <em>in progress</em>{/if}
-          {#if noSolve && wagered}· buy-in refunded{/if}
-        </p>
+	<div
+		class="md-overlay"
+		role="button"
+		tabindex="0"
+		on:click={close}
+		on:keydown={(e) => {
+			if (e.key === 'Escape') close();
+		}}
+	>
+		<div class="md" role="dialog" tabindex="0" on:click|stopPropagation on:keydown={() => {}}>
+			<button class="md-x" on:click={close}>✕</button>
+			{#if detail.loading}
+				<p class="md-msg">Loading…</p>
+			{:else}
+				<h2 class="md-title">{noSolve ? '🤝' : '⚔️'} {title}</h2>
+				<p class="md-sub">
+					{m?.pack_size} puzzle{m?.pack_size === 1 ? '' : 's'}
+					· {m?.payout === 'podium' ? 'podium 3·2·1' : 'winner-take-all'}
+					{#if wagered}· ${Number(m.wager).toLocaleString()} buy-in{:else}· friendly{/if}
+					{#if m?.status !== 'settled'}· <em>in progress</em>{/if}
+					{#if noSolve && wagered}· buy-in refunded{/if}
+				</p>
 
-        {#if wagered && m?.status === 'settled' && me && me.net != null && !noSolve}
-          <div class="md-outcome {Number(me.net) >= 0 ? 'win' : 'loss'}">
-            <span class="md-out-net">{money(me.net)}</span>
-            <span class="md-out-lbl">
-              {#if Number(me.net) >= 0}you took the pot{#if mult(me.multiple_x100)} · {mult(me.multiple_x100)}{/if}{:else}you spent ${me.spent}{/if}
-            </span>
-          </div>
-        {/if}
+				{#if wagered && m?.status === 'settled' && me && me.net != null && !noSolve}
+					<div class="md-outcome {Number(me.net) >= 0 ? 'win' : 'loss'}">
+						<span class="md-out-net">{money(me.net)}</span>
+						<span class="md-out-lbl">
+							{#if Number(me.net) >= 0}you took the pot{#if mult(me.multiple_x100)}
+									· {mult(me.multiple_x100)}{/if}{:else}you spent ${me.spent}{/if}
+						</span>
+					</div>
+				{/if}
 
-        {#if tieback}
-          <p class="md-tieback">🎯 {tieback}</p>
-        {/if}
+				{#if tieback}
+					<p class="md-tieback">🎯 {tieback}</p>
+				{/if}
 
-        <div class="md-standings">
-          {#each parts as p}
-            <div class="md-row" class:me={p.is_me}>
-              <span class="md-rank">{noSolve ? '🤝' : rankIcon(p.rank)}</span>
-              <span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
-              <span class="md-meta">
-                {#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null} · ${Number(p.spent).toLocaleString()} spent{/if}{#if wagered && p.net != null} · <span class:pos={Number(p.net) >= 0} class:neg={Number(p.net) < 0}>{money(p.net)}</span>{/if}
-                {:else}{p.state}{/if}
-              </span>
-            </div>
-          {/each}
-        </div>
+				<div class="md-standings">
+					{#each parts as p}
+						<div class="md-row" class:me={p.is_me}>
+							<span class="md-rank">{noSolve ? '🤝' : rankIcon(p.rank)}</span>
+							<span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
+							<span class="md-meta">
+								{#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null}
+										· ${Number(p.spent).toLocaleString()} spent{/if}{#if wagered && p.net != null}
+										· <span class:pos={Number(p.net) >= 0} class:neg={Number(p.net) < 0}
+											>{money(p.net)}</span
+										>{/if}
+								{:else}{p.state}{/if}
+							</span>
+						</div>
+					{/each}
+				</div>
 
-        {#if detail.pack?.length}
-          <div class="md-pack">
-            <div class="md-pack-h">Puzzles</div>
-            {#each detail.pack as pk}
-              <div class="md-pk">
-                <span class="md-pos">{pk.position}</span>
-                <span class="md-cat">{pk.category}</span>
-                <span class="md-ans">{pk.phrase ? '“' + pk.phrase + '”' : '🔒 hidden until settled'}</span>
-              </div>
-            {/each}
-          </div>
-        {/if}
-      {/if}
-    </div>
-  </div>
+				{#if detail.pack?.length}
+					<div class="md-pack">
+						<div class="md-pack-h">Puzzles</div>
+						{#each detail.pack as pk}
+							<div class="md-pk">
+								<span class="md-pos">{pk.position}</span>
+								<span class="md-cat">{pk.category}</span>
+								<span class="md-ans"
+									>{pk.phrase ? '“' + pk.phrase + '”' : '🔒 hidden until settled'}</span
+								>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			{/if}
+		</div>
+	</div>
 {/if}
 
 <style>
-  .md-overlay { position: fixed; inset: 0; z-index: 10000; display: grid; place-items: center; padding: 18px;
-    background: rgba(5,5,5,0.8); backdrop-filter: blur(4px); }
-  .md { width: 100%; max-width: 440px; max-height: 86vh; overflow-y: auto; position: relative;
-    background: var(--surface-strong); border: 1px solid var(--border-strong); border-radius: var(--r-lg); padding: 20px; }
-  .md-x { position: absolute; top: 12px; right: 14px; background: none; border: none; color: var(--text-muted); font-size: 1rem; cursor: pointer; }
-  .md-title { font-family: var(--font-display); font-size: 1.25rem; margin: 0 0 4px; }
-  .md-sub { color: var(--text-faint); font-size: 0.8rem; margin: 0 0 16px; }
-  .md-msg { color: var(--text-muted); text-align: center; padding: 24px 0; }
+	.md-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 10000;
+		display: grid;
+		place-items: center;
+		padding: 18px;
+		background: rgba(5, 5, 5, 0.8);
+		backdrop-filter: blur(4px);
+	}
+	.md {
+		width: 100%;
+		max-width: 440px;
+		max-height: 86vh;
+		overflow-y: auto;
+		position: relative;
+		background: var(--surface-strong);
+		border: 1px solid var(--border-strong);
+		border-radius: var(--r-lg);
+		padding: 20px;
+	}
+	.md-x {
+		position: absolute;
+		top: 12px;
+		right: 14px;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1rem;
+		cursor: pointer;
+	}
+	.md-title {
+		font-family: var(--font-display);
+		font-size: 1.25rem;
+		margin: 0 0 4px;
+	}
+	.md-sub {
+		color: var(--text-faint);
+		font-size: 0.8rem;
+		margin: 0 0 16px;
+	}
+	.md-msg {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 24px 0;
+	}
 
-  .md-outcome { display: flex; align-items: baseline; gap: 10px; justify-content: center; padding: 12px; margin: 0 0 16px;
-    border-radius: var(--r-md); border: 1px solid var(--border); }
-  .md-outcome.win { background: rgba(126,224,168,0.1); border-color: rgba(126,224,168,0.3); }
-  .md-outcome.loss { background: rgba(251,113,133,0.08); border-color: rgba(251,113,133,0.25); }
-  .md-out-net { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.6rem; }
-  .md-outcome.win .md-out-net { color: #7ee0a8; } .md-outcome.loss .md-out-net { color: #fb7185; }
-  .md-out-lbl { color: var(--text-muted); font-size: 0.82rem; }
-  .md-tieback { text-align: center; font-size: 0.9rem; font-weight: 600; color: var(--text); margin: 0 0 16px;
-    padding: 10px 12px; border-radius: var(--r-md); background: rgba(251,191,36,0.08); border: 1px solid rgba(251,191,36,0.25); }
-  .md-meta .pos { color: #7ee0a8; } .md-meta .neg { color: #fb7185; }
+	.md-outcome {
+		display: flex;
+		align-items: baseline;
+		gap: 10px;
+		justify-content: center;
+		padding: 12px;
+		margin: 0 0 16px;
+		border-radius: var(--r-md);
+		border: 1px solid var(--border);
+	}
+	.md-outcome.win {
+		background: rgba(126, 224, 168, 0.1);
+		border-color: rgba(126, 224, 168, 0.3);
+	}
+	.md-outcome.loss {
+		background: rgba(251, 113, 133, 0.08);
+		border-color: rgba(251, 113, 133, 0.25);
+	}
+	.md-out-net {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.6rem;
+	}
+	.md-outcome.win .md-out-net {
+		color: #7ee0a8;
+	}
+	.md-outcome.loss .md-out-net {
+		color: #fb7185;
+	}
+	.md-out-lbl {
+		color: var(--text-muted);
+		font-size: 0.82rem;
+	}
+	.md-tieback {
+		text-align: center;
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--text);
+		margin: 0 0 16px;
+		padding: 10px 12px;
+		border-radius: var(--r-md);
+		background: rgba(251, 191, 36, 0.08);
+		border: 1px solid rgba(251, 191, 36, 0.25);
+	}
+	.md-meta .pos {
+		color: #7ee0a8;
+	}
+	.md-meta .neg {
+		color: #fb7185;
+	}
 
-  .md-standings { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
-  .md-row { display: flex; align-items: center; gap: 10px; padding: 9px 11px; border-radius: var(--r-sm); background: var(--surface); }
-  .md-row.me { background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.3); }
-  .md-rank { flex: 0 0 28px; font-weight: 700; }
-  .md-name { flex: 1; font-weight: 700; color: var(--text); }
-  .md-meta { color: var(--text-faint); font-size: 0.76rem; text-align: right; }
+	.md-standings {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		margin-bottom: 16px;
+	}
+	.md-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 9px 11px;
+		border-radius: var(--r-sm);
+		background: var(--surface);
+	}
+	.md-row.me {
+		background: rgba(251, 191, 36, 0.12);
+		border: 1px solid rgba(251, 191, 36, 0.3);
+	}
+	.md-rank {
+		flex: 0 0 28px;
+		font-weight: 700;
+	}
+	.md-name {
+		flex: 1;
+		font-weight: 700;
+		color: var(--text);
+	}
+	.md-meta {
+		color: var(--text-faint);
+		font-size: 0.76rem;
+		text-align: right;
+	}
 
-  .md-pack { border-top: 1px solid var(--border); padding-top: 12px; }
-  .md-pack-h { color: var(--text-faint); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
-  .md-pk { display: flex; align-items: center; gap: 10px; padding: 5px 0; font-size: 0.84rem; }
-  .md-pos { flex: 0 0 20px; color: var(--text-faint); }
-  .md-cat { flex: 0 0 auto; color: var(--text-muted); font-size: 0.74rem; }
-  .md-ans { color: var(--gold); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+	.md-pack {
+		border-top: 1px solid var(--border);
+		padding-top: 12px;
+	}
+	.md-pack-h {
+		color: var(--text-faint);
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		margin-bottom: 8px;
+	}
+	.md-pk {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 5px 0;
+		font-size: 0.84rem;
+	}
+	.md-pos {
+		flex: 0 0 20px;
+		color: var(--text-faint);
+	}
+	.md-cat {
+		flex: 0 0 auto;
+		color: var(--text-muted);
+		font-size: 0.74rem;
+	}
+	.md-ans {
+		color: var(--gold);
+		font-weight: 600;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 </style>

--- a/src/lib/components/NotificationsPanel.svelte
+++ b/src/lib/components/NotificationsPanel.svelte
@@ -1,88 +1,185 @@
 <script>
-  // Your personal notifications inbox (results, sabotages, friend requests,
-  // incoming challenges). Shown in Community ▸ Activity. Friend requests can be
-  // accepted/declined inline; tapping a row routes via onNavigate.
-  import { notifications, dismissNotification } from '$lib/stores/notificationStore.js';
-  import { respondFriendRequest, respondJoinRequest } from '$lib/stores/statsStore.js';
-  import { fx } from '$lib/sound.js';
+	// Your personal notifications inbox (results, sabotages, friend requests,
+	// incoming challenges). Shown in Community ▸ Activity. Friend requests can be
+	// accepted/declined inline; tapping a row routes via onNavigate.
+	import { notifications, dismissNotification } from '$lib/stores/notificationStore.js';
+	import { respondFriendRequest, respondJoinRequest } from '$lib/stores/statsStore.js';
+	import { fx } from '$lib/sound.js';
 
-  /** @type {{ onNavigate?: ((n:any)=>void)|null, onChange?: (()=>void)|null }} */
-  let { onNavigate = null, onChange = null } = $props();
+	/** @type {{ onNavigate?: ((n:any)=>void)|null, onChange?: (()=>void)|null }} */
+	let { onNavigate = null, onChange = null } = $props();
 
-  /** @param {any} n @param {boolean} accept */
-  async function respond(n, accept) {
-    const fromId = n?.data?.from_id;
-    if (!fromId) return;
-    const res = await respondFriendRequest(fromId, accept);
-    if (res?.ok) {
-      fx(accept ? 'win' : 'tap');
-      dismissNotification(n.id); // acting on it clears it
-      onChange?.();
-    }
-  }
+	/** @param {any} n @param {boolean} accept */
+	async function respond(n, accept) {
+		const fromId = n?.data?.from_id;
+		if (!fromId) return;
+		const res = await respondFriendRequest(fromId, accept);
+		if (res?.ok) {
+			fx(accept ? 'win' : 'tap');
+			dismissNotification(n.id); // acting on it clears it
+			onChange?.();
+		}
+	}
 
-  /** @param {any} n @param {boolean} accept */
-  async function respondGroup(n, accept) {
-    const { group_id, from_id } = n?.data || {};
-    if (!group_id || !from_id) return;
-    const res = await respondJoinRequest(group_id, from_id, accept);
-    if (res?.ok) { fx(accept ? 'win' : 'tap'); dismissNotification(n.id); onChange?.(); }
-  }
+	/** @param {any} n @param {boolean} accept */
+	async function respondGroup(n, accept) {
+		const { group_id, from_id } = n?.data || {};
+		if (!group_id || !from_id) return;
+		const res = await respondJoinRequest(group_id, from_id, accept);
+		if (res?.ok) {
+			fx(accept ? 'win' : 'tap');
+			dismissNotification(n.id);
+			onChange?.();
+		}
+	}
 
-  // Action-required notifications (friend request / group-join request) must be
-  // accepted or declined — they can't be dismissed, and tapping them won't clear them.
-  /** @param {any} n */
-  const actionRequired = (n) =>
-    (n.type === 'friend_request' && n.data?.from_id) ||
-    (n.type === 'group_join' && n.data?.group_id && n.data?.from_id);
+	// Action-required notifications (friend request / group-join request) must be
+	// accepted or declined — they can't be dismissed, and tapping them won't clear them.
+	/** @param {any} n */
+	const actionRequired = (n) =>
+		(n.type === 'friend_request' && n.data?.from_id) ||
+		(n.type === 'group_join' && n.data?.group_id && n.data?.from_id);
 </script>
 
 {#if $notifications.length === 0}
-  <p class="empty">No notifications yet — challenge results, sabotages and requests land here.</p>
+	<p class="empty">No notifications yet — challenge results, sabotages and requests land here.</p>
 {:else}
-  <div class="notif-list">
-    {#each $notifications as n (n.id)}
-      <div class="notif-item" class:fresh={!n.read} class:needs-action={actionRequired(n)}>
-        {#if !actionRequired(n)}
-          <button class="ni-dismiss" onclick={() => dismissNotification(n.id)} aria-label="Dismiss" title="Dismiss">✕</button>
-        {/if}
-        <button class="ni-main" onclick={() => { onNavigate?.(n); if (!actionRequired(n)) dismissNotification(n.id); }}>
-          <span class="ni-title">{n.title}</span>
-          <span class="ni-body">{n.body}</span>
-        </button>
-        {#if n.type === 'friend_request' && n.data?.from_id}
-          <div class="ni-actions">
-            <button class="ni-act accept" onclick={() => respond(n, true)}>Accept</button>
-            <button class="ni-act decline" onclick={() => respond(n, false)}>Decline</button>
-          </div>
-        {:else if n.type === 'group_join' && n.data?.group_id && n.data?.from_id}
-          <div class="ni-actions">
-            <button class="ni-act accept" onclick={() => respondGroup(n, true)}>Approve</button>
-            <button class="ni-act decline" onclick={() => respondGroup(n, false)}>Decline</button>
-          </div>
-        {/if}
-      </div>
-    {/each}
-  </div>
+	<div class="notif-list">
+		{#each $notifications as n (n.id)}
+			<div class="notif-item" class:fresh={!n.read} class:needs-action={actionRequired(n)}>
+				{#if !actionRequired(n)}
+					<button
+						class="ni-dismiss"
+						onclick={() => dismissNotification(n.id)}
+						aria-label="Dismiss"
+						title="Dismiss">✕</button
+					>
+				{/if}
+				<button
+					class="ni-main"
+					onclick={() => {
+						onNavigate?.(n);
+						if (!actionRequired(n)) dismissNotification(n.id);
+					}}
+				>
+					<span class="ni-title">{n.title}</span>
+					<span class="ni-body">{n.body}</span>
+				</button>
+				{#if n.type === 'friend_request' && n.data?.from_id}
+					<div class="ni-actions">
+						<button class="ni-act accept" onclick={() => respond(n, true)}>Accept</button>
+						<button class="ni-act decline" onclick={() => respond(n, false)}>Decline</button>
+					</div>
+				{:else if n.type === 'group_join' && n.data?.group_id && n.data?.from_id}
+					<div class="ni-actions">
+						<button class="ni-act accept" onclick={() => respondGroup(n, true)}>Approve</button>
+						<button class="ni-act decline" onclick={() => respondGroup(n, false)}>Decline</button>
+					</div>
+				{/if}
+			</div>
+		{/each}
+	</div>
 {/if}
 
 <style>
-  .empty { color: var(--text-muted); font-size: 0.88rem; text-align: center; padding: 1rem 0.4rem; }
-  .notif-list { display: flex; flex-direction: column; gap: 0.5rem; }
-  .notif-item { position: relative; padding: 0.7rem 2.1rem 0.7rem 0.85rem; border-radius: 12px; background: var(--surface); border: 1px solid var(--border); color: var(--text); }
-  .notif-item.needs-action { padding-right: 0.85rem; }
-  .ni-dismiss { position: absolute; top: 6px; right: 6px; width: 26px; height: 26px; border-radius: 8px; border: none; cursor: pointer;
-    background: transparent; color: var(--text-faint); font-size: 0.9rem; }
-  .ni-dismiss:hover { background: var(--surface-2, rgba(255,255,255,0.06)); color: var(--text); }
-  .notif-item.fresh { border-color: rgba(253, 224, 71,0.45); background: linear-gradient(135deg, rgba(251, 191, 36,0.08), rgba(253, 224, 71,0.03)); }
-  .ni-main { text-align: left; display: flex; flex-direction: column; gap: 2px; width: 100%; background: none; border: none; color: inherit; cursor: pointer; padding: 0; }
-  .ni-title { font-family: var(--font-display); font-weight: 700; font-size: 0.92rem; }
-  .ni-body { font-size: 0.82rem; color: var(--text-muted); }
-  .ni-actions { display: flex; gap: 0.5rem; margin-top: 0.55rem; }
-  .ni-act { flex: 1; padding: 0.45rem 0.7rem; border-radius: 9px; font-weight: 800; font-size: 0.82rem; cursor: pointer; border: 1px solid var(--border); }
-  .ni-act.accept { color: #3a2a00; border: none; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .ni-act.decline { color: #f87171; background: transparent; border-color: rgba(248,113,113,0.4); }
-  .ni-done { display: inline-block; margin-top: 0.5rem; font-size: 0.8rem; font-weight: 800; }
-  .ni-done.accepted { color: var(--brand-2); }
-  .ni-done.declined { color: var(--text-faint); }
+	.empty {
+		color: var(--text-muted);
+		font-size: 0.88rem;
+		text-align: center;
+		padding: 1rem 0.4rem;
+	}
+	.notif-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+	.notif-item {
+		position: relative;
+		padding: 0.7rem 2.1rem 0.7rem 0.85rem;
+		border-radius: 12px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.notif-item.needs-action {
+		padding-right: 0.85rem;
+	}
+	.ni-dismiss {
+		position: absolute;
+		top: 6px;
+		right: 6px;
+		width: 26px;
+		height: 26px;
+		border-radius: 8px;
+		border: none;
+		cursor: pointer;
+		background: transparent;
+		color: var(--text-faint);
+		font-size: 0.9rem;
+	}
+	.ni-dismiss:hover {
+		background: var(--surface-2, rgba(255, 255, 255, 0.06));
+		color: var(--text);
+	}
+	.notif-item.fresh {
+		border-color: rgba(253, 224, 71, 0.45);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.08), rgba(253, 224, 71, 0.03));
+	}
+	.ni-main {
+		text-align: left;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		width: 100%;
+		background: none;
+		border: none;
+		color: inherit;
+		cursor: pointer;
+		padding: 0;
+	}
+	.ni-title {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.92rem;
+	}
+	.ni-body {
+		font-size: 0.82rem;
+		color: var(--text-muted);
+	}
+	.ni-actions {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: 0.55rem;
+	}
+	.ni-act {
+		flex: 1;
+		padding: 0.45rem 0.7rem;
+		border-radius: 9px;
+		font-weight: 800;
+		font-size: 0.82rem;
+		cursor: pointer;
+		border: 1px solid var(--border);
+	}
+	.ni-act.accept {
+		color: #3a2a00;
+		border: none;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.ni-act.decline {
+		color: #f87171;
+		background: transparent;
+		border-color: rgba(248, 113, 113, 0.4);
+	}
+	.ni-done {
+		display: inline-block;
+		margin-top: 0.5rem;
+		font-size: 0.8rem;
+		font-weight: 800;
+	}
+	.ni-done.accepted {
+		color: var(--brand-2);
+	}
+	.ni-done.declined {
+		color: var(--text-faint);
+	}
 </style>

--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -1,188 +1,372 @@
 <script>
-  // Pre-game "How to win" card. Shown the moment a mode starts so a first-time
-  // player always knows the objective. The parent gates on localStorage so it shows
-  // once — per-mode for solo modes, per-match for challenges (first entry, not resume).
-  import { createEventDispatcher } from 'svelte';
-  import { MODIFIERS } from '$lib/powerups.js';
-  const dispatch = createEventDispatcher();
+	// Pre-game "How to win" card. Shown the moment a mode starts so a first-time
+	// player always knows the objective. The parent gates on localStorage so it shows
+	// once — per-mode for solo modes, per-match for challenges (first entry, not resume).
+	import { createEventDispatcher } from 'svelte';
+	import { MODIFIERS } from '$lib/powerups.js';
+	const dispatch = createEventDispatcher();
 
-  let page = 0; // 0 = how to win, 1 = power-ups (daily only)
-  // Power-ups a player can use in the Daily: the weekday Twists + the Bounty Boosts.
-  const DAILY_PUPS = [
-    { group: 'Daily Twist — one free helper each weekday', items: Object.values(MODIFIERS) },
-    { group: 'Bounty Boosts — buy in the Store, stack your multiplier', items: [
-      { emoji: '💥', name: 'Bounty Boost', blurb: 'Adds ×0.5 to your bounty multiplier' },
-      { emoji: '💎', name: 'Jackpot', blurb: 'Adds ×1.0 to your bounty multiplier' }
-    ] }
-  ];
+	let page = 0; // 0 = how to win, 1 = power-ups (daily only)
+	// Power-ups a player can use in the Daily: the weekday Twists + the Bounty Boosts.
+	const DAILY_PUPS = [
+		{ group: 'Daily Twist — one free helper each weekday', items: Object.values(MODIFIERS) },
+		{
+			group: 'Bounty Boosts — buy in the Store, stack your multiplier',
+			items: [
+				{ emoji: '💥', name: 'Bounty Boost', blurb: 'Adds ×0.5 to your bounty multiplier' },
+				{ emoji: '💎', name: 'Jackpot', blurb: 'Adds ×1.0 to your bounty multiplier' }
+			]
+		}
+	];
 
-  /** @type {string} */ export let mode;
-  /** @type {{ opponent?: string, wager?: number, packSize?: number, fieldSize?: number }} */
-  export let ctx = {};
+	/** @type {string} */ export let mode;
+	/** @type {{ opponent?: string, wager?: number, packSize?: number, fieldSize?: number }} */
+	export let ctx = {};
 
-  /** @param {string} m @param {any} c */
-  function content(m, c) {
-    const pk = (c.packSize ?? 1) > 1 ? `${c.packSize} puzzles` : 'the puzzle';
-    switch (m) {
-      case 'daily': return { icon: '📅', title: "Today's Daily",
-        goal: 'Solve the hidden phrase.',
-        win: 'Spend as little Cash as you can — your leftover is your score.',
-        bar: 'Just showing up pays a streak reward.' };
-      case 'climb': return { icon: '🎰', title: 'Cash Game',
-        goal: 'Stake a buy-in → grow a run bankroll by solving cheaply.',
-        win: 'Cash out anytime to bank it — heat multiplies each solve.',
-        bar: 'Bust (a wrong final guess) loses the buy-in.' };
-      case 'makeup': return { icon: '🗓️', title: 'Make-up Daily',
-        goal: 'Play a daily you missed.',
-        win: 'Same rules — solve it as cheaply as you can.',
-        bar: 'Counts toward your stats.' };
-      case 'match': {
-        if ((c.fieldSize ?? 2) > 2) return { icon: '👥', title: 'Group Challenge',
-          goal: `Solve ${pk} — spend the least.`,
-          win: 'Winner takes all.',
-          bar: '' };
-        return { icon: '⚔️', title: c.opponent ? `Duel vs @${c.opponent}` : 'Challenge',
-          goal: `Solve ${pk} — spend the least.`,
-          win: 'Winner takes all.',
-          bar: '' };
-      }
-      default: return { icon: '🎯', title: 'WordBank',
-        goal: 'Solve the hidden phrase.', win: 'Spend as little as you can.', bar: '' };
-    }
-  }
+	/** @param {string} m @param {any} c */
+	function content(m, c) {
+		const pk = (c.packSize ?? 1) > 1 ? `${c.packSize} puzzles` : 'the puzzle';
+		switch (m) {
+			case 'daily':
+				return {
+					icon: '📅',
+					title: "Today's Daily",
+					goal: 'Solve the hidden phrase.',
+					win: 'Spend as little Cash as you can — your leftover is your score.',
+					bar: 'Just showing up pays a streak reward.'
+				};
+			case 'climb':
+				return {
+					icon: '🎰',
+					title: 'Cash Game',
+					goal: 'Stake a buy-in → grow a run bankroll by solving cheaply.',
+					win: 'Cash out anytime to bank it — heat multiplies each solve.',
+					bar: 'Bust (a wrong final guess) loses the buy-in.'
+				};
+			case 'makeup':
+				return {
+					icon: '🗓️',
+					title: 'Make-up Daily',
+					goal: 'Play a daily you missed.',
+					win: 'Same rules — solve it as cheaply as you can.',
+					bar: 'Counts toward your stats.'
+				};
+			case 'match': {
+				if ((c.fieldSize ?? 2) > 2)
+					return {
+						icon: '👥',
+						title: 'Group Challenge',
+						goal: `Solve ${pk} — spend the least.`,
+						win: 'Winner takes all.',
+						bar: ''
+					};
+				return {
+					icon: '⚔️',
+					title: c.opponent ? `Duel vs @${c.opponent}` : 'Challenge',
+					goal: `Solve ${pk} — spend the least.`,
+					win: 'Winner takes all.',
+					bar: ''
+				};
+			}
+			default:
+				return {
+					icon: '🎯',
+					title: 'WordBank',
+					goal: 'Solve the hidden phrase.',
+					win: 'Spend as little as you can.',
+					bar: ''
+				};
+		}
+	}
 
-  $: c = content(mode, ctx);
-  function go() { dispatch('close'); }
+	$: c = content(mode, ctx);
+	function go() {
+		dispatch('close');
+	}
 </script>
 
 <div class="obj-overlay" role="dialog" aria-modal="true" aria-label="How to win">
-  <div class="obj-card">
-    <button class="obj-x" on:click={go} aria-label="Close">✕</button>
-    {#if page === 0}
-      <span class="obj-pill">🎯 How to win</span>
-      <div class="obj-icon">{c.icon}</div>
-      <h2 class="obj-title">{c.title}</h2>
+	<div class="obj-card">
+		<button class="obj-x" on:click={go} aria-label="Close">✕</button>
+		{#if page === 0}
+			<span class="obj-pill">🎯 How to win</span>
+			<div class="obj-icon">{c.icon}</div>
+			<h2 class="obj-title">{c.title}</h2>
 
-      <p class="obj-goal">{c.goal}</p>
-      <div class="obj-win"><span class="obj-win-key">WIN</span>{c.win}</div>
-      {#if c.bar}<p class="obj-bar">{c.bar}</p>{/if}
+			<p class="obj-goal">{c.goal}</p>
+			<div class="obj-win"><span class="obj-win-key">WIN</span>{c.win}</div>
+			{#if c.bar}<p class="obj-bar">{c.bar}</p>{/if}
 
-      {#if mode === 'daily'}
-        <button class="obj-link" on:click={() => page = 1}>🎁 Power-ups &amp; boosts →</button>
-      {/if}
-      <button class="obj-btn" on:click={go}>Let’s go →</button>
-    {:else}
-      <span class="obj-pill">🎁 Power-ups</span>
-      <h2 class="obj-title">Daily Power-ups</h2>
-      <div class="pup-list">
-        {#each DAILY_PUPS as grp}
-          <div class="pup-group-h">{grp.group}</div>
-          {#each grp.items as it}
-            <div class="pup-row">
-              <span class="pup-e">{it.emoji}</span>
-              <span class="pup-txt"><span class="pup-n">{it.name}</span><span class="pup-d">{it.blurb}</span></span>
-            </div>
-          {/each}
-        {/each}
-      </div>
-      <button class="obj-btn ghost" on:click={() => page = 0}>← Back</button>
-    {/if}
-  </div>
+			{#if mode === 'daily'}
+				<button class="obj-link" on:click={() => (page = 1)}>🎁 Power-ups &amp; boosts →</button>
+			{/if}
+			<button class="obj-btn" on:click={go}>Let’s go →</button>
+		{:else}
+			<span class="obj-pill">🎁 Power-ups</span>
+			<h2 class="obj-title">Daily Power-ups</h2>
+			<div class="pup-list">
+				{#each DAILY_PUPS as grp}
+					<div class="pup-group-h">{grp.group}</div>
+					{#each grp.items as it}
+						<div class="pup-row">
+							<span class="pup-e">{it.emoji}</span>
+							<span class="pup-txt"
+								><span class="pup-n">{it.name}</span><span class="pup-d">{it.blurb}</span></span
+							>
+						</div>
+					{/each}
+				{/each}
+			</div>
+			<button class="obj-btn ghost" on:click={() => (page = 0)}>← Back</button>
+		{/if}
+	</div>
 </div>
 
 <style>
-  .obj-overlay {
-    position: fixed; inset: 0; z-index: 3100;
-    display: grid; place-items: center; padding: 20px;
-    background: rgba(4, 8, 14, 0.72); backdrop-filter: blur(8px);
-    animation: objFade 0.22s ease;
-  }
-  @keyframes objFade { from { opacity: 0; } to { opacity: 1; } }
+	.obj-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 3100;
+		display: grid;
+		place-items: center;
+		padding: 20px;
+		background: rgba(4, 8, 14, 0.72);
+		backdrop-filter: blur(8px);
+		animation: objFade 0.22s ease;
+	}
+	@keyframes objFade {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
 
-  .obj-x { position: absolute; top: 10px; right: 10px; z-index: 2; width: 30px; height: 30px; border-radius: 50%;
-    display: grid; place-items: center; cursor: pointer; font-size: 0.8rem; font-weight: 900;
-    color: #fff; background: linear-gradient(135deg, #fb5a5a, #c81e1e); border: 1px solid rgba(0,0,0,0.25);
-    box-shadow: 0 2px 6px rgba(200,30,30,0.4); }
-  .obj-x:hover { filter: brightness(1.08); }
-  .obj-x:active { transform: scale(0.92); }
-  .obj-card {
-    position: relative; width: 100%; max-width: 380px;
-    padding: 26px 24px 22px; border-radius: var(--r-lg, 20px);
-    background: var(--surface-strong, rgba(20, 26, 38, 0.92));
-    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
-    box-shadow: var(--shadow-lg, 0 24px 60px rgba(0, 0, 0, 0.5)), var(--glow-brand, 0 0 30px rgba(251, 191, 36, 0.25));
-    text-align: center;
-    animation: objPop 0.3s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
-  }
-  @keyframes objPop {
-    from { transform: translateY(14px) scale(0.96); opacity: 0; }
-    to { transform: translateY(0) scale(1); opacity: 1; }
-  }
+	.obj-x {
+		position: absolute;
+		top: 10px;
+		right: 10px;
+		z-index: 2;
+		width: 30px;
+		height: 30px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		font-size: 0.8rem;
+		font-weight: 900;
+		color: #fff;
+		background: linear-gradient(135deg, #fb5a5a, #c81e1e);
+		border: 1px solid rgba(0, 0, 0, 0.25);
+		box-shadow: 0 2px 6px rgba(200, 30, 30, 0.4);
+	}
+	.obj-x:hover {
+		filter: brightness(1.08);
+	}
+	.obj-x:active {
+		transform: scale(0.92);
+	}
+	.obj-card {
+		position: relative;
+		width: 100%;
+		max-width: 380px;
+		padding: 26px 24px 22px;
+		border-radius: var(--r-lg, 20px);
+		background: var(--surface-strong, rgba(20, 26, 38, 0.92));
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow:
+			var(--shadow-lg, 0 24px 60px rgba(0, 0, 0, 0.5)),
+			var(--glow-brand, 0 0 30px rgba(251, 191, 36, 0.25));
+		text-align: center;
+		animation: objPop 0.3s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+	}
+	@keyframes objPop {
+		from {
+			transform: translateY(14px) scale(0.96);
+			opacity: 0;
+		}
+		to {
+			transform: translateY(0) scale(1);
+			opacity: 1;
+		}
+	}
 
-  .obj-pill {
-    display: inline-block; margin-bottom: 10px; padding: 4px 12px; border-radius: 999px;
-    font-family: var(--font-display, sans-serif); font-size: 0.68rem; font-weight: 800;
-    letter-spacing: 0.08em; color: #3a2a00;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-  }
-  .obj-icon {
-    font-size: 2.8rem; line-height: 1; margin: 2px 0 10px;
-    animation: objIcon 0.4s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
-  }
-  @keyframes objIcon {
-    from { transform: scale(0.4) rotate(-12deg); opacity: 0; }
-    to { transform: scale(1) rotate(0); opacity: 1; }
-  }
-  .obj-title {
-    font-family: var(--font-display, sans-serif); font-size: 1.35rem; font-weight: 700;
-    margin: 0 0 12px; color: var(--text, #fff);
-  }
-  .obj-goal {
-    font-family: var(--font-ui, sans-serif); font-size: 0.96rem; line-height: 1.45;
-    color: var(--text, #f3f6fb); margin: 0 auto 12px; max-width: 320px;
-  }
-  .obj-win {
-    display: flex; align-items: center; gap: 10px; text-align: left;
-    margin: 0 auto 12px; max-width: 320px; padding: 11px 13px;
-    border-radius: 13px; border: 1px solid rgba(253, 224, 71, 0.45);
-    background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.05));
-    font-family: var(--font-ui, sans-serif); font-size: 0.92rem; line-height: 1.4;
-    color: var(--text, #fff); font-weight: 600;
-  }
-  .obj-win-key {
-    flex: none; font-family: var(--font-display, sans-serif); font-size: 0.6rem; font-weight: 800;
-    letter-spacing: 0.1em; color: #3a2a00; padding: 3px 7px; border-radius: 7px;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-  }
-  .obj-bar {
-    font-family: var(--font-ui, sans-serif); font-size: 0.82rem; line-height: 1.4;
-    color: var(--text-muted, #aeb8c6); margin: 0 auto 18px; max-width: 320px;
-  }
+	.obj-pill {
+		display: inline-block;
+		margin-bottom: 10px;
+		padding: 4px 12px;
+		border-radius: 999px;
+		font-family: var(--font-display, sans-serif);
+		font-size: 0.68rem;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.obj-icon {
+		font-size: 2.8rem;
+		line-height: 1;
+		margin: 2px 0 10px;
+		animation: objIcon 0.4s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+	}
+	@keyframes objIcon {
+		from {
+			transform: scale(0.4) rotate(-12deg);
+			opacity: 0;
+		}
+		to {
+			transform: scale(1) rotate(0);
+			opacity: 1;
+		}
+	}
+	.obj-title {
+		font-family: var(--font-display, sans-serif);
+		font-size: 1.35rem;
+		font-weight: 700;
+		margin: 0 0 12px;
+		color: var(--text, #fff);
+	}
+	.obj-goal {
+		font-family: var(--font-ui, sans-serif);
+		font-size: 0.96rem;
+		line-height: 1.45;
+		color: var(--text, #f3f6fb);
+		margin: 0 auto 12px;
+		max-width: 320px;
+	}
+	.obj-win {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		text-align: left;
+		margin: 0 auto 12px;
+		max-width: 320px;
+		padding: 11px 13px;
+		border-radius: 13px;
+		border: 1px solid rgba(253, 224, 71, 0.45);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.05));
+		font-family: var(--font-ui, sans-serif);
+		font-size: 0.92rem;
+		line-height: 1.4;
+		color: var(--text, #fff);
+		font-weight: 600;
+	}
+	.obj-win-key {
+		flex: none;
+		font-family: var(--font-display, sans-serif);
+		font-size: 0.6rem;
+		font-weight: 800;
+		letter-spacing: 0.1em;
+		color: #3a2a00;
+		padding: 3px 7px;
+		border-radius: 7px;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.obj-bar {
+		font-family: var(--font-ui, sans-serif);
+		font-size: 0.82rem;
+		line-height: 1.4;
+		color: var(--text-muted, #aeb8c6);
+		margin: 0 auto 18px;
+		max-width: 320px;
+	}
 
-  .obj-btn {
-    width: 100%; max-width: 220px; height: 48px; border: none; border-radius: 14px;
-    font-family: var(--font-display, sans-serif); font-size: 1.05rem; font-weight: 700;
-    color: #3a2a00; cursor: pointer;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-    box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36, 0.35));
-    transition: transform 0.16s var(--ease-spring, ease), filter 0.2s;
-  }
-  .obj-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
-  .obj-btn:active { transform: scale(0.97); }
-  .obj-btn.ghost { background: var(--surface-2, rgba(255,255,255,0.08)); color: var(--text, #fff); box-shadow: none; }
-  .obj-link { display: inline-block; margin: 0 0 12px; padding: 8px 14px; border-radius: 999px; cursor: pointer;
-    border: 1px solid rgba(110,231,183,0.45); background: rgba(110,231,183,0.1);
-    font-family: var(--font-display, sans-serif); font-weight: 800; font-size: 0.82rem; color: #6ee7b7; }
-  .obj-link:hover { background: rgba(110,231,183,0.18); }
-  /* power-ups page */
-  .pup-list { text-align: left; max-height: 46vh; overflow-y: auto; margin: 4px 0 16px;
-    border: 1px solid var(--border, rgba(255,255,255,0.1)); border-radius: 14px; padding: 4px 12px; }
-  .pup-group-h { font-family: var(--font-display, sans-serif); font-size: 0.66rem; font-weight: 800; letter-spacing: 0.04em;
-    text-transform: uppercase; color: var(--brand-2, #fcd34d); margin: 12px 0 4px; }
-  .pup-row { display: flex; gap: 11px; align-items: flex-start; padding: 7px 0; border-bottom: 1px solid var(--border, rgba(255,255,255,0.07)); }
-  .pup-row:last-child { border-bottom: none; }
-  .pup-e { font-size: 1.25rem; flex: none; width: 26px; text-align: center; line-height: 1.3; }
-  .pup-txt { display: flex; flex-direction: column; gap: 1px; }
-  .pup-n { font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.88rem; color: var(--text, #fff); }
-  .pup-d { font-size: 0.78rem; line-height: 1.35; color: var(--text-muted, #aeb8c6); }
+	.obj-btn {
+		width: 100%;
+		max-width: 220px;
+		height: 48px;
+		border: none;
+		border-radius: 14px;
+		font-family: var(--font-display, sans-serif);
+		font-size: 1.05rem;
+		font-weight: 700;
+		color: #3a2a00;
+		cursor: pointer;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36, 0.35));
+		transition:
+			transform 0.16s var(--ease-spring, ease),
+			filter 0.2s;
+	}
+	.obj-btn:hover {
+		transform: translateY(-2px);
+		filter: brightness(1.05);
+	}
+	.obj-btn:active {
+		transform: scale(0.97);
+	}
+	.obj-btn.ghost {
+		background: var(--surface-2, rgba(255, 255, 255, 0.08));
+		color: var(--text, #fff);
+		box-shadow: none;
+	}
+	.obj-link {
+		display: inline-block;
+		margin: 0 0 12px;
+		padding: 8px 14px;
+		border-radius: 999px;
+		cursor: pointer;
+		border: 1px solid rgba(110, 231, 183, 0.45);
+		background: rgba(110, 231, 183, 0.1);
+		font-family: var(--font-display, sans-serif);
+		font-weight: 800;
+		font-size: 0.82rem;
+		color: #6ee7b7;
+	}
+	.obj-link:hover {
+		background: rgba(110, 231, 183, 0.18);
+	}
+	/* power-ups page */
+	.pup-list {
+		text-align: left;
+		max-height: 46vh;
+		overflow-y: auto;
+		margin: 4px 0 16px;
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+		border-radius: 14px;
+		padding: 4px 12px;
+	}
+	.pup-group-h {
+		font-family: var(--font-display, sans-serif);
+		font-size: 0.66rem;
+		font-weight: 800;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--brand-2, #fcd34d);
+		margin: 12px 0 4px;
+	}
+	.pup-row {
+		display: flex;
+		gap: 11px;
+		align-items: flex-start;
+		padding: 7px 0;
+		border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.07));
+	}
+	.pup-row:last-child {
+		border-bottom: none;
+	}
+	.pup-e {
+		font-size: 1.25rem;
+		flex: none;
+		width: 26px;
+		text-align: center;
+		line-height: 1.3;
+	}
+	.pup-txt {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+	}
+	.pup-n {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 700;
+		font-size: 0.88rem;
+		color: var(--text, #fff);
+	}
+	.pup-d {
+		font-size: 0.78rem;
+		line-height: 1.35;
+		color: var(--text-muted, #aeb8c6);
+	}
 </style>

--- a/src/lib/components/PageNav.svelte
+++ b/src/lib/components/PageNav.svelte
@@ -1,30 +1,64 @@
 <script>
-  import { goto } from '$app/navigation';
-  import { browser } from '$app/environment';
-  /** Where "home" goes (and the back fallback when there's no history). */
-  export let home = '/';
-  /** Explicit back target. When set, "← Back" goes here deterministically instead of
-   *  window.history.back() (which is unreliable once history has accumulated). */
-  export let back = '';
-  /** Show the 🏠 home button. Hide it when "← Back" already returns to the menu. */
-  export let showHome = true;
-  function goBack() {
-    if (back) goto(back);
-    else if (browser && window.history.length > 1) window.history.back();
-    else goto(home);
-  }
+	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
+	/** Where "home" goes (and the back fallback when there's no history). */
+	export let home = '/';
+	/** Explicit back target. When set, "← Back" goes here deterministically instead of
+	 *  window.history.back() (which is unreliable once history has accumulated). */
+	export let back = '';
+	/** Show the 🏠 home button. Hide it when "← Back" already returns to the menu. */
+	export let showHome = true;
+	function goBack() {
+		if (back) goto(back);
+		else if (browser && window.history.length > 1) window.history.back();
+		else goto(home);
+	}
 </script>
 
 <nav class="page-nav">
-  <button class="pn-btn" on:click={goBack} aria-label="Back">← Back</button>
-  {#if showHome}<button class="pn-home" on:click={() => goto(home)} aria-label="Main menu" title="Main menu">🏠</button>{/if}
+	<button class="pn-btn" on:click={goBack} aria-label="Back">← Back</button>
+	{#if showHome}<button
+			class="pn-home"
+			on:click={() => goto(home)}
+			aria-label="Main menu"
+			title="Main menu">🏠</button
+		>{/if}
 </nav>
 
 <style>
-  .page-nav { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 14px; }
-  .pn-btn, .pn-home { background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; }
-  .pn-btn { padding: 0.5rem 1rem; font-size: 0.9rem; }
-  .pn-home { width: 42px; height: 38px; display: grid; place-items: center; font-size: 1.1rem; }
-  .pn-btn:hover, .pn-home:hover { border-color: var(--brand-2); }
-  .pn-btn:active, .pn-home:active { transform: scale(0.97); }
+	.page-nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+		margin-bottom: 14px;
+	}
+	.pn-btn,
+	.pn-home {
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+	}
+	.pn-btn {
+		padding: 0.5rem 1rem;
+		font-size: 0.9rem;
+	}
+	.pn-home {
+		width: 42px;
+		height: 38px;
+		display: grid;
+		place-items: center;
+		font-size: 1.1rem;
+	}
+	.pn-btn:hover,
+	.pn-home:hover {
+		border-color: var(--brand-2);
+	}
+	.pn-btn:active,
+	.pn-home:active {
+		transform: scale(0.97);
+	}
 </style>

--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -1,358 +1,540 @@
 <script>
-  import { gameStore } from '$lib/stores/GameStore.js';
-  import { onDestroy, createEventDispatcher } from 'svelte';
-  import { getGlobalIndex } from '$lib/helpers/gameUtils.js';
-  import { fx } from '$lib/sound.js';
+	import { gameStore } from '$lib/stores/GameStore.js';
+	import { onDestroy, createEventDispatcher } from 'svelte';
+	import { getGlobalIndex } from '$lib/helpers/gameUtils.js';
+	import { fx } from '$lib/sound.js';
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  // 🎰 Daily opening reveal: each empty space lands one-by-one (shake + money signs
-  // + green plus + a landing thunk), then +page counts the bounty up in green. Driven
-  // by gameStore.dailyIntro, which bumps once on a fresh daily open.
-  const INTRO_STEP = 0.34; // seconds between box landings (slow, dramatic)
-  let introActive = false;
-  let introToken = 0;
-  /** @type {ReturnType<typeof setTimeout>[]} */
-  let introTimers = [];
-  /** @param {number} gi */
-  const introDelay = (gi) => Math.min(gi, 16) * INTRO_STEP;
+	// 🎰 Daily opening reveal: each empty space lands one-by-one (shake + money signs
+	// + green plus + a landing thunk), then +page counts the bounty up in green. Driven
+	// by gameStore.dailyIntro, which bumps once on a fresh daily open.
+	const INTRO_STEP = 0.34; // seconds between box landings (slow, dramatic)
+	let introActive = false;
+	let introToken = 0;
+	/** @type {ReturnType<typeof setTimeout>[]} */
+	let introTimers = [];
+	/** @param {number} gi */
+	const introDelay = (gi) => Math.min(gi, 16) * INTRO_STEP;
 
-  $: maybeStartIntro($gameStore.dailyIntroGo);
-  /** @param {number|undefined} tok */
-  function maybeStartIntro(tok) {
-    if (!tok || tok === introToken) return;
-    introToken = tok;
-    runIntro();
-  }
-  function runIntro() {
-    const phrase = $gameStore.currentPhrase || '';
-    /** @type {number[]} */
-    const idxs = [];
-    for (let i = 0; i < phrase.length; i++) if (phrase[i] !== ' ') idxs.push(i);
-    if (!idxs.length) return;
-    introTimers.forEach(clearTimeout);
-    introTimers = [];
-    introActive = true;
-    let lastDelay = 0;
-    for (const gi of idxs) {
-      const d = introDelay(gi);
-      lastDelay = Math.max(lastDelay, d);
-      introTimers.push(setTimeout(() => fx('land'), d * 1000 + 30));
-    }
-    // Climax: the spaces "add up × the multiplier" into the green bounty.
-    introTimers.push(setTimeout(() => { fx('multiplier'); dispatch('introDone'); }, lastDelay * 1000 + 420));
-    introTimers.push(setTimeout(() => { introActive = false; }, lastDelay * 1000 + 1900));
-  }
+	$: maybeStartIntro($gameStore.dailyIntroGo);
+	/** @param {number|undefined} tok */
+	function maybeStartIntro(tok) {
+		if (!tok || tok === introToken) return;
+		introToken = tok;
+		runIntro();
+	}
+	function runIntro() {
+		const phrase = $gameStore.currentPhrase || '';
+		/** @type {number[]} */
+		const idxs = [];
+		for (let i = 0; i < phrase.length; i++) if (phrase[i] !== ' ') idxs.push(i);
+		if (!idxs.length) return;
+		introTimers.forEach(clearTimeout);
+		introTimers = [];
+		introActive = true;
+		let lastDelay = 0;
+		for (const gi of idxs) {
+			const d = introDelay(gi);
+			lastDelay = Math.max(lastDelay, d);
+			introTimers.push(setTimeout(() => fx('land'), d * 1000 + 30));
+		}
+		// Climax: the spaces "add up × the multiplier" into the green bounty.
+		introTimers.push(
+			setTimeout(
+				() => {
+					fx('multiplier');
+					dispatch('introDone');
+				},
+				lastDelay * 1000 + 420
+			)
+		);
+		introTimers.push(
+			setTimeout(
+				() => {
+					introActive = false;
+				},
+				lastDelay * 1000 + 1900
+			)
+		);
+	}
 
-  // 📤 Reactive State Setup
+	// 📤 Reactive State Setup
 
-  // 💢 Shake Animation
-  let shakeIndexes = new Set();
-  /** @type {number[]} */
-  let lastProcessedShakes = [];
+	// 💢 Shake Animation
+	let shakeIndexes = new Set();
+	/** @type {number[]} */
+	let lastProcessedShakes = [];
 
-  /** @param {number[]} indexes */
-  function triggerShake(indexes) {
-    shakeIndexes = new Set(indexes);
-    setTimeout(() => {
-      shakeIndexes.clear();
-      gameStore.update(state => ({ ...state, shakenLetters: [] }));
-    }, 1000);
-  }
+	/** @param {number[]} indexes */
+	function triggerShake(indexes) {
+		shakeIndexes = new Set(indexes);
+		setTimeout(() => {
+			shakeIndexes.clear();
+			gameStore.update((state) => ({ ...state, shakenLetters: [] }));
+		}, 1000);
+	}
 
-  $: if ($gameStore.shakenLetters?.length > 0 &&
-         JSON.stringify($gameStore.shakenLetters) !== JSON.stringify(lastProcessedShakes)) {
-    triggerShake([...$gameStore.shakenLetters]);
-    lastProcessedShakes = [...$gameStore.shakenLetters];
-  }
+	$: if (
+		$gameStore.shakenLetters?.length > 0 &&
+		JSON.stringify($gameStore.shakenLetters) !== JSON.stringify(lastProcessedShakes)
+	) {
+		triggerShake([...$gameStore.shakenLetters]);
+		lastProcessedShakes = [...$gameStore.shakenLetters];
+	}
 
-  // 🧠 Reveal Animation (Loss)
-  /** @type {ReturnType<typeof setInterval> | undefined} */
-  let revealInterval;
-  /** @type {string[]} */
-  let revealed = [];
+	// 🧠 Reveal Animation (Loss)
+	/** @type {ReturnType<typeof setInterval> | undefined} */
+	let revealInterval;
+	/** @type {string[]} */
+	let revealed = [];
 
-  $: if ($gameStore.gameState === 'lost') {
-    if (revealed.length === 0) {
-      const fullPhrase = $gameStore.currentPhrase;
-      let i = 0;
-      revealInterval = setInterval(() => {
-        revealed[i] = fullPhrase[i];
-        revealed = [...revealed];
-        i++;
-        if (i >= fullPhrase.length) {
-          clearInterval(revealInterval);
-          dispatch('revealComplete');
-        }
-      }, 300);
-    }
-  } else {
-    revealed = [];
-    clearInterval(revealInterval);
-  }
+	$: if ($gameStore.gameState === 'lost') {
+		if (revealed.length === 0) {
+			const fullPhrase = $gameStore.currentPhrase;
+			let i = 0;
+			revealInterval = setInterval(() => {
+				revealed[i] = fullPhrase[i];
+				revealed = [...revealed];
+				i++;
+				if (i >= fullPhrase.length) {
+					clearInterval(revealInterval);
+					dispatch('revealComplete');
+				}
+			}, 300);
+		}
+	} else {
+		revealed = [];
+		clearInterval(revealInterval);
+	}
 
-  // 🎰 Win: dramatic box-by-box reveal (each tile pops with green money). Hold the
-  // result modal until the slot-machine sequence finishes.
-  let wonFired = false;
-  $: if ($gameStore.gameState === 'won') {
-    if (!wonFired) {
-      wonFired = true;
-      const n = ($gameStore.currentPhrase || '').replace(/ /g, '').length;
-      setTimeout(() => dispatch('revealComplete'), Math.min(n, 14) * 95 + 750);
-    }
-  } else {
-    wonFired = false;
-  }
+	// 🎰 Win: dramatic box-by-box reveal (each tile pops with green money). Hold the
+	// result modal until the slot-machine sequence finishes.
+	let wonFired = false;
+	$: if ($gameStore.gameState === 'won') {
+		if (!wonFired) {
+			wonFired = true;
+			const n = ($gameStore.currentPhrase || '').replace(/ /g, '').length;
+			setTimeout(() => dispatch('revealComplete'), Math.min(n, 14) * 95 + 750);
+		}
+	} else {
+		wonFired = false;
+	}
 
-  onDestroy(() => { clearInterval(revealInterval); introTimers.forEach(clearTimeout); });
+	onDestroy(() => {
+		clearInterval(revealInterval);
+		introTimers.forEach(clearTimeout);
+	});
 
-  // 🎯 Active Guess Slot Logic
-  $: activeGuessIndex = $gameStore.gameState === 'guess_mode'
-    ? (() => {
-        const phrase = $gameStore.currentPhrase;
-        const editableIndices = [];
+	// 🎯 Active Guess Slot Logic
+	$: activeGuessIndex =
+		$gameStore.gameState === 'guess_mode'
+			? (() => {
+					const phrase = $gameStore.currentPhrase;
+					const editableIndices = [];
 
-        for (let i = 0; i < phrase.length; i++) {
-          if (phrase[i] === ' ') continue;
-          if ($gameStore.purchasedLetters[i] === phrase[i]) continue;
-          editableIndices.push(i);
-        }
+					for (let i = 0; i < phrase.length; i++) {
+						if (phrase[i] === ' ') continue;
+						if ($gameStore.purchasedLetters[i] === phrase[i]) continue;
+						editableIndices.push(i);
+					}
 
-        if (editableIndices.length === 0) return -1;
+					if (editableIndices.length === 0) return -1;
 
-        for (const idx of editableIndices) {
-          if (!$gameStore.guessedLetters[idx]) return idx;
-        }
+					for (const idx of editableIndices) {
+						if (!$gameStore.guessedLetters[idx]) return idx;
+					}
 
-        return editableIndices[editableIndices.length - 1];
-      })()
-    : -1;
+					return editableIndices[editableIndices.length - 1];
+				})()
+			: -1;
 </script>
-
 
 <!-- Render Game Phrase -->
 <div class="phrase-container">
-  {#each $gameStore.currentPhrase.split(' ') as word, wIndex}
-    <div class="word">
-      {#each word.split('') as letter, cIndex}
-        {#key `${wIndex}-${cIndex}`}
-          {#if $gameStore.gameState === 'lost'}
-            <span class="letter-box">
-              {revealed[getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)] || "_"}
-            </span>
-
-          {:else if $gameStore.gameState === 'guess_mode'}
-            {#if $gameStore.purchasedLetters[getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)] === letter}
-              <span class="letter-box locked {shakeIndexes.has(getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)) ? 'shake' : ''}">
-                {letter}
-              </span>
-            {:else}
-              <span class="letter-box {getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase) === activeGuessIndex ? 'active' : ''}">
-                {$gameStore.guessedLetters[getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)] || ""}
-              </span>
-            {/if}
-
-          {:else}
-            {@const gi = getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)}
-            {@const won = $gameStore.gameState === 'won'}
-            {@const intro = introActive && !won}
-            <span class="letter-box {shakeIndexes.has(gi) ? 'shake' : ''} {won ? 'win' : ''} {intro ? 'intro' : ''}"
-              style={won ? `animation-delay:${Math.min(gi, 14) * 0.095}s` : intro ? `animation-delay:${introDelay(gi)}s` : ''}>
-              {$gameStore.purchasedLetters[gi] || ""}
-              {#if won}
-                <span class="coin c1" style="animation-delay:{Math.min(gi, 14) * 0.095}s">$</span>
-                <span class="coin c2" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.07}s">$</span>
-                <span class="coin c3" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.04}s">$</span>
-                <span class="plus" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.13}s">+</span>
-              {:else if intro}
-                <span class="coin c1" style="animation-delay:{introDelay(gi) + 0.18}s">$</span>
-                <span class="coin c2" style="animation-delay:{introDelay(gi) + 0.25}s">$</span>
-                <span class="coin c3" style="animation-delay:{introDelay(gi) + 0.22}s">$</span>
-                <span class="plus" style="animation-delay:{introDelay(gi) + 0.28}s">+</span>
-              {/if}
-            </span>
-          {/if}
-        {/key}
-      {/each}
-    </div>
-  {/each}
+	{#each $gameStore.currentPhrase.split(' ') as word, wIndex}
+		<div class="word">
+			{#each word.split('') as letter, cIndex}
+				{#key `${wIndex}-${cIndex}`}
+					{#if $gameStore.gameState === 'lost'}
+						<span class="letter-box">
+							{revealed[getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)] || '_'}
+						</span>
+					{:else if $gameStore.gameState === 'guess_mode'}
+						{#if $gameStore.purchasedLetters[getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)] === letter}
+							<span
+								class="letter-box locked {shakeIndexes.has(
+									getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)
+								)
+									? 'shake'
+									: ''}"
+							>
+								{letter}
+							</span>
+						{:else}
+							<span
+								class="letter-box {getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase) ===
+								activeGuessIndex
+									? 'active'
+									: ''}"
+							>
+								{$gameStore.guessedLetters[
+									getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)
+								] || ''}
+							</span>
+						{/if}
+					{:else}
+						{@const gi = getGlobalIndex(wIndex, cIndex, $gameStore.currentPhrase)}
+						{@const won = $gameStore.gameState === 'won'}
+						{@const intro = introActive && !won}
+						<span
+							class="letter-box {shakeIndexes.has(gi) ? 'shake' : ''} {won ? 'win' : ''} {intro
+								? 'intro'
+								: ''}"
+							style={won
+								? `animation-delay:${Math.min(gi, 14) * 0.095}s`
+								: intro
+									? `animation-delay:${introDelay(gi)}s`
+									: ''}
+						>
+							{$gameStore.purchasedLetters[gi] || ''}
+							{#if won}
+								<span class="coin c1" style="animation-delay:{Math.min(gi, 14) * 0.095}s">$</span>
+								<span class="coin c2" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.07}s"
+									>$</span
+								>
+								<span class="coin c3" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.04}s"
+									>$</span
+								>
+								<span class="plus" style="animation-delay:{Math.min(gi, 14) * 0.095 + 0.13}s"
+									>+</span
+								>
+							{:else if intro}
+								<span class="coin c1" style="animation-delay:{introDelay(gi) + 0.18}s">$</span>
+								<span class="coin c2" style="animation-delay:{introDelay(gi) + 0.25}s">$</span>
+								<span class="coin c3" style="animation-delay:{introDelay(gi) + 0.22}s">$</span>
+								<span class="plus" style="animation-delay:{introDelay(gi) + 0.28}s">+</span>
+							{/if}
+						</span>
+					{/if}
+				{/key}
+			{/each}
+		</div>
+	{/each}
 </div>
+
 <style>
-  /* ---------------------------
+	/* ---------------------------
      Shake Animation for Letters
   --------------------------- */
-  @keyframes shake {
-    0%   { transform: translateX(0) scale(1); }
-    10%  { transform: translateX(-6px) scale(1.1); }
-    20%  { transform: translateX(6px) scale(1.2); }
-    30%  { transform: translateX(-5px) scale(1.1); }
-    40%  { transform: translateX(5px) scale(1.2); }
-    50%  { transform: translateX(-4px) scale(1.1); }
-    60%  { transform: translateX(4px) scale(1.2); }
-    70%  { transform: translateX(-3px) scale(1.1); }
-    80%  { transform: translateX(3px) scale(1.1); }
-    90%  { transform: translateX(-2px) scale(1); }
-    100% { transform: translateX(0) scale(1); }
-  }
-  .shake {
-    animation: shake 2s ease-in-out;
-  }
+	@keyframes shake {
+		0% {
+			transform: translateX(0) scale(1);
+		}
+		10% {
+			transform: translateX(-6px) scale(1.1);
+		}
+		20% {
+			transform: translateX(6px) scale(1.2);
+		}
+		30% {
+			transform: translateX(-5px) scale(1.1);
+		}
+		40% {
+			transform: translateX(5px) scale(1.2);
+		}
+		50% {
+			transform: translateX(-4px) scale(1.1);
+		}
+		60% {
+			transform: translateX(4px) scale(1.2);
+		}
+		70% {
+			transform: translateX(-3px) scale(1.1);
+		}
+		80% {
+			transform: translateX(3px) scale(1.1);
+		}
+		90% {
+			transform: translateX(-2px) scale(1);
+		}
+		100% {
+			transform: translateX(0) scale(1);
+		}
+	}
+	.shake {
+		animation: shake 2s ease-in-out;
+	}
 
-  /* 🎰 Daily opening reveal: each empty space drops in, rattles, and lands hard */
-  .letter-box.intro {
-    animation: introPop 0.92s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
-    z-index: 1;
-  }
-  @keyframes introPop {
-    0%   { opacity: 0; transform: translateY(-40px) scale(0.3) rotate(-10deg); }
-    24%  { opacity: 1; transform: translateY(6px) scale(1.24) rotate(6deg);
-           border-color: #4ade80; box-shadow: 0 0 0 3px rgba(74,222,128,0.55), 0 0 24px rgba(74,222,128,0.65); }
-    40%  { transform: translateY(0) scale(0.92) rotate(-4deg); }
-    54%  { transform: translateY(0) scale(1.08) rotate(3deg); }
-    68%  { transform: translateY(0) scale(0.97) rotate(-1.5deg);
-           box-shadow: 0 0 0 2px rgba(74,222,128,0.4), 0 0 16px rgba(74,222,128,0.45); }
-    100% { opacity: 1; transform: translateY(0) scale(1) rotate(0deg); }
-  }
+	/* 🎰 Daily opening reveal: each empty space drops in, rattles, and lands hard */
+	.letter-box.intro {
+		animation: introPop 0.92s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+		z-index: 1;
+	}
+	@keyframes introPop {
+		0% {
+			opacity: 0;
+			transform: translateY(-40px) scale(0.3) rotate(-10deg);
+		}
+		24% {
+			opacity: 1;
+			transform: translateY(6px) scale(1.24) rotate(6deg);
+			border-color: #4ade80;
+			box-shadow:
+				0 0 0 3px rgba(74, 222, 128, 0.55),
+				0 0 24px rgba(74, 222, 128, 0.65);
+		}
+		40% {
+			transform: translateY(0) scale(0.92) rotate(-4deg);
+		}
+		54% {
+			transform: translateY(0) scale(1.08) rotate(3deg);
+		}
+		68% {
+			transform: translateY(0) scale(0.97) rotate(-1.5deg);
+			box-shadow:
+				0 0 0 2px rgba(74, 222, 128, 0.4),
+				0 0 16px rgba(74, 222, 128, 0.45);
+		}
+		100% {
+			opacity: 1;
+			transform: translateY(0) scale(1) rotate(0deg);
+		}
+	}
 
-  /* 🎰 Win reveal: each tile pops with green money, staggered left→right */
-  .letter-box.win {
-    animation: winPop 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
-    z-index: 1;
-  }
-  @keyframes winPop {
-    0%   { transform: scale(1); }
-    30%  { transform: scale(1.28) rotate(-5deg); border-color: #4ade80;
-           box-shadow: 0 0 0 3px rgba(74,222,128,0.5), 0 0 22px rgba(74,222,128,0.6); color: #bbf7d0; }
-    60%  { transform: scale(1.12) rotate(4deg); }
-    100% { transform: scale(1); }
-  }
-  .coin, .plus { position: absolute; pointer-events: none; left: 50%; font-family: 'Orbitron', var(--font-display);
-    font-weight: 800; color: #4ade80; text-shadow: 0 0 8px rgba(74,222,128,0.7); opacity: 0; }
-  .coin { top: 6px; font-size: 0.9rem; animation: coinSpray 0.75s ease-out backwards; }
-  .c1 { --dx: -22px; } .c2 { --dx: 20px; } .c3 { --dx: 2px; }
-  @keyframes coinSpray {
-    0%   { opacity: 0; transform: translate(-50%, 0) scale(0.4); }
-    20%  { opacity: 1; transform: translate(-50%, -6px) scale(1.1); }
-    100% { opacity: 0; transform: translate(calc(-50% + var(--dx, 0px)), 32px) scale(0.85); }
-  }
-  .plus { top: -8px; font-size: 1.4rem; animation: plusPop 0.55s ease-out backwards; }
-  @keyframes plusPop {
-    0%   { opacity: 0; transform: translate(-50%, 6px) scale(0.4); }
-    40%  { opacity: 1; transform: translate(-50%, -12px) scale(1.25); }
-    100% { opacity: 0; transform: translate(-50%, -24px) scale(1); }
-  }
+	/* 🎰 Win reveal: each tile pops with green money, staggered left→right */
+	.letter-box.win {
+		animation: winPop 0.55s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+		z-index: 1;
+	}
+	@keyframes winPop {
+		0% {
+			transform: scale(1);
+		}
+		30% {
+			transform: scale(1.28) rotate(-5deg);
+			border-color: #4ade80;
+			box-shadow:
+				0 0 0 3px rgba(74, 222, 128, 0.5),
+				0 0 22px rgba(74, 222, 128, 0.6);
+			color: #bbf7d0;
+		}
+		60% {
+			transform: scale(1.12) rotate(4deg);
+		}
+		100% {
+			transform: scale(1);
+		}
+	}
+	.coin,
+	.plus {
+		position: absolute;
+		pointer-events: none;
+		left: 50%;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		color: #4ade80;
+		text-shadow: 0 0 8px rgba(74, 222, 128, 0.7);
+		opacity: 0;
+	}
+	.coin {
+		top: 6px;
+		font-size: 0.9rem;
+		animation: coinSpray 0.75s ease-out backwards;
+	}
+	.c1 {
+		--dx: -22px;
+	}
+	.c2 {
+		--dx: 20px;
+	}
+	.c3 {
+		--dx: 2px;
+	}
+	@keyframes coinSpray {
+		0% {
+			opacity: 0;
+			transform: translate(-50%, 0) scale(0.4);
+		}
+		20% {
+			opacity: 1;
+			transform: translate(-50%, -6px) scale(1.1);
+		}
+		100% {
+			opacity: 0;
+			transform: translate(calc(-50% + var(--dx, 0px)), 32px) scale(0.85);
+		}
+	}
+	.plus {
+		top: -8px;
+		font-size: 1.4rem;
+		animation: plusPop 0.55s ease-out backwards;
+	}
+	@keyframes plusPop {
+		0% {
+			opacity: 0;
+			transform: translate(-50%, 6px) scale(0.4);
+		}
+		40% {
+			opacity: 1;
+			transform: translate(-50%, -12px) scale(1.25);
+		}
+		100% {
+			opacity: 0;
+			transform: translate(-50%, -24px) scale(1);
+		}
+	}
 
-  /* ---------------------------
+	/* ---------------------------
      Layout for Phrase Display
   --------------------------- */
-  .phrase-container {
-    display: flex;
-    flex-wrap: wrap;
-    width: 100%;
-    max-width: 100vw;
-    padding: 0;
-    margin: 22px 0 12px 0;
-    gap: 1px;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-    overflow-x: hidden;
-    text-align: center;
-    perspective: 800px;
-  }
-  .letter-box.active {
-    animation: activePulse 1.4s ease-in-out infinite;
-  }
-  @keyframes activePulse {
-    0%, 100% { box-shadow: 0 0 0 4px rgba(253, 224, 71,0.14), 0 0 14px rgba(253, 224, 71,0.2); }
-    50%      { box-shadow: 0 0 0 5px rgba(253, 224, 71,0.26), 0 0 22px rgba(253, 224, 71,0.4); }
-  }
-  .word {
-    display: flex;
-    gap: 0px;
-    flex-wrap: wrap;
-    justify-content: center;
-    align-items: center;
-    margin-right: 10px;
-    text-align: center;
-  }
-  .letter-box {
-    position: relative;
-    width: 42px;
-    min-width: 42px;
-    height: 48px;
-    min-height: 48px;
-    padding: 0;
-    flex-shrink: 0; /* Prevent collapse when empty */
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    border: 1.5px solid rgba(74, 222, 128, 0.4);
-    background: var(--surface);
-    font-family: var(--font-display);
-    font-size: 22px;
-    font-weight: 700;
-    border-radius: 11px;
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.05),
-      0 2px 8px rgba(0, 0, 0, 0.3),
-      0 0 10px rgba(74, 222, 128, 0.22);
-    animation: tileShimmer 2.2s ease-in-out infinite;
-    color: var(--text);
-    backdrop-filter: blur(8px);
-    box-sizing: border-box;
-    transition: transform 0.2s var(--ease-spring), border-color 0.2s, background 0.2s, box-shadow 0.2s;
-  }
-  /* subtle synchronized green shimmer on the empty/filled tiles (all together, gentle) */
-  @keyframes tileShimmer {
-    0%, 100% { border-color: rgba(74, 222, 128, 0.34);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.05), 0 2px 8px rgba(0,0,0,0.3), 0 0 8px rgba(74,222,128,0.16); }
-    50% { border-color: rgba(110, 231, 183, 0.55);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), 0 2px 8px rgba(0,0,0,0.3), 0 0 13px rgba(74,222,128,0.32); }
-  }
-  .letter-box.locked {
-    color: #3a2a00;
-    background: var(--brand-grad);
-    border-color: transparent;
-    box-shadow: 0 4px 16px rgba(251, 191, 36, 0.35);
-    animation: tileReveal 0.55s var(--ease-spring) both;
-  }
-  @keyframes tileReveal {
-    0%   { transform: perspective(600px) rotateX(-90deg); box-shadow: 0 0 0 rgba(251, 191, 36,0); }
-    55%  { transform: perspective(600px) rotateX(0deg) scale(1.14); box-shadow: 0 0 26px rgba(253, 224, 71,0.7); }
-    100% { transform: perspective(600px) rotateX(0deg) scale(1); }
-  }
-  .letter-box.active {
-    border: 2px solid var(--brand-2);
-    box-shadow: 0 0 0 4px rgba(253, 224, 71, 0.16), 0 0 18px rgba(253, 224, 71, 0.25);
-  }
+	.phrase-container {
+		display: flex;
+		flex-wrap: wrap;
+		width: 100%;
+		max-width: 100vw;
+		padding: 0;
+		margin: 22px 0 12px 0;
+		gap: 1px;
+		justify-content: center;
+		align-items: center;
+		box-sizing: border-box;
+		overflow-x: hidden;
+		text-align: center;
+		perspective: 800px;
+	}
+	.letter-box.active {
+		animation: activePulse 1.4s ease-in-out infinite;
+	}
+	@keyframes activePulse {
+		0%,
+		100% {
+			box-shadow:
+				0 0 0 4px rgba(253, 224, 71, 0.14),
+				0 0 14px rgba(253, 224, 71, 0.2);
+		}
+		50% {
+			box-shadow:
+				0 0 0 5px rgba(253, 224, 71, 0.26),
+				0 0 22px rgba(253, 224, 71, 0.4);
+		}
+	}
+	.word {
+		display: flex;
+		gap: 0px;
+		flex-wrap: wrap;
+		justify-content: center;
+		align-items: center;
+		margin-right: 10px;
+		text-align: center;
+	}
+	.letter-box {
+		position: relative;
+		width: 42px;
+		min-width: 42px;
+		height: 48px;
+		min-height: 48px;
+		padding: 0;
+		flex-shrink: 0; /* Prevent collapse when empty */
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		text-align: center;
+		border: 1.5px solid rgba(74, 222, 128, 0.4);
+		background: var(--surface);
+		font-family: var(--font-display);
+		font-size: 22px;
+		font-weight: 700;
+		border-radius: 11px;
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.05),
+			0 2px 8px rgba(0, 0, 0, 0.3),
+			0 0 10px rgba(74, 222, 128, 0.22);
+		animation: tileShimmer 2.2s ease-in-out infinite;
+		color: var(--text);
+		backdrop-filter: blur(8px);
+		box-sizing: border-box;
+		transition:
+			transform 0.2s var(--ease-spring),
+			border-color 0.2s,
+			background 0.2s,
+			box-shadow 0.2s;
+	}
+	/* subtle synchronized green shimmer on the empty/filled tiles (all together, gentle) */
+	@keyframes tileShimmer {
+		0%,
+		100% {
+			border-color: rgba(74, 222, 128, 0.34);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 255, 255, 0.05),
+				0 2px 8px rgba(0, 0, 0, 0.3),
+				0 0 8px rgba(74, 222, 128, 0.16);
+		}
+		50% {
+			border-color: rgba(110, 231, 183, 0.55);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 255, 255, 0.06),
+				0 2px 8px rgba(0, 0, 0, 0.3),
+				0 0 13px rgba(74, 222, 128, 0.32);
+		}
+	}
+	.letter-box.locked {
+		color: #3a2a00;
+		background: var(--brand-grad);
+		border-color: transparent;
+		box-shadow: 0 4px 16px rgba(251, 191, 36, 0.35);
+		animation: tileReveal 0.55s var(--ease-spring) both;
+	}
+	@keyframes tileReveal {
+		0% {
+			transform: perspective(600px) rotateX(-90deg);
+			box-shadow: 0 0 0 rgba(251, 191, 36, 0);
+		}
+		55% {
+			transform: perspective(600px) rotateX(0deg) scale(1.14);
+			box-shadow: 0 0 26px rgba(253, 224, 71, 0.7);
+		}
+		100% {
+			transform: perspective(600px) rotateX(0deg) scale(1);
+		}
+	}
+	.letter-box.active {
+		border: 2px solid var(--brand-2);
+		box-shadow:
+			0 0 0 4px rgba(253, 224, 71, 0.16),
+			0 0 18px rgba(253, 224, 71, 0.25);
+	}
 
-  /* ---------------------------
+	/* ---------------------------
      Guess Mode Styling
   --------------------------- */
-  :global(body.guess-mode) .phrase-container {
-    animation: blinkingBorder 1.5s infinite;
-  }
-  @keyframes blinkingBorder {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
-  }
+	:global(body.guess-mode) .phrase-container {
+		animation: blinkingBorder 1.5s infinite;
+	}
+	@keyframes blinkingBorder {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.4;
+		}
+	}
 
-  /* ---------------------------
+	/* ---------------------------
      Responsive Adjustments
   --------------------------- */
-  @media (max-width: 480px) {
-    .letter-box {
-      width: 36px;
-      min-width: 36px;
-      height: 42px;
-      min-height: 42px;
-      font-size: 19px;
-      border-radius: 9px;
-    }
-    .phrase-container {
-      margin: 16px 0 10px 0;
-    }
-  }
+	@media (max-width: 480px) {
+		.letter-box {
+			width: 36px;
+			min-width: 36px;
+			height: 42px;
+			min-height: 42px;
+			font-size: 19px;
+			border-radius: 9px;
+		}
+		.phrase-container {
+			margin: 16px 0 10px 0;
+		}
+	}
 </style>

--- a/src/lib/components/PinConfirm.svelte
+++ b/src/lib/components/PinConfirm.svelte
@@ -1,73 +1,132 @@
 <script>
-  import { get } from 'svelte/store';
-  import PinPad from '$lib/components/PinPad.svelte';
-  import { pinConfirm } from '$lib/pinConfirm.js';
-  import { verifyPin, tooManyFails } from '$lib/pin.js';
+	import { get } from 'svelte/store';
+	import PinPad from '$lib/components/PinPad.svelte';
+	import { pinConfirm } from '$lib/pinConfirm.js';
+	import { verifyPin, tooManyFails } from '$lib/pin.js';
 
-  let error = false;
-  let msg = '';
-  /** @type {any} */
-  let pad;
+	let error = false;
+	let msg = '';
+	/** @type {any} */
+	let pad;
 
-  /** @param {CustomEvent<string>} e */
-  async function onSubmit(e) {
-    const uid = get(pinConfirm)?.uid;
-    if (!uid) return;
-    const ok = await verifyPin(uid, e.detail);
-    if (ok) {
-      const s = get(pinConfirm);
-      pinConfirm.set(null);
-      msg = '';
-      s?.resolve(true);
-    } else {
-      error = true;
-      msg = tooManyFails() ? 'Too many tries.' : 'Wrong PIN — try again.';
-      setTimeout(() => { error = false; pad?.reset(); }, 480);
-    }
-  }
-  function cancel() {
-    const s = get(pinConfirm);
-    pinConfirm.set(null);
-    msg = '';
-    s?.reject(new Error('cancelled'));
-  }
+	/** @param {CustomEvent<string>} e */
+	async function onSubmit(e) {
+		const uid = get(pinConfirm)?.uid;
+		if (!uid) return;
+		const ok = await verifyPin(uid, e.detail);
+		if (ok) {
+			const s = get(pinConfirm);
+			pinConfirm.set(null);
+			msg = '';
+			s?.resolve(true);
+		} else {
+			error = true;
+			msg = tooManyFails() ? 'Too many tries.' : 'Wrong PIN — try again.';
+			setTimeout(() => {
+				error = false;
+				pad?.reset();
+			}, 480);
+		}
+	}
+	function cancel() {
+		const s = get(pinConfirm);
+		pinConfirm.set(null);
+		msg = '';
+		s?.reject(new Error('cancelled'));
+	}
 </script>
 
 {#if $pinConfirm}
-  <div class="pc-overlay" role="dialog" aria-modal="true" aria-label="Confirm with PIN">
-    <div class="pc-card">
-      <h2 class="pc-title">Enter your PIN</h2>
-      <p class="pc-reason">{$pinConfirm.reason}</p>
-      {#if $pinConfirm.details?.length}
-        <div class="pc-stakes">
-          {#each $pinConfirm.details as d}
-            <div class="pc-stake"><span class="pc-sk-label">{d.label}</span><span class="pc-sk-value">{d.value}</span></div>
-          {/each}
-        </div>
-      {/if}
-      <PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
-      {#if msg}<p class="pc-msg">{msg}</p>{/if}
-      <button class="pc-cancel" on:click={cancel}>Cancel</button>
-    </div>
-  </div>
+	<div class="pc-overlay" role="dialog" aria-modal="true" aria-label="Confirm with PIN">
+		<div class="pc-card">
+			<h2 class="pc-title">Enter your PIN</h2>
+			<p class="pc-reason">{$pinConfirm.reason}</p>
+			{#if $pinConfirm.details?.length}
+				<div class="pc-stakes">
+					{#each $pinConfirm.details as d}
+						<div class="pc-stake">
+							<span class="pc-sk-label">{d.label}</span><span class="pc-sk-value">{d.value}</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+			<PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
+			{#if msg}<p class="pc-msg">{msg}</p>{/if}
+			<button class="pc-cancel" on:click={cancel}>Cancel</button>
+		</div>
+	</div>
 {/if}
 
 <style>
-  .pc-overlay {
-    /* above every in-page modal (challenge/shop modals are z-index 9999) so the
+	.pc-overlay {
+		/* above every in-page modal (challenge/shop modals are z-index 9999) so the
        PIN pad is actually visible + tappable when confirming from inside one */
-    position: fixed; inset: 0; z-index: 100000; display: grid; place-items: center; padding: 1.2rem;
-    background: radial-gradient(70% 50% at 50% 18%, rgba(251,191,36,0.12), rgba(0,0,0,0) 60%), rgba(5,5,5,0.92);
-    backdrop-filter: blur(4px);
-  }
-  .pc-card { width: 100%; max-width: 360px; text-align: center; }
-  .pc-title { font-family: var(--font-display); font-size: 1.35rem; margin: 0 0 0.2rem; }
-  .pc-reason { color: #fbbf24; font-weight: 700; font-size: 0.95rem; margin: 0 0 1rem; }
-  .pc-stakes { width: 100%; max-width: 280px; margin: 0 auto 1.3rem; display: flex; flex-direction: column; gap: 6px;
-    padding: 12px 14px; border-radius: 14px; border: 1px solid rgba(253,224,71,0.3); background: rgba(251,191,36,0.06); }
-  .pc-stake { display: flex; align-items: center; justify-content: space-between; gap: 12px; font-size: 0.86rem; }
-  .pc-sk-label { color: var(--text-muted, #aeb8c6); }
-  .pc-sk-value { font-family: var(--font-display); font-weight: 700; color: var(--text, #fff); }
-  .pc-msg { margin-top: 0.9rem; font-size: 0.86rem; color: #f87171; }
-  .pc-cancel { margin-top: 1.4rem; background: none; border: none; color: var(--text-faint); font-size: 0.85rem; text-decoration: underline; cursor: pointer; }
+		position: fixed;
+		inset: 0;
+		z-index: 100000;
+		display: grid;
+		place-items: center;
+		padding: 1.2rem;
+		background:
+			radial-gradient(70% 50% at 50% 18%, rgba(251, 191, 36, 0.12), rgba(0, 0, 0, 0) 60%),
+			rgba(5, 5, 5, 0.92);
+		backdrop-filter: blur(4px);
+	}
+	.pc-card {
+		width: 100%;
+		max-width: 360px;
+		text-align: center;
+	}
+	.pc-title {
+		font-family: var(--font-display);
+		font-size: 1.35rem;
+		margin: 0 0 0.2rem;
+	}
+	.pc-reason {
+		color: #fbbf24;
+		font-weight: 700;
+		font-size: 0.95rem;
+		margin: 0 0 1rem;
+	}
+	.pc-stakes {
+		width: 100%;
+		max-width: 280px;
+		margin: 0 auto 1.3rem;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		padding: 12px 14px;
+		border-radius: 14px;
+		border: 1px solid rgba(253, 224, 71, 0.3);
+		background: rgba(251, 191, 36, 0.06);
+	}
+	.pc-stake {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		font-size: 0.86rem;
+	}
+	.pc-sk-label {
+		color: var(--text-muted, #aeb8c6);
+	}
+	.pc-sk-value {
+		font-family: var(--font-display);
+		font-weight: 700;
+		color: var(--text, #fff);
+	}
+	.pc-msg {
+		margin-top: 0.9rem;
+		font-size: 0.86rem;
+		color: #f87171;
+	}
+	.pc-cancel {
+		margin-top: 1.4rem;
+		background: none;
+		border: none;
+		color: var(--text-faint);
+		font-size: 0.85rem;
+		text-decoration: underline;
+		cursor: pointer;
+	}
 </style>

--- a/src/lib/components/PinGate.svelte
+++ b/src/lib/components/PinGate.svelte
@@ -1,206 +1,394 @@
 <script>
-  import { createEventDispatcher, onMount } from 'svelte';
-  import { tweened } from 'svelte/motion';
-  import { cubicOut } from 'svelte/easing';
-  import PinPad from '$lib/components/PinPad.svelte';
-  import { setPin, verifyPin, tooManyFails, rememberedName } from '$lib/pin.js';
-  import { getBank } from '$lib/stores/statsStore.js';
-  import { fx } from '$lib/sound.js';
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { tweened } from 'svelte/motion';
+	import { cubicOut } from 'svelte/easing';
+	import PinPad from '$lib/components/PinPad.svelte';
+	import { setPin, verifyPin, tooManyFails, rememberedName } from '$lib/pin.js';
+	import { getBank } from '$lib/stores/statsStore.js';
+	import { fx } from '$lib/sound.js';
 
-  /** @type {'set'|'unlock'} */
-  export let mode = 'unlock';
-  export let uid = '';
-  /** @type {string|null} */
-  export let name = null;
-  /** @type {number|null} */
-  export let balance = null;
+	/** @type {'set'|'unlock'} */
+	export let mode = 'unlock';
+	export let uid = '';
+	/** @type {string|null} */
+	export let name = null;
+	/** @type {number|null} */
+	export let balance = null;
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  // set-PIN flow
-  let step = 'create'; // 'create' | 'confirm'
-  let firstPin = '';
-  let msg = '';
-  let error = false;
-  /** @type {any} */
-  let pad;
+	// set-PIN flow
+	let step = 'create'; // 'create' | 'confirm'
+	let firstPin = '';
+	let msg = '';
+	let error = false;
+	/** @type {any} */
+	let pad;
 
-  // vault reveal
-  let revealing = false;
-  let doorOpen = false;
-  const shownBalance = tweened(0, { duration: 1100, easing: cubicOut });
+	// vault reveal
+	let revealing = false;
+	let doorOpen = false;
+	const shownBalance = tweened(0, { duration: 1100, easing: cubicOut });
 
-  let displayName = name || rememberedName();
+	let displayName = name || rememberedName();
 
-  function flashError(text) {
-    msg = text; error = true;
-    setTimeout(() => { error = false; pad?.reset(); }, 480);
-  }
+	/** @param {string} text */
+	function flashError(text) {
+		msg = text;
+		error = true;
+		setTimeout(() => {
+			error = false;
+			pad?.reset();
+		}, 480);
+	}
 
-  /** @param {CustomEvent<string>} e */
-  async function onSubmit(e) {
-    const pin = e.detail;
-    msg = '';
-    if (mode === 'set') {
-      if (step === 'create') {
-        firstPin = pin;
-        step = 'confirm';
-        pad?.reset();
-      } else {
-        if (pin === firstPin) {
-          await setPin(uid, name, pin);
-          fx('win');
-          dispatch('pinset');
-        } else {
-          step = 'create'; firstPin = '';
-          flashError('PINs didn’t match — try again.');
-        }
-      }
-      return;
-    }
-    // unlock
-    const ok = await verifyPin(uid, pin);
-    if (ok) {
-      await openVault();
-    } else if (tooManyFails()) {
-      msg = 'Too many tries — sign in with your password.';
-      setTimeout(() => dispatch('logout'), 900);
-    } else {
-      flashError('Wrong PIN — try again.');
-    }
-  }
+	/** @param {CustomEvent<string>} e */
+	async function onSubmit(e) {
+		const pin = e.detail;
+		msg = '';
+		if (mode === 'set') {
+			if (step === 'create') {
+				firstPin = pin;
+				step = 'confirm';
+				pad?.reset();
+			} else {
+				if (pin === firstPin) {
+					await setPin(uid, name, pin);
+					fx('win');
+					dispatch('pinset');
+				} else {
+					step = 'create';
+					firstPin = '';
+					flashError('PINs didn’t match — try again.');
+				}
+			}
+			return;
+		}
+		// unlock
+		const ok = await verifyPin(uid, pin);
+		if (ok) {
+			await openVault();
+		} else if (tooManyFails()) {
+			msg = 'Too many tries — sign in with your password.';
+			setTimeout(() => dispatch('logout'), 900);
+		} else {
+			flashError('Wrong PIN — try again.');
+		}
+	}
 
-  async function openVault() {
-    revealing = true;
-    // fetch a fresh balance for the reveal if we weren't handed one
-    let bal = balance;
-    if (bal == null) { try { const b = await getBank(); bal = b?.bank ?? b?.cash ?? 0; } catch { bal = 0; } }
-    // brief pause on the closed door, then CLUNK + light burst + swing open
-    setTimeout(() => { doorOpen = true; fx('vault'); }, 650);
-    setTimeout(() => { shownBalance.set(bal ?? 0); }, 1150);
-  }
+	async function openVault() {
+		revealing = true;
+		// fetch a fresh balance for the reveal if we weren't handed one
+		let bal = balance;
+		if (bal == null) {
+			try {
+				const b = await getBank();
+				bal = b?.bank ?? 0;
+			} catch {
+				bal = 0;
+			}
+		}
+		// brief pause on the closed door, then CLUNK + light burst + swing open
+		setTimeout(() => {
+			doorOpen = true;
+			fx('vault');
+		}, 650);
+		setTimeout(() => {
+			shownBalance.set(bal ?? 0);
+		}, 1150);
+	}
 
-  function enter() { dispatch('unlocked'); }
-  onMount(() => { /* mode-driven render */ });
+	function enter() {
+		dispatch('unlocked');
+	}
+	onMount(() => {
+		/* mode-driven render */
+	});
 
-  $: title = mode === 'set'
-    ? (step === 'create' ? 'Create your PIN' : 'Confirm your PIN')
-    : 'Enter your PIN';
-  $: sub = mode === 'set'
-    ? (step === 'create' ? 'A 4-digit PIN to unlock WordBank fast on this device.' : 'Type it once more to confirm.')
-    : (displayName ? `Welcome back, @${displayName}` : 'Welcome back');
+	$: title =
+		mode === 'set'
+			? step === 'create'
+				? 'Create your PIN'
+				: 'Confirm your PIN'
+			: 'Enter your PIN';
+	$: sub =
+		mode === 'set'
+			? step === 'create'
+				? 'A 4-digit PIN to unlock WordBank fast on this device.'
+				: 'Type it once more to confirm.'
+			: displayName
+				? `Welcome back, @${displayName}`
+				: 'Welcome back';
 </script>
 
 {#if revealing}
-  <!-- 🔐 Vault reveal -->
-  <div class="vault" class:open={doorOpen} on:click={enter} role="button" tabindex="0"
-       on:keydown={(e) => { if (e.key === 'Enter') enter(); }}>
-    <div class="vault-stage">
-      <div class="reveal">
-        <span class="reveal-label">Your balance</span>
-        <span class="reveal-amount">${Math.round($shownBalance).toLocaleString()}</span>
-        {#if doorOpen}<span class="reveal-go">Tap to enter →</span>{/if}
-      </div>
-      <div class="door-hinge">
-        <div class="door">
-          <div class="door-ring"></div>
-          <div class="door-dial"><span class="spoke"></span><span class="spoke"></span><span class="spoke"></span></div>
-          <img class="door-coin" src="/logo-coin.png" alt="" />
-        </div>
-      </div>
-    </div>
-    <!-- full-screen gold flash, on top of everything, at the open moment -->
-    <div class="flash"></div>
-  </div>
+	<!-- 🔐 Vault reveal -->
+	<div
+		class="vault"
+		class:open={doorOpen}
+		on:click={enter}
+		role="button"
+		tabindex="0"
+		on:keydown={(e) => {
+			if (e.key === 'Enter') enter();
+		}}
+	>
+		<div class="vault-stage">
+			<div class="reveal">
+				<span class="reveal-label">Your balance</span>
+				<span class="reveal-amount">${Math.round($shownBalance).toLocaleString()}</span>
+				{#if doorOpen}<span class="reveal-go">Tap to enter →</span>{/if}
+			</div>
+			<div class="door-hinge">
+				<div class="door">
+					<div class="door-ring"></div>
+					<div class="door-dial">
+						<span class="spoke"></span><span class="spoke"></span><span class="spoke"></span>
+					</div>
+					<img class="door-coin" src="/logo-coin.png" alt="" />
+				</div>
+			</div>
+		</div>
+		<!-- full-screen gold flash, on top of everything, at the open moment -->
+		<div class="flash"></div>
+	</div>
 {:else}
-  <!-- PIN entry (set or unlock) -->
-  <div class="pin-screen">
-    <img class="pin-coin" src="/logo-coin.png" alt="" />
-    <h2 class="pin-title">{title}</h2>
-    <p class="pin-sub">{sub}</p>
-    <PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
-    {#if msg}<p class="pin-msg" class:err={error}>{msg}</p>{/if}
-    {#if mode === 'unlock'}
-      <button class="pin-forgot" on:click={() => dispatch('logout')}>Forgot PIN? Reset with your email &amp; password</button>
-    {:else if step === 'create'}
-      <button class="pin-forgot" on:click={() => dispatch('skip')}>Skip for now — set it later in My Account</button>
-    {/if}
-  </div>
+	<!-- PIN entry (set or unlock) -->
+	<div class="pin-screen">
+		<img class="pin-coin" src="/logo-coin.png" alt="" />
+		<h2 class="pin-title">{title}</h2>
+		<p class="pin-sub">{sub}</p>
+		<PinPad bind:this={pad} {error} on:submit={onSubmit} on:change={() => (msg = '')} />
+		{#if msg}<p class="pin-msg" class:err={error}>{msg}</p>{/if}
+		{#if mode === 'unlock'}
+			<button class="pin-forgot" on:click={() => dispatch('logout')}
+				>Forgot PIN? Reset with your email &amp; password</button
+			>
+		{:else if step === 'create'}
+			<button class="pin-forgot" on:click={() => dispatch('skip')}
+				>Skip for now — set it later in My Account</button
+			>
+		{/if}
+	</div>
 {/if}
 
 <style>
-  .pin-screen {
-    position: fixed; inset: 0; z-index: 2500; display: flex; flex-direction: column; align-items: center;
-    justify-content: flex-start; padding: 8vh 1.2rem 2rem; text-align: center;
-    background: radial-gradient(70% 50% at 50% 12%, rgba(251,191,36,0.14), rgba(0,0,0,0) 60%), #070707;
-  }
-  .pin-coin { width: 84px; height: auto; filter: drop-shadow(0 6px 22px rgba(251,191,36,0.45)); }
-  .pin-title { font-family: var(--font-display); font-size: 1.5rem; margin: 0.6rem 0 0.2rem; }
-  .pin-sub { color: var(--text-muted); font-size: 0.9rem; margin: 0 0 1.8rem; max-width: 300px; }
-  .pin-msg { margin-top: 1rem; font-size: 0.88rem; color: var(--text-muted); }
-  .pin-msg.err { color: #f87171; }
-  .pin-forgot { margin-top: 1.6rem; background: none; border: none; color: var(--text-faint); font-size: 0.82rem; text-decoration: underline; cursor: pointer; }
+	.pin-screen {
+		position: fixed;
+		inset: 0;
+		z-index: 2500;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: flex-start;
+		padding: 8vh 1.2rem 2rem;
+		text-align: center;
+		background:
+			radial-gradient(70% 50% at 50% 12%, rgba(251, 191, 36, 0.14), rgba(0, 0, 0, 0) 60%), #070707;
+	}
+	.pin-coin {
+		width: 84px;
+		height: auto;
+		filter: drop-shadow(0 6px 22px rgba(251, 191, 36, 0.45));
+	}
+	.pin-title {
+		font-family: var(--font-display);
+		font-size: 1.5rem;
+		margin: 0.6rem 0 0.2rem;
+	}
+	.pin-sub {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin: 0 0 1.8rem;
+		max-width: 300px;
+	}
+	.pin-msg {
+		margin-top: 1rem;
+		font-size: 0.88rem;
+		color: var(--text-muted);
+	}
+	.pin-msg.err {
+		color: #f87171;
+	}
+	.pin-forgot {
+		margin-top: 1.6rem;
+		background: none;
+		border: none;
+		color: var(--text-faint);
+		font-size: 0.82rem;
+		text-decoration: underline;
+		cursor: pointer;
+	}
 
-  /* ---- vault reveal ---- */
-  .vault {
-    position: fixed; inset: 0; z-index: 2600; display: grid; place-items: center; cursor: pointer;
-    background: radial-gradient(60% 50% at 50% 50%, #14110a, #050505 70%);
-    overflow: hidden;
-  }
-  .vault-stage { position: relative; width: 300px; height: 300px; display: grid; place-items: center; perspective: 1100px; }
+	/* ---- vault reveal ---- */
+	.vault {
+		position: fixed;
+		inset: 0;
+		z-index: 2600;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		background: radial-gradient(60% 50% at 50% 50%, #14110a, #050505 70%);
+		overflow: hidden;
+	}
+	.vault-stage {
+		position: relative;
+		width: 300px;
+		height: 300px;
+		display: grid;
+		place-items: center;
+		perspective: 1100px;
+	}
 
-  /* full-screen gold flash, ABOVE everything, at the open moment */
-  .flash {
-    position: fixed; inset: 0; z-index: 50; pointer-events: none; opacity: 0;
-    background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.95), rgba(253,224,71,0.85) 22%, rgba(251,191,36,0.5) 42%, rgba(251,191,36,0) 70%);
-  }
-  .vault.open .flash { animation: flash 0.9s ease-out 0.15s; }
-  @keyframes flash {
-    0% { opacity: 0; }
-    18% { opacity: 1; }
-    100% { opacity: 0; }
-  }
+	/* full-screen gold flash, ABOVE everything, at the open moment */
+	.flash {
+		position: fixed;
+		inset: 0;
+		z-index: 50;
+		pointer-events: none;
+		opacity: 0;
+		background: radial-gradient(
+			circle at 50% 50%,
+			rgba(255, 255, 255, 0.95),
+			rgba(253, 224, 71, 0.85) 22%,
+			rgba(251, 191, 36, 0.5) 42%,
+			rgba(251, 191, 36, 0) 70%
+		);
+	}
+	.vault.open .flash {
+		animation: flash 0.9s ease-out 0.15s;
+	}
+	@keyframes flash {
+		0% {
+			opacity: 0;
+		}
+		18% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+		}
+	}
 
-  .reveal {
-    position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
-    gap: 6px; opacity: 0; transform: scale(0.9); transition: opacity 0.7s 0.45s, transform 0.7s 0.45s;
-  }
-  .vault.open .reveal { opacity: 1; transform: scale(1); }
-  .reveal-label { font-size: 0.85rem; letter-spacing: 0.18em; text-transform: uppercase; color: #b9962f; }
-  .reveal-amount {
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.6rem; color: #fde047;
-    text-shadow: 0 0 18px rgba(251,191,36,0.7), 0 0 40px rgba(251,191,36,0.4);
-  }
-  .reveal-go { margin-top: 1rem; font-size: 0.82rem; color: var(--text-faint); animation: pulse 1.4s ease-in-out infinite; }
-  @keyframes pulse { 0%,100% { opacity: 0.5; } 50% { opacity: 1; } }
+	.reveal {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		opacity: 0;
+		transform: scale(0.9);
+		transition:
+			opacity 0.7s 0.45s,
+			transform 0.7s 0.45s;
+	}
+	.vault.open .reveal {
+		opacity: 1;
+		transform: scale(1);
+	}
+	.reveal-label {
+		font-size: 0.85rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: #b9962f;
+	}
+	.reveal-amount {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2.6rem;
+		color: #fde047;
+		text-shadow:
+			0 0 18px rgba(251, 191, 36, 0.7),
+			0 0 40px rgba(251, 191, 36, 0.4);
+	}
+	.reveal-go {
+		margin-top: 1rem;
+		font-size: 0.82rem;
+		color: var(--text-faint);
+		animation: pulse 1.4s ease-in-out infinite;
+	}
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
 
-  /* circular safe door that swings open on a left hinge */
-  .door-hinge { position: absolute; inset: 0; transform-style: preserve-3d; }
-  .door {
-    position: absolute; inset: 0; display: grid; place-items: center; border-radius: 50%;
-    background: radial-gradient(circle at 38% 32%, #3a2f12, #1a1407 70%);
-    box-shadow: inset 0 0 0 10px rgba(251,191,36,0.18), inset 0 0 60px rgba(0,0,0,0.7), 0 18px 50px rgba(0,0,0,0.7);
-    transform-origin: left center;
-    transition: transform 1.15s cubic-bezier(0.55,0.06,0.2,1);
-  }
-  .door-ring {
-    position: absolute; inset: 20px; border-radius: 50%;
-    border: 6px solid rgba(251,191,36,0.45); box-shadow: inset 0 0 24px rgba(251,191,36,0.2);
-  }
-  .door-dial {
-    position: absolute; width: 96px; height: 96px; border-radius: 50%;
-    background: radial-gradient(circle at 40% 35%, #fbcf4b, #9a6f12);
-    box-shadow: 0 0 0 8px rgba(0,0,0,0.35), 0 6px 14px rgba(0,0,0,0.6);
-    transition: transform 0.85s cubic-bezier(0.5,0,0.2,1);
-  }
-  .spoke { position: absolute; top: 50%; left: 50%; width: 54px; height: 6px; border-radius: 3px;
-    background: linear-gradient(90deg, #7a5a0e, #fde047, #7a5a0e); transform-origin: 0 50%; }
-  .spoke:nth-child(1) { transform: translate(-50%,-50%) rotate(0deg); }
-  .spoke:nth-child(2) { transform: translate(-50%,-50%) rotate(60deg); }
-  .spoke:nth-child(3) { transform: translate(-50%,-50%) rotate(120deg); }
-  .door-coin { position: absolute; width: 70px; height: auto; opacity: 0.9; }
+	/* circular safe door that swings open on a left hinge */
+	.door-hinge {
+		position: absolute;
+		inset: 0;
+		transform-style: preserve-3d;
+	}
+	.door {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		border-radius: 50%;
+		background: radial-gradient(circle at 38% 32%, #3a2f12, #1a1407 70%);
+		box-shadow:
+			inset 0 0 0 10px rgba(251, 191, 36, 0.18),
+			inset 0 0 60px rgba(0, 0, 0, 0.7),
+			0 18px 50px rgba(0, 0, 0, 0.7);
+		transform-origin: left center;
+		transition: transform 1.15s cubic-bezier(0.55, 0.06, 0.2, 1);
+	}
+	.door-ring {
+		position: absolute;
+		inset: 20px;
+		border-radius: 50%;
+		border: 6px solid rgba(251, 191, 36, 0.45);
+		box-shadow: inset 0 0 24px rgba(251, 191, 36, 0.2);
+	}
+	.door-dial {
+		position: absolute;
+		width: 96px;
+		height: 96px;
+		border-radius: 50%;
+		background: radial-gradient(circle at 40% 35%, #fbcf4b, #9a6f12);
+		box-shadow:
+			0 0 0 8px rgba(0, 0, 0, 0.35),
+			0 6px 14px rgba(0, 0, 0, 0.6);
+		transition: transform 0.85s cubic-bezier(0.5, 0, 0.2, 1);
+	}
+	.spoke {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 54px;
+		height: 6px;
+		border-radius: 3px;
+		background: linear-gradient(90deg, #7a5a0e, #fde047, #7a5a0e);
+		transform-origin: 0 50%;
+	}
+	.spoke:nth-child(1) {
+		transform: translate(-50%, -50%) rotate(0deg);
+	}
+	.spoke:nth-child(2) {
+		transform: translate(-50%, -50%) rotate(60deg);
+	}
+	.spoke:nth-child(3) {
+		transform: translate(-50%, -50%) rotate(120deg);
+	}
+	.door-coin {
+		position: absolute;
+		width: 70px;
+		height: auto;
+		opacity: 0.9;
+	}
 
-  /* dial spins first, then the whole door swings outward revealing the balance */
-  .vault.open .door-dial { transform: rotate(540deg); }
-  .vault.open .door { transform: rotateY(-115deg); box-shadow: 0 18px 60px rgba(0,0,0,0.8); }
+	/* dial spins first, then the whole door swings outward revealing the balance */
+	.vault.open .door-dial {
+		transform: rotate(540deg);
+	}
+	.vault.open .door {
+		transform: rotateY(-115deg);
+		box-shadow: 0 18px 60px rgba(0, 0, 0, 0.8);
+	}
 </style>

--- a/src/lib/components/PinPad.svelte
+++ b/src/lib/components/PinPad.svelte
@@ -1,95 +1,173 @@
 <script>
-  import { createEventDispatcher } from 'svelte';
-  import { fx } from '$lib/sound.js';
+	import { createEventDispatcher } from 'svelte';
+	import { fx } from '$lib/sound.js';
 
-  export let length = 4;
-  export let error = false; // parent sets true to flash/shake
+	export let length = 4;
+	export let error = false; // parent sets true to flash/shake
 
-  const dispatch = createEventDispatcher();
-  let digits = '';
+	const dispatch = createEventDispatcher();
+	let digits = '';
 
-  export function reset() { digits = ''; }
+	export function reset() {
+		digits = '';
+	}
 
-  /** @param {string} d */
-  function press(d) {
-    if (digits.length >= length) return;
-    digits += d;
-    fx('tap');
-    dispatch('change', digits);
-    if (digits.length === length) dispatch('submit', digits);
-  }
-  function backspace() { if (digits.length) { digits = digits.slice(0, -1); fx('tap'); dispatch('change', digits); } }
-  function clearAll() { digits = ''; fx('tap'); dispatch('change', digits); }
-  function enter() { if (digits.length === length) dispatch('submit', digits); }
+	/** @param {string} d */
+	function press(d) {
+		if (digits.length >= length) return;
+		digits += d;
+		fx('tap');
+		dispatch('change', digits);
+		if (digits.length === length) dispatch('submit', digits);
+	}
+	function backspace() {
+		if (digits.length) {
+			digits = digits.slice(0, -1);
+			fx('tap');
+			dispatch('change', digits);
+		}
+	}
+	function clearAll() {
+		digits = '';
+		fx('tap');
+		dispatch('change', digits);
+	}
+	function enter() {
+		if (digits.length === length) dispatch('submit', digits);
+	}
 </script>
 
 <div class="pinpad" class:error>
-  <!-- entered-digit dots -->
-  <div class="dots">
-    {#each Array(length) as _, i}
-      <span class="dot" class:filled={i < digits.length}></span>
-    {/each}
-  </div>
+	<!-- entered-digit dots -->
+	<div class="dots">
+		{#each Array(length) as _, i}
+			<span class="dot" class:filled={i < digits.length}></span>
+		{/each}
+	</div>
 
-  <div class="keys">
-    <button class="key num" on:click={() => press('1')}>1</button>
-    <button class="key num" on:click={() => press('2')}>2</button>
-    <button class="key num" on:click={() => press('3')}>3</button>
-    <button class="key act cancel" on:click={clearAll} aria-label="Cancel">✕</button>
+	<div class="keys">
+		<button class="key num" on:click={() => press('1')}>1</button>
+		<button class="key num" on:click={() => press('2')}>2</button>
+		<button class="key num" on:click={() => press('3')}>3</button>
+		<button class="key act cancel" on:click={clearAll} aria-label="Cancel">✕</button>
 
-    <button class="key num" on:click={() => press('4')}>4</button>
-    <button class="key num" on:click={() => press('5')}>5</button>
-    <button class="key num" on:click={() => press('6')}>6</button>
-    <button class="key act clear" on:click={backspace} aria-label="Delete">⌫</button>
+		<button class="key num" on:click={() => press('4')}>4</button>
+		<button class="key num" on:click={() => press('5')}>5</button>
+		<button class="key num" on:click={() => press('6')}>6</button>
+		<button class="key act clear" on:click={backspace} aria-label="Delete">⌫</button>
 
-    <button class="key num" on:click={() => press('7')}>7</button>
-    <button class="key num" on:click={() => press('8')}>8</button>
-    <button class="key num" on:click={() => press('9')}>9</button>
-    <button class="key act enter" on:click={enter} aria-label="Enter">⏎</button>
+		<button class="key num" on:click={() => press('7')}>7</button>
+		<button class="key num" on:click={() => press('8')}>8</button>
+		<button class="key num" on:click={() => press('9')}>9</button>
+		<button class="key act enter" on:click={enter} aria-label="Enter">⏎</button>
 
-    <button class="key num zero" on:click={() => press('0')}>0</button>
-  </div>
+		<button class="key num zero" on:click={() => press('0')}>0</button>
+	</div>
 </div>
 
 <style>
-  .pinpad { width: 100%; max-width: 320px; margin: 0 auto; }
-  .dots { display: flex; justify-content: center; gap: 16px; margin-bottom: 22px; }
-  .dot {
-    width: 15px; height: 15px; border-radius: 50%;
-    border: 2px solid rgba(251, 191, 36, 0.5); background: transparent;
-    transition: transform 0.12s, background 0.15s, box-shadow 0.15s;
-  }
-  .dot.filled {
-    background: #fde047; border-color: #fde047;
-    box-shadow: 0 0 10px rgba(251, 191, 36, 0.8); transform: scale(1.08);
-  }
-  .pinpad.error .dots { animation: shake 0.4s; }
-  .pinpad.error .dot { border-color: #f87171; }
-  @keyframes shake {
-    0%,100% { transform: translateX(0); }
-    20%,60% { transform: translateX(-8px); }
-    40%,80% { transform: translateX(8px); }
-  }
+	.pinpad {
+		width: 100%;
+		max-width: 320px;
+		margin: 0 auto;
+	}
+	.dots {
+		display: flex;
+		justify-content: center;
+		gap: 16px;
+		margin-bottom: 22px;
+	}
+	.dot {
+		width: 15px;
+		height: 15px;
+		border-radius: 50%;
+		border: 2px solid rgba(251, 191, 36, 0.5);
+		background: transparent;
+		transition:
+			transform 0.12s,
+			background 0.15s,
+			box-shadow 0.15s;
+	}
+	.dot.filled {
+		background: #fde047;
+		border-color: #fde047;
+		box-shadow: 0 0 10px rgba(251, 191, 36, 0.8);
+		transform: scale(1.08);
+	}
+	.pinpad.error .dots {
+		animation: shake 0.4s;
+	}
+	.pinpad.error .dot {
+		border-color: #f87171;
+	}
+	@keyframes shake {
+		0%,
+		100% {
+			transform: translateX(0);
+		}
+		20%,
+		60% {
+			transform: translateX(-8px);
+		}
+		40%,
+		80% {
+			transform: translateX(8px);
+		}
+	}
 
-  .keys { display: grid; grid-template-columns: repeat(4, 1fr); gap: 9px; }
-  .key {
-    height: 56px; border-radius: 12px; cursor: pointer; position: relative;
-    font-family: 'Orbitron', var(--font-display); font-weight: 700; font-size: 22px;
-    border: 1px solid rgba(251, 191, 36, 0.3);
-    background: linear-gradient(160deg, #1c1f28, #0c0e13);
-    color: #f4e7c6;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), 0 2px 0 rgba(0,0,0,0.6), 0 4px 8px rgba(0,0,0,0.5);
-    transition: transform 0.1s, box-shadow 0.12s, border-color 0.15s;
-  }
-  .key:active {
-    transform: translateY(1px) scale(0.97);
-    border-color: #fde047;
-    box-shadow: 0 0 0 2px rgba(253,224,71,1), 0 0 16px rgba(251,191,36,0.9), 0 0 34px rgba(251,191,36,0.6);
-  }
-  .key.zero { grid-column: 1 / 4; }
-  /* ATM colored action keys */
-  .key.act { font-size: 18px; }
-  .key.cancel { background: linear-gradient(160deg, #f0584a, #b5311f); color: #fff; border-color: #b5311f; }
-  .key.clear  { background: linear-gradient(160deg, #f6c945, #c98f12); color: #2a2000; border-color: #c98f12; }
-  .key.enter  { background: linear-gradient(160deg, #46d07e, #1f9b4e); color: #3a2a00; border-color: #1f9b4e; }
+	.keys {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 9px;
+	}
+	.key {
+		height: 56px;
+		border-radius: 12px;
+		cursor: pointer;
+		position: relative;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 700;
+		font-size: 22px;
+		border: 1px solid rgba(251, 191, 36, 0.3);
+		background: linear-gradient(160deg, #1c1f28, #0c0e13);
+		color: #f4e7c6;
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.06),
+			0 2px 0 rgba(0, 0, 0, 0.6),
+			0 4px 8px rgba(0, 0, 0, 0.5);
+		transition:
+			transform 0.1s,
+			box-shadow 0.12s,
+			border-color 0.15s;
+	}
+	.key:active {
+		transform: translateY(1px) scale(0.97);
+		border-color: #fde047;
+		box-shadow:
+			0 0 0 2px rgba(253, 224, 71, 1),
+			0 0 16px rgba(251, 191, 36, 0.9),
+			0 0 34px rgba(251, 191, 36, 0.6);
+	}
+	.key.zero {
+		grid-column: 1 / 4;
+	}
+	/* ATM colored action keys */
+	.key.act {
+		font-size: 18px;
+	}
+	.key.cancel {
+		background: linear-gradient(160deg, #f0584a, #b5311f);
+		color: #fff;
+		border-color: #b5311f;
+	}
+	.key.clear {
+		background: linear-gradient(160deg, #f6c945, #c98f12);
+		color: #2a2000;
+		border-color: #c98f12;
+	}
+	.key.enter {
+		background: linear-gradient(160deg, #46d07e, #1f9b4e);
+		color: #3a2a00;
+		border-color: #1f9b4e;
+	}
 </style>

--- a/src/lib/components/PowerupHotbar.svelte
+++ b/src/lib/components/PowerupHotbar.svelte
@@ -1,143 +1,312 @@
 <script>
-  // ⚡ Power-up hotbar: 2 slots each side of the (fixed) Solve button.
-  // Pages through your mode-eligible inventory with ◀ ▶ arrows; duplicates show
-  // a count bubble. Filtering to "power-ups allowed in this game type" happens in
-  // the parent — this component just renders whatever `items` it's given.
-  import { createEventDispatcher, onDestroy } from 'svelte';
-  const dispatch = createEventDispatcher();
+	// ⚡ Power-up hotbar: 2 slots each side of the (fixed) Solve button.
+	// Pages through your mode-eligible inventory with ◀ ▶ arrows; duplicates show
+	// a count bubble. Filtering to "power-ups allowed in this game type" happens in
+	// the parent — this component just renders whatever `items` it's given.
+	import { createEventDispatcher, onDestroy } from 'svelte';
+	const dispatch = createEventDispatcher();
 
-  /** @type {{ id: string, emoji: string, name: string, blurb?: string, count?: number }[]} */
-  export let items = [];
-  export let busy = false;
-  /** Optional helper line under the bar (e.g. the Daily "keep it for ×1.5" nudge). */
-  export let hint = '';
+	/** @type {{ id: string, emoji: string, name: string, blurb?: string, count?: number }[]} */
+	export let items = [];
+	export let busy = false;
+	/** Optional helper line under the bar (e.g. the Daily "keep it for ×1.5" nudge). */
+	export let hint = '';
 
-  const PAGE = 4; // 2 left + 2 right
-  let page = 0;
-  // Clamp the page whenever the inventory shrinks/grows.
-  $: totalPages = Math.max(1, Math.ceil(items.length / PAGE));
-  $: if (page > totalPages - 1) page = totalPages - 1;
-  $: pageItems = items.slice(page * PAGE, page * PAGE + PAGE);
+	const PAGE = 4; // 2 left + 2 right
+	let page = 0;
+	// Clamp the page whenever the inventory shrinks/grows.
+	$: totalPages = Math.max(1, Math.ceil(items.length / PAGE));
+	$: if (page > totalPages - 1) page = totalPages - 1;
+	$: pageItems = items.slice(page * PAGE, page * PAGE + PAGE);
 
-  // Fill inner slots first so a few power-ups cluster symmetrically around Solve:
-  // [leftInner, rightInner, leftOuter, rightOuter].
-  $: leftCells = [pageItems[2] ?? null, pageItems[0] ?? null]; // [outer, inner]
-  $: rightCells = [pageItems[1] ?? null, pageItems[3] ?? null]; // [inner, outer]
+	// Fill inner slots first so a few power-ups cluster symmetrically around Solve:
+	// [leftInner, rightInner, leftOuter, rightOuter].
+	$: leftCells = [pageItems[2] ?? null, pageItems[0] ?? null]; // [outer, inner]
+	$: rightCells = [pageItems[1] ?? null, pageItems[3] ?? null]; // [inner, outer]
 
-  // Tap once → float the item name + "double tap to use" (2s); tap the same slot
-  // again within that window → actually use it. Prevents accidental one-tap use.
-  let armedId = /** @type {string|null} */ (null);
-  let floatMsg = '';
-  let floatKey = 0;
-  /** @type {ReturnType<typeof setTimeout>|undefined} */
-  let disarmTimer;
-  onDestroy(() => clearTimeout(disarmTimer));
+	// Tap once → float the item name + "double tap to use" (2s); tap the same slot
+	// again within that window → actually use it. Prevents accidental one-tap use.
+	let armedId = /** @type {string|null} */ (null);
+	let floatMsg = '';
+	let floatKey = 0;
+	/** @type {ReturnType<typeof setTimeout>|undefined} */
+	let disarmTimer;
+	onDestroy(() => clearTimeout(disarmTimer));
 
-  /** @param {any} cell */
-  function use(cell) {
-    if (!cell || busy) return;
-    if (armedId === cell.id) {
-      clearTimeout(disarmTimer);
-      armedId = null; floatMsg = '';
-      dispatch('use', cell);
-      return;
-    }
-    armedId = cell.id;
-    floatMsg = cell.name + ' · double tap to use';
-    floatKey++; // restart the float animation on each fresh tap
-    clearTimeout(disarmTimer);
-    disarmTimer = setTimeout(() => { armedId = null; floatMsg = ''; }, 2000);
-  }
-  /** @param {number} d */
-  function flip(d) {
-    page = Math.min(totalPages - 1, Math.max(0, page + d));
-  }
+	/** @param {any} cell */
+	function use(cell) {
+		if (!cell || busy) return;
+		if (armedId === cell.id) {
+			clearTimeout(disarmTimer);
+			armedId = null;
+			floatMsg = '';
+			dispatch('use', cell);
+			return;
+		}
+		armedId = cell.id;
+		floatMsg = cell.name + ' · double tap to use';
+		floatKey++; // restart the float animation on each fresh tap
+		clearTimeout(disarmTimer);
+		disarmTimer = setTimeout(() => {
+			armedId = null;
+			floatMsg = '';
+		}, 2000);
+	}
+	/** @param {number} d */
+	function flip(d) {
+		page = Math.min(totalPages - 1, Math.max(0, page + d));
+	}
 </script>
 
 {#if items.length}
-  <div class="ph-wrap">
-    {#if totalPages > 1}
-      <div class="ph-pager">
-        <button class="ph-arrow" on:click={() => flip(-1)} disabled={page === 0} aria-label="Previous power-ups">◀</button>
-        <span class="ph-dots">{page + 1}/{totalPages}</span>
-        <button class="ph-arrow" on:click={() => flip(1)} disabled={page === totalPages - 1} aria-label="More power-ups">▶</button>
-      </div>
-    {/if}
-    <div class="ph-bar">
-      <div class="ph-group">
-        {#each leftCells as cell}
-          {#if cell}
-            <button class="ph-slot filled" class:armed={armedId === cell.id} disabled={busy} on:click={() => use(cell)} title={cell.name + (cell.blurb ? ' — ' + cell.blurb : '')} aria-label={cell.name}>
-              <span class="ph-emoji">{cell.emoji}</span>
-              {#if (cell.count ?? 1) > 1}<span class="ph-count">{cell.count}</span>{/if}
-            </button>
-          {:else}
-            <span class="ph-slot empty" aria-hidden="true"></span>
-          {/if}
-        {/each}
-      </div>
-      <div class="ph-spacer" aria-hidden="true"></div>
-      <div class="ph-group">
-        {#each rightCells as cell}
-          {#if cell}
-            <button class="ph-slot filled" class:armed={armedId === cell.id} disabled={busy} on:click={() => use(cell)} title={cell.name + (cell.blurb ? ' — ' + cell.blurb : '')} aria-label={cell.name}>
-              <span class="ph-emoji">{cell.emoji}</span>
-              {#if (cell.count ?? 1) > 1}<span class="ph-count">{cell.count}</span>{/if}
-            </button>
-          {:else}
-            <span class="ph-slot empty" aria-hidden="true"></span>
-          {/if}
-        {/each}
-      </div>
-    </div>
-  </div>
-  {#if floatMsg}
-    {#key floatKey}
-      <div class="ph-float" aria-live="polite">{floatMsg}</div>
-    {/key}
-  {/if}
-  {#if hint}<div class="ph-hint">{@html hint}</div>{/if}
+	<div class="ph-wrap">
+		{#if totalPages > 1}
+			<div class="ph-pager">
+				<button
+					class="ph-arrow"
+					on:click={() => flip(-1)}
+					disabled={page === 0}
+					aria-label="Previous power-ups">◀</button
+				>
+				<span class="ph-dots">{page + 1}/{totalPages}</span>
+				<button
+					class="ph-arrow"
+					on:click={() => flip(1)}
+					disabled={page === totalPages - 1}
+					aria-label="More power-ups">▶</button
+				>
+			</div>
+		{/if}
+		<div class="ph-bar">
+			<div class="ph-group">
+				{#each leftCells as cell}
+					{#if cell}
+						<button
+							class="ph-slot filled"
+							class:armed={armedId === cell.id}
+							disabled={busy}
+							on:click={() => use(cell)}
+							title={cell.name + (cell.blurb ? ' — ' + cell.blurb : '')}
+							aria-label={cell.name}
+						>
+							<span class="ph-emoji">{cell.emoji}</span>
+							{#if (cell.count ?? 1) > 1}<span class="ph-count">{cell.count}</span>{/if}
+						</button>
+					{:else}
+						<span class="ph-slot empty" aria-hidden="true"></span>
+					{/if}
+				{/each}
+			</div>
+			<div class="ph-spacer" aria-hidden="true"></div>
+			<div class="ph-group">
+				{#each rightCells as cell}
+					{#if cell}
+						<button
+							class="ph-slot filled"
+							class:armed={armedId === cell.id}
+							disabled={busy}
+							on:click={() => use(cell)}
+							title={cell.name + (cell.blurb ? ' — ' + cell.blurb : '')}
+							aria-label={cell.name}
+						>
+							<span class="ph-emoji">{cell.emoji}</span>
+							{#if (cell.count ?? 1) > 1}<span class="ph-count">{cell.count}</span>{/if}
+						</button>
+					{:else}
+						<span class="ph-slot empty" aria-hidden="true"></span>
+					{/if}
+				{/each}
+			</div>
+		</div>
+	</div>
+	{#if floatMsg}
+		{#key floatKey}
+			<div class="ph-float" aria-live="polite">{floatMsg}</div>
+		{/key}
+	{/if}
+	{#if hint}<div class="ph-hint">{@html hint}</div>{/if}
 {/if}
 
 <style>
-  .ph-wrap { position: fixed; left: 50%; transform: translateX(-50%); z-index: 998; pointer-events: none;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 188px); display: flex; flex-direction: column; align-items: center; gap: 5px; }
-  .ph-pager { display: flex; align-items: center; gap: 10px; pointer-events: auto; }
-  .ph-arrow { width: 30px; height: 24px; border-radius: 8px; display: grid; place-items: center;
-    border: 1px solid var(--border-strong, rgba(255,255,255,0.18)); background: var(--surface-2, rgba(255,255,255,0.06));
-    color: var(--text); font-size: 0.72rem; cursor: pointer; }
-  .ph-arrow:disabled { opacity: 0.3; cursor: default; }
-  .ph-arrow:active:not(:disabled) { transform: scale(0.92); }
-  .ph-dots { font-size: 0.66rem; color: var(--text-faint); font-variant-numeric: tabular-nums; min-width: 26px; text-align: center; }
-  .ph-bar { display: flex; align-items: center; gap: 8px; }
-  .ph-group { display: flex; gap: 5px; pointer-events: auto; }
-  .ph-spacer { width: 200px; height: 46px; flex: none; } /* the Solve button overlays this */
-  .ph-slot { position: relative; width: 36px; height: 46px; border-radius: 11px; display: grid; place-items: center; box-sizing: border-box; }
-  .ph-slot.filled { cursor: pointer;
-    border: 1px solid rgba(253, 224, 71, 0.6); background: linear-gradient(135deg, rgba(251, 191, 36, 0.22), rgba(251, 191, 36, 0.05));
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2); animation: phPulse 1.8s ease-in-out infinite; }
-  .ph-slot.filled:active { transform: scale(0.93); }
-  .ph-slot.filled.armed { border-color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.55), 0 2px 8px rgba(0,0,0,0.4); animation: none; }
-  .ph-slot.filled:disabled { opacity: 0.5; cursor: default; animation: none; }
-  .ph-slot.empty { border: 1.5px solid rgba(255, 255, 255, 0.2); background: rgba(255, 255, 255, 0.05); box-shadow: inset 0 2px 7px rgba(0, 0, 0, 0.55); }
-  @keyframes phPulse { 0%,100% { box-shadow: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 0 rgba(251,191,36,0.5); } 50% { box-shadow: 0 2px 8px rgba(0,0,0,0.4), 0 0 0 5px rgba(251,191,36,0); } }
-  .ph-emoji { font-size: 1.3rem; line-height: 1; }
-  .ph-count { position: absolute; top: -5px; right: -5px; min-width: 16px; height: 16px; padding: 0 4px; border-radius: 999px;
-    background: #1f2937; border: 1px solid rgba(253,224,71,0.7); color: #fde047; font-family: var(--font-display); font-weight: 800;
-    font-size: 0.62rem; display: grid; place-items: center; }
-  .ph-hint { position: fixed; left: 50%; transform: translateX(-50%); z-index: 998; text-align: center; pointer-events: none;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 158px); font-size: 0.7rem; color: var(--text-muted); max-width: 320px; }
-  .ph-hint :global(b) { color: #6ee7b7; }
-  /* tap-once floating cue: item name + "double tap to use", drifts up and fades (~2s) */
-  .ph-float { position: fixed; left: 50%; z-index: 1001; pointer-events: none; white-space: nowrap;
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
-    color: #fff; font-weight: 700; font-size: 0.82rem; letter-spacing: 0.01em;
-    text-shadow: 0 1px 5px rgba(0,0,0,0.8), 0 0 12px rgba(0,0,0,0.5);
-    animation: phFloat 2s ease-out forwards; }
-  @keyframes phFloat {
-    0%   { opacity: 0; transform: translate(-50%, 12px); }
-    15%  { opacity: 1; transform: translate(-50%, 0); }
-    80%  { opacity: 1; transform: translate(-50%, -10px); }
-    100% { opacity: 0; transform: translate(-50%, -22px); }
-  }
+	.ph-wrap {
+		position: fixed;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 998;
+		pointer-events: none;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 188px);
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 5px;
+	}
+	.ph-pager {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		pointer-events: auto;
+	}
+	.ph-arrow {
+		width: 30px;
+		height: 24px;
+		border-radius: 8px;
+		display: grid;
+		place-items: center;
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.18));
+		background: var(--surface-2, rgba(255, 255, 255, 0.06));
+		color: var(--text);
+		font-size: 0.72rem;
+		cursor: pointer;
+	}
+	.ph-arrow:disabled {
+		opacity: 0.3;
+		cursor: default;
+	}
+	.ph-arrow:active:not(:disabled) {
+		transform: scale(0.92);
+	}
+	.ph-dots {
+		font-size: 0.66rem;
+		color: var(--text-faint);
+		font-variant-numeric: tabular-nums;
+		min-width: 26px;
+		text-align: center;
+	}
+	.ph-bar {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.ph-group {
+		display: flex;
+		gap: 5px;
+		pointer-events: auto;
+	}
+	.ph-spacer {
+		width: 200px;
+		height: 46px;
+		flex: none;
+	} /* the Solve button overlays this */
+	.ph-slot {
+		position: relative;
+		width: 36px;
+		height: 46px;
+		border-radius: 11px;
+		display: grid;
+		place-items: center;
+		box-sizing: border-box;
+	}
+	.ph-slot.filled {
+		cursor: pointer;
+		border: 1px solid rgba(253, 224, 71, 0.6);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.22), rgba(251, 191, 36, 0.05));
+		box-shadow:
+			0 2px 8px rgba(0, 0, 0, 0.4),
+			inset 0 1px 0 rgba(255, 255, 255, 0.2);
+		animation: phPulse 1.8s ease-in-out infinite;
+	}
+	.ph-slot.filled:active {
+		transform: scale(0.93);
+	}
+	.ph-slot.filled.armed {
+		border-color: #fff;
+		box-shadow:
+			0 0 0 2px rgba(255, 255, 255, 0.55),
+			0 2px 8px rgba(0, 0, 0, 0.4);
+		animation: none;
+	}
+	.ph-slot.filled:disabled {
+		opacity: 0.5;
+		cursor: default;
+		animation: none;
+	}
+	.ph-slot.empty {
+		border: 1.5px solid rgba(255, 255, 255, 0.2);
+		background: rgba(255, 255, 255, 0.05);
+		box-shadow: inset 0 2px 7px rgba(0, 0, 0, 0.55);
+	}
+	@keyframes phPulse {
+		0%,
+		100% {
+			box-shadow:
+				0 2px 8px rgba(0, 0, 0, 0.4),
+				0 0 0 0 rgba(251, 191, 36, 0.5);
+		}
+		50% {
+			box-shadow:
+				0 2px 8px rgba(0, 0, 0, 0.4),
+				0 0 0 5px rgba(251, 191, 36, 0);
+		}
+	}
+	.ph-emoji {
+		font-size: 1.3rem;
+		line-height: 1;
+	}
+	.ph-count {
+		position: absolute;
+		top: -5px;
+		right: -5px;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 4px;
+		border-radius: 999px;
+		background: #1f2937;
+		border: 1px solid rgba(253, 224, 71, 0.7);
+		color: #fde047;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.62rem;
+		display: grid;
+		place-items: center;
+	}
+	.ph-hint {
+		position: fixed;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 998;
+		text-align: center;
+		pointer-events: none;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 158px);
+		font-size: 0.7rem;
+		color: var(--text-muted);
+		max-width: 320px;
+	}
+	.ph-hint :global(b) {
+		color: #6ee7b7;
+	}
+	/* tap-once floating cue: item name + "double tap to use", drifts up and fades (~2s) */
+	.ph-float {
+		position: fixed;
+		left: 50%;
+		z-index: 1001;
+		pointer-events: none;
+		white-space: nowrap;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 246px);
+		color: #fff;
+		font-weight: 700;
+		font-size: 0.82rem;
+		letter-spacing: 0.01em;
+		text-shadow:
+			0 1px 5px rgba(0, 0, 0, 0.8),
+			0 0 12px rgba(0, 0, 0, 0.5);
+		animation: phFloat 2s ease-out forwards;
+	}
+	@keyframes phFloat {
+		0% {
+			opacity: 0;
+			transform: translate(-50%, 12px);
+		}
+		15% {
+			opacity: 1;
+			transform: translate(-50%, 0);
+		}
+		80% {
+			opacity: 1;
+			transform: translate(-50%, -10px);
+		}
+		100% {
+			opacity: 0;
+			transform: translate(-50%, -22px);
+		}
+	}
 </style>

--- a/src/lib/components/StandingStrip.svelte
+++ b/src/lib/components/StandingStrip.svelte
@@ -1,47 +1,91 @@
 <script>
-  // Compact challenge standing: just your rank vs FINISHED rivals (never the exact
-  // spend to beat) + a lead celebration. The money (left to spend + bar) lives in the
-  // top bankroll bar now. Hidden until at least one rival has finished.
-  import { fx } from '$lib/sound.js';
+	// Compact challenge standing: just your rank vs FINISHED rivals (never the exact
+	// spend to beat) + a lead celebration. The money (left to spend + bar) lives in the
+	// top bankroll bar now. Hidden until at least one rival has finished.
+	import { fx } from '$lib/sound.js';
 
-  /** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play', provisional?:boolean } | null} */
-  export let standing = null;
+	/** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play', provisional?:boolean } | null} */
+	export let standing = null;
 
-  let prevState;
-  function onStanding(/** @type {any} */ s) {
-    if (s && s.state === 'lead' && prevState && prevState !== 'lead') fx('lead');
-    prevState = s?.state;
-  }
-  $: onStanding(standing);
+	/** @type {string|undefined} */
+	let prevState;
+	function onStanding(/** @type {any} */ s) {
+		if (s && s.state === 'lead' && prevState && prevState !== 'lead') fx('lead');
+		prevState = s?.state;
+	}
+	$: onStanding(standing);
 
-  const ord = (/** @type {number} */ n) => { const s = ['th','st','nd','rd'], v = n % 100; return n + (s[(v - 20) % 10] || s[v] || s[0]); };
-  const medal = (/** @type {number} */ r) => r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
-  $: ranked = !!standing && standing.state !== 'first_to_play';
+	const ord = (/** @type {number} */ n) => {
+		const s = ['th', 'st', 'nd', 'rd'],
+			v = n % 100;
+		return n + (s[(v - 20) % 10] || s[v] || s[0]);
+	};
+	const medal = (/** @type {number} */ r) =>
+		r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
+	$: ranked = !!standing && standing.state !== 'first_to_play';
 </script>
 
 {#if ranked && standing}
-  {#key standing.state}
-    <div class="standing {standing.state}">
-      <span class="rank">{medal(standing.rank)} {ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar">so far</span>{/if}</span>
-      {#if standing.state === 'lead'}<span class="lead-badge">✓ In the lead</span>{/if}
-    </div>
-  {/key}
+	{#key standing.state}
+		<div class="standing {standing.state}">
+			<span class="rank"
+				>{medal(standing.rank)}
+				{ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar"
+						>so far</span
+					>{/if}</span
+			>
+			{#if standing.state === 'lead'}<span class="lead-badge">✓ In the lead</span>{/if}
+		</div>
+	{/key}
 {/if}
 
 <style>
-  .standing {
-    display: flex; align-items: center; justify-content: center; gap: 10px;
-    max-width: 360px; margin: 0 auto 6px; padding: 6px 14px; border-radius: 11px;
-    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
-    background: var(--surface, rgba(255, 255, 255, 0.05));
-    font-family: var(--font-display, sans-serif); font-weight: 700; font-size: 0.9rem; color: var(--text, #fff);
-    animation: stPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
-  }
-  @keyframes stPop { from { transform: scale(0.96); opacity: 0.5; } to { transform: scale(1); opacity: 1; } }
-  .sofar { margin-left: 6px; font-family: var(--font-ui, sans-serif); font-weight: 600; font-size: 0.62rem;
-    text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint, #8090a0); }
-  .lead-badge { font-size: 0.78rem; font-weight: 700; color: #7ee0a8; }
-  .standing.lead { border-color: rgba(126, 224, 168, 0.5);
-    background: linear-gradient(135deg, rgba(126, 224, 168, 0.13), rgba(126, 224, 168, 0.04)); }
-  .standing.behind { border-color: rgba(251, 191, 36, 0.45); }
+	.standing {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		max-width: 360px;
+		margin: 0 auto 6px;
+		padding: 6px 14px;
+		border-radius: 11px;
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		font-family: var(--font-display, sans-serif);
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: var(--text, #fff);
+		animation: stPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes stPop {
+		from {
+			transform: scale(0.96);
+			opacity: 0.5;
+		}
+		to {
+			transform: scale(1);
+			opacity: 1;
+		}
+	}
+	.sofar {
+		margin-left: 6px;
+		font-family: var(--font-ui, sans-serif);
+		font-weight: 600;
+		font-size: 0.62rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-faint, #8090a0);
+	}
+	.lead-badge {
+		font-size: 0.78rem;
+		font-weight: 700;
+		color: #7ee0a8;
+	}
+	.standing.lead {
+		border-color: rgba(126, 224, 168, 0.5);
+		background: linear-gradient(135deg, rgba(126, 224, 168, 0.13), rgba(126, 224, 168, 0.04));
+	}
+	.standing.behind {
+		border-color: rgba(251, 191, 36, 0.45);
+	}
 </style>

--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -1,72 +1,91 @@
 <script>
-  import { goto } from '$app/navigation';
-  import { toasts, dismissToast, requestInbox } from '$lib/stores/notificationStore.js';
-  import { fx } from '$lib/sound.js';
+	import { goto } from '$app/navigation';
+	import { toasts, dismissToast, requestInbox } from '$lib/stores/notificationStore.js';
+	import { fx } from '$lib/sound.js';
 
-  /** @param {any} t */
-  function open(t) {
-    fx('select');
-    dismissToast(t.id);
-    // Your-turn challenge → home Community ▸ Challenges; everything else (results,
-    // sabotage, chat, friend requests) → your alerts inbox in Profile.
-    if (t.type === 'challenge_incoming') { goto('/'); requestInbox('challenges'); }
-    else goto('/profile?tab=alerts');
-  }
+	/** @param {any} t */
+	function open(t) {
+		fx('select');
+		dismissToast(t.id);
+		// Your-turn challenge → home Community ▸ Challenges; everything else (results,
+		// sabotage, chat, friend requests) → your alerts inbox in Profile.
+		if (t.type === 'challenge_incoming') {
+			goto('/');
+			requestInbox('challenges');
+		} else goto('/profile?tab=alerts');
+	}
 </script>
 
 <div class="toaster" aria-live="polite">
-  {#each $toasts as t (t.id)}
-    <button class="toast" on:click={() => open(t)}>
-      <span class="t-title">{t.title}</span>
-      <span class="t-body">{t.body}</span>
-      <span class="t-x" role="presentation" on:click|stopPropagation={() => dismissToast(t.id)}>✕</span>
-    </button>
-  {/each}
+	{#each $toasts as t (t.id)}
+		<button class="toast" on:click={() => open(t)}>
+			<span class="t-title">{t.title}</span>
+			<span class="t-body">{t.body}</span>
+			<span class="t-x" role="presentation" on:click|stopPropagation={() => dismissToast(t.id)}
+				>✕</span
+			>
+		</button>
+	{/each}
 </div>
 
 <style>
-  .toaster {
-    position: fixed;
-    top: max(10px, env(safe-area-inset-top));
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 5000;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    width: calc(100% - 24px);
-    max-width: 420px;
-    pointer-events: none;
-  }
-  .toast {
-    pointer-events: auto;
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    text-align: left;
-    padding: 12px 34px 12px 14px;
-    border-radius: 14px;
-    border: 1px solid rgba(253, 224, 71, 0.4);
-    background: linear-gradient(135deg, rgba(20, 26, 38, 0.96), rgba(16, 22, 32, 0.96));
-    box-shadow: 0 14px 36px rgba(0, 0, 0, 0.45), 0 0 18px rgba(251, 191, 36, 0.18);
-    color: var(--text, #fff);
-    cursor: pointer;
-    backdrop-filter: blur(8px);
-    animation: toastIn 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
-  }
-  @keyframes toastIn {
-    from { transform: translateY(-14px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
-  }
-  .t-title { font-family: var(--font-display, sans-serif); font-weight: 800; font-size: 0.95rem; }
-  .t-body { font-size: 0.82rem; color: var(--text-muted, #c2cbd8); }
-  .t-x {
-    position: absolute;
-    top: 8px;
-    right: 10px;
-    font-size: 0.8rem;
-    color: var(--text-faint, #6b7686);
-    line-height: 1;
-  }
+	.toaster {
+		position: fixed;
+		top: max(10px, env(safe-area-inset-top));
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 5000;
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		width: calc(100% - 24px);
+		max-width: 420px;
+		pointer-events: none;
+	}
+	.toast {
+		pointer-events: auto;
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		text-align: left;
+		padding: 12px 34px 12px 14px;
+		border-radius: 14px;
+		border: 1px solid rgba(253, 224, 71, 0.4);
+		background: linear-gradient(135deg, rgba(20, 26, 38, 0.96), rgba(16, 22, 32, 0.96));
+		box-shadow:
+			0 14px 36px rgba(0, 0, 0, 0.45),
+			0 0 18px rgba(251, 191, 36, 0.18);
+		color: var(--text, #fff);
+		cursor: pointer;
+		backdrop-filter: blur(8px);
+		animation: toastIn 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes toastIn {
+		from {
+			transform: translateY(-14px);
+			opacity: 0;
+		}
+		to {
+			transform: translateY(0);
+			opacity: 1;
+		}
+	}
+	.t-title {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 800;
+		font-size: 0.95rem;
+	}
+	.t-body {
+		font-size: 0.82rem;
+		color: var(--text-muted, #c2cbd8);
+	}
+	.t-x {
+		position: absolute;
+		top: 8px;
+		right: 10px;
+		font-size: 0.8rem;
+		color: var(--text-faint, #6b7686);
+		line-height: 1;
+	}
 </style>

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -1,220 +1,251 @@
 <script>
-  import { createEventDispatcher } from 'svelte';
-  import { fx } from '$lib/sound.js';
+	import { createEventDispatcher } from 'svelte';
+	import { fx } from '$lib/sound.js';
 
-  const dispatch = createEventDispatcher();
+	const dispatch = createEventDispatcher();
 
-  const steps = [
-    {
-      icon: '💰',
-      title: 'Spend less, think more',
-      body: 'Crack the hidden phrase buying as few letters as you can.'
-    },
-    {
-      icon: '🔤',
-      title: 'Buy letters',
-      body: 'Tap a letter to buy every copy. Wrong letters still cost you. Guessing the phrase is free — unlimited tries.'
-    },
-    {
-      icon: '💵',
-      title: 'Cash is your score',
-      isNew: true,
-      body: 'Start with $2,000 — your balance and your leaderboard rank. Spend it smart.'
-    },
-    {
-      icon: '📅',
-      title: 'Daily paycheck',
-      isNew: true,
-      body: 'One puzzle a day for everyone. Just showing up pays — more for a streak.'
-    },
-    {
-      icon: '🧗',
-      title: 'Cash Game & Challenges',
-      isNew: true,
-      body: 'Endless puzzles for Cash, or wager friends — spend the least to take the pot.'
-    }
-  ];
+	const steps = [
+		{
+			icon: '💰',
+			title: 'Spend less, think more',
+			body: 'Crack the hidden phrase buying as few letters as you can.'
+		},
+		{
+			icon: '🔤',
+			title: 'Buy letters',
+			body: 'Tap a letter to buy every copy. Wrong letters still cost you. Guessing the phrase is free — unlimited tries.'
+		},
+		{
+			icon: '💵',
+			title: 'Cash is your score',
+			isNew: true,
+			body: 'Start with $2,000 — your balance and your leaderboard rank. Spend it smart.'
+		},
+		{
+			icon: '📅',
+			title: 'Daily paycheck',
+			isNew: true,
+			body: 'One puzzle a day for everyone. Just showing up pays — more for a streak.'
+		},
+		{
+			icon: '🧗',
+			title: 'Cash Game & Challenges',
+			isNew: true,
+			body: 'Endless puzzles for Cash, or wager friends — spend the least to take the pot.'
+		}
+	];
 
-  let i = 0;
-  $: step = steps[i];
-  $: last = i === steps.length - 1;
+	let i = 0;
+	$: step = steps[i];
+	$: last = i === steps.length - 1;
 
-  function next() {
-    fx('tap');
-    if (last) dispatch('close');
-    else i += 1;
-  }
-  function back() {
-    fx('tap');
-    if (i > 0) i -= 1;
-  }
-  function skip() {
-    dispatch('close');
-  }
+	function next() {
+		fx('tap');
+		if (last) dispatch('close');
+		else i += 1;
+	}
+	function back() {
+		fx('tap');
+		if (i > 0) i -= 1;
+	}
+	function skip() {
+		dispatch('close');
+	}
 </script>
 
 <div class="tut-overlay" role="dialog" aria-modal="true" aria-label="How to play WordBank">
-  <div class="tut-card">
-    <button class="tut-skip" on:click={skip}>Skip</button>
+	<div class="tut-card">
+		<button class="tut-skip" on:click={skip}>Skip</button>
 
-    {#key i}
-      {#if step.isNew}<span class="tut-new">NEW</span>{/if}
-      <div class="tut-icon">{step.icon}</div>
-      <h2 class="tut-title">{step.title}</h2>
-      <p class="tut-body">{step.body}</p>
-    {/key}
+		{#key i}
+			{#if step.isNew}<span class="tut-new">NEW</span>{/if}
+			<div class="tut-icon">{step.icon}</div>
+			<h2 class="tut-title">{step.title}</h2>
+			<p class="tut-body">{step.body}</p>
+		{/key}
 
-    <div class="tut-dots">
-      {#each steps as _, d}
-        <span class="tut-dot" class:active={d === i}></span>
-      {/each}
-    </div>
+		<div class="tut-dots">
+			{#each steps as _, d}
+				<span class="tut-dot" class:active={d === i}></span>
+			{/each}
+		</div>
 
-    <div class="tut-actions">
-      {#if i > 0}
-        <button class="tut-btn ghost" on:click={back}>Back</button>
-      {/if}
-      <button class="tut-btn primary" on:click={next}>{last ? 'Play →' : 'Next'}</button>
-    </div>
-  </div>
+		<div class="tut-actions">
+			{#if i > 0}
+				<button class="tut-btn ghost" on:click={back}>Back</button>
+			{/if}
+			<button class="tut-btn primary" on:click={next}>{last ? 'Play →' : 'Next'}</button>
+		</div>
+	</div>
 </div>
 
 <style>
-  .tut-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 3000;
-    display: grid;
-    place-items: center;
-    padding: 20px;
-    background: rgba(4, 8, 14, 0.72);
-    backdrop-filter: blur(8px);
-    animation: tutFade 0.25s ease;
-  }
-  @keyframes tutFade {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
+	.tut-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 3000;
+		display: grid;
+		place-items: center;
+		padding: 20px;
+		background: rgba(4, 8, 14, 0.72);
+		backdrop-filter: blur(8px);
+		animation: tutFade 0.25s ease;
+	}
+	@keyframes tutFade {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
 
-  .tut-card {
-    position: relative;
-    width: 100%;
-    max-width: 380px;
-    padding: 30px 24px 22px;
-    border-radius: var(--r-lg, 20px);
-    background: var(--surface-strong, rgba(20, 26, 38, 0.9));
-    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
-    box-shadow: var(--shadow-lg, 0 24px 60px rgba(0, 0, 0, 0.5)), var(--glow-brand, 0 0 30px rgba(251, 191, 36, 0.25));
-    text-align: center;
-    animation: tutPop 0.3s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
-  }
-  @keyframes tutPop {
-    from { transform: translateY(14px) scale(0.96); opacity: 0; }
-    to { transform: translateY(0) scale(1); opacity: 1; }
-  }
+	.tut-card {
+		position: relative;
+		width: 100%;
+		max-width: 380px;
+		padding: 30px 24px 22px;
+		border-radius: var(--r-lg, 20px);
+		background: var(--surface-strong, rgba(20, 26, 38, 0.9));
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow:
+			var(--shadow-lg, 0 24px 60px rgba(0, 0, 0, 0.5)),
+			var(--glow-brand, 0 0 30px rgba(251, 191, 36, 0.25));
+		text-align: center;
+		animation: tutPop 0.3s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+	}
+	@keyframes tutPop {
+		from {
+			transform: translateY(14px) scale(0.96);
+			opacity: 0;
+		}
+		to {
+			transform: translateY(0) scale(1);
+			opacity: 1;
+		}
+	}
 
-  .tut-skip {
-    position: absolute;
-    top: 12px;
-    right: 14px;
-    background: none;
-    border: none;
-    color: var(--text-muted, #9aa6b8);
-    font-family: var(--font-ui, sans-serif);
-    font-size: 0.78rem;
-    font-weight: 600;
-    cursor: pointer;
-    padding: 4px 6px;
-  }
-  .tut-skip:hover { color: var(--text, #fff); }
+	.tut-skip {
+		position: absolute;
+		top: 12px;
+		right: 14px;
+		background: none;
+		border: none;
+		color: var(--text-muted, #9aa6b8);
+		font-family: var(--font-ui, sans-serif);
+		font-size: 0.78rem;
+		font-weight: 600;
+		cursor: pointer;
+		padding: 4px 6px;
+	}
+	.tut-skip:hover {
+		color: var(--text, #fff);
+	}
 
-  .tut-new {
-    display: inline-block;
-    margin-bottom: 8px;
-    padding: 3px 10px;
-    border-radius: 999px;
-    font-family: var(--font-display, sans-serif);
-    font-size: 0.68rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    color: #3a2a00;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-  }
-  .tut-icon {
-    font-size: 3rem;
-    line-height: 1;
-    margin: 4px 0 14px;
-    animation: tutIcon 0.4s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
-  }
-  @keyframes tutIcon {
-    from { transform: scale(0.4) rotate(-12deg); opacity: 0; }
-    to { transform: scale(1) rotate(0); opacity: 1; }
-  }
+	.tut-new {
+		display: inline-block;
+		margin-bottom: 8px;
+		padding: 3px 10px;
+		border-radius: 999px;
+		font-family: var(--font-display, sans-serif);
+		font-size: 0.68rem;
+		font-weight: 800;
+		letter-spacing: 0.08em;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.tut-icon {
+		font-size: 3rem;
+		line-height: 1;
+		margin: 4px 0 14px;
+		animation: tutIcon 0.4s var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+	}
+	@keyframes tutIcon {
+		from {
+			transform: scale(0.4) rotate(-12deg);
+			opacity: 0;
+		}
+		to {
+			transform: scale(1) rotate(0);
+			opacity: 1;
+		}
+	}
 
-  .tut-title {
-    font-family: var(--font-display, sans-serif);
-    font-size: 1.4rem;
-    font-weight: 700;
-    margin: 0 0 10px;
-    color: var(--text, #fff);
-  }
-  .tut-body {
-    font-family: var(--font-ui, sans-serif);
-    font-size: 0.95rem;
-    line-height: 1.5;
-    color: var(--text-muted, #c2cbd8);
-    margin: 0 auto 20px;
-    max-width: 320px;
-    min-height: 4.5em;
-  }
+	.tut-title {
+		font-family: var(--font-display, sans-serif);
+		font-size: 1.4rem;
+		font-weight: 700;
+		margin: 0 0 10px;
+		color: var(--text, #fff);
+	}
+	.tut-body {
+		font-family: var(--font-ui, sans-serif);
+		font-size: 0.95rem;
+		line-height: 1.5;
+		color: var(--text-muted, #c2cbd8);
+		margin: 0 auto 20px;
+		max-width: 320px;
+		min-height: 4.5em;
+	}
 
-  .tut-dots {
-    display: flex;
-    justify-content: center;
-    gap: 7px;
-    margin-bottom: 20px;
-  }
-  .tut-dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 999px;
-    background: var(--border-strong, rgba(255, 255, 255, 0.2));
-    transition: all 0.2s ease;
-  }
-  .tut-dot.active {
-    width: 22px;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-  }
+	.tut-dots {
+		display: flex;
+		justify-content: center;
+		gap: 7px;
+		margin-bottom: 20px;
+	}
+	.tut-dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 999px;
+		background: var(--border-strong, rgba(255, 255, 255, 0.2));
+		transition: all 0.2s ease;
+	}
+	.tut-dot.active {
+		width: 22px;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
 
-  .tut-actions {
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-  }
-  .tut-btn {
-    flex: 1;
-    max-width: 160px;
-    height: 46px;
-    border-radius: 14px;
-    font-family: var(--font-display, sans-serif);
-    font-size: 1rem;
-    font-weight: 700;
-    cursor: pointer;
-    transition: transform 0.16s var(--ease-spring, ease), filter 0.2s;
-  }
-  .tut-btn.primary {
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-    color: #3a2a00;
-    border: none;
-    box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36, 0.35));
-  }
-  .tut-btn.primary:hover { transform: translateY(-2px); filter: brightness(1.05); }
-  .tut-btn.primary:active { transform: scale(0.97); }
-  .tut-btn.ghost {
-    background: var(--surface-2, rgba(255, 255, 255, 0.06));
-    color: var(--text, #fff);
-    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
-  }
-  .tut-btn.ghost:hover { transform: translateY(-1px); }
-  .tut-btn.ghost:active { transform: scale(0.97); }
+	.tut-actions {
+		display: flex;
+		gap: 10px;
+		justify-content: center;
+	}
+	.tut-btn {
+		flex: 1;
+		max-width: 160px;
+		height: 46px;
+		border-radius: 14px;
+		font-family: var(--font-display, sans-serif);
+		font-size: 1rem;
+		font-weight: 700;
+		cursor: pointer;
+		transition:
+			transform 0.16s var(--ease-spring, ease),
+			filter 0.2s;
+	}
+	.tut-btn.primary {
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		color: #3a2a00;
+		border: none;
+		box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36, 0.35));
+	}
+	.tut-btn.primary:hover {
+		transform: translateY(-2px);
+		filter: brightness(1.05);
+	}
+	.tut-btn.primary:active {
+		transform: scale(0.97);
+	}
+	.tut-btn.ghost {
+		background: var(--surface-2, rgba(255, 255, 255, 0.06));
+		color: var(--text, #fff);
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+	}
+	.tut-btn.ghost:hover {
+		transform: translateY(-1px);
+	}
+	.tut-btn.ghost:active {
+		transform: scale(0.97);
+	}
 </style>

--- a/src/lib/components/VaultReveal.svelte
+++ b/src/lib/components/VaultReveal.svelte
@@ -1,85 +1,218 @@
 <script>
-  // 🔐 Vault door-open flourish (same feel as the login balance reveal), but it
-  // opens the safe and then hands you off to your items. Auto-advances; tap to skip.
-  import { createEventDispatcher, onMount } from 'svelte';
-  import { fx } from '$lib/sound.js';
-  const dispatch = createEventDispatcher();
+	// 🔐 Vault door-open flourish (same feel as the login balance reveal), but it
+	// opens the safe and then hands you off to your items. Auto-advances; tap to skip.
+	import { createEventDispatcher, onMount } from 'svelte';
+	import { fx } from '$lib/sound.js';
+	const dispatch = createEventDispatcher();
 
-  let doorOpen = false;
-  onMount(() => {
-    const t1 = setTimeout(() => { doorOpen = true; fx('vault'); }, 480);
-    const t2 = setTimeout(() => dispatch('done'), 1850); // hand off to the items
-    return () => { clearTimeout(t1); clearTimeout(t2); };
-  });
-  function skip() { dispatch('done'); }
+	let doorOpen = false;
+	onMount(() => {
+		const t1 = setTimeout(() => {
+			doorOpen = true;
+			fx('vault');
+		}, 480);
+		const t2 = setTimeout(() => dispatch('done'), 1850); // hand off to the items
+		return () => {
+			clearTimeout(t1);
+			clearTimeout(t2);
+		};
+	});
+	function skip() {
+		dispatch('done');
+	}
 </script>
 
-<div class="vault" class:open={doorOpen} on:click={skip} role="button" tabindex="0"
-     on:keydown={(e) => { if (e.key === 'Enter' || e.key === 'Escape') skip(); }}>
-  <div class="vault-stage">
-    <div class="reveal">
-      <span class="reveal-amount">Unlocked</span>
-    </div>
-    <div class="door-hinge">
-      <div class="door">
-        <div class="door-ring"></div>
-        <div class="door-dial"><span class="spoke"></span><span class="spoke"></span><span class="spoke"></span></div>
-        <img class="door-coin" src="/logo-coin.png" alt="" />
-      </div>
-    </div>
-  </div>
-  <div class="flash"></div>
+<div
+	class="vault"
+	class:open={doorOpen}
+	on:click={skip}
+	role="button"
+	tabindex="0"
+	on:keydown={(e) => {
+		if (e.key === 'Enter' || e.key === 'Escape') skip();
+	}}
+>
+	<div class="vault-stage">
+		<div class="reveal">
+			<span class="reveal-amount">Unlocked</span>
+		</div>
+		<div class="door-hinge">
+			<div class="door">
+				<div class="door-ring"></div>
+				<div class="door-dial">
+					<span class="spoke"></span><span class="spoke"></span><span class="spoke"></span>
+				</div>
+				<img class="door-coin" src="/logo-coin.png" alt="" />
+			</div>
+		</div>
+	</div>
+	<div class="flash"></div>
 </div>
 
 <style>
-  .vault {
-    position: fixed; inset: 0; z-index: 6500; display: grid; place-items: center; cursor: pointer;
-    background: radial-gradient(60% 50% at 50% 50%, #14110a, #050505 70%); overflow: hidden;
-  }
-  .vault-stage { position: relative; width: 300px; height: 300px; display: grid; place-items: center; perspective: 1100px; }
-  .flash {
-    position: fixed; inset: 0; z-index: 50; pointer-events: none; opacity: 0;
-    background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.95), rgba(253,224,71,0.85) 22%, rgba(251,191,36,0.5) 42%, rgba(251,191,36,0) 70%);
-  }
-  .vault.open .flash { animation: flash 0.9s ease-out 0.15s; }
-  @keyframes flash { 0% { opacity: 0; } 18% { opacity: 1; } 100% { opacity: 0; } }
+	.vault {
+		position: fixed;
+		inset: 0;
+		z-index: 6500;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		background: radial-gradient(60% 50% at 50% 50%, #14110a, #050505 70%);
+		overflow: hidden;
+	}
+	.vault-stage {
+		position: relative;
+		width: 300px;
+		height: 300px;
+		display: grid;
+		place-items: center;
+		perspective: 1100px;
+	}
+	.flash {
+		position: fixed;
+		inset: 0;
+		z-index: 50;
+		pointer-events: none;
+		opacity: 0;
+		background: radial-gradient(
+			circle at 50% 50%,
+			rgba(255, 255, 255, 0.95),
+			rgba(253, 224, 71, 0.85) 22%,
+			rgba(251, 191, 36, 0.5) 42%,
+			rgba(251, 191, 36, 0) 70%
+		);
+	}
+	.vault.open .flash {
+		animation: flash 0.9s ease-out 0.15s;
+	}
+	@keyframes flash {
+		0% {
+			opacity: 0;
+		}
+		18% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+		}
+	}
 
-  .reveal {
-    position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center;
-    gap: 6px; opacity: 0; transform: scale(0.9); transition: opacity 0.6s 0.4s, transform 0.6s 0.4s;
-  }
-  .vault.open .reveal { opacity: 1; transform: scale(1); }
-  .reveal-label { font-size: 0.85rem; letter-spacing: 0.18em; text-transform: uppercase; color: #b9962f; }
-  .reveal-amount {
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.2rem; color: #fde047;
-    text-shadow: 0 0 18px rgba(251,191,36,0.7), 0 0 40px rgba(251,191,36,0.4);
-  }
-  .reveal-go { margin-top: 1rem; font-size: 0.82rem; color: var(--text-faint); animation: pulse 1.4s ease-in-out infinite; }
-  @keyframes pulse { 0%,100% { opacity: 0.5; } 50% { opacity: 1; } }
+	.reveal {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		opacity: 0;
+		transform: scale(0.9);
+		transition:
+			opacity 0.6s 0.4s,
+			transform 0.6s 0.4s;
+	}
+	.vault.open .reveal {
+		opacity: 1;
+		transform: scale(1);
+	}
+	.reveal-label {
+		font-size: 0.85rem;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		color: #b9962f;
+	}
+	.reveal-amount {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2.2rem;
+		color: #fde047;
+		text-shadow:
+			0 0 18px rgba(251, 191, 36, 0.7),
+			0 0 40px rgba(251, 191, 36, 0.4);
+	}
+	.reveal-go {
+		margin-top: 1rem;
+		font-size: 0.82rem;
+		color: var(--text-faint);
+		animation: pulse 1.4s ease-in-out infinite;
+	}
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
 
-  .door-hinge { position: absolute; inset: 0; transform-style: preserve-3d; }
-  .door {
-    position: absolute; inset: 0; display: grid; place-items: center; border-radius: 50%;
-    background: radial-gradient(circle at 38% 32%, #3a2f12, #1a1407 70%);
-    box-shadow: inset 0 0 0 10px rgba(251,191,36,0.18), inset 0 0 60px rgba(0,0,0,0.7), 0 18px 50px rgba(0,0,0,0.7);
-    transform-origin: left center; transition: transform 1.15s cubic-bezier(0.55,0.06,0.2,1);
-  }
-  .door-ring {
-    position: absolute; inset: 20px; border-radius: 50%;
-    border: 6px solid rgba(251,191,36,0.45); box-shadow: inset 0 0 24px rgba(251,191,36,0.2);
-  }
-  .door-dial {
-    position: absolute; width: 96px; height: 96px; border-radius: 50%;
-    background: radial-gradient(circle at 40% 35%, #fbcf4b, #9a6f12);
-    box-shadow: 0 0 0 8px rgba(0,0,0,0.35), 0 6px 14px rgba(0,0,0,0.6);
-    transition: transform 0.85s cubic-bezier(0.5,0,0.2,1);
-  }
-  .spoke { position: absolute; top: 50%; left: 50%; width: 54px; height: 6px; border-radius: 3px;
-    background: linear-gradient(90deg, #7a5a0e, #fde047, #7a5a0e); transform-origin: 0 50%; }
-  .spoke:nth-child(1) { transform: translate(-50%,-50%) rotate(0deg); }
-  .spoke:nth-child(2) { transform: translate(-50%,-50%) rotate(60deg); }
-  .spoke:nth-child(3) { transform: translate(-50%,-50%) rotate(120deg); }
-  .door-coin { position: absolute; width: 70px; height: auto; opacity: 0.9; }
-  .vault.open .door-dial { transform: rotate(540deg); }
-  .vault.open .door { transform: rotateY(-115deg); box-shadow: 0 18px 60px rgba(0,0,0,0.8); }
+	.door-hinge {
+		position: absolute;
+		inset: 0;
+		transform-style: preserve-3d;
+	}
+	.door {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		border-radius: 50%;
+		background: radial-gradient(circle at 38% 32%, #3a2f12, #1a1407 70%);
+		box-shadow:
+			inset 0 0 0 10px rgba(251, 191, 36, 0.18),
+			inset 0 0 60px rgba(0, 0, 0, 0.7),
+			0 18px 50px rgba(0, 0, 0, 0.7);
+		transform-origin: left center;
+		transition: transform 1.15s cubic-bezier(0.55, 0.06, 0.2, 1);
+	}
+	.door-ring {
+		position: absolute;
+		inset: 20px;
+		border-radius: 50%;
+		border: 6px solid rgba(251, 191, 36, 0.45);
+		box-shadow: inset 0 0 24px rgba(251, 191, 36, 0.2);
+	}
+	.door-dial {
+		position: absolute;
+		width: 96px;
+		height: 96px;
+		border-radius: 50%;
+		background: radial-gradient(circle at 40% 35%, #fbcf4b, #9a6f12);
+		box-shadow:
+			0 0 0 8px rgba(0, 0, 0, 0.35),
+			0 6px 14px rgba(0, 0, 0, 0.6);
+		transition: transform 0.85s cubic-bezier(0.5, 0, 0.2, 1);
+	}
+	.spoke {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 54px;
+		height: 6px;
+		border-radius: 3px;
+		background: linear-gradient(90deg, #7a5a0e, #fde047, #7a5a0e);
+		transform-origin: 0 50%;
+	}
+	.spoke:nth-child(1) {
+		transform: translate(-50%, -50%) rotate(0deg);
+	}
+	.spoke:nth-child(2) {
+		transform: translate(-50%, -50%) rotate(60deg);
+	}
+	.spoke:nth-child(3) {
+		transform: translate(-50%, -50%) rotate(120deg);
+	}
+	.door-coin {
+		position: absolute;
+		width: 70px;
+		height: auto;
+		opacity: 0.9;
+	}
+	.vault.open .door-dial {
+		transform: rotate(540deg);
+	}
+	.vault.open .door {
+		transform: rotateY(-115deg);
+		box-shadow: 0 18px 60px rgba(0, 0, 0, 0.8);
+	}
 </style>

--- a/src/lib/confirm.js
+++ b/src/lib/confirm.js
@@ -7,14 +7,14 @@ export const confirmStore = writable(null);
 
 /** @param {{title:string, message?:string, confirmText?:string, cancelText?:string, danger?:boolean}} opts @returns {Promise<boolean>} */
 export function requireConfirm(opts) {
-  return new Promise((resolve) => {
-    confirmStore.set({
-      title: opts.title,
-      message: opts.message,
-      confirmText: opts.confirmText ?? 'Confirm',
-      cancelText: opts.cancelText ?? 'Cancel',
-      danger: opts.danger ?? false,
-      resolve
-    });
-  });
+	return new Promise((resolve) => {
+		confirmStore.set({
+			title: opts.title,
+			message: opts.message,
+			confirmText: opts.confirmText ?? 'Confirm',
+			cancelText: opts.cancelText ?? 'Cancel',
+			danger: opts.danger ?? false,
+			resolve
+		});
+	});
 }

--- a/src/lib/helpers/gameUtils.js
+++ b/src/lib/helpers/gameUtils.js
@@ -9,43 +9,42 @@
  * @param {number} [maxPerLine=14]
  */
 export function getFormattedPhrase(phrase, maxPerLine = 14) {
-    if (!phrase) return [];
-  
-    const words = phrase.split(' ');
-    const lines = [];
-    let currentLine = '';
-  
-    for (let word of words) {
-      if ((currentLine + word).length <= maxPerLine) {
-        currentLine += (currentLine ? ' ' : '') + word;
-      } else {
-        lines.push(currentLine);
-        currentLine = word;
-      }
-    }
-  
-    if (currentLine) {
-      lines.push(currentLine);
-    }
-  
-    return lines;
-  }
-  
-  /**
-   * Converts a 2D word/letter index (wordIndex and charIndex)
-   * into the correct global index of the full phrase string.
-   * @param {number} wordIndex
-   * @param {number} charIndex
-   * @param {string} phrase
-   */
-  export function getGlobalIndex(wordIndex, charIndex, phrase) {
-    const words = phrase.split(' ');
-    let index = 0;
-  
-    for (let i = 0; i < wordIndex; i++) {
-      index += words[i].length + 1; // +1 for the space
-    }
-  
-    return index + charIndex;
-  }
-  
+	if (!phrase) return [];
+
+	const words = phrase.split(' ');
+	const lines = [];
+	let currentLine = '';
+
+	for (let word of words) {
+		if ((currentLine + word).length <= maxPerLine) {
+			currentLine += (currentLine ? ' ' : '') + word;
+		} else {
+			lines.push(currentLine);
+			currentLine = word;
+		}
+	}
+
+	if (currentLine) {
+		lines.push(currentLine);
+	}
+
+	return lines;
+}
+
+/**
+ * Converts a 2D word/letter index (wordIndex and charIndex)
+ * into the correct global index of the full phrase string.
+ * @param {number} wordIndex
+ * @param {number} charIndex
+ * @param {string} phrase
+ */
+export function getGlobalIndex(wordIndex, charIndex, phrase) {
+	const words = phrase.split(' ');
+	let index = 0;
+
+	for (let i = 0; i < wordIndex; i++) {
+		index += words[i].length + 1; // +1 for the space
+	}
+
+	return index + charIndex;
+}

--- a/src/lib/music.js
+++ b/src/lib/music.js
@@ -9,26 +9,26 @@ import { browser } from '$app/environment';
 /** Track manifest. id is stable + persisted; src is under static/. The UI labels them
  *  "Track 1/2/3" by position, so the order here is what the player sees. */
 export const TRACKS = [
-  { id: 'native-jazz', title: 'Native Jazz', src: '/music/native-jazz.mp3' },
-  { id: 'young-love', title: 'Young Love', src: '/music/young-love.mp3' },
-  { id: 'stu-ball-recipes', title: 'Stu Ball Recipes', src: '/music/stu-ball-recipes.mp3' }
+	{ id: 'native-jazz', title: 'Native Jazz', src: '/music/native-jazz.mp3' },
+	{ id: 'young-love', title: 'Young Love', src: '/music/young-love.mp3' },
+	{ id: 'stu-ball-recipes', title: 'Stu Ball Recipes', src: '/music/stu-ball-recipes.mp3' }
 ];
 
 const VOL_KEY = 'wb_music_vol';
 const ON_KEY = 'wb_music_on';
 const TRACK_KEY = 'wb_music_track';
-const DEFAULT_VOL = 0.20; // quiet by default (~20%)
+const DEFAULT_VOL = 0.2; // quiet by default (~20%)
 
 /** @param {any} v @param {number} d */
 function clamp01(v, d) {
-  if (v === null || v === undefined || v === '') return d; // unset → default (Number(null) is 0, not NaN!)
-  const n = Number(v);
-  return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : d;
+	if (v === null || v === undefined || v === '') return d; // unset → default (Number(null) is 0, not NaN!)
+	const n = Number(v);
+	return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : d;
 }
 
 const initVol = browser ? clamp01(localStorage.getItem(VOL_KEY), DEFAULT_VOL) : DEFAULT_VOL;
 const initOn = browser ? localStorage.getItem(ON_KEY) !== 'false' : true;
-const initTrack = browser ? (localStorage.getItem(TRACK_KEY) || TRACKS[0].id) : TRACKS[0].id;
+const initTrack = browser ? localStorage.getItem(TRACK_KEY) || TRACKS[0].id : TRACKS[0].id;
 
 /** Whether lobby music is enabled (persisted). */
 export const musicEnabled = writable(initOn);
@@ -45,86 +45,98 @@ let armed = false;
 /** @type {HTMLAudioElement|null} */
 let audio = null;
 
-function trackById(id) { return TRACKS.find((t) => t.id === id) || TRACKS[0]; }
+/** @param {string} id */
+function trackById(id) {
+	return TRACKS.find((t) => t.id === id) || TRACKS[0];
+}
 
 function ensureAudio() {
-  if (!browser) return null;
-  if (!audio) {
-    audio = new Audio(trackById(trackId).src);
-    audio.loop = true;
-    audio.preload = 'auto';
-    audio.volume = enabled ? volume : 0;
-  }
-  return audio;
+	if (!browser) return null;
+	if (!audio) {
+		audio = new Audio(trackById(trackId).src);
+		audio.loop = true;
+		audio.preload = 'auto';
+		audio.volume = enabled ? volume : 0;
+	}
+	return audio;
 }
 
 function apply() {
-  const a = audio;
-  if (!a) return;
-  a.volume = enabled ? volume : 0;
-  if (wantPlaying && enabled) a.play().catch(() => armAutoplay());
-  else if (!enabled) a.pause();
+	const a = audio;
+	if (!a) return;
+	a.volume = enabled ? volume : 0;
+	if (wantPlaying && enabled) a.play().catch(() => armAutoplay());
+	else if (!enabled) a.pause();
 }
 
 // Browsers block audio until a user gesture. If play() is rejected, wait for the
 // next tap/keypress and try again, then stop listening.
 function armAutoplay() {
-  if (!browser || armed) return;
-  armed = true;
-  const onGesture = () => {
-    if (wantPlaying && enabled && audio) {
-      audio.play().then(cleanup).catch(() => {});
-    } else {
-      cleanup();
-    }
-  };
-  function cleanup() {
-    window.removeEventListener('pointerdown', onGesture);
-    window.removeEventListener('keydown', onGesture);
-    armed = false;
-  }
-  window.addEventListener('pointerdown', onGesture);
-  window.addEventListener('keydown', onGesture);
+	if (!browser || armed) return;
+	armed = true;
+	const onGesture = () => {
+		if (wantPlaying && enabled && audio) {
+			audio
+				.play()
+				.then(cleanup)
+				.catch(() => {});
+		} else {
+			cleanup();
+		}
+	};
+	function cleanup() {
+		window.removeEventListener('pointerdown', onGesture);
+		window.removeEventListener('keydown', onGesture);
+		armed = false;
+	}
+	window.addEventListener('pointerdown', onGesture);
+	window.addEventListener('keydown', onGesture);
 }
 
 musicEnabled.subscribe((v) => {
-  enabled = v;
-  if (browser) localStorage.setItem(ON_KEY, String(v));
-  apply();
+	enabled = v;
+	if (browser) localStorage.setItem(ON_KEY, String(v));
+	apply();
 });
 musicVolume.subscribe((v) => {
-  volume = clamp01(v, DEFAULT_VOL);
-  if (browser) localStorage.setItem(VOL_KEY, String(volume));
-  if (audio) audio.volume = enabled ? volume : 0;
+	volume = clamp01(v, DEFAULT_VOL);
+	if (browser) localStorage.setItem(VOL_KEY, String(volume));
+	if (audio) audio.volume = enabled ? volume : 0;
 });
 currentTrackId.subscribe((v) => {
-  if (!v) return;
-  const changed = v !== trackId;
-  trackId = v;
-  if (browser) localStorage.setItem(TRACK_KEY, v);
-  if (changed && audio) {
-    audio.src = trackById(trackId).src;
-    audio.load();
-    if (wantPlaying && enabled) audio.play().catch(() => armAutoplay());
-  }
+	if (!v) return;
+	const changed = v !== trackId;
+	trackId = v;
+	if (browser) localStorage.setItem(TRACK_KEY, v);
+	if (changed && audio) {
+		audio.src = trackById(trackId).src;
+		audio.load();
+		if (wantPlaying && enabled) audio.play().catch(() => armAutoplay());
+	}
 });
 
 /** Start lobby music (call when entering the menu lobby). */
 export function startMusic() {
-  wantPlaying = true;
-  const a = ensureAudio();
-  if (!a) return;
-  if (enabled) a.play().catch(() => armAutoplay());
+	wantPlaying = true;
+	const a = ensureAudio();
+	if (!a) return;
+	if (enabled) a.play().catch(() => armAutoplay());
 }
 
 /** Pause lobby music (call when leaving the lobby / starting a game). */
 export function stopMusic() {
-  wantPlaying = false;
-  if (audio) audio.pause();
+	wantPlaying = false;
+	if (audio) audio.pause();
 }
 
 /** @param {number} v 0..1 */
-export function setMusicVolume(v) { musicVolume.set(clamp01(v, DEFAULT_VOL)); }
-export function toggleMusic() { musicEnabled.update((v) => !v); }
+export function setMusicVolume(v) {
+	musicVolume.set(clamp01(v, DEFAULT_VOL));
+}
+export function toggleMusic() {
+	musicEnabled.update((v) => !v);
+}
 /** @param {string} id */
-export function selectTrack(id) { currentTrackId.set(id); }
+export function selectTrack(id) {
+	currentTrackId.set(id);
+}

--- a/src/lib/pin.js
+++ b/src/lib/pin.js
@@ -6,8 +6,8 @@ import { writable } from 'svelte/store';
 import { browser } from '$app/environment';
 
 const HASH_KEY = 'wb_pin_hash';
-const USER_KEY = 'wb_pin_user';   // user id this device's PIN belongs to
-const NAME_KEY = 'wb_pin_name';   // remembered @username for the lock screen
+const USER_KEY = 'wb_pin_user'; // user id this device's PIN belongs to
+const NAME_KEY = 'wb_pin_name'; // remembered @username for the lock screen
 const FAILS_KEY = 'wb_pin_fails';
 
 export const MAX_PIN_FAILS = 5;
@@ -18,70 +18,83 @@ export const pinLocked = writable(false);
 
 /** @param {string} pin @param {string} uid */
 async function hashPin(pin, uid) {
-  const data = new TextEncoder().encode(`wb:${uid}:${pin}`);
-  const buf = await crypto.subtle.digest('SHA-256', data);
-  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+	const data = new TextEncoder().encode(`wb:${uid}:${pin}`);
+	const buf = await crypto.subtle.digest('SHA-256', data);
+	return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
 }
 
 /** Is a PIN set on THIS device for this user? @param {string} uid */
 export function hasPinFor(uid) {
-  return !!(browser && localStorage.getItem(HASH_KEY) && localStorage.getItem(USER_KEY) === uid);
+	return !!(browser && localStorage.getItem(HASH_KEY) && localStorage.getItem(USER_KEY) === uid);
 }
 
 /** Remembered username for the lock screen (this device). */
 export function rememberedName() {
-  return browser ? localStorage.getItem(NAME_KEY) : null;
+	return browser ? localStorage.getItem(NAME_KEY) : null;
 }
 
 /** Store a new PIN for this device+user. @param {string} uid @param {string|null} name @param {string} pin */
 export async function setPin(uid, name, pin) {
-  if (!browser) return;
-  localStorage.setItem(HASH_KEY, await hashPin(pin, uid));
-  localStorage.setItem(USER_KEY, uid);
-  if (name) localStorage.setItem(NAME_KEY, name);
-  localStorage.removeItem(FAILS_KEY);
+	if (!browser) return;
+	localStorage.setItem(HASH_KEY, await hashPin(pin, uid));
+	localStorage.setItem(USER_KEY, uid);
+	if (name) localStorage.setItem(NAME_KEY, name);
+	localStorage.removeItem(FAILS_KEY);
 }
 
 /** Verify an entered PIN; tracks failures. @param {string} uid @param {string} pin */
 export async function verifyPin(uid, pin) {
-  if (!browser) return false;
-  const ok = (await hashPin(pin, uid)) === localStorage.getItem(HASH_KEY);
-  if (ok) localStorage.removeItem(FAILS_KEY);
-  else localStorage.setItem(FAILS_KEY, String(pinFails() + 1));
-  return ok;
+	if (!browser) return false;
+	const ok = (await hashPin(pin, uid)) === localStorage.getItem(HASH_KEY);
+	if (ok) localStorage.removeItem(FAILS_KEY);
+	else localStorage.setItem(FAILS_KEY, String(pinFails() + 1));
+	return ok;
 }
 
 export function pinFails() {
-  return browser ? Number(localStorage.getItem(FAILS_KEY) || 0) : 0;
+	return browser ? Number(localStorage.getItem(FAILS_KEY) || 0) : 0;
 }
 export function tooManyFails() {
-  return pinFails() >= MAX_PIN_FAILS;
+	return pinFails() >= MAX_PIN_FAILS;
 }
 
 // Session unlock flag (sessionStorage): survives in-app navigation + refresh, but
 // is cleared when the app/tab is closed. So the PIN is asked on a cold open — not
 // every time you return to the menu.
 const UNLOCKED_KEY = 'wb_unlocked';
-export function markUnlocked() { if (browser) sessionStorage.setItem(UNLOCKED_KEY, '1'); }
-export function sessionIsUnlocked() { return !!(browser && sessionStorage.getItem(UNLOCKED_KEY) === '1'); }
+export function markUnlocked() {
+	if (browser) sessionStorage.setItem(UNLOCKED_KEY, '1');
+}
+export function sessionIsUnlocked() {
+	return !!(browser && sessionStorage.getItem(UNLOCKED_KEY) === '1');
+}
 /** Force a re-lock this session (e.g. before a purchase). */
-export function relock() { if (browser) sessionStorage.removeItem(UNLOCKED_KEY); pinLocked.set(true); }
+export function relock() {
+	if (browser) sessionStorage.removeItem(UNLOCKED_KEY);
+	pinLocked.set(true);
+}
 
 // "Skip for now" choice — persisted per device+user so the set-PIN screen doesn't
 // nag on every cold open. Cleared when a PIN is actually set or on logout.
 const SKIP_KEY = 'wb_pin_skipped';
 /** @param {string} uid */
-export function markPinSkipped(uid) { if (browser) localStorage.setItem(SKIP_KEY, uid); }
+export function markPinSkipped(uid) {
+	if (browser) localStorage.setItem(SKIP_KEY, uid);
+}
 /** @param {string} uid */
-export function pinSkipped(uid) { return !!(browser && localStorage.getItem(SKIP_KEY) === uid); }
-export function clearPinSkipped() { if (browser) localStorage.removeItem(SKIP_KEY); }
+export function pinSkipped(uid) {
+	return !!(browser && localStorage.getItem(SKIP_KEY) === uid);
+}
+export function clearPinSkipped() {
+	if (browser) localStorage.removeItem(SKIP_KEY);
+}
 
 /** Forget the PIN (forgot-PIN / logout). Keeps the remembered name unless full=true. */
 export function clearPin(full = false) {
-  if (!browser) return;
-  localStorage.removeItem(HASH_KEY);
-  localStorage.removeItem(USER_KEY);
-  localStorage.removeItem(FAILS_KEY);
-  sessionStorage.removeItem(UNLOCKED_KEY);
-  if (full) localStorage.removeItem(NAME_KEY);
+	if (!browser) return;
+	localStorage.removeItem(HASH_KEY);
+	localStorage.removeItem(USER_KEY);
+	localStorage.removeItem(FAILS_KEY);
+	sessionStorage.removeItem(UNLOCKED_KEY);
+	if (full) localStorage.removeItem(NAME_KEY);
 }

--- a/src/lib/pinConfirm.js
+++ b/src/lib/pinConfirm.js
@@ -12,11 +12,18 @@ export const pinConfirm = writable(null);
 
 /** @param {string} reason @param {{label:string,value:string}[]} [details] line items (e.g. challenge stakes) shown above the pad @returns {Promise<boolean>} */
 export async function requirePin(reason = 'Confirm', details) {
-  // Resolve the uid from the store, or the session (so it works on any route).
-  let uid = get(user)?.id;
-  if (!uid) { try { const { data } = await supabase.auth.getSession(); uid = data?.session?.user?.id; } catch { /* ignore */ } }
-  if (!uid || !hasPinFor(uid)) return true; // nothing to confirm
-  return await new Promise((resolve, reject) => {
-    pinConfirm.set({ reason, details, uid, resolve, reject });
-  });
+	// Resolve the uid from the store, or the session (so it works on any route).
+	let uid = get(user)?.id;
+	if (!uid) {
+		try {
+			const { data } = await supabase.auth.getSession();
+			uid = data?.session?.user?.id;
+		} catch {
+			/* ignore */
+		}
+	}
+	if (!uid || !hasPinFor(uid)) return true; // nothing to confirm
+	return await new Promise((resolve, reject) => {
+		pinConfirm.set({ reason, details, uid, resolve, reject });
+	});
 }

--- a/src/lib/powerups.js
+++ b/src/lib/powerups.js
@@ -3,30 +3,46 @@
 // earns it (shown in the solve modal so players learn the feats).
 /** @type {Record<string, { emoji: string, name: string, desc: string, feat: string, armed?: boolean }>} */
 export const POWERUPS = {
-  multiplier_boost:{ emoji: '⚡', name: 'Multiplier Boost', desc: '+0.5× to your streak now',     feat: 'Blind Solve' },
-  double_payout:   { emoji: '💎', name: 'Double Payout',   desc: 'Next solve pays 2×', armed: true, feat: 'Consonant King' },
-  extra_guess:     { emoji: '❤️', name: 'Extra Guess',     desc: '+1 to your guess pool',         feat: 'Hot Streak' }
+	multiplier_boost: {
+		emoji: '⚡',
+		name: 'Multiplier Boost',
+		desc: '+0.5× to your streak now',
+		feat: 'Blind Solve'
+	},
+	double_payout: {
+		emoji: '💎',
+		name: 'Double Payout',
+		desc: 'Next solve pays 2×',
+		armed: true,
+		feat: 'Consonant King'
+	},
+	extra_guess: {
+		emoji: '❤️',
+		name: 'Extra Guess',
+		desc: '+1 to your guess pool',
+		feat: 'Hot Streak'
+	}
 };
 
 /** @param {string} id */
 export function powerupInfo(id) {
-  return POWERUPS[id] || { emoji: '⚡', name: id, desc: '' };
+	return POWERUPS[id] || { emoji: '⚡', name: id, desc: '' };
 }
 
 // Daily Modifier — the single shared effect active for everyone on a given day.
 // Keys match the server _daily_modifier() pool. `blurb` is the short "twist" line.
 /** @type {Record<string, { emoji: string, name: string, blurb: string }>} */
 export const MODIFIERS = {
-  discount:       { emoji: '🏷️', name: 'Discount Day',  blurb: 'Every letter is 25% off' },
-  vowel_vision:   { emoji: '👁️', name: 'Vowel Vision',  blurb: 'Vowels cost half price' },
-  flat_rate:      { emoji: '⚖️', name: 'Flat Rate',     blurb: 'Every letter is a flat $50' },
-  free_vowel:     { emoji: '🎁', name: 'Free Vowel',    blurb: 'One vowel revealed free' },
-  consonant_sale: { emoji: '🔡', name: 'Consonant Sale', blurb: 'Consonants are 25% off' },
-  head_start:     { emoji: '🅰️', name: 'Head Start',    blurb: 'First letter of each word free' },
-  insured:        { emoji: '🛡️', name: 'Insured',       blurb: 'Your first wrong letter is free' }
+	discount: { emoji: '🏷️', name: 'Discount Day', blurb: 'Every letter is 25% off' },
+	vowel_vision: { emoji: '👁️', name: 'Vowel Vision', blurb: 'Vowels cost half price' },
+	flat_rate: { emoji: '⚖️', name: 'Flat Rate', blurb: 'Every letter is a flat $50' },
+	free_vowel: { emoji: '🎁', name: 'Free Vowel', blurb: 'One vowel revealed free' },
+	consonant_sale: { emoji: '🔡', name: 'Consonant Sale', blurb: 'Consonants are 25% off' },
+	head_start: { emoji: '🅰️', name: 'Head Start', blurb: 'First letter of each word free' },
+	insured: { emoji: '🛡️', name: 'Insured', blurb: 'Your first wrong letter is free' }
 };
 
 /** @param {string} id */
 export function modifierInfo(id) {
-  return MODIFIERS[id] || null;
+	return MODIFIERS[id] || null;
 }

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -14,37 +14,37 @@ const initHaptics = browser ? localStorage.getItem(HAPTICS_KEY) !== 'false' : tr
 export const soundEnabled = writable(initial);
 let enabled = initial;
 soundEnabled.subscribe((v) => {
-  enabled = v;
-  if (browser) localStorage.setItem(STORAGE_KEY, String(v));
+	enabled = v;
+	if (browser) localStorage.setItem(STORAGE_KEY, String(v));
 });
 
 /** Whether vibration/haptics are enabled (persisted, separate from sound). */
 export const hapticsEnabled = writable(initHaptics);
 let hapticsOn = initHaptics;
 hapticsEnabled.subscribe((v) => {
-  hapticsOn = v;
-  if (browser) localStorage.setItem(HAPTICS_KEY, String(v));
+	hapticsOn = v;
+	if (browser) localStorage.setItem(HAPTICS_KEY, String(v));
 });
 
 export function toggleSound() {
-  soundEnabled.update((v) => !v);
+	soundEnabled.update((v) => !v);
 }
 export function toggleHaptics() {
-  hapticsEnabled.update((v) => !v);
+	hapticsEnabled.update((v) => !v);
 }
 
 /** @type {AudioContext | null} */
 let ctx = null;
 function ac() {
-  if (!browser) return null;
-  if (!ctx) {
-    const AC = window.AudioContext || /** @type {any} */ (window).webkitAudioContext;
-    if (!AC) return null;
-    ctx = new AC();
-  }
-  // Browsers start the context suspended until a user gesture; resume on demand.
-  if (ctx.state === 'suspended') ctx.resume().catch(() => {});
-  return ctx;
+	if (!browser) return null;
+	if (!ctx) {
+		const AC = window.AudioContext || /** @type {any} */ (window).webkitAudioContext;
+		if (!AC) return null;
+		ctx = new AC();
+	}
+	// Browsers start the context suspended until a user gesture; resume on demand.
+	if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+	return ctx;
 }
 
 /**
@@ -53,19 +53,19 @@ function ac() {
  * @param {number} [gain] @param {number} [when] seconds from now
  */
 function tone(freq, dur, type = 'sine', gain = 0.16, when = 0) {
-  const c = ac();
-  if (!c) return;
-  const t0 = c.currentTime + when;
-  const osc = c.createOscillator();
-  const g = c.createGain();
-  osc.type = type;
-  osc.frequency.setValueAtTime(freq, t0);
-  g.gain.setValueAtTime(0.0001, t0);
-  g.gain.exponentialRampToValueAtTime(gain, t0 + 0.012);
-  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
-  osc.connect(g).connect(c.destination);
-  osc.start(t0);
-  osc.stop(t0 + dur + 0.03);
+	const c = ac();
+	if (!c) return;
+	const t0 = c.currentTime + when;
+	const osc = c.createOscillator();
+	const g = c.createGain();
+	osc.type = type;
+	osc.frequency.setValueAtTime(freq, t0);
+	g.gain.setValueAtTime(0.0001, t0);
+	g.gain.exponentialRampToValueAtTime(gain, t0 + 0.012);
+	g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+	osc.connect(g).connect(c.destination);
+	osc.start(t0);
+	osc.stop(t0 + dur + 0.03);
 }
 
 /**
@@ -74,124 +74,136 @@ function tone(freq, dur, type = 'sine', gain = 0.16, when = 0) {
  * @param {OscillatorType} [type] @param {number} [gain] @param {number} [when]
  */
 function sweep(f1, f2, dur, type = 'triangle', gain = 0.15, when = 0) {
-  const c = ac();
-  if (!c) return;
-  const t0 = c.currentTime + when;
-  const osc = c.createOscillator();
-  const g = c.createGain();
-  osc.type = type;
-  osc.frequency.setValueAtTime(f1, t0);
-  osc.frequency.exponentialRampToValueAtTime(Math.max(1, f2), t0 + dur);
-  g.gain.setValueAtTime(0.0001, t0);
-  g.gain.exponentialRampToValueAtTime(gain, t0 + 0.02);
-  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
-  osc.connect(g).connect(c.destination);
-  osc.start(t0);
-  osc.stop(t0 + dur + 0.03);
+	const c = ac();
+	if (!c) return;
+	const t0 = c.currentTime + when;
+	const osc = c.createOscillator();
+	const g = c.createGain();
+	osc.type = type;
+	osc.frequency.setValueAtTime(f1, t0);
+	osc.frequency.exponentialRampToValueAtTime(Math.max(1, f2), t0 + dur);
+	g.gain.setValueAtTime(0.0001, t0);
+	g.gain.exponentialRampToValueAtTime(gain, t0 + 0.02);
+	g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+	osc.connect(g).connect(c.destination);
+	osc.start(t0);
+	osc.stop(t0 + dur + 0.03);
 }
 
 /** @type {Record<string, () => void>} */
 const SOUNDS = {
-  tap: () => tone(420, 0.05, 'square', 0.05),
-  select: () => tone(660, 0.07, 'sine', 0.09),
-  correct: () => {
-    tone(720, 0.1, 'sine', 0.15);
-    tone(960, 0.12, 'sine', 0.11, 0.06);
-  },
-  wrong: () => tone(150, 0.2, 'sawtooth', 0.11),
-  reveal: () => sweep(420, 1150, 0.24, 'triangle', 0.13),
-  // Box landing thunk for the daily opening reveal: a low knock + a bright coin ping.
-  land: () => {
-    tone(180, 0.08, 'square', 0.13);
-    tone(1180, 0.09, 'sine', 0.09, 0.03);
-  },
-  win: () => [523, 659, 784, 1047].forEach((f, i) => tone(f, 0.2, 'sine', 0.16, i * 0.09)),
-  bust: () => sweep(440, 80, 0.55, 'sawtooth', 0.16),
-  multiplier: () => {
-    tone(880, 0.09, 'sine', 0.13);
-    tone(1320, 0.13, 'sine', 0.12, 0.08);
-  },
-  // Bright rising blip — you just took the lead in a challenge.
-  lead: () => {
-    tone(784, 0.08, 'sine', 0.12);
-    tone(1175, 0.12, 'sine', 0.11, 0.07);
-  },
-  // Heavy metallic vault CLUNK: mechanism click → deep thunk → metal overtone.
-  vault: () => {
-    tone(140, 0.05, 'square', 0.16);            // latch click
-    tone(82, 0.34, 'sine', 0.34, 0.03);         // heavy thunk
-    tone(58, 0.42, 'triangle', 0.24, 0.05);     // low body
-    tone(360, 0.2, 'triangle', 0.07, 0.04);     // metallic ring
-    sweep(520, 180, 0.3, 'sawtooth', 0.06, 0.05); // dampened resonance
-  }
+	tap: () => tone(420, 0.05, 'square', 0.05),
+	select: () => tone(660, 0.07, 'sine', 0.09),
+	correct: () => {
+		tone(720, 0.1, 'sine', 0.15);
+		tone(960, 0.12, 'sine', 0.11, 0.06);
+	},
+	wrong: () => tone(150, 0.2, 'sawtooth', 0.11),
+	reveal: () => sweep(420, 1150, 0.24, 'triangle', 0.13),
+	// Box landing thunk for the daily opening reveal: a low knock + a bright coin ping.
+	land: () => {
+		tone(180, 0.08, 'square', 0.13);
+		tone(1180, 0.09, 'sine', 0.09, 0.03);
+	},
+	win: () => [523, 659, 784, 1047].forEach((f, i) => tone(f, 0.2, 'sine', 0.16, i * 0.09)),
+	bust: () => sweep(440, 80, 0.55, 'sawtooth', 0.16),
+	multiplier: () => {
+		tone(880, 0.09, 'sine', 0.13);
+		tone(1320, 0.13, 'sine', 0.12, 0.08);
+	},
+	// Bright rising blip — you just took the lead in a challenge.
+	lead: () => {
+		tone(784, 0.08, 'sine', 0.12);
+		tone(1175, 0.12, 'sine', 0.11, 0.07);
+	},
+	// Heavy metallic vault CLUNK: mechanism click → deep thunk → metal overtone.
+	vault: () => {
+		tone(140, 0.05, 'square', 0.16); // latch click
+		tone(82, 0.34, 'sine', 0.34, 0.03); // heavy thunk
+		tone(58, 0.42, 'triangle', 0.24, 0.05); // low body
+		tone(360, 0.2, 'triangle', 0.07, 0.04); // metallic ring
+		sweep(520, 180, 0.3, 'sawtooth', 0.06, 0.05); // dampened resonance
+	}
 };
 
 /** @type {Record<string, number[]>} */
 const HAPTICS = {
-  tap: [8],
-  select: [8],
-  correct: [14],
-  wrong: [22, 36, 22],
-  reveal: [12],
-  land: [10],
-  win: [18, 40, 18, 40, 36],
-  bust: [60, 30, 60],
-  multiplier: [10, 24, 10],
-  lead: [12, 20, 16],
-  vault: [50, 30, 90]
+	tap: [8],
+	select: [8],
+	correct: [14],
+	wrong: [22, 36, 22],
+	reveal: [12],
+	land: [10],
+	win: [18, 40, 18, 40, 36],
+	bust: [60, 30, 60],
+	multiplier: [10, 24, 10],
+	lead: [12, 20, 16],
+	vault: [50, 30, 90]
 };
 
 /** Play an audio cue by name (no-op when disabled). @param {string} name */
 export function playSound(name) {
-  if (!enabled) return;
-  const fn = SOUNDS[name];
-  if (fn) {
-    try {
-      fn();
-    } catch {
-      /* audio is best-effort */
-    }
-  }
+	if (!enabled) return;
+	const fn = SOUNDS[name];
+	if (fn) {
+		try {
+			fn();
+		} catch {
+			/* audio is best-effort */
+		}
+	}
 }
 
 // Map each cue to a Capacitor Haptics call (real haptics on iOS; falls back to
 // navigator.vibrate on web). Tunes intensity per event.
 /** @param {string} name @returns {Promise<any>} */
 function nativeHaptic(name) {
-  switch (name) {
-    case 'win':  return Haptics.notification({ type: NotificationType.Success });
-    case 'wrong': return Haptics.notification({ type: NotificationType.Warning });
-    case 'bust': return Haptics.notification({ type: NotificationType.Error });
-    case 'vault': return Haptics.impact({ style: ImpactStyle.Heavy });
-    case 'multiplier': case 'lead': return Haptics.impact({ style: ImpactStyle.Medium });
-    default: return Haptics.impact({ style: ImpactStyle.Light });
-  }
+	switch (name) {
+		case 'win':
+			return Haptics.notification({ type: NotificationType.Success });
+		case 'wrong':
+			return Haptics.notification({ type: NotificationType.Warning });
+		case 'bust':
+			return Haptics.notification({ type: NotificationType.Error });
+		case 'vault':
+			return Haptics.impact({ style: ImpactStyle.Heavy });
+		case 'multiplier':
+		case 'lead':
+			return Haptics.impact({ style: ImpactStyle.Medium });
+		default:
+			return Haptics.impact({ style: ImpactStyle.Light });
+	}
 }
 
 /** Fire a haptic by name (no-op when haptics are off / unsupported). @param {string} name */
 export function vibrate(name) {
-  if (!hapticsOn || !browser) return;
-  if (!(name in HAPTICS)) return;
-  try {
-    nativeHaptic(name).catch(() => {
-      // last-resort web fallback if the plugin couldn't run
-      if (navigator.vibrate) navigator.vibrate(HAPTICS[name]);
-    });
-  } catch {
-    if (navigator.vibrate) try { navigator.vibrate(HAPTICS[name]); } catch { /* best-effort */ }
-  }
+	if (!hapticsOn || !browser) return;
+	if (!(name in HAPTICS)) return;
+	try {
+		nativeHaptic(name).catch(() => {
+			// last-resort web fallback if the plugin couldn't run
+			if (navigator.vibrate) navigator.vibrate(HAPTICS[name]);
+		});
+	} catch {
+		if (navigator.vibrate)
+			try {
+				navigator.vibrate(HAPTICS[name]);
+			} catch {
+				/* best-effort */
+			}
+	}
 }
 
 /** @type {Record<string, number>} */
 const _lastFx = {};
 /** Combined sound + haptic feedback for a named event. @param {string} name */
 export function fx(name) {
-  // Collapse rapid duplicate cues (e.g. the global button beep + a handler's own fx('tap')).
-  if (browser) {
-    const now = typeof performance !== 'undefined' ? performance.now() : 0;
-    if (_lastFx[name] && now - _lastFx[name] < 60) return;
-    _lastFx[name] = now;
-  }
-  playSound(name);
-  vibrate(name);
+	// Collapse rapid duplicate cues (e.g. the global button beep + a handler's own fx('tap')).
+	if (browser) {
+		const now = typeof performance !== 'undefined' ? performance.now() : 0;
+		if (_lastFx[name] && now - _lastFx[name] < 60) return;
+		_lastFx[name] = now;
+	}
+	playSound(name);
+	vibrate(name);
 }

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -3,12 +3,67 @@
 import { writable, get } from 'svelte/store';
 import confetti from 'canvas-confetti';
 import { fx } from '$lib/sound.js';
-import { dailyStart, dailyUseTwist, dailyUseBoost, dailyBuyLetter, dailyReveal, dailySubmitGuess, dailyFold as dailyFoldRpc, getDailyModifier, getDailyClue } from '$lib/stores/statsStore.js';
-import { createChallenge, acceptChallenge, getChallengeBoard, challengeBuyLetter, challengeReveal, challengeSubmitGuess, challengeCheck } from '$lib/stores/statsStore.js';
-import { makeupStart, makeupBuyLetter, makeupReveal, makeupSubmitGuess } from '$lib/stores/statsStore.js';
-import { climbStart, cashgameStart, cashgameCashout, climbBuyLetter, climbReveal, climbSubmitGuess, climbNext, climbLeave, climbSkip, climbDoubleOrNothing, getPowerups, buyPowerup, climbUsePowerup, getClimbClue } from '$lib/stores/statsStore.js';
-import { createMatch, acceptMatch, matchStart, matchBuyLetter, matchReveal, matchSubmitGuess, matchFold as matchFoldRpc, matchCheck, matchUsePowerup, matchSabotage } from '$lib/stores/statsStore.js';
-import { blitzStart, blitzBuyLetter, blitzSubmitGuess, blitzSkip, blitzEnd } from '$lib/stores/statsStore.js';
+import {
+	dailyStart,
+	dailyUseTwist,
+	dailyUseBoost,
+	dailyBuyLetter,
+	dailyReveal,
+	dailySubmitGuess,
+	dailyFold as dailyFoldRpc,
+	getDailyModifier,
+	getDailyClue
+} from '$lib/stores/statsStore.js';
+import {
+	createChallenge,
+	acceptChallenge,
+	getChallengeBoard,
+	challengeBuyLetter,
+	challengeReveal,
+	challengeSubmitGuess,
+	challengeCheck
+} from '$lib/stores/statsStore.js';
+import {
+	makeupStart,
+	makeupBuyLetter,
+	makeupReveal,
+	makeupSubmitGuess
+} from '$lib/stores/statsStore.js';
+import {
+	climbStart,
+	cashgameStart,
+	cashgameCashout,
+	climbBuyLetter,
+	climbReveal,
+	climbSubmitGuess,
+	climbNext,
+	climbLeave,
+	climbSkip,
+	climbDoubleOrNothing,
+	getPowerups,
+	buyPowerup,
+	climbUsePowerup,
+	getClimbClue
+} from '$lib/stores/statsStore.js';
+import {
+	createMatch,
+	acceptMatch,
+	matchStart,
+	matchBuyLetter,
+	matchReveal,
+	matchSubmitGuess,
+	matchFold as matchFoldRpc,
+	matchCheck,
+	matchUsePowerup,
+	matchSabotage
+} from '$lib/stores/statsStore.js';
+import {
+	blitzStart,
+	blitzBuyLetter,
+	blitzSubmitGuess,
+	blitzSkip,
+	blitzEnd
+} from '$lib/stores/statsStore.js';
 import { track } from '$lib/analytics.js';
 
 /* ================================
@@ -50,7 +105,10 @@ import { track } from '$lib/analytics.js';
  *   blitzInfo?: any,
  *   matchInfo?: any,
  *   cashToast?: { amount:number, label:string } | null,
- *   dailyLive?: { remaining:number, mult:number, winnings:number } | null
+ *   dailyLive?: { remaining:number, mult:number, winnings:number } | null,
+ *   dailyIntro?: number,
+ *   dailyIntroGo?: number,
+ *   dailyIntroPlayed?: number
  * }} GameState
  */
 
@@ -62,45 +120,70 @@ import { track } from '$lib/analytics.js';
 /** @type {Record<string, number>} */
 // Mirror of server public.letter_cost() (economy v3.2: −25%, cheapest $20).
 export const LETTER_COSTS = {
-  Q: 20, W: 40, E: 100, R: 90, T: 90, Y: 50, U: 60, I: 80, O: 70, P: 60,
-  A: 100, S: 90, D: 60, F: 50, G: 50, H: 50, J: 20, K: 40, L: 60,
-  Z: 30, X: 30, C: 60, V: 40, B: 50, N: 80, M: 50
+	Q: 20,
+	W: 40,
+	E: 100,
+	R: 90,
+	T: 90,
+	Y: 50,
+	U: 60,
+	I: 80,
+	O: 70,
+	P: 60,
+	A: 100,
+	S: 90,
+	D: 60,
+	F: 50,
+	G: 50,
+	H: 50,
+	J: 20,
+	K: 40,
+	L: 60,
+	Z: 30,
+	X: 30,
+	C: 60,
+	V: 40,
+	B: 50,
+	N: 80,
+	M: 50
 };
 
 /** @type {import('svelte/store').Writable<GameState>} */
-export const gameStore = writable(/** @type {GameState} */ ({
-  bankroll: 1000,
-  wagerAmount: 1,
-  guessesRemaining: 3,
-  category: '',
-  currentPhrase: '',
-  gameState: 'default', // States: "default", "purchase_pending", "guess_mode", "won", "lost"
-  purchasedLetters: [],
-  guessedLetters: {},
-  lockedLetters: {},
-  incorrectLetters: [],
-  selectedPurchase: null,
-  shakenLetters: [],
-  message: '',
-  subcategory: '',
-  gameMode: 'daily', // 'daily' | 'climb' | 'challenge' | 'match' | 'makeup'
-  freeReveals: 0, // owned Free Reveal power-ups (daily)
-  modifier: null, // today's Daily Twist power-up id (daily only)
-  twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
-  bountyMult: 1, // bounty multiplier (1.0 once Twist used, else 1.5)
-  wrongGuesses: 0, // wrong phrase guesses this Daily (each −0.2× mult, floor 1.0)
-  clue: null, // witty one-line hint for the current puzzle
-  challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
-  makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
-  climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
-  blitzInfo: null, // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state } (blitz mode)
-  matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
-  cashToast: null, // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
-  dailyLive: null, // { remaining, mult, winnings } — live Daily V2 HUD (Prize left → what you'd bank)
-  dailyIntro: 0, // bumps on a FRESH daily open → ARMS the opening reveal (pending)
-  dailyIntroGo: 0, // bumps once the board is actually visible → PLAYS the opening reveal
-  dailyIntroPlayed: 0 // the dailyIntro token that has already played (persists across remounts)
-}));
+export const gameStore = writable(
+	/** @type {GameState} */ ({
+		bankroll: 1000,
+		wagerAmount: 1,
+		guessesRemaining: 3,
+		category: '',
+		currentPhrase: '',
+		gameState: 'default', // States: "default", "purchase_pending", "guess_mode", "won", "lost"
+		purchasedLetters: [],
+		guessedLetters: {},
+		lockedLetters: {},
+		incorrectLetters: [],
+		selectedPurchase: null,
+		shakenLetters: [],
+		message: '',
+		subcategory: '',
+		gameMode: 'daily', // 'daily' | 'climb' | 'challenge' | 'match' | 'makeup'
+		freeReveals: 0, // owned Free Reveal power-ups (daily)
+		modifier: null, // today's Daily Twist power-up id (daily only)
+		twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
+		bountyMult: 1, // bounty multiplier (1.0 once Twist used, else 1.5)
+		wrongGuesses: 0, // wrong phrase guesses this Daily (each −0.2× mult, floor 1.0)
+		clue: null, // witty one-line hint for the current puzzle
+		challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
+		makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
+		climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
+		blitzInfo: null, // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state } (blitz mode)
+		matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
+		cashToast: null, // { amount, label } — transient Cash-earned toast (attendance / free-play reward)
+		dailyLive: null, // { remaining, mult, winnings } — live Daily V2 HUD (Prize left → what you'd bank)
+		dailyIntro: 0, // bumps on a FRESH daily open → ARMS the opening reveal (pending)
+		dailyIntroGo: 0, // bumps once the board is actually visible → PLAYS the opening reveal
+		dailyIntroPlayed: 0 // the dailyIntro token that has already played (persists across remounts)
+	})
+);
 
 /* ================================
    Utility Functions
@@ -138,41 +221,47 @@ let dailyInFlight = false;
  * @param {any} board @param {GameState} prev
  */
 function boardToState(board, prev) {
-  /** @type {number[]} */
-  const wordLengths = board.word_lengths || [];
-  const chars = wordLengths.map((/** @type {number} */ len) => '#'.repeat(len)).join(' ').split('');
-  /** @type {Record<string, string>} */
-  const revealed = board.revealed || {};
-  /** @type {string[]} */
-  const purchased = [];
-  /** @type {number[]} */
-  const newlyRevealed = [];
-  for (const [k, v] of Object.entries(revealed)) {
-    const i = Number(k);
-    chars[i] = /** @type {string} */ (v);
-    purchased[i] = /** @type {string} */ (v);
-    if (prev.purchasedLetters?.[i] !== v) newlyRevealed.push(i);
-  }
-  const finished = board.state !== 'active';
-  const currentPhrase = finished && board.phrase ? String(board.phrase).toUpperCase() : chars.join('');
-  /** @type {Record<string, boolean>} */
-  const lockedLetters = {};
-  (board.locked_letters || []).forEach((/** @type {string} */ l) => { lockedLetters[l] = true; });
-  return {
-    bankroll: board.bankroll,
-    guessesRemaining: board.guesses_remaining,
-    category: board.category ?? prev.category,
-    subcategory: board.subcategory ?? '',
-    currentPhrase,
-    purchasedLetters: purchased,
-    guessedLetters: {},
-    lockedLetters,
-    incorrectLetters: board.incorrect_letters || [],
-    selectedPurchase: null,
-    shakenLetters: newlyRevealed,
-    wagerAmount: 0,
-    message: ''
-  };
+	/** @type {number[]} */
+	const wordLengths = board.word_lengths || [];
+	const chars = wordLengths
+		.map((/** @type {number} */ len) => '#'.repeat(len))
+		.join(' ')
+		.split('');
+	/** @type {Record<string, string>} */
+	const revealed = board.revealed || {};
+	/** @type {string[]} */
+	const purchased = [];
+	/** @type {number[]} */
+	const newlyRevealed = [];
+	for (const [k, v] of Object.entries(revealed)) {
+		const i = Number(k);
+		chars[i] = /** @type {string} */ (v);
+		purchased[i] = /** @type {string} */ (v);
+		if (prev.purchasedLetters?.[i] !== v) newlyRevealed.push(i);
+	}
+	const finished = board.state !== 'active';
+	const currentPhrase =
+		finished && board.phrase ? String(board.phrase).toUpperCase() : chars.join('');
+	/** @type {Record<string, boolean>} */
+	const lockedLetters = {};
+	(board.locked_letters || []).forEach((/** @type {string} */ l) => {
+		lockedLetters[l] = true;
+	});
+	return {
+		bankroll: board.bankroll,
+		guessesRemaining: board.guesses_remaining,
+		category: board.category ?? prev.category,
+		subcategory: board.subcategory ?? '',
+		currentPhrase,
+		purchasedLetters: purchased,
+		guessedLetters: {},
+		lockedLetters,
+		incorrectLetters: board.incorrect_letters || [],
+		selectedPurchase: null,
+		shakenLetters: newlyRevealed,
+		wagerAmount: 0,
+		message: ''
+	};
 }
 
 /**
@@ -181,43 +270,51 @@ function boardToState(board, prev) {
  * @param {GameState} prev @param {any} board
  */
 function playMoveCue(prev, board) {
-  const revealed = board.revealed || {};
-  let newReveals = 0;
-  for (const [k, v] of Object.entries(revealed)) {
-    if (prev.purchasedLetters?.[Number(k)] !== v) newReveals++;
-  }
-  const incGrew = (board.incorrect_letters || []).length > (prev.incorrectLetters || []).length;
-  if (newReveals >= 2) fx('reveal');
-  else if (newReveals > 0) fx('correct');
-  else if (incGrew) fx('wrong');
+	const revealed = board.revealed || {};
+	let newReveals = 0;
+	for (const [k, v] of Object.entries(revealed)) {
+		if (prev.purchasedLetters?.[Number(k)] !== v) newReveals++;
+	}
+	const incGrew = (board.incorrect_letters || []).length > (prev.incorrectLetters || []).length;
+	if (newReveals >= 2) fx('reveal');
+	else if (newReveals > 0) fx('correct');
+	else if (incGrew) fx('wrong');
 }
 
 /** @param {any} board */
 function reconcileDailyBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-  const finished = board.state !== 'active';
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(board, prev),
-    gameMode: 'daily',
-    gameState: finished ? board.state : 'default',
-    dailyResult: board.daily_result ?? prev.dailyResult ?? null,
-    dailyLive: board.live ?? prev.dailyLive ?? null,
-    // Daily Twist: the available modifier id + whether you've used it + bounty multiplier.
-    modifier: board.modifier !== undefined ? board.modifier : prev.modifier,
-    twistUsed: board.twist_used !== undefined ? board.twist_used : (prev.twistUsed ?? false),
-    bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1),
-    wrongGuesses: board.wrong_guesses !== undefined ? board.wrong_guesses : (prev.wrongGuesses ?? 0)
-  }));
-  // Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
-  // not when re-opening an already-completed daily (which comes back 'won' with no result).
-  if (board.state === 'won') { if (board.daily_result) { fx('win'); } } // no confetti — the slot-machine reveal is the celebration
-  else if (finished) fx('bust');
-  else playMoveCue(prev, board);
-  // analytics: fire once, only on the actual solve transition
-  if (board.daily_result && prev.gameState !== 'won' && prev.gameState !== 'lost') {
-    track('daily_result', { won: true, bankroll: board.bankroll ?? 0 });
-  }
+	if (!board) return;
+	const prev = get(gameStore);
+	const finished = board.state !== 'active';
+	gameStore.set(
+		/** @type {GameState} */ ({
+			...prev,
+			...boardToState(board, prev),
+			gameMode: 'daily',
+			gameState: finished ? board.state : 'default',
+			dailyResult: board.daily_result ?? prev.dailyResult ?? null,
+			dailyLive: board.live ?? prev.dailyLive ?? null,
+			// Daily Twist: the available modifier id + whether you've used it + bounty multiplier.
+			modifier: board.modifier !== undefined ? board.modifier : prev.modifier,
+			twistUsed: board.twist_used !== undefined ? board.twist_used : (prev.twistUsed ?? false),
+			bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1),
+			wrongGuesses:
+				board.wrong_guesses !== undefined ? board.wrong_guesses : (prev.wrongGuesses ?? 0)
+		})
+	);
+	// Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),
+	// not when re-opening an already-completed daily (which comes back 'won' with no result).
+	if (board.state === 'won') {
+		if (board.daily_result) {
+			fx('win');
+		}
+	} // no confetti — the slot-machine reveal is the celebration
+	else if (finished) fx('bust');
+	else playMoveCue(prev, board);
+	// analytics: fire once, only on the actual solve transition
+	if (board.daily_result && prev.gameState !== 'won' && prev.gameState !== 'lost') {
+		track('daily_result', { won: true, bankroll: board.bankroll ?? 0 });
+	}
 }
 
 /* ===== Challenges (friend wager; same puzzle, score = leftover bankroll) ===== */
@@ -226,87 +323,104 @@ let activeChallengeId = null;
 
 /** @param {any} board */
 function reconcileChallengeBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-  const finished = board.state !== 'active';
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(board, prev),
-    gameMode: 'challenge',
-    gameState: finished ? board.state : 'default',
-    modifier: null,
-    challengeInfo: board.challenge ?? prev.challengeInfo ?? null
-  }));
-  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
-  else if (finished) fx('bust');
-  else playMoveCue(prev, board);
+	if (!board) return;
+	const prev = get(gameStore);
+	const finished = board.state !== 'active';
+	gameStore.set(
+		/** @type {GameState} */ ({
+			...prev,
+			...boardToState(board, prev),
+			gameMode: 'challenge',
+			gameState: finished ? board.state : 'default',
+			modifier: null,
+			challengeInfo: board.challenge ?? prev.challengeInfo ?? null
+		})
+	);
+	if (board.state === 'won') {
+		setTimeout(() => launchConfetti(), 300);
+		fx('win');
+	} else if (finished) fx('bust');
+	else playMoveCue(prev, board);
 }
 
 /** Start playing a challenge created/accepted elsewhere. @param {any} resp @returns {boolean} */
 export function enterChallenge(resp) {
-  if (!resp?.ok || !resp.board) return false;
-  activeChallengeId = resp.challenge_id;
-  reconcileChallengeBoard(resp.board);
-  return true;
+	if (!resp?.ok || !resp.board) return false;
+	activeChallengeId = resp.challenge_id;
+	reconcileChallengeBoard(resp.board);
+	return true;
 }
 
 /** Create a challenge and drop into play. @param {string} code @param {string} category @param {number} wager @param {string} [mode] */
 export async function startChallenge(code, category, wager, mode = 'score') {
-  const resp = await createChallenge(code, category, wager, mode);
-  if (resp?.ok) { track('challenge_create', { wager, mode }); return enterChallenge(resp) ? resp : { ok: false, reason: 'board' }; }
-  return resp;
+	const resp = await createChallenge(code, category, wager, mode);
+	if (resp?.ok) {
+		track('challenge_create', { wager, mode });
+		return enterChallenge(resp) ? resp : { ok: false, reason: 'board' };
+	}
+	return resp;
 }
 
 /** Accept an incoming challenge and drop into play. @param {string} id */
 export async function acceptAndPlayChallenge(id) {
-  const resp = await acceptChallenge(id);
-  if (resp?.ok) { track('challenge_accept'); return enterChallenge(resp) ? resp : { ok: false, reason: 'board' }; }
-  return resp;
+	const resp = await acceptChallenge(id);
+	if (resp?.ok) {
+		track('challenge_accept');
+		return enterChallenge(resp) ? resp : { ok: false, reason: 'board' };
+	}
+	return resp;
 }
 
 /** Resume a challenge I've already started. @param {string} id */
 export async function resumeChallenge(id) {
-  const board = await getChallengeBoard(id);
-  if (board) { activeChallengeId = id; reconcileChallengeBoard(board); return true; }
-  return false;
+	const board = await getChallengeBoard(id);
+	if (board) {
+		activeChallengeId = id;
+		reconcileChallengeBoard(board);
+		return true;
+	}
+	return false;
 }
 
 /** Pressure mode: force the server to settle the active play when the clock expires. */
 export async function challengeTimeoutCheck() {
-  if (!activeChallengeId) return;
-  const board = await challengeCheck(activeChallengeId);
-  if (board) reconcileChallengeBoard(board);
+	if (!activeChallengeId) return;
+	const board = await challengeCheck(activeChallengeId);
+	if (board) reconcileChallengeBoard(board);
 }
 
 /** @param {GameState} state */
 async function confirmPurchaseChallenge(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight || !activeChallengeId) return;
-  dailyInFlight = true;
-  try {
-    let board = null;
-    if (purchase.type === 'letter') board = await challengeBuyLetter(activeChallengeId, purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await challengeReveal(activeChallengeId);
-    if (board) reconcileChallengeBoard(board);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally {
-    dailyInFlight = false;
-  }
+	const purchase = state.selectedPurchase;
+	if (!purchase || dailyInFlight || !activeChallengeId) return;
+	dailyInFlight = true;
+	try {
+		let board = null;
+		if (purchase.type === 'letter')
+			board = await challengeBuyLetter(activeChallengeId, purchase.value ?? '');
+		else if (purchase.type === 'hint') board = await challengeReveal(activeChallengeId);
+		if (board) reconcileChallengeBoard(board);
+		else gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** @param {GameState} state */
 async function submitGuessChallenge(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight || !activeChallengeId) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const board = await challengeSubmitGuess(activeChallengeId, guess);
-    if (board) reconcileChallengeBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (state.gameState !== 'guess_mode' || dailyInFlight || !activeChallengeId) return;
+	/** @type {Record<string, string>} */
+	const guess = {};
+	for (const [k, v] of Object.entries(state.guessedLetters || {}))
+		guess[k] = /** @type {string} */ (v);
+	if (Object.keys(guess).length === 0) return;
+	dailyInFlight = true;
+	try {
+		const board = await challengeSubmitGuess(activeChallengeId, guess);
+		if (board) reconcileChallengeBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /* ===== Make-up daily (play a past missed day; no streak/Bank, badges only) ===== */
@@ -315,354 +429,397 @@ let activeMakeupDate = null;
 
 /** @param {any} board */
 function reconcileMakeupBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-  const finished = board.state !== 'active';
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(board, prev),
-    gameMode: 'makeup',
-    gameState: finished ? board.state : 'default',
-    modifier: null,
-    clue: board.clue ?? prev.clue ?? null,
-    makeupDate: board.makeup?.date ?? prev.makeupDate ?? activeMakeupDate
-  }));
-  if (board.state === 'won') { setTimeout(() => launchConfetti(), 300); fx('win'); }
-  else if (finished) fx('bust');
-  else playMoveCue(prev, board);
-  if (finished && prev.gameState !== 'won' && prev.gameState !== 'lost') {
-    track('makeup_result', { won: board.state === 'won', date: board.makeup?.date });
-  }
+	if (!board) return;
+	const prev = get(gameStore);
+	const finished = board.state !== 'active';
+	gameStore.set(
+		/** @type {GameState} */ ({
+			...prev,
+			...boardToState(board, prev),
+			gameMode: 'makeup',
+			gameState: finished ? board.state : 'default',
+			modifier: null,
+			clue: board.clue ?? prev.clue ?? null,
+			makeupDate: board.makeup?.date ?? prev.makeupDate ?? activeMakeupDate
+		})
+	);
+	if (board.state === 'won') {
+		setTimeout(() => launchConfetti(), 300);
+		fx('win');
+	} else if (finished) fx('bust');
+	else playMoveCue(prev, board);
+	if (finished && prev.gameState !== 'won' && prev.gameState !== 'lost') {
+		track('makeup_result', { won: board.state === 'won', date: board.makeup?.date });
+	}
 }
 
 /** Begin (or resume) a make-up for a past date. @param {string} date YYYY-MM-DD */
 export async function enterMakeup(date) {
-  track('makeup_start', { date });
-  const board = await makeupStart(date);
-  if (!board) return false;
-  activeMakeupDate = date;
-  if (typeof localStorage !== 'undefined') {
-    localStorage.setItem('gameMode', 'makeup');
-    localStorage.setItem('makeupDate', date);
-  }
-  reconcileMakeupBoard(board);
-  return true;
+	track('makeup_start', { date });
+	const board = await makeupStart(date);
+	if (!board) return false;
+	activeMakeupDate = date;
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('gameMode', 'makeup');
+		localStorage.setItem('makeupDate', date);
+	}
+	reconcileMakeupBoard(board);
+	return true;
 }
 
 /** Re-enter the make-up game on the home route (deep link / refresh). */
 export async function fetchMakeupGame() {
-  try {
-    if (!activeMakeupDate && typeof localStorage !== 'undefined') {
-      activeMakeupDate = localStorage.getItem('makeupDate');
-    }
-    if (!activeMakeupDate) return false;
-    const board = await makeupStart(activeMakeupDate);
-    if (!board) return false;
-    reconcileMakeupBoard(board);
-    return true;
-  } catch (err) {
-    console.error('❌ Error starting make-up:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
+	try {
+		if (!activeMakeupDate && typeof localStorage !== 'undefined') {
+			activeMakeupDate = localStorage.getItem('makeupDate');
+		}
+		if (!activeMakeupDate) return false;
+		const board = await makeupStart(activeMakeupDate);
+		if (!board) return false;
+		reconcileMakeupBoard(board);
+		return true;
+	} catch (err) {
+		console.error('❌ Error starting make-up:', err instanceof Error ? err.message : String(err));
+		return false;
+	}
 }
 
 /** @param {GameState} state */
 async function confirmPurchaseMakeup(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight || !activeMakeupDate) return;
-  dailyInFlight = true;
-  try {
-    let board = null;
-    if (purchase.type === 'letter') board = await makeupBuyLetter(activeMakeupDate, purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await makeupReveal(activeMakeupDate);
-    if (board) reconcileMakeupBoard(board);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally {
-    dailyInFlight = false;
-  }
+	const purchase = state.selectedPurchase;
+	if (!purchase || dailyInFlight || !activeMakeupDate) return;
+	dailyInFlight = true;
+	try {
+		let board = null;
+		if (purchase.type === 'letter')
+			board = await makeupBuyLetter(activeMakeupDate, purchase.value ?? '');
+		else if (purchase.type === 'hint') board = await makeupReveal(activeMakeupDate);
+		if (board) reconcileMakeupBoard(board);
+		else gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** @param {GameState} state */
 async function submitGuessMakeup(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight || !activeMakeupDate) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const board = await makeupSubmitGuess(activeMakeupDate, guess);
-    if (board) reconcileMakeupBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (state.gameState !== 'guess_mode' || dailyInFlight || !activeMakeupDate) return;
+	/** @type {Record<string, string>} */
+	const guess = {};
+	for (const [k, v] of Object.entries(state.guessedLetters || {}))
+		guess[k] = /** @type {string} */ (v);
+	if (Object.keys(guess).length === 0) return;
+	dailyInFlight = true;
+	try {
+		const board = await makeupSubmitGuess(activeMakeupDate, guess);
+		if (board) reconcileMakeupBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /* ===== Cash Game / the Climb (real-Cash, fluid, par/bounty + heat) ===== */
 /** Refresh the clue for the current climb puzzle (changes each rung). */
 async function refreshClimbClue() {
-  try {
-    const clue = await getClimbClue();
-    gameStore.update(s => ({ ...s, clue }));
-  } catch { /* non-fatal */ }
+	try {
+		const clue = await getClimbClue();
+		gameStore.update((s) => ({ ...s, clue }));
+	} catch {
+		/* non-fatal */
+	}
 }
 
 /** @param {any} board */
 function reconcileClimbBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-  const climb = board.climb || {};
-  // 'solved' shows a win beat (then climbAdvance); 'busted' ends the run (you lost the buy-in).
-  const solved = climb.state === 'solved';
-  const busted = climb.state === 'busted' || climb.busted === true;
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(board, prev),
-    gameMode: 'climb',
-    gameState: busted ? 'lost' : (solved ? 'won' : 'default'),
-    modifier: null,
-    climbInfo: climb
-  }));
-  // No confetti — the slot-machine reveal (box-by-box win pop) is the celebration, like Daily.
-  if (busted) fx('bust');
-  else if (solved) { fx('win'); }
-  else playMoveCue(prev, board);
+	if (!board) return;
+	const prev = get(gameStore);
+	const climb = board.climb || {};
+	// 'solved' shows a win beat (then climbAdvance); 'busted' ends the run (you lost the buy-in).
+	const solved = climb.state === 'solved';
+	const busted = climb.state === 'busted' || climb.busted === true;
+	gameStore.set(
+		/** @type {GameState} */ ({
+			...prev,
+			...boardToState(board, prev),
+			gameMode: 'climb',
+			gameState: busted ? 'lost' : solved ? 'won' : 'default',
+			modifier: null,
+			climbInfo: climb
+		})
+	);
+	// No confetti — the slot-machine reveal (box-by-box win pop) is the celebration, like Daily.
+	if (busted) fx('bust');
+	else if (solved) {
+		fx('win');
+	} else playMoveCue(prev, board);
 }
 
 /** Arm the dramatic opening reveal for a FRESH (untouched) climb puzzle. */
 function maybeArmClimbIntro() {
-  const s = get(gameStore);
-  const hasProgress = (s.purchasedLetters || []).some(Boolean) || (s.climbInfo?.spent ?? 0) > 0;
-  if (!hasProgress && s.gameState === 'default') {
-    gameStore.update(st => ({ ...st, dailyIntro: (st.dailyIntro || 0) + 1 }));
-  }
+	const s = get(gameStore);
+	const hasProgress = (s.purchasedLetters || []).some(Boolean) || (s.climbInfo?.spent ?? 0) > 0;
+	if (!hasProgress && s.gameState === 'default') {
+		gameStore.update((st) => ({ ...st, dailyIntro: (st.dailyIntro || 0) + 1 }));
+	}
 }
 
 /** Arm the dramatic opening reveal for a FRESH challenge puzzle (per-puzzle progress is
  *  empty). The no-progress gate means a mid-puzzle RESUME never replays the reveal. */
 function maybeArmMatchIntro() {
-  const s = get(gameStore);
-  const hasProgress = (s.purchasedLetters || []).some(Boolean) || (s.incorrectLetters || []).length > 0;
-  if (!hasProgress && s.gameState === 'default') {
-    gameStore.update(st => ({ ...st, dailyIntro: (st.dailyIntro || 0) + 1 }));
-  }
+	const s = get(gameStore);
+	const hasProgress =
+		(s.purchasedLetters || []).some(Boolean) || (s.incorrectLetters || []).length > 0;
+	if (!hasProgress && s.gameState === 'default') {
+		gameStore.update((st) => ({ ...st, dailyIntro: (st.dailyIntro || 0) + 1 }));
+	}
 }
 
 /** Resume an in-progress Cash Game run. Returns 'needs_tier' when there's no live run
  *  (the caller then shows the tier-select), true if a run was restored, false on error. */
 export async function fetchClimbGame() {
-  try {
-    const board = await climbStart();
-    if (!board) return false;
-    if (board.needs_tier) return 'needs_tier';
-    reconcileClimbBoard(board);
-    maybeArmClimbIntro();
-    await refreshClimbClue();
-    return true;
-  } catch (err) {
-    console.error('❌ Error resuming Cash Game:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
+	try {
+		const board = await climbStart();
+		if (!board) return false;
+		if (board.needs_tier) return 'needs_tier';
+		reconcileClimbBoard(board);
+		maybeArmClimbIntro();
+		await refreshClimbClue();
+		return true;
+	} catch (err) {
+		console.error('❌ Error resuming Cash Game:', err instanceof Error ? err.message : String(err));
+		return false;
+	}
 }
 
 /** Buy in at a tier and start a fresh run. @param {string} tier @returns {Promise<any>} */
 export async function startCashGame(tier) {
-  try {
-    track('cashgame_start', { tier });
-    const resp = await cashgameStart(tier);
-    if (!resp?.ok) return resp || { ok: false };
-    reconcileClimbBoard(resp);
-    maybeArmClimbIntro();
-    await refreshClimbClue();
-    return resp;
-  } catch (err) {
-    console.error('❌ Error starting Cash Game:', err instanceof Error ? err.message : String(err));
-    return { ok: false };
-  }
+	try {
+		track('cashgame_start', { tier });
+		const resp = await cashgameStart(tier);
+		if (!resp?.ok) return resp || { ok: false };
+		reconcileClimbBoard(resp);
+		maybeArmClimbIntro();
+		await refreshClimbClue();
+		return resp;
+	} catch (err) {
+		console.error('❌ Error starting Cash Game:', err instanceof Error ? err.message : String(err));
+		return { ok: false };
+	}
 }
 
 /** Cash out the current run → bank the bankroll, end the run. @returns {Promise<any>} */
 export async function cashOutClimb() {
-  if (dailyInFlight) return { ok: false };
-  dailyInFlight = true;
-  try {
-    const resp = await cashgameCashout();
-    if (resp?.ok) {
-      fx('multiplier');
-      // Surface a cash-out result the UI can celebrate, then clear the run.
-      gameStore.update(s => ({ ...s, gameState: 'won', climbInfo: { ...(s.climbInfo || {}), state: 'cashed_out', cashout: resp } }));
-    }
-    return resp || { ok: false };
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight) return { ok: false };
+	dailyInFlight = true;
+	try {
+		const resp = await cashgameCashout();
+		if (resp?.ok) {
+			fx('multiplier');
+			// Surface a cash-out result the UI can celebrate, then clear the run.
+			gameStore.update((s) => ({
+				...s,
+				gameState: 'won',
+				climbInfo: { ...(s.climbInfo || {}), state: 'cashed_out', cashout: resp }
+			}));
+		}
+		return resp || { ok: false };
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** @param {GameState} state */
 async function confirmPurchaseClimb(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    let board = null;
-    if (purchase.type === 'letter') board = await climbBuyLetter(purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await climbReveal();
-    if (board) reconcileClimbBoard(board);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally {
-    dailyInFlight = false;
-  }
+	const purchase = state.selectedPurchase;
+	if (!purchase || dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		let board = null;
+		if (purchase.type === 'letter') board = await climbBuyLetter(purchase.value ?? '');
+		else if (purchase.type === 'hint') board = await climbReveal();
+		if (board) reconcileClimbBoard(board);
+		else gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** @param {GameState} state */
 async function submitGuessClimb(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const board = await climbSubmitGuess(guess);
-    if (board) reconcileClimbBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+	/** @type {Record<string, string>} */
+	const guess = {};
+	for (const [k, v] of Object.entries(state.guessedLetters || {}))
+		guess[k] = /** @type {string} */ (v);
+	if (Object.keys(guess).length === 0) return;
+	dailyInFlight = true;
+	try {
+		const board = await climbSubmitGuess(guess);
+		if (board) reconcileClimbBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Advance to the next climb puzzle after a solve. */
 export async function climbAdvance() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await climbNext();
-    if (board) { reconcileClimbBoard(board); maybeArmClimbIntro(); await refreshClimbClue(); }
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await climbNext();
+		if (board) {
+			reconcileClimbBoard(board);
+			maybeArmClimbIntro();
+			await refreshClimbClue();
+		}
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Leave the Cash Game (clears heat; position + Cash persist). */
 export async function climbLeaveGame() {
-  try { await climbLeave(); } catch { /* non-fatal */ }
+	try {
+		await climbLeave();
+	} catch {
+		/* non-fatal */
+	}
 }
 
 /** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). */
 export async function climbSkipPuzzle() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await climbSkip();
-    if (board) { reconcileClimbBoard(board); maybeArmClimbIntro(); await refreshClimbClue(); }
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await climbSkip();
+		if (board) {
+			reconcileClimbBoard(board);
+			maybeArmClimbIntro();
+			await refreshClimbClue();
+		}
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Arm Double-or-Nothing on the current Cash Game puzzle (heat ≥ ×1.5).
  *  Solve → payout doubles; get stuck → $0 and you forfeit your spend. You can't skip once armed. */
 export async function climbArmDoubleOrNothing() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await climbDoubleOrNothing();
-    if (board) reconcileClimbBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await climbDoubleOrNothing();
+		if (board) reconcileClimbBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Equip a power-up in the Climb (v3: charges Cash on use, counts as spend). @param {string} id */
 export async function climbPowerup(id) {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await climbUsePowerup(id);
-    if (board) reconcileClimbBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await climbUsePowerup(id);
+		if (board) reconcileClimbBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /* ===== Blitz (timed speed run) ===== */
 /** @param {any} resp */
 function reconcileBlitzBoard(resp) {
-  if (!resp) return;
-  const prev = get(gameStore);
-  const blitz = resp.blitz || {};
-  const ended = blitz.state === 'ended';
-  if (ended) {
-    gameStore.update(s => ({ ...s, gameMode: 'blitz', gameState: 'lost', blitzInfo: blitz }));
-    fx('bust');
-    return;
-  }
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...boardToState(resp, prev),
-    gameMode: 'blitz',
-    gameState: 'default',
-    modifier: null,
-    blitzInfo: blitz
-  }));
-  playMoveCue(prev, resp);
+	if (!resp) return;
+	const prev = get(gameStore);
+	const blitz = resp.blitz || {};
+	const ended = blitz.state === 'ended';
+	if (ended) {
+		gameStore.update((s) => ({ ...s, gameMode: 'blitz', gameState: 'lost', blitzInfo: blitz }));
+		fx('bust');
+		return;
+	}
+	gameStore.set(
+		/** @type {GameState} */ ({
+			...prev,
+			...boardToState(resp, prev),
+			gameMode: 'blitz',
+			gameState: 'default',
+			modifier: null,
+			blitzInfo: blitz
+		})
+	);
+	playMoveCue(prev, resp);
 }
 
 /** Buy in at a tier and start a timed run. @param {string} tier @returns {Promise<any>} */
 export async function startBlitz(tier) {
-  try {
-    track('blitz_start', { tier });
-    const resp = await blitzStart(tier);
-    if (!resp?.ok) return resp || { ok: false };
-    reconcileBlitzBoard(resp);
-    return resp;
-  } catch (err) {
-    console.error('❌ Error starting Blitz:', err instanceof Error ? err.message : String(err));
-    return { ok: false };
-  }
+	try {
+		track('blitz_start', { tier });
+		const resp = await blitzStart(tier);
+		if (!resp?.ok) return resp || { ok: false };
+		reconcileBlitzBoard(resp);
+		return resp;
+	} catch (err) {
+		console.error('❌ Error starting Blitz:', err instanceof Error ? err.message : String(err));
+		return { ok: false };
+	}
 }
 
 /** @param {GameState} state */
 async function confirmPurchaseBlitz(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    let resp = null;
-    if (purchase.type === 'letter') resp = await blitzBuyLetter(purchase.value ?? '');
-    if (resp) reconcileBlitzBoard(resp);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally { dailyInFlight = false; }
+	const purchase = state.selectedPurchase;
+	if (!purchase || dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		let resp = null;
+		if (purchase.type === 'letter') resp = await blitzBuyLetter(purchase.value ?? '');
+		if (resp) reconcileBlitzBoard(resp);
+		else gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** @param {GameState} state */
 async function submitGuessBlitz(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const resp = await blitzSubmitGuess(guess);
-    if (resp) reconcileBlitzBoard(resp);
-  } finally { dailyInFlight = false; }
+	if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+	/** @type {Record<string, string>} */
+	const guess = {};
+	for (const [k, v] of Object.entries(state.guessedLetters || {}))
+		guess[k] = /** @type {string} */ (v);
+	if (Object.keys(guess).length === 0) return;
+	dailyInFlight = true;
+	try {
+		const resp = await blitzSubmitGuess(guess);
+		if (resp) reconcileBlitzBoard(resp);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Skip the current Blitz puzzle (combo resets, −3s). */
 export async function blitzSkipPuzzle() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try { const resp = await blitzSkip(); if (resp) reconcileBlitzBoard(resp); }
-  finally { dailyInFlight = false; }
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const resp = await blitzSkip();
+		if (resp) reconcileBlitzBoard(resp);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** End the run when the clock hits 0 → bank winnings, show the result. */
 export async function endBlitz() {
-  try {
-    const resp = await blitzEnd();
-    reconcileBlitzBoard(resp);
-    return resp?.blitz ?? null;
-  } catch (err) {
-    console.error('❌ Error ending Blitz:', err instanceof Error ? err.message : String(err));
-    return null;
-  }
+	try {
+		const resp = await blitzEnd();
+		reconcileBlitzBoard(resp);
+		return resp?.blitz ?? null;
+	} catch (err) {
+		console.error('❌ Error ending Blitz:', err instanceof Error ? err.message : String(err));
+		return null;
+	}
 }
 
 /* ===== Challenge Builder match play (pack of puzzles vs friends/group) ===== */
@@ -671,121 +828,142 @@ let activeMatchId = null;
 
 /** @param {any} board */
 function reconcileMatchBoard(board) {
-  if (!board) return;
-  const prev = get(gameStore);
-  const match = board.match || {};
-  const done = match.done === true;
-  gameStore.set(/** @type {GameState} */ ({
-    ...prev, ...(done ? {} : boardToState(board, prev)),
-    gameMode: 'match',
-    gameState: done ? 'won' : 'default',
-    modifier: null,
-    clue: done ? prev.clue : (board.clue ?? null),
-    matchInfo: { ...match, id: activeMatchId, standing: board.standing ?? null }
-  }));
-  if (done) { setTimeout(() => launchConfetti(), 250); fx('win'); }
-  // Celebrate EACH solved puzzle — but only on an in-session advance (prev.matchInfo
-  // exists), so opening/resuming a match never fires the winner fireworks.
-  else if (prev.matchInfo && (match.last_score ?? 0) > 0 && (match.position ?? 1) > (prev.matchInfo.position ?? 0)) {
-    setTimeout(() => launchConfetti(), 250); fx('win');
-    maybeArmMatchIntro(); // next puzzle in the pack gets the dramatic opening reveal
-  }
-  else playMoveCue(prev, board);
+	if (!board) return;
+	const prev = get(gameStore);
+	const match = board.match || {};
+	const done = match.done === true;
+	gameStore.set(
+		/** @type {GameState} */ ({
+			...prev,
+			...(done ? {} : boardToState(board, prev)),
+			gameMode: 'match',
+			gameState: done ? 'won' : 'default',
+			modifier: null,
+			clue: done ? prev.clue : (board.clue ?? null),
+			matchInfo: { ...match, id: activeMatchId, standing: board.standing ?? null }
+		})
+	);
+	if (done) {
+		setTimeout(() => launchConfetti(), 250);
+		fx('win');
+	}
+	// Celebrate EACH solved puzzle — but only on an in-session advance (prev.matchInfo
+	// exists), so opening/resuming a match never fires the winner fireworks.
+	else if (
+		prev.matchInfo &&
+		(match.last_score ?? 0) > 0 &&
+		(match.position ?? 1) > (prev.matchInfo.position ?? 0)
+	) {
+		setTimeout(() => launchConfetti(), 250);
+		fx('win');
+		maybeArmMatchIntro(); // next puzzle in the pack gets the dramatic opening reveal
+	} else playMoveCue(prev, board);
 }
 
 /** Create a match and drop into play. @param {any} opts @returns {Promise<any>} */
 export async function startMatch(opts) {
-  const resp = await createMatch(opts);
-  if (resp?.ok && resp.match) {
-    track('match_create', { wager: opts.wager ?? 0, pack: opts.pack_size ?? 1 });
-    const id = resp.match.id;
-    activeMatchId = id;
-    const board = await matchStart(id);
-    if (board) { reconcileMatchBoard(board); maybeArmMatchIntro(); }
-  }
-  return resp;
+	const resp = await createMatch(opts);
+	if (resp?.ok && resp.match) {
+		track('match_create', { wager: opts.wager ?? 0, pack: opts.pack_size ?? 1 });
+		const id = resp.match.id;
+		activeMatchId = id;
+		const board = await matchStart(id);
+		if (board) {
+			reconcileMatchBoard(board);
+			maybeArmMatchIntro();
+		}
+	}
+	return resp;
 }
 
 /** Use an owned power-up in the active match (if items allowed). @param {string} powerupId */
 export async function matchPowerup(powerupId) {
-  if (dailyInFlight || !activeMatchId) return;
-  dailyInFlight = true;
-  try {
-    const board = await matchUsePowerup(activeMatchId, powerupId);
-    if (board) reconcileMatchBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight || !activeMatchId) return;
+	dailyInFlight = true;
+	try {
+		const board = await matchUsePowerup(activeMatchId, powerupId);
+		if (board) reconcileMatchBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Sabotage an opponent in the active match. @param {string} targetId @param {string} powerupId */
 export async function matchSabotageOpponent(targetId, powerupId) {
-  if (dailyInFlight || !activeMatchId) return;
-  dailyInFlight = true;
-  try {
-    const board = await matchSabotage(activeMatchId, targetId, powerupId);
-    if (board) reconcileMatchBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight || !activeMatchId) return;
+	dailyInFlight = true;
+	try {
+		const board = await matchSabotage(activeMatchId, targetId, powerupId);
+		if (board) reconcileMatchBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Accept (escrow) an invited match and start playing. @param {string} id @param {boolean} [reduced] stake only what you have @returns {Promise<boolean>} */
 export async function acceptAndPlayMatch(id, reduced = false) {
-  const resp = await acceptMatch(id, reduced);
-  if (!resp?.ok) return false;
-  track('match_accept');
-  activeMatchId = id;
-  const board = await matchStart(id);
-  if (board) { reconcileMatchBoard(board); maybeArmMatchIntro(); }
-  return true;
+	const resp = await acceptMatch(id, reduced);
+	if (!resp?.ok) return false;
+	track('match_accept');
+	activeMatchId = id;
+	const board = await matchStart(id);
+	if (board) {
+		reconcileMatchBoard(board);
+		maybeArmMatchIntro();
+	}
+	return true;
 }
 
 /** Blitz: force the server to lock the score when the clock expires. */
 export async function matchTimeoutCheck() {
-  if (!activeMatchId) return;
-  const board = await matchCheck(activeMatchId);
-  if (board) reconcileMatchBoard(board);
+	if (!activeMatchId) return;
+	const board = await matchCheck(activeMatchId);
+	if (board) reconcileMatchBoard(board);
 }
 
 /** Resume a match I'm already in. @param {string} id @returns {Promise<boolean>} */
 export async function resumeMatch(id) {
-  activeMatchId = id;
-  const board = await matchStart(id);
-  if (board) { reconcileMatchBoard(board); return true; } // resume = no dramatic reveal (you've seen this puzzle)
-  return false;
+	activeMatchId = id;
+	const board = await matchStart(id);
+	if (board) {
+		reconcileMatchBoard(board);
+		return true;
+	} // resume = no dramatic reveal (you've seen this puzzle)
+	return false;
 }
 
 /** @param {GameState} state */
 async function confirmPurchaseMatch(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight || !activeMatchId) return;
-  dailyInFlight = true;
-  try {
-    let board = null;
-    if (purchase.type === 'letter') board = await matchBuyLetter(activeMatchId, purchase.value ?? '');
-    else if (purchase.type === 'hint') board = await matchReveal(activeMatchId);
-    if (board) reconcileMatchBoard(board);
-    else gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-  } finally {
-    dailyInFlight = false;
-  }
+	const purchase = state.selectedPurchase;
+	if (!purchase || dailyInFlight || !activeMatchId) return;
+	dailyInFlight = true;
+	try {
+		let board = null;
+		if (purchase.type === 'letter')
+			board = await matchBuyLetter(activeMatchId, purchase.value ?? '');
+		else if (purchase.type === 'hint') board = await matchReveal(activeMatchId);
+		if (board) reconcileMatchBoard(board);
+		else gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** @param {GameState} state */
 async function submitGuessMatch(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight || !activeMatchId) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
-  dailyInFlight = true;
-  try {
-    const board = await matchSubmitGuess(activeMatchId, guess);
-    if (board) reconcileMatchBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (state.gameState !== 'guess_mode' || dailyInFlight || !activeMatchId) return;
+	/** @type {Record<string, string>} */
+	const guess = {};
+	for (const [k, v] of Object.entries(state.guessedLetters || {}))
+		guess[k] = /** @type {string} */ (v);
+	if (Object.keys(guess).length === 0) return;
+	dailyInFlight = true;
+	try {
+		const board = await matchSubmitGuess(activeMatchId, guess);
+		if (board) reconcileMatchBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /**
@@ -794,26 +972,26 @@ async function submitGuessMatch(state) {
  * @param {GameState} state
  */
 async function confirmPurchaseDaily(state) {
-  const purchase = state.selectedPurchase;
-  if (!purchase || dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    let board = null;
-    if (purchase.type === 'letter') {
-      board = await dailyBuyLetter(purchase.value ?? '');
-    } else if (purchase.type === 'hint') {
-      // Daily has no personal power-ups — Reveal always costs $150 (fair for all).
-      board = await dailyReveal();
-    }
+	const purchase = state.selectedPurchase;
+	if (!purchase || dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		let board = null;
+		if (purchase.type === 'letter') {
+			board = await dailyBuyLetter(purchase.value ?? '');
+		} else if (purchase.type === 'hint') {
+			// Daily has no personal power-ups — Reveal always costs $150 (fair for all).
+			board = await dailyReveal();
+		}
 
-    if (board) {
-      reconcileDailyBoard(board);
-    } else {
-      gameStore.update(s => ({ ...s, selectedPurchase: null, gameState: 'default' }));
-    }
-  } finally {
-    dailyInFlight = false;
-  }
+		if (board) {
+			reconcileDailyBoard(board);
+		} else {
+			gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
+		}
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /**
@@ -823,43 +1001,44 @@ async function confirmPurchaseDaily(state) {
  * @param {GameState} state
  */
 async function submitGuessDaily(state) {
-  if (state.gameState !== 'guess_mode' || dailyInFlight) return;
-  /** @type {Record<string, string>} */
-  const guess = {};
-  for (const [k, v] of Object.entries(state.guessedLetters || {})) guess[k] = /** @type {string} */ (v);
-  if (Object.keys(guess).length === 0) return;
+	if (state.gameState !== 'guess_mode' || dailyInFlight) return;
+	/** @type {Record<string, string>} */
+	const guess = {};
+	for (const [k, v] of Object.entries(state.guessedLetters || {}))
+		guess[k] = /** @type {string} */ (v);
+	if (Object.keys(guess).length === 0) return;
 
-  dailyInFlight = true;
-  try {
-    const board = await dailySubmitGuess(guess);
-    if (board) reconcileDailyBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	dailyInFlight = true;
+	try {
+		const board = await dailySubmitGuess(guess);
+		if (board) reconcileDailyBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Fold (give up) today's Daily — marks it lost, reveals the answer. */
 export async function dailyFold() {
-  if (dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await dailyFoldRpc();
-    if (board) reconcileDailyBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await dailyFoldRpc();
+		if (board) reconcileDailyBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /** Fold (forfeit) the current Challenge puzzle — advances without a solve. */
 export async function matchFold() {
-  if (!activeMatchId || dailyInFlight) return;
-  dailyInFlight = true;
-  try {
-    const board = await matchFoldRpc(activeMatchId);
-    if (board) reconcileMatchBoard(board);
-  } finally {
-    dailyInFlight = false;
-  }
+	if (!activeMatchId || dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await matchFoldRpc(activeMatchId);
+		if (board) reconcileMatchBoard(board);
+	} finally {
+		dailyInFlight = false;
+	}
 }
 
 /* ================================
@@ -873,34 +1052,38 @@ export async function matchFold() {
  * @param {string} letter - The letter to select.
  */
 export function selectLetter(letter) {
-  gameStore.update(/** @param {GameState} state */ (state) => {
-    const cost = LETTER_COSTS[letter] || 0;
-    if (state.bankroll < cost) {
-      console.log(`Insufficient funds to purchase letter ${letter}`);
-      return state;
-    }
-    // Deselect if already selected
-    if (
-      state.selectedPurchase &&
-      state.selectedPurchase.type === 'letter' &&
-      state.selectedPurchase.value === letter
-    ) {
-      console.log(`Deselecting letter: ${letter}`);
-      return { ...state, selectedPurchase: null, gameState: "default" };
-    }
-    // Prevent selection if letter is locked or marked incorrect
-    if ((state.lockedLetters && state.lockedLetters[letter]) ||
-        state.incorrectLetters.includes(letter)) {
-      console.log(`Letter ${letter} is fully locked or marked incorrect.`);
-      return state;
-    }
-    console.log(`Selecting letter: ${letter}`);
-    return {
-      ...state,
-      gameState: "purchase_pending",
-      selectedPurchase: { type: 'letter', value: letter }
-    };
-  });
+	gameStore.update(
+		/** @param {GameState} state */ (state) => {
+			const cost = LETTER_COSTS[letter] || 0;
+			if (state.bankroll < cost) {
+				console.log(`Insufficient funds to purchase letter ${letter}`);
+				return state;
+			}
+			// Deselect if already selected
+			if (
+				state.selectedPurchase &&
+				state.selectedPurchase.type === 'letter' &&
+				state.selectedPurchase.value === letter
+			) {
+				console.log(`Deselecting letter: ${letter}`);
+				return { ...state, selectedPurchase: null, gameState: 'default' };
+			}
+			// Prevent selection if letter is locked or marked incorrect
+			if (
+				(state.lockedLetters && state.lockedLetters[letter]) ||
+				state.incorrectLetters.includes(letter)
+			) {
+				console.log(`Letter ${letter} is fully locked or marked incorrect.`);
+				return state;
+			}
+			console.log(`Selecting letter: ${letter}`);
+			return {
+				...state,
+				gameState: 'purchase_pending',
+				selectedPurchase: { type: 'letter', value: letter }
+			};
+		}
+	);
 }
 
 /**
@@ -908,40 +1091,37 @@ export function selectLetter(letter) {
  * Toggles hint selection for purchase.
  */
 export function selectHint() {
-  gameStore.update(state => {
-    if (state.selectedPurchase && state.selectedPurchase.type === 'hint') {
-      console.log("Deselecting hint");
-      return { ...state, selectedPurchase: null, gameState: "default" };
-    }
-    console.log("Selecting hint");
-    return {
-      ...state,
-      gameState: "purchase_pending",
-      selectedPurchase: { type: 'hint' }
-    };
-  });
+	gameStore.update((state) => {
+		if (state.selectedPurchase && state.selectedPurchase.type === 'hint') {
+			console.log('Deselecting hint');
+			return { ...state, selectedPurchase: null, gameState: 'default' };
+		}
+		console.log('Selecting hint');
+		return {
+			...state,
+			gameState: 'purchase_pending',
+			selectedPurchase: { type: 'hint' }
+		};
+	});
 }
 
-
 // src/lib/stores/GameStore.js
 
-
 // src/lib/stores/GameStore.js
-
 
 /**
  * confirmPurchase
  * Handles purchase of a letter or hint and updates game state.
  */
 export function confirmPurchase() {
-  // All modes are server-authoritative: commit via RPC and reconcile.
-  const current = get(gameStore);
-  if (current.gameMode === 'daily') confirmPurchaseDaily(current);
-  else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
-  else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
-  else if (current.gameMode === 'climb') confirmPurchaseClimb(current);
-  else if (current.gameMode === 'blitz') confirmPurchaseBlitz(current);
-  else if (current.gameMode === 'match') confirmPurchaseMatch(current);
+	// All modes are server-authoritative: commit via RPC and reconcile.
+	const current = get(gameStore);
+	if (current.gameMode === 'daily') confirmPurchaseDaily(current);
+	else if (current.gameMode === 'challenge') confirmPurchaseChallenge(current);
+	else if (current.gameMode === 'makeup') confirmPurchaseMakeup(current);
+	else if (current.gameMode === 'climb') confirmPurchaseClimb(current);
+	else if (current.gameMode === 'blitz') confirmPurchaseBlitz(current);
+	else if (current.gameMode === 'match') confirmPurchaseMatch(current);
 }
 /* ================================
    Guess Mode Functions
@@ -952,14 +1132,14 @@ export function confirmPurchase() {
  * Toggles between default mode and guess mode.
  */
 export function enterGuessMode() {
-  gameStore.update(state => {
-    if (state.gameState === 'guess_mode') {
-      console.log("Exiting guess mode.");
-      return { ...state, gameState: "default", guessedLetters: {} };
-    }
-    console.log("Entering guess mode.");
-    return { ...state, gameState: "guess_mode", selectedPurchase: null, guessedLetters: {} };
-  });
+	gameStore.update((state) => {
+		if (state.gameState === 'guess_mode') {
+			console.log('Exiting guess mode.');
+			return { ...state, gameState: 'default', guessedLetters: {} };
+		}
+		console.log('Entering guess mode.');
+		return { ...state, gameState: 'guess_mode', selectedPurchase: null, guessedLetters: {} };
+	});
 }
 
 /**
@@ -970,13 +1150,13 @@ export function enterGuessMode() {
  * @returns {number[]} Array of editable indices.
  */
 function getEditableIndices(state) {
-  const indices = [];
-  for (let i = 0; i < state.currentPhrase.length; i++) {
-    if (state.currentPhrase[i] === ' ') continue;
-    if (state.purchasedLetters[i] === state.currentPhrase[i]) continue;
-    indices.push(i);
-  }
-  return indices;
+	const indices = [];
+	for (let i = 0; i < state.currentPhrase.length; i++) {
+		if (state.currentPhrase[i] === ' ') continue;
+		if (state.purchasedLetters[i] === state.currentPhrase[i]) continue;
+		indices.push(i);
+	}
+	return indices;
 }
 
 /**
@@ -986,24 +1166,24 @@ function getEditableIndices(state) {
  * @param {string} letter - The guessed letter.
  */
 export function inputGuessLetter(letter) {
-  gameStore.update(state => {
-    if (state.gameState !== "guess_mode") return state;
-    if (state.lockedLetters && state.lockedLetters[letter]) {
-      console.log("Letter already fully locked; ignoring input in guess mode.");
-      return state;
-    }
-    const editableIndices = getEditableIndices(state);
-    if (editableIndices.length === 0) return state;
+	gameStore.update((state) => {
+		if (state.gameState !== 'guess_mode') return state;
+		if (state.lockedLetters && state.lockedLetters[letter]) {
+			console.log('Letter already fully locked; ignoring input in guess mode.');
+			return state;
+		}
+		const editableIndices = getEditableIndices(state);
+		if (editableIndices.length === 0) return state;
 
-    // Find the first empty slot; if all filled, overwrite the last slot.
-    let activeIndex = editableIndices.find(idx => !Object.hasOwn(state.guessedLetters, idx));
-    if (activeIndex === undefined) {
-      activeIndex = editableIndices[editableIndices.length - 1];
-    }
-    const newGuessed = { ...state.guessedLetters, [activeIndex]: letter };
-    console.log(`Input letter ${letter} at index ${activeIndex}.`, newGuessed);
-    return { ...state, guessedLetters: newGuessed };
-  });
+		// Find the first empty slot; if all filled, overwrite the last slot.
+		let activeIndex = editableIndices.find((idx) => !Object.hasOwn(state.guessedLetters, idx));
+		if (activeIndex === undefined) {
+			activeIndex = editableIndices[editableIndices.length - 1];
+		}
+		const newGuessed = { ...state.guessedLetters, [activeIndex]: letter };
+		console.log(`Input letter ${letter} at index ${activeIndex}.`, newGuessed);
+		return { ...state, guessedLetters: newGuessed };
+	});
 }
 
 /**
@@ -1011,25 +1191,25 @@ export function inputGuessLetter(letter) {
  * Removes the last entered guessed letter.
  */
 export function deleteGuessLetter() {
-  gameStore.update(state => {
-    if (state.gameState !== "guess_mode") return state;
-    const editableIndices = getEditableIndices(state);
-    if (editableIndices.length === 0) return state;
+	gameStore.update((state) => {
+		if (state.gameState !== 'guess_mode') return state;
+		const editableIndices = getEditableIndices(state);
+		if (editableIndices.length === 0) return state;
 
-    // Remove the last filled slot
-    let activeIndex = null;
-    for (let i = editableIndices.length - 1; i >= 0; i--) {
-      if (state.guessedLetters[editableIndices[i]]) {
-        activeIndex = editableIndices[i];
-        break;
-      }
-    }
-    if (activeIndex === null) return state;
-    const newGuessed = { ...state.guessedLetters };
-    delete newGuessed[activeIndex];
-    console.log(`Deleted letter at index ${activeIndex}.`, newGuessed);
-    return { ...state, guessedLetters: newGuessed };
-  });
+		// Remove the last filled slot
+		let activeIndex = null;
+		for (let i = editableIndices.length - 1; i >= 0; i--) {
+			if (state.guessedLetters[editableIndices[i]]) {
+				activeIndex = editableIndices[i];
+				break;
+			}
+		}
+		if (activeIndex === null) return state;
+		const newGuessed = { ...state.guessedLetters };
+		delete newGuessed[activeIndex];
+		console.log(`Deleted letter at index ${activeIndex}.`, newGuessed);
+		return { ...state, guessedLetters: newGuessed };
+	});
 }
 
 /**
@@ -1037,14 +1217,14 @@ export function deleteGuessLetter() {
  * Routes the full guess to the server, which validates and scores.
  */
 export function submitGuess() {
-  // All modes are server-authoritative: the server validates + scores.
-  const current = get(gameStore);
-  if (current.gameMode === 'daily') submitGuessDaily(current);
-  else if (current.gameMode === 'challenge') submitGuessChallenge(current);
-  else if (current.gameMode === 'makeup') submitGuessMakeup(current);
-  else if (current.gameMode === 'climb') submitGuessClimb(current);
-  else if (current.gameMode === 'blitz') submitGuessBlitz(current);
-  else if (current.gameMode === 'match') submitGuessMatch(current);
+	// All modes are server-authoritative: the server validates + scores.
+	const current = get(gameStore);
+	if (current.gameMode === 'daily') submitGuessDaily(current);
+	else if (current.gameMode === 'challenge') submitGuessChallenge(current);
+	else if (current.gameMode === 'makeup') submitGuessMakeup(current);
+	else if (current.gameMode === 'climb') submitGuessClimb(current);
+	else if (current.gameMode === 'blitz') submitGuessBlitz(current);
+	else if (current.gameMode === 'match') submitGuessMatch(current);
 }
 /* ================================
    Puzzle Fetch Functions
@@ -1058,51 +1238,72 @@ export function submitGuess() {
  */
 /** Use today's Daily Twist power-up (applies effect, bounty → ×1.0). */
 export async function useDailyTwist() {
-  try {
-    const board = await dailyUseTwist();
-    if (board) { reconcileDailyBoard(board); return true; }
-    return false;
-  } catch (err) {
-    console.error('❌ Error using daily twist:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
+	try {
+		const board = await dailyUseTwist();
+		if (board) {
+			reconcileDailyBoard(board);
+			return true;
+		}
+		return false;
+	} catch (err) {
+		console.error('❌ Error using daily twist:', err instanceof Error ? err.message : String(err));
+		return false;
+	}
 }
 
 /** Spend an owned Bounty Boost on today's Daily (bumps the bounty multiplier). */
+/** @param {string} id */
 export async function useDailyBoost(id) {
-  try {
-    const board = await dailyUseBoost(id);
-    if (board) { reconcileDailyBoard(board); return true; }
-    return false;
-  } catch (err) {
-    console.error('❌ Error using daily boost:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
+	try {
+		const board = await dailyUseBoost(id);
+		if (board) {
+			reconcileDailyBoard(board);
+			return true;
+		}
+		return false;
+	} catch (err) {
+		console.error('❌ Error using daily boost:', err instanceof Error ? err.message : String(err));
+		return false;
+	}
 }
 
 export async function fetchDailyGame() {
-  try {
-    track('daily_start');
-    const board = await dailyStart([]);
-    if (!board) {
-      console.error('❌ daily_start returned no board');
-      return false;
-    }
-    reconcileDailyBoard(board); // sets modifier / twistActive / bountyMult from the board
-    // Attendance reward (paid once on the first open of the day) → transient toast.
-    const ab = /** @type {any} */ (board);
-    if (ab.attendance != null && ab.attendance > 0) {
-      gameStore.update(s => ({ ...s, cashToast: { amount: ab.attendance, label: `Day ${ab.attendance_day} streak · for showing up` } }));
-    }
-    // 🎰 Fresh open (first time today, board still active) → play the opening reveal.
-    if (ab.state === 'active' && ab.attendance != null && ab.attendance > 0) {
-      gameStore.update(s => ({ ...s, dailyIntro: (s.dailyIntro || 0) + 1 }));
-    }
-    try { const clue = await getDailyClue(); gameStore.update(s => ({ ...s, clue })); } catch { /* non-fatal */ }
-    console.log('✅ Daily session started/resumed');
-    return true;
-  } catch (err) {
-    console.error('❌ Error starting daily game:', err instanceof Error ? err.message : String(err));
-    return false;
-  }
+	try {
+		track('daily_start');
+		const board = await dailyStart([]);
+		if (!board) {
+			console.error('❌ daily_start returned no board');
+			return false;
+		}
+		reconcileDailyBoard(board); // sets modifier / twistActive / bountyMult from the board
+		// Attendance reward (paid once on the first open of the day) → transient toast.
+		const ab = /** @type {any} */ (board);
+		if (ab.attendance != null && ab.attendance > 0) {
+			gameStore.update((s) => ({
+				...s,
+				cashToast: {
+					amount: ab.attendance,
+					label: `Day ${ab.attendance_day} streak · for showing up`
+				}
+			}));
+		}
+		// 🎰 Fresh open (first time today, board still active) → play the opening reveal.
+		if (ab.state === 'active' && ab.attendance != null && ab.attendance > 0) {
+			gameStore.update((s) => ({ ...s, dailyIntro: (s.dailyIntro || 0) + 1 }));
+		}
+		try {
+			const clue = await getDailyClue();
+			gameStore.update((s) => ({ ...s, clue }));
+		} catch {
+			/* non-fatal */
+		}
+		console.log('✅ Daily session started/resumed');
+		return true;
+	} catch (err) {
+		console.error(
+			'❌ Error starting daily game:',
+			err instanceof Error ? err.message : String(err)
+		);
+		return false;
+	}
 }

--- a/src/lib/stores/localGameUtils.js
+++ b/src/lib/stores/localGameUtils.js
@@ -6,67 +6,68 @@ import { user } from '$lib/stores/userStore.js';
  * 💾 Save the current game state to localStorage (scoped by user ID)
  */
 export function saveGameToLocalStorage() {
-    const state = get(gameStore);
-    const currentUser = get(user);
-    const userId = currentUser?.id;
-  
-    if (!userId) {
-      console.warn("⚠️ Cannot save game — no user ID");
-      return;
-    }
-  
-    const isValid =
-      typeof state.currentPhrase === 'string' &&
-      state.currentPhrase.trim().length > 0 &&
-      typeof state.category === 'string' &&
-      state.category.trim().length > 0 &&
-      Array.isArray(state.purchasedLetters) &&
-      typeof state.bankroll === 'number';
-  
-    if (!isValid) {
-      console.warn("⚠️ Skipping save — invalid state:", state);
-      return;
-    }
-  
-    const key = `wordbank_game_state_${userId}`;
-    localStorage.setItem(key, JSON.stringify(state));
-    console.log(`💾 Game saved for user ${userId}:`, state);
-  }
-  
-  /**
-   * 📋 Peek at saved game without restoring (for menu labels: Resume daily/etc.)
-   * @param {string} userId
-   * @returns {{ gameMode: string, gameState: string } | null}
-   */
-  export function getSavedGameInfo(userId) {
-    if (!userId) return null;
-    const key = `wordbank_game_state_${userId}`;
-    const saved = localStorage.getItem(key);
-    if (!saved) return null;
-    try {
-      const parsed = JSON.parse(saved);
-      if (!parsed || typeof parsed.currentPhrase !== 'string' || !parsed.currentPhrase.trim()) return null;
-      const gameMode = parsed.gameMode || 'daily';
-      const gameState = parsed.gameState || 'default';
-      return { gameMode, gameState };
-    } catch {
-      return null;
-    }
-  }
+	const state = get(gameStore);
+	const currentUser = get(user);
+	const userId = currentUser?.id;
 
-  /**
-   * 🧹 Clear saved game from localStorage (scoped by user ID)
-   */
-  export function clearSavedGame() {
-    const currentUser = get(user);
-    const userId = currentUser?.id;
-  
-    if (!userId) {
-      console.warn("⚠️ Cannot clear saved game — no user ID");
-      return;
-    }
-  
-    const key = `wordbank_game_state_${userId}`;
-    localStorage.removeItem(key);
-    console.log(`🧹 Saved game cleared for user ${userId}`);
-  }
+	if (!userId) {
+		console.warn('⚠️ Cannot save game — no user ID');
+		return;
+	}
+
+	const isValid =
+		typeof state.currentPhrase === 'string' &&
+		state.currentPhrase.trim().length > 0 &&
+		typeof state.category === 'string' &&
+		state.category.trim().length > 0 &&
+		Array.isArray(state.purchasedLetters) &&
+		typeof state.bankroll === 'number';
+
+	if (!isValid) {
+		console.warn('⚠️ Skipping save — invalid state:', state);
+		return;
+	}
+
+	const key = `wordbank_game_state_${userId}`;
+	localStorage.setItem(key, JSON.stringify(state));
+	console.log(`💾 Game saved for user ${userId}:`, state);
+}
+
+/**
+ * 📋 Peek at saved game without restoring (for menu labels: Resume daily/etc.)
+ * @param {string} userId
+ * @returns {{ gameMode: string, gameState: string } | null}
+ */
+export function getSavedGameInfo(userId) {
+	if (!userId) return null;
+	const key = `wordbank_game_state_${userId}`;
+	const saved = localStorage.getItem(key);
+	if (!saved) return null;
+	try {
+		const parsed = JSON.parse(saved);
+		if (!parsed || typeof parsed.currentPhrase !== 'string' || !parsed.currentPhrase.trim())
+			return null;
+		const gameMode = parsed.gameMode || 'daily';
+		const gameState = parsed.gameState || 'default';
+		return { gameMode, gameState };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * 🧹 Clear saved game from localStorage (scoped by user ID)
+ */
+export function clearSavedGame() {
+	const currentUser = get(user);
+	const userId = currentUser?.id;
+
+	if (!userId) {
+		console.warn('⚠️ Cannot clear saved game — no user ID');
+		return;
+	}
+
+	const key = `wordbank_game_state_${userId}`;
+	localStorage.removeItem(key);
+	console.log(`🧹 Saved game cleared for user ${userId}`);
+}

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -15,7 +15,10 @@ export const inboxRequest = writable(0);
 /** Which Community tab the next inboxRequest should land on. */
 export const inboxTarget = writable(/** @type {'challenges'|'activity'|'people'} */ ('challenges'));
 /** @param {'challenges'|'activity'|'people'} [target] */
-export function requestInbox(target = 'challenges') { inboxTarget.set(target); inboxRequest.update((n) => n + 1); }
+export function requestInbox(target = 'challenges') {
+	inboxTarget.set(target);
+	inboxRequest.update((n) => n + 1);
+}
 
 const POLL_MS = 45000;
 /** @type {ReturnType<typeof setInterval>|undefined} */
@@ -30,102 +33,123 @@ let onVis;
 let channel;
 
 async function poll() {
-  const res = await getNotifications();
-  const items = res.items ?? [];
-  notifications.set(items);
-  unreadCount.set(res.unread_count ?? 0);
-  if (primed) {
-    // newest first; toast anything new + still unread, oldest-of-the-new first
-    const fresh = items.filter((n) => !knownIds.has(n.id) && !n.read).reverse();
-    for (const n of fresh) pushToast(n);
-  }
-  for (const n of items) knownIds.add(n.id);
-  primed = true;
+	const res = await getNotifications();
+	const items = res.items ?? [];
+	notifications.set(items);
+	unreadCount.set(res.unread_count ?? 0);
+	if (primed) {
+		// newest first; toast anything new + still unread, oldest-of-the-new first
+		const fresh = items.filter((n) => !knownIds.has(n.id) && !n.read).reverse();
+		for (const n of fresh) pushToast(n);
+	}
+	for (const n of items) knownIds.add(n.id);
+	primed = true;
 }
 
 /** @param {any} n */
 function pushToast(n) {
-  toasts.update((t) => [...t, { id: n.id, title: n.title, body: n.body, data: n.data, type: n.type }]);
-  setTimeout(() => dismissToast(n.id), 6000);
+	toasts.update((t) => [
+		...t,
+		{ id: n.id, title: n.title, body: n.body, data: n.data, type: n.type }
+	]);
+	setTimeout(() => dismissToast(n.id), 6000);
 }
 /** @param {string} id */
 export function dismissToast(id) {
-  toasts.update((t) => t.filter((x) => x.id !== id));
+	toasts.update((t) => t.filter((x) => x.id !== id));
 }
 
 /** @param {string} [uid] subscribe to this user's notifications for instant updates */
 export function startNotifications(uid) {
-  if (started || typeof window === 'undefined') return;
-  started = true;
-  poll();
-  pollTimer = setInterval(poll, POLL_MS);
-  onVis = () => { if (!document.hidden) poll(); };
-  document.addEventListener('visibilitychange', onVis);
-  // Realtime: a new challenge / friend request shows up instantly (not just on poll).
-  if (uid) {
-    channel = supabase.channel(`notifs:${uid}`)
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${uid}` }, () => poll())
-      .subscribe();
-  }
+	if (started || typeof window === 'undefined') return;
+	started = true;
+	poll();
+	pollTimer = setInterval(poll, POLL_MS);
+	onVis = () => {
+		if (!document.hidden) poll();
+	};
+	document.addEventListener('visibilitychange', onVis);
+	// Realtime: a new challenge / friend request shows up instantly (not just on poll).
+	if (uid) {
+		channel = supabase
+			.channel(`notifs:${uid}`)
+			.on(
+				'postgres_changes',
+				{ event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${uid}` },
+				() => poll()
+			)
+			.subscribe();
+	}
 }
 
 export function stopNotifications() {
-  started = false;
-  primed = false;
-  knownIds = new Set();
-  notifications.set([]);
-  unreadCount.set(0);
-  toasts.set([]);
-  if (pollTimer) clearInterval(pollTimer);
-  pollTimer = undefined;
-  if (onVis && typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVis);
-  if (channel) { supabase.removeChannel(channel); channel = undefined; }
+	started = false;
+	primed = false;
+	knownIds = new Set();
+	notifications.set([]);
+	unreadCount.set(0);
+	toasts.set([]);
+	if (pollTimer) clearInterval(pollTimer);
+	pollTimer = undefined;
+	if (onVis && typeof document !== 'undefined')
+		document.removeEventListener('visibilitychange', onVis);
+	if (channel) {
+		supabase.removeChannel(channel);
+		channel = undefined;
+	}
 }
 
 /** Force an immediate refresh (e.g. after acting on a challenge). */
 export async function refreshNotifications() {
-  if (started) await poll();
+	if (started) await poll();
 }
 
 export async function markAllNotificationsRead() {
-  await markNotificationsRead();
-  unreadCount.set(0);
-  notifications.update((list) => list.map((n) => ({ ...n, read: true })));
+	await markNotificationsRead();
+	unreadCount.set(0);
+	notifications.update((list) => list.map((n) => ({ ...n, read: true })));
 }
 
 /** Optimistically clear the badge for notifications matching a predicate, then sync. */
 function clearLocal(/** @type {(n:any)=>boolean} */ match) {
-  notifications.update((list) => {
-    let cleared = 0;
-    const next = list.map((n) => {
-      if (!n.read && match(n)) { cleared++; return { ...n, read: true }; }
-      return n;
-    });
-    if (cleared) unreadCount.update((c) => Math.max(0, c - cleared));
-    return next;
-  });
+	notifications.update((list) => {
+		let cleared = 0;
+		const next = list.map((n) => {
+			if (!n.read && match(n)) {
+				cleared++;
+				return { ...n, read: true };
+			}
+			return n;
+		});
+		if (cleared) unreadCount.update((c) => Math.max(0, c - cleared));
+		return next;
+	});
 }
 /** Clear the notification(s) for one challenge — e.g. after accepting it from the banner. */
 export async function markChallengeNotifRead(/** @type {string} */ matchId) {
-  if (!matchId) return;
-  clearLocal((n) => n?.data?.match_id === matchId);
-  await markNotificationsRead(matchId, null);
-  if (started) await poll();
+	if (!matchId) return;
+	clearLocal((n) => n?.data?.match_id === matchId);
+	await markNotificationsRead(matchId, null);
+	if (started) await poll();
 }
 /** Clear the friend-request notification from one person — e.g. accepting from the banner. */
 export async function markFriendNotifRead(/** @type {string} */ fromId) {
-  if (!fromId) return;
-  clearLocal((n) => n?.data?.from_id === fromId);
-  await markNotificationsRead(null, fromId);
-  if (started) await poll();
+	if (!fromId) return;
+	clearLocal((n) => n?.data?.from_id === fromId);
+	await markNotificationsRead(null, fromId);
+	if (started) await poll();
 }
 /** Permanently dismiss (delete) one notification. @param {string} id */
 export async function dismissNotification(id) {
-  if (!id) return;
-  notifications.update((list) => {
-    const n = list.find((x) => x.id === id);
-    if (n && !n.read) unreadCount.update((c) => Math.max(0, c - 1));
-    return list.filter((x) => x.id !== id);
-  });
-  try { await supabase.rpc('dismiss_notification', { p_id: id }); } catch { /* best-effort */ }
+	if (!id) return;
+	notifications.update((list) => {
+		const n = list.find((x) => x.id === id);
+		if (n && !n.read) unreadCount.update((c) => Math.max(0, c - 1));
+		return list.filter((x) => x.id !== id);
+	});
+	try {
+		await supabase.rpc('dismiss_notification', { p_id: id });
+	} catch {
+		/* best-effort */
+	}
 }

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -4,19 +4,19 @@ import { supabase } from '$lib/supabaseClient';
  * Fetch today's daily puzzle (same for everyone)
  */
 export async function fetchTodaysPuzzle() {
-  const { data, error } = await supabase.rpc('get_todays_puzzle').maybeSingle();
-  if (error) {
-    console.error('❌ Error fetching daily puzzle:', error);
-    return null;
-  }
-  if (!data) return null;
-  /** @type {{ phrase?: string, category?: string, subcategory?: string }} */
-  const puzzle = data;
-  return {
-    phrase: puzzle.phrase,
-    category: puzzle.category,
-    subcategory: puzzle.subcategory ?? ''
-  };
+	const { data, error } = await supabase.rpc('get_todays_puzzle').maybeSingle();
+	if (error) {
+		console.error('❌ Error fetching daily puzzle:', error);
+		return null;
+	}
+	if (!data) return null;
+	/** @type {{ phrase?: string, category?: string, subcategory?: string }} */
+	const puzzle = data;
+	return {
+		phrase: puzzle.phrase,
+		category: puzzle.category,
+		subcategory: puzzle.subcategory ?? ''
+	};
 }
 
 /**
@@ -24,14 +24,14 @@ export async function fetchTodaysPuzzle() {
  * @param {string} userId
  */
 export async function hasPlayedDailyToday(userId) {
-  const { data, error } = await supabase.rpc('has_played_daily_today', {
-    p_user_id: userId
-  });
-  if (error) {
-    console.error('❌ Error checking daily play status:', error);
-    return false;
-  }
-  return !!data;
+	const { data, error } = await supabase.rpc('has_played_daily_today', {
+		p_user_id: userId
+	});
+	if (error) {
+		console.error('❌ Error checking daily play status:', error);
+		return false;
+	}
+	return !!data;
 }
 
 /**
@@ -39,269 +39,410 @@ export async function hasPlayedDailyToday(userId) {
  * @param {string} userId
  */
 export async function getDailyStatus(userId) {
-  const { data, error } = await supabase.rpc('get_daily_status', {
-    p_user_id: userId
-  });
-  if (error) {
-    console.error('❌ Error fetching daily status:', error);
-    return { has_played_today: false, last_daily_won: null, daily_bankroll: 0, bank: 2000, current_streak: 0, streak_freezes: 0, today_score: 0, win_streak: 0, daily_in_progress: false };
-  }
-  const row = Array.isArray(data) ? data[0] : data;
-  return {
-    has_played_today: !!row?.has_played_today,
-    last_daily_won: row?.last_daily_won ?? null,
-    daily_bankroll: row?.daily_bankroll ?? 0,
-    bank: row?.bank ?? 2000,
-    current_streak: row?.current_streak ?? 0, // PLAY streak (attendance / showing up)
-    streak_freezes: row?.streak_freezes ?? 0,
-    today_score: row?.today_score ?? 0,
-    win_streak: row?.win_streak ?? 0, // WIN streak (consecutive solves)
-    daily_in_progress: !!row?.daily_in_progress // SERVER truth: today's session still active → resume, don't mark lost
-  };
+	const { data, error } = await supabase.rpc('get_daily_status', {
+		p_user_id: userId
+	});
+	if (error) {
+		console.error('❌ Error fetching daily status:', error);
+		return {
+			has_played_today: false,
+			last_daily_won: null,
+			daily_bankroll: 0,
+			bank: 2000,
+			current_streak: 0,
+			streak_freezes: 0,
+			today_score: 0,
+			win_streak: 0,
+			daily_in_progress: false
+		};
+	}
+	const row = Array.isArray(data) ? data[0] : data;
+	return {
+		has_played_today: !!row?.has_played_today,
+		last_daily_won: row?.last_daily_won ?? null,
+		daily_bankroll: row?.daily_bankroll ?? 0,
+		bank: row?.bank ?? 2000,
+		current_streak: row?.current_streak ?? 0, // PLAY streak (attendance / showing up)
+		streak_freezes: row?.streak_freezes ?? 0,
+		today_score: row?.today_score ?? 0,
+		win_streak: row?.win_streak ?? 0, // WIN streak (consecutive solves)
+		daily_in_progress: !!row?.daily_in_progress // SERVER truth: today's session still active → resume, don't mark lost
+	};
 }
-
 
 /** My Cash: balance (= Net Worth) and recent ledger. (v3: loans removed.)
  * @returns {Promise<{ bank:number, net_worth:number, ledger:any[] }>} */
 /** @param {number} [limit] ledger rows to return (default 12; pass a big number for full history) */
 export async function getBank(limit) {
-  const { data, error } = await supabase.rpc('get_bank', limit ? { p_limit: limit } : {});
-  if (error || !data) { if (error) console.error('❌ get_bank:', error); return { bank: 0, net_worth: 0, loan: 0, loan_cap: 0, in_the_red: false, ledger: [] }; }
-  return { bank: data.bank ?? 0, net_worth: data.net_worth ?? data.bank ?? 0,
-    loan: data.loan ?? 0, loan_cap: data.loan_cap ?? 0, in_the_red: !!data.in_the_red,
-    ledger: Array.isArray(data.ledger) ? data.ledger : [] };
+	const { data, error } = await supabase.rpc('get_bank', limit ? { p_limit: limit } : {});
+	if (error || !data) {
+		if (error) console.error('❌ get_bank:', error);
+		return { bank: 0, net_worth: 0, loan: 0, loan_cap: 0, in_the_red: false, ledger: [] };
+	}
+	return {
+		bank: data.bank ?? 0,
+		net_worth: data.net_worth ?? data.bank ?? 0,
+		loan: data.loan ?? 0,
+		loan_cap: data.loan_cap ?? 0,
+		in_the_red: !!data.in_the_red,
+		ledger: Array.isArray(data.ledger) ? data.ledger : []
+	};
 }
 
 /** Borrow from the Loan Shark (25% fee, one at a time, ≤ credit limit). @param {number} amount */
 export async function takeLoan(amount) {
-  const { data, error } = await supabase.rpc('take_loan', { p_amount: amount });
-  if (error || !data) { if (error) console.error('❌ take_loan:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('take_loan', { p_amount: amount });
+	if (error || !data) {
+		if (error) console.error('❌ take_loan:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /** Repay the loan from Cash (null = pay the max you can afford). @param {number|null} amount */
 export async function repayLoan(amount = null) {
-  const { data, error } = await supabase.rpc('repay_loan', { p_amount: amount });
-  if (error || !data) { if (error) console.error('❌ repay_loan:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('repay_loan', { p_amount: amount });
+	if (error || !data) {
+		if (error) console.error('❌ repay_loan:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /** Lowest winning spend per mode (e.g. { daily: 20, climb: 60 }) — powers the
  *  solo "beat your best" goal line. @returns {Promise<Record<string, number>>} */
 export async function getPersonalBests() {
-  const { data, error } = await supabase.rpc('get_personal_bests');
-  if (error) { console.error('❌ get_personal_bests:', error); return {}; }
-  return data && typeof data === 'object' ? data : {};
+	const { data, error } = await supabase.rpc('get_personal_bests');
+	if (error) {
+		console.error('❌ get_personal_bests:', error);
+		return {};
+	}
+	return data && typeof data === 'object' ? data : {};
 }
 
 /** My chosen username (null until claimed). @returns {Promise<string|null>} */
 export async function getMyUsername() {
-  const { data, error } = await supabase.rpc('get_my_username');
-  if (error) { console.error('❌ get_my_username:', error); return null; }
-  return data ?? null;
+	const { data, error } = await supabase.rpc('get_my_username');
+	if (error) {
+		console.error('❌ get_my_username:', error);
+		return null;
+	}
+	return data ?? null;
 }
 
 /** Claim / change my username. @param {string} name @returns {Promise<{ok:boolean, reason?:string, username?:string}>} */
 export async function setUsername(name) {
-  const { data, error } = await supabase.rpc('set_username', { p_username: name });
-  if (error || !data) { if (error) console.error('❌ set_username:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('set_username', { p_username: name });
+	if (error || !data) {
+		if (error) console.error('❌ set_username:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /** Permanently delete my account + all my data. @returns {Promise<{ok:boolean}>} */
 export async function deleteMyAccount() {
-  const { error } = await supabase.rpc('delete_my_account');
-  if (error) { console.error('❌ delete_my_account:', error); return { ok: false }; }
-  return { ok: true };
+	const { error } = await supabase.rpc('delete_my_account');
+	if (error) {
+		console.error('❌ delete_my_account:', error);
+		return { ok: false };
+	}
+	return { ok: true };
 }
 
-/** Username typeahead search. @param {string} query @returns {Promise<{username:string,is_friend:boolean}[]>} */
+/** Username typeahead search. @param {string} query @returns {Promise<Array<{username:string,name?:string,status?:string,id?:string,is_friend:boolean}>>} */
 export async function searchUsers(query) {
-  const { data, error } = await supabase.rpc('search_users', { p_query: query });
-  if (error) { console.error('❌ search_users:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('search_users', { p_query: query });
+	if (error) {
+		console.error('❌ search_users:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /* ===== Groups ===== */
 /** @returns {Promise<any[]>} */
 export async function getMyGroups() {
-  const { data, error } = await supabase.rpc('get_my_groups');
-  if (error) { console.error('❌ get_my_groups:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_my_groups');
+	if (error) {
+		console.error('❌ get_my_groups:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} id @returns {Promise<any|null>} */
 export async function getGroup(id) {
-  const { data, error } = await supabase.rpc('get_group', { p_id: id });
-  if (error) { console.error('❌ get_group:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_group', { p_id: id });
+	if (error) {
+		console.error('❌ get_group:', error);
+		return null;
+	}
+	return data;
 }
 /** Ask to join a group (owner approves). @param {string} groupId @returns {Promise<{ok:boolean, reason?:string, status?:string}>} */
 export async function requestJoinGroup(groupId) {
-  const { data, error } = await supabase.rpc('request_join_group', { p_group: groupId });
-  if (error || !data) { if (error) console.error('❌ request_join_group:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('request_join_group', { p_group: groupId });
+	if (error || !data) {
+		if (error) console.error('❌ request_join_group:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Owner: approve/decline a join request. @param {string} groupId @param {string} userId @param {boolean} accept */
 export async function respondJoinRequest(groupId, userId, accept) {
-  const { data, error } = await supabase.rpc('respond_join_request', { p_group: groupId, p_user: userId, p_accept: accept });
-  if (error || !data) { if (error) console.error('❌ respond_join_request:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('respond_join_request', {
+		p_group: groupId,
+		p_user: userId,
+		p_accept: accept
+	});
+	if (error || !data) {
+		if (error) console.error('❌ respond_join_request:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} name @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
 export async function createGroup(name) {
-  const { data, error } = await supabase.rpc('create_group', { p_name: name });
-  if (error || !data) { if (error) console.error('❌ create_group:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('create_group', { p_name: name });
+	if (error || !data) {
+		if (error) console.error('❌ create_group:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} code @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
 export async function joinGroup(code) {
-  const { data, error } = await supabase.rpc('join_group', { p_code: code });
-  if (error || !data) { if (error) console.error('❌ join_group:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('join_group', { p_code: code });
+	if (error || !data) {
+		if (error) console.error('❌ join_group:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} id @returns {Promise<{ok:boolean}>} */
 export async function leaveGroup(id) {
-  const { data, error } = await supabase.rpc('leave_group', { p_id: id });
-  if (error || !data) { if (error) console.error('❌ leave_group:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('leave_group', { p_id: id });
+	if (error || !data) {
+		if (error) console.error('❌ leave_group:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Add one of your friends to a group. @param {string} groupId @param {string} username @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
 export async function addGroupMember(groupId, username) {
-  const { data, error } = await supabase.rpc('add_group_member', { p_group_id: groupId, p_username: username });
-  if (error || !data) { if (error) console.error('❌ add_group_member:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('add_group_member', {
+		p_group_id: groupId,
+		p_username: username
+	});
+	if (error || !data) {
+		if (error) console.error('❌ add_group_member:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Owner removes a member. @param {string} groupId @param {string} username @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
 export async function removeGroupMember(groupId, username) {
-  const { data, error } = await supabase.rpc('remove_group_member', { p_group_id: groupId, p_username: username });
-  if (error || !data) { if (error) console.error('❌ remove_group_member:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('remove_group_member', {
+		p_group_id: groupId,
+		p_username: username
+	});
+	if (error || !data) {
+		if (error) console.error('❌ remove_group_member:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Owner renames a group. @param {string} groupId @param {string} name @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
 export async function renameGroup(groupId, name) {
-  const { data, error } = await supabase.rpc('rename_group', { p_group_id: groupId, p_name: name });
-  if (error || !data) { if (error) console.error('❌ rename_group:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('rename_group', { p_group_id: groupId, p_name: name });
+	if (error || !data) {
+		if (error) console.error('❌ rename_group:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} groupId @returns {Promise<any[]>} */
 export async function getGroupMessages(groupId) {
-  const { data, error } = await supabase.rpc('get_group_messages', { p_group_id: groupId });
-  if (error) { console.error('❌ get_group_messages:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_group_messages', { p_group_id: groupId });
+	if (error) {
+		console.error('❌ get_group_messages:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} groupId @param {string} body @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function sendGroupMessage(groupId, body) {
-  const { data, error } = await supabase.rpc('send_group_message', { p_group_id: groupId, p_body: body });
-  if (error || !data) { if (error) console.error('❌ send_group_message:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('send_group_message', {
+		p_group_id: groupId,
+		p_body: body
+	});
+	if (error || !data) {
+		if (error) console.error('❌ send_group_message:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /* ===== Notifications ===== */
 /** @returns {Promise<{items:any[], unread_count:number}>} */
 export async function getNotifications() {
-  const { data, error } = await supabase.rpc('get_notifications');
-  if (error || !data) { if (error) console.error('❌ get_notifications:', error); return { items: [], unread_count: 0 }; }
-  return { items: Array.isArray(data.items) ? data.items : [], unread_count: data.unread_count ?? 0 };
+	const { data, error } = await supabase.rpc('get_notifications');
+	if (error || !data) {
+		if (error) console.error('❌ get_notifications:', error);
+		return { items: [], unread_count: 0 };
+	}
+	return {
+		items: Array.isArray(data.items) ? data.items : [],
+		unread_count: data.unread_count ?? 0
+	};
 }
 /** Mark notifications read — all, one challenge (matchId), or one friend request (fromId).
  *  @param {string|null} [matchId] @param {string|null} [fromId] */
 export async function markNotificationsRead(matchId = null, fromId = null) {
-  const { error } = await supabase.rpc('mark_notifications_read', { p_match_id: matchId, p_from_id: fromId });
-  if (error) console.error('❌ mark_notifications_read:', error);
+	const { error } = await supabase.rpc('mark_notifications_read', {
+		p_match_id: matchId,
+		p_from_id: fromId
+	});
+	if (error) console.error('❌ mark_notifications_read:', error);
 }
 
 /** Send a friend request by username (auto-accepts if they already requested you). @param {string} username @returns {Promise<{ok:boolean, reason?:string, status?:string, friend_name?:string}>} */
 export async function addFriend(username) {
-  const { data, error } = await supabase.rpc('add_friend', { p_username: username });
-  if (error || !data) { if (error) console.error('❌ add_friend:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('add_friend', { p_username: username });
+	if (error || !data) {
+		if (error) console.error('❌ add_friend:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /** Accept or decline an incoming request, by requester id. @param {string} requesterId @param {boolean} accept @returns {Promise<{ok:boolean, reason?:string, status?:string}>} */
 export async function respondFriendRequest(requesterId, accept) {
-  const { data, error } = await supabase.rpc('respond_friend_request', { p_requester: requesterId, p_accept: accept });
-  if (error || !data) { if (error) console.error('❌ respond_friend_request:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('respond_friend_request', {
+		p_requester: requesterId,
+		p_accept: accept
+	});
+	if (error || !data) {
+		if (error) console.error('❌ respond_friend_request:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /** Unfriend by user id. @param {string} otherId @returns {Promise<{ok:boolean}>} */
 export async function removeFriend(otherId) {
-  const { data, error } = await supabase.rpc('remove_friend', { p_other: otherId });
-  if (error || !data) { if (error) console.error('❌ remove_friend:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('remove_friend', { p_other: otherId });
+	if (error || !data) {
+		if (error) console.error('❌ remove_friend:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /** My accepted friends. @returns {Promise<{username:string,name:string}[]>} */
 export async function listFriends() {
-  const { data, error } = await supabase.rpc('list_friends');
-  if (error) { console.error('❌ list_friends:', error); return []; }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('list_friends');
+	if (error) {
+		console.error('❌ list_friends:', error);
+		return [];
+	}
+	return data ?? [];
 }
 
 /** Pending requests. @returns {Promise<{incoming:{username:string,name:string}[], outgoing:{username:string,name:string}[]}>} */
 export async function listFriendRequests() {
-  const { data, error } = await supabase.rpc('list_friend_requests');
-  if (error) { console.error('❌ list_friend_requests:', error); return { incoming: [], outgoing: [] }; }
-  return data ?? { incoming: [], outgoing: [] };
+	const { data, error } = await supabase.rpc('list_friend_requests');
+	if (error) {
+		console.error('❌ list_friend_requests:', error);
+		return { incoming: [], outgoing: [] };
+	}
+	return data ?? { incoming: [], outgoing: [] };
 }
 
 /** Count of incoming friend requests (menu badge). @returns {Promise<number>} */
 export async function getFriendRequestCount() {
-  const { data, error } = await supabase.rpc('get_friend_request_count');
-  if (error) { console.error('❌ get_friend_request_count:', error); return 0; }
-  return data ?? 0;
+	const { data, error } = await supabase.rpc('get_friend_request_count');
+	if (error) {
+		console.error('❌ get_friend_request_count:', error);
+		return 0;
+	}
+	return data ?? 0;
 }
 
 /** Me + friends ranked by today's Daily score. @returns {Promise<any[]>} */
 export async function getFriendsDailyLeaderboard() {
-  const { data, error } = await supabase.rpc('get_friends_daily_leaderboard');
-  if (error) { console.error('❌ get_friends_daily_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_friends_daily_leaderboard');
+	if (error) {
+		console.error('❌ get_friends_daily_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /** Net Worth leaderboard (= Cash). @param {'friends'|'global'} scope @returns {Promise<any[]>} */
 export async function getNetworthLeaderboard(scope = 'friends') {
-  const { data, error } = await supabase.rpc('get_networth_leaderboard', { p_scope: scope });
-  if (error) { console.error('❌ get_networth_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_networth_leaderboard', { p_scope: scope });
+	if (error) {
+		console.error('❌ get_networth_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /* ===== Cosmetics shop (Bank spending sink; earned-Bank-only, no pay-to-win) ===== */
 /** Shop catalog + owned/equipped flags + my Bank. @returns {Promise<{bank:number, items:any[]}>} */
 export async function getShop() {
-  const { data, error } = await supabase.rpc('get_shop');
-  if (error || !data) { if (error) console.error('❌ get_shop:', error); return { bank: 0, items: [] }; }
-  return { bank: data.bank ?? 0, items: Array.isArray(data.items) ? data.items : [] };
+	const { data, error } = await supabase.rpc('get_shop');
+	if (error || !data) {
+		if (error) console.error('❌ get_shop:', error);
+		return { bank: 0, items: [] };
+	}
+	return { bank: data.bank ?? 0, items: Array.isArray(data.items) ? data.items : [] };
 }
 /** Buy a cosmetic with Bank. @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function buyCosmetic(id) {
-  const { data, error } = await supabase.rpc('buy_cosmetic', { p_id: id });
-  if (error || !data) { if (error) console.error('❌ buy_cosmetic:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('buy_cosmetic', { p_id: id });
+	if (error || !data) {
+		if (error) console.error('❌ buy_cosmetic:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** My avatar config + owned avatar cosmetic ids. @returns {Promise<{config:any, owned:string[]}>} */
 export async function getMyAvatar() {
-  const { data, error } = await supabase.rpc('get_my_avatar');
-  if (error) { console.error('❌ get_my_avatar:', error); return { config: null, owned: [] }; }
-  return { config: data?.config ?? null, owned: data?.owned ?? [] };
+	const { data, error } = await supabase.rpc('get_my_avatar');
+	if (error) {
+		console.error('❌ get_my_avatar:', error);
+		return { config: null, owned: [] };
+	}
+	return { config: data?.config ?? null, owned: data?.owned ?? [] };
 }
 /** Save my equipped avatar look. @param {any} config @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function setAvatar(config) {
-  const { data, error } = await supabase.rpc('set_avatar', { p_config: config });
-  if (error || !data) { if (error) console.error('❌ set_avatar:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('set_avatar', { p_config: config });
+	if (error || !data) {
+		if (error) console.error('❌ set_avatar:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Equip an owned cosmetic. @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function equipCosmetic(id) {
-  const { data, error } = await supabase.rpc('equip_cosmetic', { p_id: id });
-  if (error || !data) { if (error) console.error('❌ equip_cosmetic:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('equip_cosmetic', { p_id: id });
+	if (error || !data) {
+		if (error) console.error('❌ equip_cosmetic:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Unequip the current title or color. @param {'title'|'color'} kind @returns {Promise<{ok:boolean}>} */
 export async function unequipCosmetic(kind) {
-  const { data, error } = await supabase.rpc('unequip_cosmetic', { p_kind: kind });
-  if (error || !data) { if (error) console.error('❌ unequip_cosmetic:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('unequip_cosmetic', { p_kind: kind });
+	if (error || !data) {
+		if (error) console.error('❌ unequip_cosmetic:', error);
+		return { ok: false };
+	}
+	return data;
 }
 
 /**
@@ -310,17 +451,17 @@ export async function unequipCosmetic(kind) {
  * @returns {Promise<{ current_streak:number, highest_streak:number, freezes:number, days:{d:string,won:boolean}[] }>}
  */
 export async function getStreakOverview() {
-  const { data, error } = await supabase.rpc('get_streak_overview');
-  if (error || !data) {
-    if (error) console.error('❌ Error fetching streak overview:', error);
-    return { current_streak: 0, highest_streak: 0, freezes: 0, days: [] };
-  }
-  return {
-    current_streak: data.current_streak ?? 0,
-    highest_streak: data.highest_streak ?? 0,
-    freezes: data.freezes ?? 0,
-    days: Array.isArray(data.days) ? data.days : []
-  };
+	const { data, error } = await supabase.rpc('get_streak_overview');
+	if (error || !data) {
+		if (error) console.error('❌ Error fetching streak overview:', error);
+		return { current_streak: 0, highest_streak: 0, freezes: 0, days: [] };
+	}
+	return {
+		current_streak: data.current_streak ?? 0,
+		highest_streak: data.highest_streak ?? 0,
+		freezes: data.freezes ?? 0,
+		days: Array.isArray(data.days) ? data.days : []
+	};
 }
 
 /**
@@ -329,15 +470,15 @@ export async function getStreakOverview() {
  * @param {string} orderBy - 'bankroll' | 'streak' | 'puzzles' | 'win_pct'
  */
 export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score') {
-  const { data, error } = await supabase.rpc('get_daily_leaderboard', {
-    p_period: period,
-    p_order_by: orderBy
-  });
-  if (error) {
-    console.error('❌ Error fetching daily leaderboard:', error);
-    return [];
-  }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('get_daily_leaderboard', {
+		p_period: period,
+		p_order_by: orderBy
+	});
+	if (error) {
+		console.error('❌ Error fetching daily leaderboard:', error);
+		return [];
+	}
+	return data ?? [];
 }
 
 /**
@@ -345,23 +486,32 @@ export async function fetchDailyLeaderboard(period = 'daily', orderBy = 'score')
  * @returns {Promise<{category: string, solves: number}[]>}
  */
 export async function getCategoryStats() {
-  const { data, error } = await supabase.rpc('get_category_stats');
-  if (error) { console.error('❌ get_category_stats error:', error); return []; }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('get_category_stats');
+	if (error) {
+		console.error('❌ get_category_stats error:', error);
+		return [];
+	}
+	return data ?? [];
 }
 
 /** Witty clue for the caller's current daily puzzle. @returns {Promise<string|null>} */
 export async function getDailyClue() {
-  const { data, error } = await supabase.rpc('daily_clue');
-  if (error) { console.error('❌ daily_clue error:', error); return null; }
-  return data ?? null;
+	const { data, error } = await supabase.rpc('daily_clue');
+	if (error) {
+		console.error('❌ daily_clue error:', error);
+		return null;
+	}
+	return data ?? null;
 }
 
 /** Witty clue for the caller's current Cash Game (climb) puzzle. @returns {Promise<string|null>} */
 export async function getClimbClue() {
-  const { data, error } = await supabase.rpc('climb_clue');
-  if (error) { console.error('❌ climb_clue error:', error); return null; }
-  return data ?? null;
+	const { data, error } = await supabase.rpc('climb_clue');
+	if (error) {
+		console.error('❌ climb_clue error:', error);
+		return null;
+	}
+	return data ?? null;
 }
 
 /**
@@ -369,9 +519,12 @@ export async function getClimbClue() {
  * @returns {Promise<string|null>}
  */
 export async function getDailyModifier() {
-  const { data, error } = await supabase.rpc('get_daily_modifier');
-  if (error) { console.error('❌ get_daily_modifier error:', error); return null; }
-  return data ?? null;
+	const { data, error } = await supabase.rpc('get_daily_modifier');
+	if (error) {
+		console.error('❌ get_daily_modifier error:', error);
+		return null;
+	}
+	return data ?? null;
 }
 
 /**
@@ -380,9 +533,12 @@ export async function getDailyModifier() {
  * @returns {Promise<null | { yesterday_played: boolean, yesterday_banked: number|null, yesterday_won: boolean, yesterday_score: number|null, today_banked: number|null, today_score: number|null, today_players: number, today_percentile: number|null }>}
  */
 export async function getDailyGhost() {
-  const { data, error } = await supabase.rpc('get_daily_ghost');
-  if (error) { console.error('❌ get_daily_ghost error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_daily_ghost');
+	if (error) {
+		console.error('❌ get_daily_ghost error:', error);
+		return null;
+	}
+	return data;
 }
 
 /* ============================================================
@@ -400,36 +556,51 @@ export async function getDailyGhost() {
  * @returns {Promise<object|null>} board
  */
 export async function dailyStart(powerups = []) {
-  const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups });
-  if (error) { console.error('❌ daily_start error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_start', { p_powerups: powerups });
+	if (error) {
+		console.error('❌ daily_start error:', error);
+		return null;
+	}
+	return data;
 }
 /** Use today's Daily Twist power-up (applies its effect; bounty drops to ×1.0). */
 export async function dailyUseTwist() {
-  const { data, error } = await supabase.rpc('daily_use_twist');
-  if (error) { console.error('❌ daily_use_twist error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_use_twist');
+	if (error) {
+		console.error('❌ daily_use_twist error:', error);
+		return null;
+	}
+	return data;
 }
 
-/** Spend an owned Bounty Boost on today's Daily (adds to the bounty multiplier). */
+/** Spend an owned Bounty Boost on today's Daily (adds to the bounty multiplier). @param {string} id */
 export async function dailyUseBoost(id) {
-  const { data, error } = await supabase.rpc('daily_use_boost', { p_id: id });
-  if (error) { console.error('❌ daily_use_boost error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_use_boost', { p_id: id });
+	if (error) {
+		console.error('❌ daily_use_boost error:', error);
+		return null;
+	}
+	return data;
 }
 
 /** Your rank on today's global Daily leaderboard → { rank, total, score }. */
 export async function getMyDailyRank() {
-  const { data, error } = await supabase.rpc('get_my_daily_rank');
-  if (error) { console.error('❌ get_my_daily_rank:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_my_daily_rank');
+	if (error) {
+		console.error('❌ get_my_daily_rank:', error);
+		return null;
+	}
+	return data;
 }
 
 /** Boosts available to use in today's Daily (snapshot at start) → { id: remaining }. */
 export async function getDailyAvailBoosts() {
-  const { data, error } = await supabase.rpc('get_daily_avail_boosts');
-  if (error) { console.error('❌ get_daily_avail_boosts:', error); return {}; }
-  return data ?? {};
+	const { data, error } = await supabase.rpc('get_daily_avail_boosts');
+	if (error) {
+		console.error('❌ get_daily_avail_boosts:', error);
+		return {};
+	}
+	return data ?? {};
 }
 
 /* ===== Make-up daily (play a past missed day in the current month) =====
@@ -437,191 +608,299 @@ export async function getDailyAvailBoosts() {
    Each returns a daily board with an extra { makeup: { date } } marker. */
 /** @param {string} date YYYY-MM-DD @returns {Promise<any>} */
 export async function makeupStart(date) {
-  const { data, error } = await supabase.rpc('makeup_start', { p_date: date });
-  if (error) { console.error('❌ makeup_start error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('makeup_start', { p_date: date });
+	if (error) {
+		console.error('❌ makeup_start error:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} date @param {string} letter @returns {Promise<any>} */
 export async function makeupBuyLetter(date, letter) {
-  const { data, error } = await supabase.rpc('makeup_buy_letter', { p_date: date, p_letter: letter });
-  if (error) { console.error('❌ makeup_buy_letter error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('makeup_buy_letter', {
+		p_date: date,
+		p_letter: letter
+	});
+	if (error) {
+		console.error('❌ makeup_buy_letter error:', error);
+		return null;
+	}
+	return data;
 }
 
 /* ===== Cash Game / the Climb (real-Cash forward-only climb) ===== */
 /** @returns {Promise<any>} */
 export async function climbStart() {
-  const { data, error } = await supabase.rpc('climb_start');
-  if (error) { console.error('❌ climb_start:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_start');
+	if (error) {
+		console.error('❌ climb_start:', error);
+		return null;
+	}
+	return data;
 }
 /** Cash Game V2: buy in at a tier → a fresh run. @param {string} tier @returns {Promise<any>} */
 export async function cashgameStart(tier) {
-  const { data, error } = await supabase.rpc('cashgame_start', { p_tier: tier });
-  if (error || !data) { if (error) console.error('❌ cashgame_start:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('cashgame_start', { p_tier: tier });
+	if (error || !data) {
+		if (error) console.error('❌ cashgame_start:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Cash out the current run → bank the bankroll, end the run. @returns {Promise<any>} */
 export async function cashgameCashout() {
-  const { data, error } = await supabase.rpc('cashgame_cashout');
-  if (error || !data) { if (error) console.error('❌ cashgame_cashout:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('cashgame_cashout');
+	if (error || !data) {
+		if (error) console.error('❌ cashgame_cashout:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Tier-select meta: unlocked tiers + Cash Game stats. @returns {Promise<any>} */
 export async function getCashgameMeta() {
-  const { data, error } = await supabase.rpc('get_cashgame_meta');
-  if (error) { console.error('❌ get_cashgame_meta:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_cashgame_meta');
+	if (error) {
+		console.error('❌ get_cashgame_meta:', error);
+		return null;
+	}
+	return data;
 }
 
 /* ===== Blitz (timed speed run) ===== */
 /** @param {string} tier @returns {Promise<any>} */
 export async function blitzStart(tier) {
-  const { data, error } = await supabase.rpc('blitz_start', { p_tier: tier });
-  if (error || !data) { if (error) console.error('❌ blitz_start:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('blitz_start', { p_tier: tier });
+	if (error || !data) {
+		if (error) console.error('❌ blitz_start:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} letter @returns {Promise<any>} */
 export async function blitzBuyLetter(letter) {
-  const { data, error } = await supabase.rpc('blitz_buy_letter', { p_letter: letter });
-  if (error) { console.error('❌ blitz_buy_letter:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('blitz_buy_letter', { p_letter: letter });
+	if (error) {
+		console.error('❌ blitz_buy_letter:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {Record<string,string>} guess @returns {Promise<any>} */
 export async function blitzSubmitGuess(guess) {
-  const { data, error } = await supabase.rpc('blitz_submit_guess', { p_guess: guess });
-  if (error) { console.error('❌ blitz_submit_guess:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('blitz_submit_guess', { p_guess: guess });
+	if (error) {
+		console.error('❌ blitz_submit_guess:', error);
+		return null;
+	}
+	return data;
 }
 /** @returns {Promise<any>} */
 export async function blitzSkip() {
-  const { data, error } = await supabase.rpc('blitz_skip');
-  if (error) { console.error('❌ blitz_skip:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('blitz_skip');
+	if (error) {
+		console.error('❌ blitz_skip:', error);
+		return null;
+	}
+	return data;
 }
 /** End the run (clock hit 0). @returns {Promise<any>} */
 export async function blitzEnd() {
-  const { data, error } = await supabase.rpc('blitz_end');
-  if (error || !data) { if (error) console.error('❌ blitz_end:', error); return { blitz: { state: 'ended' } }; }
-  return data;
+	const { data, error } = await supabase.rpc('blitz_end');
+	if (error || !data) {
+		if (error) console.error('❌ blitz_end:', error);
+		return { blitz: { state: 'ended' } };
+	}
+	return data;
 }
 /** Tier-select meta + Blitz stats. @returns {Promise<any>} */
 export async function getBlitzMeta() {
-  const { data, error } = await supabase.rpc('get_blitz_meta');
-  if (error) { console.error('❌ get_blitz_meta:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_blitz_meta');
+	if (error) {
+		console.error('❌ get_blitz_meta:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} letter @returns {Promise<any>} */
 export async function climbBuyLetter(letter) {
-  const { data, error } = await supabase.rpc('climb_buy_letter', { p_letter: letter });
-  if (error) { console.error('❌ climb_buy_letter:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_buy_letter', { p_letter: letter });
+	if (error) {
+		console.error('❌ climb_buy_letter:', error);
+		return null;
+	}
+	return data;
 }
 /** @returns {Promise<any>} */
 export async function climbReveal() {
-  const { data, error } = await supabase.rpc('climb_reveal');
-  if (error) { console.error('❌ climb_reveal:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_reveal');
+	if (error) {
+		console.error('❌ climb_reveal:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {Record<string,string>} guess @returns {Promise<any>} */
 export async function climbSubmitGuess(guess) {
-  const { data, error } = await supabase.rpc('climb_submit_guess', { p_guess: guess });
-  if (error) { console.error('❌ climb_submit_guess:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_submit_guess', { p_guess: guess });
+	if (error) {
+		console.error('❌ climb_submit_guess:', error);
+		return null;
+	}
+	return data;
 }
 /** @returns {Promise<any>} */
 export async function climbNext() {
-  const { data, error } = await supabase.rpc('climb_next');
-  if (error) { console.error('❌ climb_next:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_next');
+	if (error) {
+		console.error('❌ climb_next:', error);
+		return null;
+	}
+	return data;
 }
 /** @returns {Promise<any>} */
 export async function climbLeave() {
-  const { data, error } = await supabase.rpc('climb_leave');
-  if (error) { console.error('❌ climb_leave:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_leave');
+	if (error) {
+		console.error('❌ climb_leave:', error);
+		return null;
+	}
+	return data;
 }
 /** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). @returns {Promise<any>} */
 export async function climbSkip() {
-  const { data, error } = await supabase.rpc('climb_skip');
-  if (error) { console.error('❌ climb_skip:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_skip');
+	if (error) {
+		console.error('❌ climb_skip:', error);
+		return null;
+	}
+	return data;
 }
 /** Arm Double-or-Nothing on the current Cash Game puzzle (heat ≥ ×1.5). @returns {Promise<any>} */
 export async function climbDoubleOrNothing() {
-  const { data, error } = await supabase.rpc('climb_double_or_nothing');
-  if (error) { console.error('❌ climb_double_or_nothing:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_double_or_nothing');
+	if (error) {
+		console.error('❌ climb_double_or_nothing:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getClimbLeaderboard(scope = 'friends', group = null) {
-  const { data, error } = await supabase.rpc('get_climb_leaderboard', { p_scope: scope, p_group: group });
-  if (error) { console.error('❌ get_climb_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_climb_leaderboard', {
+		p_scope: scope,
+		p_group: group
+	});
+	if (error) {
+		console.error('❌ get_climb_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /** Finalize the caller's unfinished Daily puzzles from prior days as losses (no broke
  *  timer anymore — an unsolved Daily expires at day's end, forfeiting the spend, and
  *  shows in History). Lazy "midnight" finalization; call on app open. @returns {Promise<number>} */
 export async function expireStaleDailies() {
-  const { data, error } = await supabase.rpc('expire_stale_dailies');
-  if (error) { console.error('❌ expire_stale_dailies:', error); return 0; }
-  return data ?? 0;
+	const { data, error } = await supabase.rpc('expire_stale_dailies');
+	if (error) {
+		console.error('❌ expire_stale_dailies:', error);
+		return 0;
+	}
+	return data ?? 0;
 }
 
 /** The caller's currently-resumable solo games (daily/climb), newest first.
  *  Server truth for menu resume labels + the top-level Resume shortcut.
  *  @returns {Promise<{mode:string, updated_at:string}[]>} */
 export async function getOpenGames() {
-  const { data, error } = await supabase.rpc('get_open_games');
-  if (error) { console.error('❌ get_open_games:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_open_games');
+	if (error) {
+		console.error('❌ get_open_games:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /** Cash Game run leaderboard — ranks by best run profit (skill, not longevity).
  *  @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getClimbRunLeaderboard(scope = 'friends', group = null) {
-  const { data, error } = await supabase.rpc('get_climb_run_leaderboard', { p_scope: scope, p_group: group });
-  if (error) { console.error('❌ get_climb_run_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_climb_run_leaderboard', {
+		p_scope: scope,
+		p_group: group
+	});
+	if (error) {
+		console.error('❌ get_climb_run_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /* ===== Leaderboards v2 (3 boards × scope) ===== */
 /** @param {string} scope @param {'week'|'all'} period @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getWealthLeaderboard(scope = 'friends', period = 'week', group = null) {
-  const { data, error } = await supabase.rpc('get_wealth_leaderboard', { p_scope: scope, p_period: period, p_group: group });
-  if (error) { console.error('❌ get_wealth_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_wealth_leaderboard', {
+		p_scope: scope,
+		p_period: period,
+		p_group: group
+	});
+	if (error) {
+		console.error('❌ get_wealth_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} scope @param {string|null} [group] @returns {Promise<any[]>} */
 export async function getDailyBoard(scope = 'friends', group = null) {
-  const { data, error } = await supabase.rpc('get_daily_board', { p_scope: scope, p_group: group });
-  if (error) { console.error('❌ get_daily_board:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_daily_board', { p_scope: scope, p_group: group });
+	if (error) {
+		console.error('❌ get_daily_board:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** Best return-multiple board (the brand metric). @param {string} scope @param {string|null} group @param {'week'|'all'} period */
 export async function getEfficiencyLeaderboard(scope = 'friends', group = null, period = 'week') {
-  const { data, error } = await supabase.rpc('get_efficiency_leaderboard', { p_scope: scope, p_group: group, p_period: period });
-  if (error) { console.error('❌ get_efficiency_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_efficiency_leaderboard', {
+		p_scope: scope,
+		p_group: group,
+		p_period: period
+	});
+	if (error) {
+		console.error('❌ get_efficiency_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** Challenge wins / pot-won board. @param {string} scope @param {string|null} group @param {'week'|'all'} period */
 export async function getChallengeLeaderboard(scope = 'friends', group = null, period = 'week') {
-  const { data, error } = await supabase.rpc('get_challenge_leaderboard', { p_scope: scope, p_group: group, p_period: period });
-  if (error) { console.error('❌ get_challenge_leaderboard:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_challenge_leaderboard', {
+		p_scope: scope,
+		p_group: group,
+		p_period: period
+	});
+	if (error) {
+		console.error('❌ get_challenge_leaderboard:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @returns {Promise<any|null>} */
 export async function getProfileStats() {
-  const { data, error } = await supabase.rpc('get_profile_stats');
-  if (error) { console.error('❌ get_profile_stats:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_profile_stats');
+	if (error) {
+		console.error('❌ get_profile_stats:', error);
+		return null;
+	}
+	return data;
 }
 /** Stat-heavy profile: per-mode sections + records. @returns {Promise<any|null>} */
 export async function getProfileDetail() {
-  const { data, error } = await supabase.rpc('get_profile_detail');
-  if (error) { console.error('❌ get_profile_detail:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_profile_detail');
+	if (error) {
+		console.error('❌ get_profile_detail:', error);
+		return null;
+	}
+	return data;
 }
 
 /* ===== Play Log: history, head-to-head, challenge detail ===== */
@@ -633,93 +912,144 @@ export async function getProfileDetail() {
  * @returns {Promise<any[]>}
  */
 export async function getHistory(f = {}) {
-  const { data, error } = await supabase.rpc('get_history', {
-    p_mode: f.mode ?? null, p_result: f.result ?? null, p_category: f.category ?? null,
-    p_opponent: f.opponent ?? null, p_group: f.group ?? null,
-    p_since: f.since ?? null, p_until: f.until ?? null,
-    p_sort: f.sort ?? 'recent', p_limit: f.limit ?? 30, p_offset: f.offset ?? 0
-  });
-  if (error) { console.error('❌ get_history:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_history', {
+		p_mode: f.mode ?? null,
+		p_result: f.result ?? null,
+		p_category: f.category ?? null,
+		p_opponent: f.opponent ?? null,
+		p_group: f.group ?? null,
+		p_since: f.since ?? null,
+		p_until: f.until ?? null,
+		p_sort: f.sort ?? 'recent',
+		p_limit: f.limit ?? 30,
+		p_offset: f.offset ?? 0
+	});
+	if (error) {
+		console.error('❌ get_history:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} opponentId @returns {Promise<any|null>} */
 export async function getHeadToHead(opponentId) {
-  const { data, error } = await supabase.rpc('get_head_to_head', { p_opponent: opponentId });
-  if (error) { console.error('❌ get_head_to_head:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_head_to_head', { p_opponent: opponentId });
+	if (error) {
+		console.error('❌ get_head_to_head:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} matchId @returns {Promise<any|null>} */
 export async function getMatchDetail(matchId) {
-  const { data, error } = await supabase.rpc('get_match_detail', { p_match_id: matchId });
-  if (error) { console.error('❌ get_match_detail:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_match_detail', { p_match_id: matchId });
+	if (error) {
+		console.error('❌ get_match_detail:', error);
+		return null;
+	}
+	return data;
 }
 /** The caller's active sabotage debuffs in a match, each with who applied it.
  *  @param {string} matchId @returns {Promise<{effect:string, by:string|null}[]>} */
 export async function getMatchDebuffs(matchId) {
-  const { data, error } = await supabase.rpc('get_match_debuffs', { p_id: matchId });
-  if (error) { console.error('❌ get_match_debuffs:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_match_debuffs', { p_id: matchId });
+	if (error) {
+		console.error('❌ get_match_debuffs:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** Opponents in a match with their puzzle position + ante left — feeds the sabotage
  *  target picker. @param {string} matchId @returns {Promise<{id:string,name:string,position:number,ante_left:number,done:boolean}[]>} */
 export async function getMatchOpponents(matchId) {
-  const { data, error } = await supabase.rpc('get_match_opponents', { p_id: matchId });
-  if (error) { console.error('❌ get_match_opponents:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_match_opponents', { p_id: matchId });
+	if (error) {
+		console.error('❌ get_match_opponents:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** Public profile by username + viewer's head-to-head + relationship flags.
  * @param {string} username @returns {Promise<any|null>} */
 export async function getPublicProfile(username) {
-  const { data, error } = await supabase.rpc('get_public_profile', { p_username: username });
-  if (error) { console.error('❌ get_public_profile:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_public_profile', { p_username: username });
+	if (error) {
+		console.error('❌ get_public_profile:', error);
+		return null;
+	}
+	return data;
 }
 /** In-group challenge standings (W/played per member) + recent matches.
  * @param {string} groupId @returns {Promise<any|null>} */
 export async function getGroupStandings(groupId) {
-  const { data, error } = await supabase.rpc('get_group_standings', { p_group_id: groupId });
-  if (error) { console.error('❌ get_group_standings:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_group_standings', { p_group_id: groupId });
+	if (error) {
+		console.error('❌ get_group_standings:', error);
+		return null;
+	}
+	return data;
 }
 /** Activity feed — you + friends + your groups (games, badges, joins).
  * @param {number} [limit] @param {number} [offset] @returns {Promise<any[]>} */
 export async function getActivityFeed(limit = 30, offset = 0) {
-  const { data, error } = await supabase.rpc('get_activity_feed', { p_limit: limit, p_offset: offset });
-  if (error) { console.error('❌ get_activity_feed:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_activity_feed', {
+		p_limit: limit,
+		p_offset: offset
+	});
+	if (error) {
+		console.error('❌ get_activity_feed:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 
 /* ===== Power-ups (catalog + buy + use-in-Climb) ===== */
 /** @returns {Promise<{cash:number, items:any[]}>} */
 export async function getPowerups() {
-  const { data, error } = await supabase.rpc('get_powerups');
-  if (error || !data) { if (error) console.error('❌ get_powerups:', error); return { cash: 0, items: [] }; }
-  return { cash: data.cash ?? 0, items: Array.isArray(data.items) ? data.items : [] };
+	const { data, error } = await supabase.rpc('get_powerups');
+	if (error || !data) {
+		if (error) console.error('❌ get_powerups:', error);
+		return { cash: 0, items: [] };
+	}
+	return { cash: data.cash ?? 0, items: Array.isArray(data.items) ? data.items : [] };
 }
 /** @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function buyPowerup(id) {
-  const { data, error } = await supabase.rpc('buy_powerup', { p_id: id });
-  if (error || !data) { if (error) console.error('❌ buy_powerup:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('buy_powerup', { p_id: id });
+	if (error || !data) {
+		if (error) console.error('❌ buy_powerup:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Use a power-up in the Climb. @param {string} id @returns {Promise<any>} */
 export async function climbUsePowerup(id) {
-  const { data, error } = await supabase.rpc('climb_use_powerup', { p_id: id });
-  if (error) { console.error('❌ climb_use_powerup:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('climb_use_powerup', { p_id: id });
+	if (error) {
+		console.error('❌ climb_use_powerup:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} date @returns {Promise<any>} */
 export async function makeupReveal(date) {
-  const { data, error } = await supabase.rpc('makeup_reveal', { p_date: date });
-  if (error) { console.error('❌ makeup_reveal error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('makeup_reveal', { p_date: date });
+	if (error) {
+		console.error('❌ makeup_reveal error:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} date @param {Record<string,string>} guess @returns {Promise<any>} */
 export async function makeupSubmitGuess(date, guess) {
-  const { data, error } = await supabase.rpc('makeup_submit_guess', { p_date: date, p_guess: guess });
-  if (error) { console.error('❌ makeup_submit_guess error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('makeup_submit_guess', {
+		p_date: date,
+		p_guess: guess
+	});
+	if (error) {
+		console.error('❌ makeup_submit_guess error:', error);
+		return null;
+	}
+	return data;
 }
 
 /* ===== Challenge Builder (configurable N-player packs) ===== */
@@ -729,163 +1059,260 @@ export async function makeupSubmitGuess(date, guess) {
  * @returns {Promise<{ok:boolean, reason?:string, match?:any}>}
  */
 export async function createMatch(opts) {
-  const { data, error } = await supabase.rpc('create_match', {
-    p_opponent: opts.opponent ?? null, p_group_id: opts.group_id ?? null,
-    p_categories: opts.categories ?? [], p_pack_size: opts.pack_size ?? 1,
-    p_mode: opts.mode ?? 'standard', p_wager: opts.wager ?? 0,
-    p_payout: opts.payout ?? 'winner', p_window_seconds: opts.window_seconds ?? 172800,
-    p_items_allowed: opts.items_allowed ?? false
-  });
-  if (error || !data) { if (error) console.error('❌ create_match:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('create_match', {
+		p_opponent: opts.opponent ?? null,
+		p_group_id: opts.group_id ?? null,
+		p_categories: opts.categories ?? [],
+		p_pack_size: opts.pack_size ?? 1,
+		p_mode: opts.mode ?? 'standard',
+		p_wager: opts.wager ?? 0,
+		p_payout: opts.payout ?? 'winner',
+		p_window_seconds: opts.window_seconds ?? 172800,
+		p_items_allowed: opts.items_allowed ?? false
+	});
+	if (error || !data) {
+		if (error) console.error('❌ create_match:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} id @returns {Promise<{ok:boolean, reason?:string, match?:any}>} */
 export async function acceptMatch(id, reduced = false) {
-  const { data, error } = await supabase.rpc('accept_match', { p_id: id, p_reduced: reduced });
-  if (error || !data) { if (error) console.error('❌ accept_match:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('accept_match', { p_id: id, p_reduced: reduced });
+	if (error || !data) {
+		if (error) console.error('❌ accept_match:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Decline an invited challenge (voids + refunds if it can no longer happen). @param {string} id */
 export async function declineMatch(id) {
-  const { data, error } = await supabase.rpc('decline_match', { p_id: id });
-  if (error || !data) { if (error) console.error('❌ decline_match:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('decline_match', { p_id: id });
+	if (error || !data) {
+		if (error) console.error('❌ decline_match:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} id @returns {Promise<any|null>} */
 export async function getMatch(id) {
-  const { data, error } = await supabase.rpc('get_match', { p_id: id });
-  if (error) { console.error('❌ get_match:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_match', { p_id: id });
+	if (error) {
+		console.error('❌ get_match:', error);
+		return null;
+	}
+	return data;
 }
 /** @returns {Promise<any[]>} */
 export async function getMyMatches() {
-  const { data, error } = await supabase.rpc('get_my_matches');
-  if (error) { console.error('❌ get_my_matches:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_my_matches');
+	if (error) {
+		console.error('❌ get_my_matches:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} id @returns {Promise<any|null>} */
 export async function matchStart(id) {
-  const { data, error } = await supabase.rpc('match_start', { p_id: id });
-  if (error) { console.error('❌ match_start:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_start', { p_id: id });
+	if (error) {
+		console.error('❌ match_start:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} id @param {string} letter @returns {Promise<any|null>} */
 export async function matchBuyLetter(id, letter) {
-  const { data, error } = await supabase.rpc('match_buy_letter', { p_id: id, p_letter: letter });
-  if (error) { console.error('❌ match_buy_letter:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_buy_letter', { p_id: id, p_letter: letter });
+	if (error) {
+		console.error('❌ match_buy_letter:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} id @returns {Promise<any|null>} */
 export async function matchReveal(id) {
-  const { data, error } = await supabase.rpc('match_reveal', { p_id: id });
-  if (error) { console.error('❌ match_reveal:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_reveal', { p_id: id });
+	if (error) {
+		console.error('❌ match_reveal:', error);
+		return null;
+	}
+	return data;
 }
 /** Use an owned power-up in a match (if items are allowed). @param {string} id @param {string} powerup @returns {Promise<any|null>} */
 export async function matchUsePowerup(id, powerup) {
-  const { data, error } = await supabase.rpc('match_use_powerup', { p_id: id, p_powerup: powerup });
-  if (error) { console.error('❌ match_use_powerup:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_use_powerup', { p_id: id, p_powerup: powerup });
+	if (error) {
+		console.error('❌ match_use_powerup:', error);
+		return null;
+	}
+	return data;
 }
 /** Sabotage an opponent in a match. @param {string} id @param {string} target @param {string} powerup @returns {Promise<any|null>} */
 export async function matchSabotage(id, target, powerup) {
-  const { data, error } = await supabase.rpc('match_sabotage', { p_id: id, p_target: target, p_powerup: powerup });
-  if (error) { console.error('❌ match_sabotage:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_sabotage', {
+		p_id: id,
+		p_target: target,
+		p_powerup: powerup
+	});
+	if (error) {
+		console.error('❌ match_sabotage:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} matchId @returns {Promise<any[]>} */
 export async function getMatchMessages(matchId) {
-  const { data, error } = await supabase.rpc('get_match_messages', { p_match_id: matchId });
-  if (error) { console.error('❌ get_match_messages:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_match_messages', { p_match_id: matchId });
+	if (error) {
+		console.error('❌ get_match_messages:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} matchId @param {string} body @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function sendMatchMessage(matchId, body) {
-  const { data, error } = await supabase.rpc('send_match_message', { p_match_id: matchId, p_body: body });
-  if (error || !data) { if (error) console.error('❌ send_match_message:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('send_match_message', {
+		p_match_id: matchId,
+		p_body: body
+	});
+	if (error || !data) {
+		if (error) console.error('❌ send_match_message:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} id @param {Record<string,string>} guess @returns {Promise<any|null>} */
 export async function matchSubmitGuess(id, guess) {
-  const { data, error } = await supabase.rpc('match_submit_guess', { p_id: id, p_guess: guess });
-  if (error) { console.error('❌ match_submit_guess:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_submit_guess', { p_id: id, p_guess: guess });
+	if (error) {
+		console.error('❌ match_submit_guess:', error);
+		return null;
+	}
+	return data;
 }
 /** Fold (forfeit) the current match puzzle → advances without a solve. @param {string} id */
 export async function matchFold(id) {
-  const { data, error } = await supabase.rpc('match_fold', { p_id: id });
-  if (error) { console.error('❌ match_fold:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_fold', { p_id: id });
+	if (error) {
+		console.error('❌ match_fold:', error);
+		return null;
+	}
+	return data;
 }
 /** Force the server to settle a Blitz match when its clock expires. @param {string} id */
 export async function matchCheck(id) {
-  const { data, error } = await supabase.rpc('match_check', { p_id: id });
-  if (error) { console.error('❌ match_check:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('match_check', { p_id: id });
+	if (error) {
+		console.error('❌ match_check:', error);
+		return null;
+	}
+	return data;
 }
 
 /* ===== Challenges (friend wagers) ===== */
 /** @param {string} username @param {string} category @param {number} wager @param {string} [mode] */
 export async function createChallenge(username, category, wager, mode = 'score') {
-  const { data, error } = await supabase.rpc('create_challenge', { p_username: username, p_category: category, p_wager: wager, p_mode: mode });
-  if (error || !data) { if (error) console.error('❌ create_challenge:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('create_challenge', {
+		p_username: username,
+		p_category: category,
+		p_wager: wager,
+		p_mode: mode
+	});
+	if (error || !data) {
+		if (error) console.error('❌ create_challenge:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** Force the server to re-check a challenge play (used when a Pressure timer expires). @param {string} id */
 export async function challengeCheck(id) {
-  const { data, error } = await supabase.rpc('challenge_check', { p_id: id });
-  if (error) { console.error('❌ challenge_check:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('challenge_check', { p_id: id });
+	if (error) {
+		console.error('❌ challenge_check:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} id */
 export async function acceptChallenge(id) {
-  const { data, error } = await supabase.rpc('accept_challenge', { p_id: id });
-  if (error || !data) { if (error) console.error('❌ accept_challenge:', error); return { ok: false }; }
-  return data;
+	const { data, error } = await supabase.rpc('accept_challenge', { p_id: id });
+	if (error || !data) {
+		if (error) console.error('❌ accept_challenge:', error);
+		return { ok: false };
+	}
+	return data;
 }
 /** @param {string} id */
 export async function getChallengeBoard(id) {
-  const { data, error } = await supabase.rpc('get_challenge', { p_id: id });
-  if (error) { console.error('❌ get_challenge:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('get_challenge', { p_id: id });
+	if (error) {
+		console.error('❌ get_challenge:', error);
+		return null;
+	}
+	return data;
 }
 /** My challenges inbox. @returns {Promise<any[]>} */
 export async function getMyChallenges() {
-  const { data, error } = await supabase.rpc('get_my_challenges');
-  if (error) { console.error('❌ get_my_challenges:', error); return []; }
-  return Array.isArray(data) ? data : [];
+	const { data, error } = await supabase.rpc('get_my_challenges');
+	if (error) {
+		console.error('❌ get_my_challenges:', error);
+		return [];
+	}
+	return Array.isArray(data) ? data : [];
 }
 /** @param {string} id @param {string} letter */
 export async function challengeBuyLetter(id, letter) {
-  const { data, error } = await supabase.rpc('challenge_buy_letter', { p_id: id, p_letter: letter });
-  if (error) { console.error('❌ challenge_buy_letter:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('challenge_buy_letter', {
+		p_id: id,
+		p_letter: letter
+	});
+	if (error) {
+		console.error('❌ challenge_buy_letter:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} id */
 export async function challengeReveal(id) {
-  const { data, error } = await supabase.rpc('challenge_reveal', { p_id: id });
-  if (error) { console.error('❌ challenge_reveal:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('challenge_reveal', { p_id: id });
+	if (error) {
+		console.error('❌ challenge_reveal:', error);
+		return null;
+	}
+	return data;
 }
 /** @param {string} id @param {Record<string,string>} guess */
 export async function challengeSubmitGuess(id, guess) {
-  const { data, error } = await supabase.rpc('challenge_submit_guess', { p_id: id, p_guess: guess });
-  if (error) { console.error('❌ challenge_submit_guess:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('challenge_submit_guess', {
+		p_id: id,
+		p_guess: guess
+	});
+	if (error) {
+		console.error('❌ challenge_submit_guess:', error);
+		return null;
+	}
+	return data;
 }
 
 /** Whether the caller already has a session for today (drives the pre-game picker). */
 export async function dailySessionExists() {
-  const { data, error } = await supabase.rpc('daily_session_exists');
-  if (error) { console.error('❌ daily_session_exists error:', error); return false; }
-  return !!data;
+	const { data, error } = await supabase.rpc('daily_session_exists');
+	if (error) {
+		console.error('❌ daily_session_exists error:', error);
+		return false;
+	}
+	return !!data;
 }
 
 /** Buy a letter. @param {string} letter @returns {Promise<object|null>} board */
 export async function dailyBuyLetter(letter) {
-  const { data, error } = await supabase.rpc('daily_buy_letter', { p_letter: letter });
-  if (error) { console.error('❌ daily_buy_letter error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_buy_letter', { p_letter: letter });
+	if (error) {
+		console.error('❌ daily_buy_letter error:', error);
+		return null;
+	}
+	return data;
 }
 
 /**
@@ -894,9 +1321,15 @@ export async function dailyBuyLetter(letter) {
  * @returns {Promise<string[]>}
  */
 export async function getUserBadges(userId) {
-  const { data, error } = await supabase.rpc('get_user_badges', userId ? { p_user_id: userId } : {});
-  if (error) { console.error('❌ get_user_badges error:', error); return []; }
-  return (data ?? []).map((/** @type {{ badge: string }} */ r) => r.badge);
+	const { data, error } = await supabase.rpc(
+		'get_user_badges',
+		userId ? { p_user_id: userId } : {}
+	);
+	if (error) {
+		console.error('❌ get_user_badges error:', error);
+		return [];
+	}
+	return (data ?? []).map((/** @type {{ badge: string }} */ r) => r.badge);
 }
 
 /**
@@ -904,23 +1337,32 @@ export async function getUserBadges(userId) {
  * @returns {Promise<{powerup: string, count: number}[]>}
  */
 export async function getUserPowerups() {
-  const { data, error } = await supabase.rpc('get_user_powerups');
-  if (error) { console.error('❌ get_user_powerups error:', error); return []; }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('get_user_powerups');
+	if (error) {
+		console.error('❌ get_user_powerups error:', error);
+		return [];
+	}
+	return data ?? [];
 }
 
 /** Use a Free Reveal power-up (free smart reveal). @returns {Promise<object|null>} board */
 export async function dailyUseFreeReveal() {
-  const { data, error } = await supabase.rpc('daily_use_free_reveal');
-  if (error) { console.error('❌ daily_use_free_reveal error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_use_free_reveal');
+	if (error) {
+		console.error('❌ daily_use_free_reveal error:', error);
+		return null;
+	}
+	return data;
 }
 
 /** Reveal ($150): all instances of the most-useful unrevealed letter. @returns {Promise<object|null>} board */
 export async function dailyReveal() {
-  const { data, error } = await supabase.rpc('daily_reveal');
-  if (error) { console.error('❌ daily_reveal error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_reveal');
+	if (error) {
+		console.error('❌ daily_reveal error:', error);
+		return null;
+	}
+	return data;
 }
 
 /**
@@ -929,51 +1371,57 @@ export async function dailyReveal() {
  * @returns {Promise<object|null>} board
  */
 export async function dailySubmitGuess(guess) {
-  const { data, error } = await supabase.rpc('daily_submit_guess', { p_guess: guess });
-  if (error) { console.error('❌ daily_submit_guess error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_submit_guess', { p_guess: guess });
+	if (error) {
+		console.error('❌ daily_submit_guess error:', error);
+		return null;
+	}
+	return data;
 }
 /** Fold (give up) today's Daily → marks it lost and reveals the answer. */
 export async function dailyFold() {
-  const { data, error } = await supabase.rpc('daily_fold');
-  if (error) { console.error('❌ daily_fold error:', error); return null; }
-  return data;
+	const { data, error } = await supabase.rpc('daily_fold');
+	if (error) {
+		console.error('❌ daily_fold error:', error);
+		return null;
+	}
+	return data;
 }
 
 /**
  * Fetch weekly leaderboard (limited)
  */
 export async function fetchWeeklyLeaderboard(limit = 10) {
-  const { data, error } = await supabase.rpc('get_weekly_leaderboard', { p_limit: limit });
-  if (error) {
-    console.error('❌ Error fetching leaderboard:', error);
-    return [];
-  }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('get_weekly_leaderboard', { p_limit: limit });
+	if (error) {
+		console.error('❌ Error fetching leaderboard:', error);
+		return [];
+	}
+	return data ?? [];
 }
 
 /**
  * Fetch ALL users with all stats (zeros when no record)
  */
 export async function fetchAllUsersLeaderboard() {
-  const { data, error } = await supabase.rpc('get_all_users_leaderboard');
-  if (error) {
-    console.error('❌ Error fetching all users leaderboard:', error);
-    return [];
-  }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('get_all_users_leaderboard');
+	if (error) {
+		console.error('❌ Error fetching all users leaderboard:', error);
+		return [];
+	}
+	return data ?? [];
 }
 
 /**
  * Fetch leaderboard filtered by period: 'daily' | 'weekly' | 'monthly' | 'yearly'
  */
 export async function fetchLeaderboardByPeriod(period = 'weekly') {
-  const { data, error } = await supabase.rpc('get_leaderboard_by_period', {
-    p_period: period
-  });
-  if (error) {
-    console.error('❌ Error fetching leaderboard by period:', error);
-    return [];
-  }
-  return data ?? [];
+	const { data, error } = await supabase.rpc('get_leaderboard_by_period', {
+		p_period: period
+	});
+	if (error) {
+		console.error('❌ Error fetching leaderboard by period:', error);
+		return [];
+	}
+	return data ?? [];
 }

--- a/src/lib/stores/userStore.js
+++ b/src/lib/stores/userStore.js
@@ -13,15 +13,15 @@ export const user = writable(/** @type {AppUser | null} */ (null));
 // 🧾 Player profile store (stats & bankroll)
 /** @type {import('svelte/store').Writable<ProfileData>} */
 export const userProfile = writable({
-  current_bankroll: 1000,
-  total_games_played: 0,
-  total_games_won: 0,
-  total_games_lost: 0,
-  win_percentage: 0,
-  highest_cash_streak: 0,
-  most_puzzles_completed: 0,
-  total_cash_accrued: 0,
-  total_cash_spent: 0,
+	current_bankroll: 1000,
+	total_games_played: 0,
+	total_games_won: 0,
+	total_games_lost: 0,
+	win_percentage: 0,
+	highest_cash_streak: 0,
+	most_puzzles_completed: 0,
+	total_cash_accrued: 0,
+	total_cash_spent: 0
 });
 
 /**
@@ -30,33 +30,36 @@ export const userProfile = writable({
  * @returns {Promise<{ data: ProfileData | null, error: Error | { message?: string } | null }>} - User profile data or error
  */
 export async function fetchUserProfile(userId) {
-  try {
-    console.log("🔄 Fetching profile for userId:", userId);
+	try {
+		console.log('🔄 Fetching profile for userId:', userId);
 
-    const { data, error } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('id', userId)
-      .maybeSingle();
+		const { data, error } = await supabase
+			.from('profiles')
+			.select('*')
+			.eq('id', userId)
+			.maybeSingle();
 
-    if (error) {
-      console.error("❌ Failed to fetch profile:", error.message);
-      return { data: null, error };
-    }
+		if (error) {
+			console.error('❌ Failed to fetch profile:', error.message);
+			return { data: null, error };
+		}
 
-    if (!data) {
-      const errMsg = `❌ No profile found for userId: ${userId}`;
-      console.error(errMsg);
-      return { data: null, error: new Error(errMsg) };
-    }
+		if (!data) {
+			const errMsg = `❌ No profile found for userId: ${userId}`;
+			console.error(errMsg);
+			return { data: null, error: new Error(errMsg) };
+		}
 
-    console.log("✅ Profile loaded:", data);
-    userProfile.set(data);
-    return { data, error: null };
-  } catch (err) {
-    console.error("❌ Error in fetching user profile:", err instanceof Error ? err.message : String(err));
-    return { data: null, error: err instanceof Error ? err : new Error(String(err)) };
-  }
+		console.log('✅ Profile loaded:', data);
+		userProfile.set(data);
+		return { data, error: null };
+	} catch (err) {
+		console.error(
+			'❌ Error in fetching user profile:',
+			err instanceof Error ? err.message : String(err)
+		);
+		return { data: null, error: err instanceof Error ? err : new Error(String(err)) };
+	}
 }
 
 /**
@@ -67,21 +70,22 @@ export async function fetchUserProfile(userId) {
  * @returns {Promise<null | Error | { message?: string }>} - Returns error if creation truly failed
  */
 export async function ensureProfileExists(userId) {
-  try {
-    const { error } = await supabase
-      .from('profiles')
-      .insert({ id: userId, bank: 2000 });
+	try {
+		const { error } = await supabase.from('profiles').insert({ id: userId, bank: 2000 });
 
-    // 23505 = unique_violation: the profile already exists (created by the on-signup trigger).
-    // That's the expected happy path, not an error.
-    if (error && error.code !== '23505') {
-      console.error("❌ Failed to create profile:", error.message);
-      return error;
-    }
+		// 23505 = unique_violation: the profile already exists (created by the on-signup trigger).
+		// That's the expected happy path, not an error.
+		if (error && error.code !== '23505') {
+			console.error('❌ Failed to create profile:', error.message);
+			return error;
+		}
 
-    return null;
-  } catch (err) {
-    console.error("❌ Error ensuring user profile:", err instanceof Error ? err.message : String(err));
-    return err instanceof Error ? err : new Error(String(err));
-  }
+		return null;
+	} catch (err) {
+		console.error(
+			'❌ Error ensuring user profile:',
+			err instanceof Error ? err.message : String(err)
+		);
+		return err instanceof Error ? err : new Error(String(err));
+	}
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,55 +1,61 @@
 <script>
-  import '../app.css';
-  import { onMount } from 'svelte';
-  import { supabase } from '$lib/supabaseClient';
-  import { startNotifications, stopNotifications } from '$lib/stores/notificationStore.js';
-  import { fx } from '$lib/sound.js';
-  import Toaster from '$lib/components/Toaster.svelte';
-  import PinConfirm from '$lib/components/PinConfirm.svelte';
-  import ConfirmModal from '$lib/components/ConfirmModal.svelte';
+	import '../app.css';
+	import { onMount } from 'svelte';
+	import { supabase } from '$lib/supabaseClient';
+	import { startNotifications, stopNotifications } from '$lib/stores/notificationStore.js';
+	import { fx } from '$lib/sound.js';
+	import Toaster from '$lib/components/Toaster.svelte';
+	import PinConfirm from '$lib/components/PinConfirm.svelte';
+	import ConfirmModal from '$lib/components/ConfirmModal.svelte';
 
-  let { children } = $props();
+	let { children } = $props();
 
-  // Every button beeps + flashes gold on a REAL click/tap. Using 'click' (not
-  // pointerdown/:active) means scrolling or brushing a button on a phone never
-  // triggers it — click only fires on a genuine activation.
-  /** @param {Event} e */
-  function buttonPress(e) {
-    const el = /** @type {HTMLElement} */ (e.target)?.closest?.('button, [role="button"]');
-    if (!el || /** @type {HTMLButtonElement} */ (el).disabled) return;
-    if (!el.classList.contains('key')) fx('tap'); // .key has its own 'select' cue
-    el.classList.add('gold-flash');
-    setTimeout(() => el.classList.remove('gold-flash'), 200);
-  }
-  onMount(() => {
-    document.addEventListener('click', buttonPress, true);
-    return () => document.removeEventListener('click', buttonPress, true);
-  });
+	// Every button beeps + flashes gold on a REAL click/tap. Using 'click' (not
+	// pointerdown/:active) means scrolling or brushing a button on a phone never
+	// triggers it — click only fires on a genuine activation.
+	/** @param {Event} e */
+	function buttonPress(e) {
+		const el = /** @type {HTMLElement} */ (e.target)?.closest?.('button, [role="button"]');
+		if (!el || /** @type {HTMLButtonElement} */ (el).disabled) return;
+		if (!el.classList.contains('key')) fx('tap'); // .key has its own 'select' cue
+		el.classList.add('gold-flash');
+		setTimeout(() => el.classList.remove('gold-flash'), 200);
+	}
+	onMount(() => {
+		document.addEventListener('click', buttonPress, true);
+		return () => document.removeEventListener('click', buttonPress, true);
+	});
 
-  onMount(() => {
-    // "Keep me logged in" = off → end the session on a cold open (new browser
-    // session) but not on in-app reloads. wb_sess marks the live browser session.
-    try {
-      const keep = localStorage.getItem('wb_keep');
-      const sessActive = sessionStorage.getItem('wb_sess');
-      if (keep === '0' && !sessActive) {
-        supabase.auth.signOut().finally(() => { try { localStorage.removeItem('wb_keep'); } catch {} });
-      } else {
-        sessionStorage.setItem('wb_sess', '1');
-      }
-    } catch { /* storage blocked — keep default persistent session */ }
+	onMount(() => {
+		// "Keep me logged in" = off → end the session on a cold open (new browser
+		// session) but not on in-app reloads. wb_sess marks the live browser session.
+		try {
+			const keep = localStorage.getItem('wb_keep');
+			const sessActive = sessionStorage.getItem('wb_sess');
+			if (keep === '0' && !sessActive) {
+				supabase.auth.signOut().finally(() => {
+					try {
+						localStorage.removeItem('wb_keep');
+					} catch {}
+				});
+			} else {
+				sessionStorage.setItem('wb_sess', '1');
+			}
+		} catch {
+			/* storage blocked — keep default persistent session */
+		}
 
-    // Start the global notification poller whenever a session is present,
-    // and react to sign-in / sign-out across every route.
-    supabase.auth.getSession().then(({ data }) => {
-      if (data.session) startNotifications(data.session.user?.id);
-    });
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session) startNotifications(session.user?.id);
-      else stopNotifications();
-    });
-    return () => sub.subscription.unsubscribe();
-  });
+		// Start the global notification poller whenever a session is present,
+		// and react to sign-in / sign-out across every route.
+		supabase.auth.getSession().then(({ data }) => {
+			if (data.session) startNotifications(data.session.user?.id);
+		});
+		const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+			if (session) startNotifications(session.user?.id);
+			else stopNotifications();
+		});
+		return () => sub.subscription.unsubscribe();
+	});
 </script>
 
 {@render children()}

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -2,46 +2,44 @@
 import { createServerClient } from '@supabase/ssr';
 
 export const load = async ({ cookies }) => {
-  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-  if (!supabaseUrl || !supabaseAnonKey) {
-    console.error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY on Vercel. Add them in Project Settings → Environment Variables.');
-    return { user: null };
-  }
+	const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+	const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+	if (!supabaseUrl || !supabaseAnonKey) {
+		console.error(
+			'Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY on Vercel. Add them in Project Settings → Environment Variables.'
+		);
+		return { user: null };
+	}
 
-  const supabase = createServerClient(
-    supabaseUrl,
-    supabaseAnonKey,
-    {
-      cookies: {
-        get(name) {
-          return cookies.get(name);
-        },
-        set(name, value, options) {
-          cookies.set(name, value, {
-            ...options,
-            path: '/',
-            httpOnly: true,
-            sameSite: 'lax',
-            secure: import.meta.env.PROD, // false in dev so cookies persist on http://localhost
-          });
-        },
-        remove(name, options) {
-          cookies.delete(name, {
-            ...options,
-            path: '/',
-            httpOnly: true,
-            sameSite: 'lax',
-            secure: import.meta.env.PROD,
-          });
-        }
-      }
-    }
-  );
+	const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+		cookies: {
+			get(name) {
+				return cookies.get(name);
+			},
+			set(name, value, options) {
+				cookies.set(name, value, {
+					...options,
+					path: '/',
+					httpOnly: true,
+					sameSite: 'lax',
+					secure: import.meta.env.PROD // false in dev so cookies persist on http://localhost
+				});
+			},
+			remove(name, options) {
+				cookies.delete(name, {
+					...options,
+					path: '/',
+					httpOnly: true,
+					sameSite: 'lax',
+					secure: import.meta.env.PROD
+				});
+			}
+		}
+	});
 
-  const {
-    data: { user }
-  } = await supabase.auth.getUser();
+	const {
+		data: { user }
+	} = await supabase.auth.getUser();
 
-  return { user };
+	return { user };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4548 +1,9379 @@
 <script>
-  import { onMount, onDestroy, tick } from 'svelte';
-  import { browser } from '$app/environment';
-  import { supabase } from '$lib/supabaseClient';
-  import { get } from 'svelte/store';
-  import { tweened } from 'svelte/motion';
-  import { cubicOut } from 'svelte/easing';
-
-  import { gameStore, fetchDailyGame, useDailyTwist, useDailyBoost, startChallenge, acceptAndPlayChallenge, resumeChallenge, challengeTimeoutCheck, fetchMakeupGame, fetchClimbGame, startCashGame, cashOutClimb, climbAdvance, climbLeaveGame, climbSkipPuzzle, climbArmDoubleOrNothing, climbPowerup, startBlitz, endBlitz, blitzSkipPuzzle, startMatch, acceptAndPlayMatch, resumeMatch, matchTimeoutCheck, matchPowerup, matchSabotageOpponent, dailyFold, matchFold } from '$lib/stores/GameStore.js';
-  import { getMyChallenges, getPowerups, getDailyAvailBoosts, getMyMatches, getMyGroups, getMatch, getMatchDetail, getMatchDebuffs, getMatchOpponents, declineMatch } from '$lib/stores/statsStore.js';
-  import { CATEGORIES } from '$lib/categories.js';
-  import { user, userProfile, fetchUserProfile, ensureProfileExists } from '$lib/stores/userStore.js';
-  import { getDailyStatus, getOpenGames, expireStaleDailies, getDailyGhost, getMyDailyRank, addFriend, searchUsers, getMyUsername, setUsername, getBank, getDailyBoard, getMatchMessages, sendMatchMessage, getFriendRequestCount, respondFriendRequest, listFriendRequests, getDailyModifier, deleteMyAccount, getMyAvatar, getCashgameMeta, getBlitzMeta } from '$lib/stores/statsStore.js';
-  import Avatar from '$lib/components/Avatar.svelte';
-  import { unreadCount, refreshNotifications, inboxRequest, inboxTarget, markChallengeNotifRead, markFriendNotifRead } from '$lib/stores/notificationStore.js';
-  import { track } from '$lib/analytics.js';
-  import { modifierInfo } from '$lib/powerups.js';
-  import {
-    saveGameToLocalStorage,
-    clearSavedGame,
-    getSavedGameInfo
-  } from '$lib/stores/localGameUtils.js';
-  import { gameWasRestored } from '$lib/stores/GameStateFlags.js';
-  import { soundEnabled, toggleSound, hapticsEnabled, toggleHaptics, fx } from '$lib/sound.js';
-  import { startMusic, stopMusic, musicEnabled, musicVolume, setMusicVolume, toggleMusic, TRACKS, currentTrackId, selectTrack } from '$lib/music.js';
-  import PinGate from '$lib/components/PinGate.svelte';
-  import { pinLocked, hasPinFor, clearPin, markUnlocked, sessionIsUnlocked, markPinSkipped, pinSkipped, clearPinSkipped } from '$lib/pin.js';
-  import { requirePin } from '$lib/pinConfirm.js';
-  import { requireConfirm } from '$lib/confirm.js';
-  import { goto } from '$app/navigation';
-
-  import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
-  import InventoryList from '$lib/components/InventoryList.svelte';
-  import VaultReveal from '$lib/components/VaultReveal.svelte';
-  import Keyboard from '$lib/components/Keyboard.svelte';
-  import GameButtons from '$lib/components/GameButtons.svelte';
-  import FlipDigit from '$lib/components/FlipDigit.svelte';
-  import Auth from '$lib/components/Auth.svelte';
-  import Tutorial from '$lib/components/Tutorial.svelte';
-  import ObjectiveCard from '$lib/components/ObjectiveCard.svelte';
-  import StandingStrip from '$lib/components/StandingStrip.svelte';
-  import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
-  import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
-  import FriendsPanel from '$lib/components/FriendsPanel.svelte';
-  import GroupsPanel from '$lib/components/GroupsPanel.svelte';
-
-  export let data;
-
-  // UI state
-  let showTutorial = false;
-  let showLaunchWelcome = false;
-  let menuView = 'home'; // 'home' | 'play' | 'challenge' | 'progress'
-  let blitzSoon = false;
-  let showResultModal = false;
-  let hasTriggeredModal = false;
-  let hasInitialized = false;
-  let sessionUid = '';     // current session user id (for the PIN gate)
-  let pinNotSet = false;   // logged in on this device with no PIN yet → prompt setup
-  /** @type {string | null} */
-  let initError = null; // 🔍 Diagnostic: what failed during init
-  /** Show main menu (Daily / Cash Game / Leaderboard / My account) when true; game when false */
-  let showMainMenu = false;
-  /** When showing menu: can we show "Resume daily" / "Resume in-progress game"? */
-  let savedGameInfo = /** @type {{ gameMode: string, gameState: string } | null} */ (null);
-  /** When showing menu: has user already played daily today? */
-  let menuDailyPlayed = false;
-  /** Today's daily result for the menu indicator (won/lost + score). */
-  let dailyStatus = /** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, bank: number, current_streak: number, streak_freezes: number, today_score: number, win_streak: number, daily_in_progress?: boolean } | null} */ (null);
-  // 🎮 Live solo games from SERVER truth (daily/climb), newest first. The old
-  // single localStorage save slot got overwritten whenever you played another mode, which
-  // made a live Daily show as "complete + lost". openGames lets every mode resume independently.
-  /** @type {{mode:string, updated_at:string}[]} */
-  let openGames = [];
-  async function refreshOpenGames() {
-    const u = get(user); if (!u?.id) return;
-    // Filter out any legacy Free Play rows the server may still return (mode retired in V2).
-    try { openGames = (await getOpenGames()).filter((/** @type {any} */ g) => g.mode !== 'freeplay'); } catch { /* keep last */ }
-  }
-  // "In progress" must come from SERVER truth, not the clobberable localStorage slot.
-  $: dailyInProgress = openGames.some((g) => g.mode === 'daily') || (dailyStatus?.daily_in_progress ?? false);
-  $: dailyDone = menuDailyPlayed && !dailyInProgress;
-  $: climbInProgress = openGames.some((g) => g.mode === 'climb');
-  // 🔁 Resume: every in-progress game — solo modes AND challenges you've started.
-  const RESUME_LABEL = /** @type {Record<string,string>} */ ({ daily: 'Daily', climb: 'Cash Game' });
-  $: resumables = [
-    ...openGames.map((/** @type {any} */ g) => ({ key: 'solo-' + g.mode, label: RESUME_LABEL[g.mode] ?? 'Game', icon: (/** @type {Record<string,string>} */ ({daily:'📅',climb:'🎰'}))[g.mode] ?? '▶', go: () => resumeSolo(g.mode) })),
-    ...((myMatches ?? []).filter((/** @type {any} */ m) => m.status === 'open' && m.my_state === 'active')
-        .map((/** @type {any} */ m) => ({ key: 'match-' + m.id, label: m.group_name || (m.opponent ? '@' + m.opponent : 'Challenge'), icon: '⚔️', go: () => respondToMatch(m) })))
-  ];
-  let showResumeMenu = false;
-  function resumeSolo(/** @type {string} */ mode) {
-    if (mode === 'daily') handleMenuDaily();
-    else if (mode === 'climb') handleMenuClimb();
-  }
-  function onResume() {
-    fx('tap');
-    if (resumables.length === 1) resumables[0].go();
-    else showResumeMenu = true;
-  }
-  /** Net Worth for the menu chip. */
-  let netWorth = /** @type {number|null} */ (null);
-  let menuLoan = 0; // outstanding loan → drives the menu debt banner
-  async function refreshBank() {
-    try { const gb = await getBank(); netWorth = gb.net_worth; menuLoan = gb.loan ?? 0; } catch { /* non-fatal */ }
-  }
-
-  // ✅ Load Supabase user profile and sync bankroll (creates profile if missing)
-  /** @param {string} userId */
-  async function loadUserProfile(userId) {
-    try {
-      const { data: profile, error } = await fetchUserProfile(userId);
-      if (error || !profile) {
-        console.warn("⚠️ Failed to load profile:", error?.message ?? error);
-        // Auto-create profile for new users (no profile row yet)
-        const createError = await ensureProfileExists(userId);
-        if (createError) {
-          console.error("❌ Failed to create profile:", createError);
-          return null;
-        }
-        const { data: newProfile } = await fetchUserProfile(userId);
-        if (!newProfile) return null;
-        userProfile.set(newProfile);
-        gameStore.update(state => ({ ...state, bankroll: 2000 }));
-        console.log("✅ Profile created. Bankroll: 2000");
-        return newProfile;
-      }
-
-      userProfile.set(profile);
-      gameStore.update(state => ({
-        ...state,
-        bankroll: profile.bank ?? 2000
-      }));
-
-      console.log("✅ Profile loaded. Bankroll:", profile.current_bankroll ?? profile.bank);
-      return profile;
-    } catch (err) {
-      console.error("❌ Profile load error:", err instanceof Error ? err.message : String(err));
-      return null;
-    }
-  }
-
-  // ✅ Main logic on initial mount
-  onMount(async () => {
-    initError = null;
-    track('app_open');
-    // Safety net: never strand a logged-in user on the loading screen if a slow or
-    // failed secondary call blocks init.
-    const initFallback = setTimeout(() => {
-      if (!hasInitialized) { showMainMenu = true; hasInitialized = true; }
-    }, 6000);
-    try {
-      const { data: { session }, error } = await supabase.auth.getSession();
-      if (!session || error) {
-        initError = "No session (session: " + (session ? "yes" : "no") + ", error: " + (error?.message || "none") + ")";
-        console.warn("⛔", initError);
-        return;
-      }
-
-      user.set(/** @type {{ id: string }} */ (session.user));
-      const profile = await loadUserProfile(session.user.id);
-      if (!profile) {
-        initError = "Profile failed to load or create. Check Supabase profiles table and RLS policies.";
-        console.warn("⛔", initError);
-        showMainMenu = true; hasInitialized = true;  // surface the menu instead of hanging
-        return;
-      }
-
-      // Device PIN gate (approach A): if a PIN is set on this device, lock until it's
-      // entered; otherwise mark that we should prompt to set one (after username).
-      sessionUid = session.user.id;
-      // Lock only on a cold open (close → reopen), not on in-app navigation back
-      // to the menu — sessionIsUnlocked() persists the unlock for this app session.
-      if (hasPinFor(sessionUid)) { if (!sessionIsUnlocked()) pinLocked.set(true); }
-      else pinNotSet = !pinSkipped(sessionUid); // don't re-nag if they chose "Skip for now"
-
-      // Make-up daily launched from the streak calendar → drop straight into the board.
-      if (localStorage.getItem('gameMode') === 'makeup' && localStorage.getItem('makeupDate')) {
-        showMainMenu = false;
-        hasInitialized = true;
-        await fetchMakeupGame();
-        return;
-      }
-
-      // Into the menu immediately — the loading screen only gates on auth + profile.
-      showMainMenu = true;
-      // Load any in-progress game so the menu shows "Resume" (not "Missed") after
-      // returning from another route (e.g. the Store).
-      savedGameInfo = getSavedGameInfo(session.user.id);
-      hasInitialized = true;
-
-      // Secondary menu data: must NOT block the loading screen or each other.
-      // Finalize any unfinished Daily from a prior day (no timer → it expires as a loss)
-      // BEFORE reading status/open games, so the menu reflects it.
-      expireStaleDailies().catch(() => {}).finally(() => {
-        getDailyStatus(session.user.id)
-          .then((ds) => { dailyStatus = ds; menuDailyPlayed = ds.has_played_today; })
-          .catch((e) => console.error('daily status:', e));
-        refreshOpenGames();
-      });
-      refreshBank();
-      refreshChallengeCount();
-      // First-run username gate: prompt if this account hasn't claimed one yet.
-      getMyUsername().then((u) => { needsUsername = !u; }).catch(() => {});
-
-      // Friend invite link: ?add=USERNAME → add them, then open the Friends board.
-      try {
-        const params = new URLSearchParams(window.location.search);
-        const addName = params.get('add');
-        if (addName) {
-          const res = await addFriend(addName);
-          if (res?.ok) { track('friend_add', { via: 'link' }); goto('/leaderboard?mode=friends'); }
-        } else if (params.get('challenges')) {
-          openChallenges();
-        }
-      } catch { /* non-fatal */ }
-
-    } catch (err) {
-      initError = "Init error: " + (err instanceof Error ? err.message : String(err));
-      console.error("❌", initError);
-      showMainMenu = true; hasInitialized = true;  // don't hang on a transient error
-    } finally {
-      clearTimeout(initFallback);
-    }
-  });
-
-  // ✅ Reactive puzzle loader if puzzle is missing (skip when showing main menu)
-  $: if (
-    hasInitialized &&
-    loggedIn &&
-    !showMainMenu &&
-    $gameStore.currentPhrase === '' &&
-    !$gameWasRestored
-  ) {
-    const gameMode = localStorage.getItem('gameMode') || 'daily';
-    if (gameMode === 'makeup') {
-      fetchMakeupGame().then((ok) => { if (!ok) showMainMenu = true; });
-    } else if (gameMode === 'climb') {
-      fetchClimbGame().then((ok) => { if (!ok) showMainMenu = true; });
-    } else if (gameMode === 'match' || gameMode === 'blitz') {
-      // Matches (need the active id) + Blitz (a live timed run) aren't deep-link restorable.
-      localStorage.setItem('gameMode', 'daily');
-      showMainMenu = true;
-    } else {
-      fetchDailyGame().then((ok) => {
-        if (!ok) initError = "Daily puzzle failed to load.";
-      });
-    }
-  }
-
-  // ✅ Set user from SSR if present (profile load happens once in onMount)
-  $: if (data?.user) {
-    user.set(/** @type {{ id: string }} */ (data.user));
-  }
-
-  // Reactive state values
-  $: loggedIn = !!$user?.id;
-  // PIN gate: unlock screen for returning users; set-PIN after username for new ones.
-  $: showPinUnlock = loggedIn && hasInitialized && $pinLocked;
-  $: showPinSetup = loggedIn && hasInitialized && !$pinLocked && pinNotSet && !needsUsername;
-  // ===== Home "act-now" banner: the single most-urgent thing needing me =====
-  /** @type {any[]} incoming friend requests [{id,name,username}] */
-  let friendRequests = [];
-  // When a new notification lands (badge ticks up), refresh the act-now banner's
-  // matches/requests too — so a fresh challenge shows up live, not just the count.
-  let _prevUnread = 0;
-  $: handleUnreadRise($unreadCount);
-  function handleUnreadRise(/** @type {number} */ n) {
-    if (browser && loggedIn && hasInitialized && n > _prevUnread) refreshChallengeCount();
-    _prevUnread = n;
-  }
-  // (Resume + challenge-invite + friend-request notifications now live as their own
-  //  top-of-menu buttons — see resumables / challengeInvites / friendRequests.)
-  /** @param {any} r */
-  async function acceptFriend(r) {
-    fx('tap');
-    await respondFriendRequest(r.id, true);
-    markFriendNotifRead(r.id);
-    await refreshChallengeCount();
-  }
-  function onPinUnlocked() { markUnlocked(); pinLocked.set(false); }
-  function onPinSet() { markUnlocked(); clearPinSkipped(); pinNotSet = false; }
-  function onPinSkip() { markUnlocked(); markPinSkipped(sessionUid); pinNotSet = false; } // remember the skip so it doesn't nag every open
-  function onPinLogout() { clearPin(); clearPinSkipped(); pinLocked.set(false); pinNotSet = false; handleLogout(); }
-  // Background music: play continuously through the whole session — menu AND in-game
-  // (it loops seamlessly across screens) — pausing only while locked / setting a PIN.
-  $: if (browser) { (loggedIn && hasInitialized && !showPinUnlock && !showPinSetup) ? startMusic() : stopMusic(); }
-  $: bankroll = $gameStore.bankroll || 0;
-  $: digits = String(bankroll).split('');
-
-  // ✨ Bankroll change reaction (pulse + floating delta)
-  let bankrollPulse = '';
-  let bankrollDelta = 0;
-  /** @type {number | null} */
-  let _prevBankroll = null;
-  $: {
-    const b = $gameStore.bankroll;
-    if (_prevBankroll !== null && typeof b === 'number' && b !== _prevBankroll) {
-      bankrollDelta = b - _prevBankroll;
-      bankrollPulse = bankrollDelta > 0 ? 'up' : 'down';
-      const token = bankrollDelta;
-      setTimeout(() => { if (bankrollDelta === token) bankrollPulse = ''; }, 950);
-    }
-    if (typeof b === 'number') _prevBankroll = b;
-  }
-
-
-  // ---- Daily result: shareable card ----
-  // Each day is its own puzzle (one per date), so show the date — not a counter.
-  // Pinned to UTC — the server schedules the Daily/Twist by UTC CURRENT_DATE, so the
-  // label must match it (otherwise it disagrees near local midnight).
-  $: todayLabel = browser ? new Date().toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric', timeZone: 'UTC' }) : '';
-
-  /** @param {number} br @param {boolean} won */
-  function medalFor(br, won) {
-    if (!won) return { emoji: '💀', name: 'Busted', tier: 'none' };
-    if (br >= 700) return { emoji: '🥇', name: 'Gold', tier: 'gold' };
-    if (br >= 400) return { emoji: '🥈', name: 'Silver', tier: 'silver' };
-    return { emoji: '🥉', name: 'Bronze', tier: 'bronze' };
-  }
-  $: resultWon = $gameStore.gameState === 'won';
-  $: isDailyResult = $gameStore.gameMode === 'daily';
-  // Live Daily HUD metrics (only while actively playing the daily).
-  $: dLive = (($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'makeup') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost')
-    ? $gameStore.dailyLive : null;
-  $: isChallenge = $gameStore.gameMode === 'challenge';
-  $: isMakeup = $gameStore.gameMode === 'makeup';
-  // Auto-dismiss the Cash-earned toast after a few seconds.
-  /** @type {ReturnType<typeof setTimeout>|undefined} */
-  let _attTimer;
-  $: if ($gameStore.cashToast) {
-    clearTimeout(_attTimer);
-    _attTimer = setTimeout(() => gameStore.update(s => ({ ...s, cashToast: null })), 4000);
-  }
-  $: isClimb = $gameStore.gameMode === 'climb';
-  $: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
-  // ⚡ Blitz — the live client clock counts down to blitzInfo.remaining_ms (server-authoritative);
-  // each action resyncs it. At 0 we call endBlitz() once.
-  $: isBlitz = $gameStore.gameMode === 'blitz';
-  $: blitz = $gameStore.blitzInfo; // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state }
-  let blitzClockMs = 0;
-  /** @type {ReturnType<typeof setInterval>|undefined} */
-  let blitzTimer;
-  let blitzEnding = false;
-  // Resync the local clock whenever the server sends a fresh remaining_ms.
-  $: if (isBlitz && blitz && blitz.state !== 'ended' && blitz.remaining_ms != null) {
-    blitzClockMs = blitz.remaining_ms;
-  }
-  $: if (isBlitz && blitz && blitz.state !== 'ended') {
-    if (!blitzTimer) {
-      blitzEnding = false;
-      blitzTimer = setInterval(() => {
-        blitzClockMs = Math.max(0, blitzClockMs - 100);
-        if (blitzClockMs <= 0 && !blitzEnding) { blitzEnding = true; clearInterval(blitzTimer); blitzTimer = undefined; endBlitz(); }
-      }, 100);
-    }
-  } else if (blitzTimer) { clearInterval(blitzTimer); blitzTimer = undefined; }
-  onDestroy(() => { if (blitzTimer) clearInterval(blitzTimer); });
-  $: blitzSec = Math.ceil(blitzClockMs / 1000);
-  // 🏷️ Which mode you're in — a consistent pill under the wordmark on every game screen.
-  $: modeLabel = ({
-    daily:     { emoji: '📅', name: 'Daily' },
-    climb:     { emoji: '🎰', name: 'Cash Game' },
-    blitz:     { emoji: '⚡', name: 'Blitz' },
-    makeup:    { emoji: '📅', name: 'Make-up' },
-    match:     { emoji: '⚔️', name: 'Challenge' },
-    challenge: { emoji: '⚔️', name: 'Challenge' }
-  })[$gameStore.gameMode] ?? null;
-  $: isMatch = $gameStore.gameMode === 'match';
-  $: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, solved, spent, budget, wager, items_allowed, used_powerups, started_at, clock_seconds, combo }
-  $: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
-  $: matchCombo = ((matchInfo?.combo ?? 100) / 100).toFixed(2);
-  let matchExpiredFired = false;
-  // 💥 Double or Nothing (Cash Game): server exposes don_armed + don_available (heat ≥ ×1.5).
-  $: donArmed = !!climb?.don_armed;
-  $: donAvailable = !!climb?.don_available;
-  // The doubled target payout (matches server: bounty ×2, then × heat, rounded).
-  $: donTarget = (isClimb && climb) ? Math.round((climb.bounty ?? 0) * 2 * (climb.heat ?? 100) / 100) : 0;
-  // Climb live: Spent · Payout (bounty × heat, doubled while armed) · Net.
-  $: climbLive = (isClimb && climb && climb.state === 'active')
-    ? (() => { const m = climb.don_armed ? 2 : 1; const pay = Math.round((climb.bounty ?? 0) * m * (climb.heat ?? 100) / 100); const sp = climb.spent ?? 0; return { spent: sp, payout: pay, net: pay - sp }; })()
-    : null;
-  // Win banner needs to know the solve was a Double-or-Nothing (server clears don_armed on solve).
-  let donArmedThisPuzzle = false;
-  $: if (isClimb && climb) {
-    if (climb.don_armed) donArmedThisPuzzle = true;
-    else if (climb.state === 'stuck' || (climb.state === 'active' && (climb.spent ?? 0) === 0)) donArmedThisPuzzle = false;
-  }
-  // Challenge live: Spent of your ante budget — lowest spend wins (standard only).
-  $: matchLive = (isMatch && matchInfo && !matchInfo.done && matchInfo.mode !== 'blitz')
-    ? { spent: matchInfo.spent ?? 0, budget: matchInfo.budget ?? 0 } : null;
-  $: matchLeft = matchLive ? Math.max(0, (matchLive.budget ?? 0) - (matchLive.spent ?? 0)) : 0;
-  // Unified money hero (Daily · Cash Game = net you keep; Challenge = ante left to spend).
-  $: soloHero = climbLive ? { net: climbLive.net } : (dLive ? { net: dLive.net } : (matchLive ? { net: matchLeft } : null));
-
-  // 🎰 Slot-machine money feel: count up/down the bankroll + the green "Solve to Earn",
-  // and float a -$X by the number each time you spend.
-  const tweenBank = tweened(0, { duration: 550, easing: cubicOut });
-  const tweenNet = tweened(0, { duration: 900, easing: cubicOut });
-  // 🏆 Win-banner animations: profit counts up, then Cash scrolls to the new total.
-  const resultProfit = tweened(0, { duration: 1100, easing: cubicOut });
-  const resultBankAnim = tweened(0, { duration: 1300, easing: cubicOut });
-  /** @type {{rank:number,total:number,score:number}|null} */
-  let resultRank = null;
-  $: tweenBank.set(Math.round($gameStore.bankroll ?? 0));
-  // While the opening reveal is landing boxes, hold the bounty at $0 so it can
-  // dramatically count up at the climax (introDone).
-  $: tweenNet.set(introBuilding ? 0 : (soloHero ? Math.round(soloHero.net) : 0));
-
-  // 🎰 Daily opening reveal coordination (boxes land → bounty counts up × multiplier).
-  // fetchDailyGame ARMS it (dailyIntro token); we only PLAY it once the board is
-  // actually on screen — i.e. the "How to win" card is dismissed — by bumping
-  // dailyIntroGo, which PhraseDisplay watches.
-  let introBuilding = false;
-  let _introFired = 0;
-  let introCountPop = false;
-  // Play the armed opening reveal — but only when the board is truly on screen
-  // (no objective card up, not on the menu). Called from dismissObjective and,
-  // when the card is suppressed, right after the board renders.
-  function playDailyIntroIfArmed() {
-    const st = get(gameStore);
-    const tok = st.dailyIntro;
-    // Play once per FRESH open (token). dailyIntroPlayed lives in the store so it
-    // survives remounts (e.g. back from the leaderboard); the auto-applied Twist
-    // revealing letters no longer wrongly suppresses the reveal.
-    if (!browser || !tok || tok === st.dailyIntroPlayed) return;
-    if (objective || showMainMenu) return;
-    gameStore.update((s) => ({ ...s, dailyIntroPlayed: tok, dailyIntroGo: (s.dailyIntroGo || 0) + 1 }));
-    introBuilding = true;
-    tweenNet.set(0, { duration: 0 });
-  }
-  function onDailyIntroDone() {
-    introBuilding = false; // releases the reactive above → bounty counts 0 → net
-    introCountPop = true;
-    setTimeout(() => { introCountPop = false; }, 1200);
-  }
-  // 🎬 Challenges auto-advance through a pack, so play the armed opening reveal on each
-  // new puzzle (and on first entry). Resets between matches so a new pack re-triggers.
-  let _lastMatchPos = -1;
-  $: if (!isMatch) { _lastMatchPos = -1; }
-     else if (matchInfo && (matchInfo.position ?? 1) !== _lastMatchPos && !showMainMenu) {
-       _lastMatchPos = matchInfo.position ?? 1;
-       tick().then(playDailyIntroIfArmed);
-     }
-
-  // 💰 In-game bank: a modal (not a route) so closing it returns to the game, not the menu.
-  let showBank = false;
-  /** @type {{ bank:number, net_worth:number, ledger:any[] }|null} */
-  let bankData = null;
-  async function openBankModal() {
-    fx('tap');
-    showBank = true;
-    try { bankData = await getBank(); } catch { bankData = null; }
-  }
-  const fmtCash = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
-  /** @param {string} reason */
-  const bankReason = (reason) => (/** @type {Record<string,string>} */ ({
-    daily_win: 'Daily reward', daily_reward: 'Daily reward',
-    attendance: 'Daily attendance reward', arcade_cashout: 'Cash Game cash-out', climb_bounty: 'Climb bounty',
-    freeplay_reward: 'Free Play reward', cosmetic_buy: 'Shop purchase', powerup_buy: 'Power-up purchase',
-    wager_win: 'Won a wager', wager_stake: 'Wager staked', wager_refund: 'Wager refunded'
-  }))[reason] || reason;
-
-  // 🔐 My Vault — owned inventory; use power-ups in-game (mode-eligible only).
-  let showBag = false;
-  let vaultVideo = false;
-  /** @type {any[]} */ let vaultOwned = [];
-  /** @type {Record<string,number>} */ let dailyAvailBoosts = {};
-  let vaultMsg = '';
-  /** @type {ReturnType<typeof setTimeout>|undefined} */ let _vaultMsgTimer;
-  async function loadVault() {
-    try { vaultOwned = ((await getPowerups()).items ?? []).filter((/** @type {any} */ i) => (i.owned ?? 0) > 0); } catch { vaultOwned = []; }
-    if (!showMainMenu && $gameStore.gameMode === 'daily') {
-      try { dailyAvailBoosts = await getDailyAvailBoosts(); } catch { dailyAvailBoosts = {}; }
-    }
-  }
-  function openBag() { fx('tap'); showBag = true; loadVault(); }
-  // From the main menu: require the device PIN (if set), play the safe-open reveal, then open.
-  async function openVaultFromMenu() {
-    fx('tap');
-    try { await requirePin('Open your Vault'); } catch { return; }
-    loadVault();
-    vaultVideo = true;
-  }
-  function onVaultVideoEnd() { if (vaultVideo) { vaultVideo = false; showBag = true; } }
-
-  // In-game vault contents: every item, with the mode-eligible ones usable and the
-  // rest grayed out (with a reason on tap).
-  $: vaultItems = (!showBag || showMainMenu) ? [] : (() => {
-    const out = [];
-    if ($gameStore.gameMode === 'daily' && dailyMod && !$gameStore.twistUsed && gameActive) {
-      out.push({ id: 'twist', emoji: dailyMod.emoji, name: dailyMod.name, blurb: dailyMod.blurb, count: 1, usable: true, reason: '' });
-    }
-    for (const it of vaultOwned) {
-      if (it.kind === 'daily') {
-        const avail = ($gameStore.gameMode === 'daily') && (dailyAvailBoosts[it.id] ?? 0) > 0 && gameActive;
-        out.push({ id: it.id, emoji: BOOST_META[it.id]?.emoji ?? '💥', name: it.name, blurb: BOOST_META[it.id]?.blurb ?? '', count: it.owned,
-          usable: avail, reason: avail ? '' : 'Bought after you started — usable on your next puzzle.' });
-      } else if (it.kind === 'climb') {
-        // Self-buffs work in BOTH the Cash Game and Challenges.
-        const climbUsed = (climb?.equipped ?? []).includes(it.id);
-        const matchUsed = (matchInfo?.used_powerups ?? []).includes(it.id);
-        const climbAvail = $gameStore.gameMode === 'climb' && gameActive && !climbUsed && (it.owned ?? 0) > 0;
-        const matchAvail = isMatch && !!matchInfo?.items_allowed && gameActive && !matchUsed && (it.owned ?? 0) > 0;
-        const avail = climbAvail || matchAvail;
-        out.push({ id: it.id, emoji: PUP_ICON[it.id] ?? '✨', name: it.name, blurb: avail ? 'Tap to use now' : '', count: it.owned, usable: avail,
-          reason: (climbUsed || matchUsed) ? 'Already used on this puzzle.' : (($gameStore.gameMode === 'climb' || isMatch) ? '' : 'For the Cash Game or Challenges — not this mode.') });
-      } else if (it.kind === 'sabotage') {
-        const sabAvail = isMatch && !!matchInfo?.items_allowed && gameActive && (it.owned ?? 0) > 0;
-        out.push({ id: it.id, emoji: PUP_ICON[it.id] ?? '😈', name: it.name, blurb: sabAvail ? '😈 Tap to aim at an opponent' : '', count: it.owned, usable: sabAvail, kind: 'sabotage',
-          reason: sabAvail ? '' : 'For Challenges — use it during a challenge.' });
-      } else {
-        out.push({ id: it.id, emoji: PUP_ICON[it.id] ?? '✨', name: it.name, blurb: '', count: it.owned, usable: false,
-          reason: 'For the Cash Game or Challenges — not this mode.' });
-      }
-    }
-    return out;
-  })();
-  /** @param {any} item */
-  function tapVaultItem(item) {
-    if (item.usable) { useFromBag(item); return; }
-    vaultMsg = item.reason || "This item can't be used for this puzzle.";
-    clearTimeout(_vaultMsgTimer);
-    _vaultMsgTimer = setTimeout(() => { vaultMsg = ''; }, 2600);
-  }
-  /** @param {any} item */
-  function useFromBag(item) {
-    if (item?.id === 'twist') useTwist();
-    else if (item?.id === 'bounty_boost' || item?.id === 'jackpot_boost') { useBoost(item.id); loadVault(); }
-    else if ($gameStore.gameMode === 'climb') { climbPowerup(item.id).then(() => { refreshClimbPups(); loadVault(); }); }
-    else if (isMatch && item?.kind === 'sabotage') { openSabotagePicker(item); return; } // keeps flow for the target step
-    else if (isMatch) { matchPowerup(item.id).then(() => { refreshClimbPups(); loadVault(); }); }
-    showBag = false;
-  }
-  // 😈 Sabotage from the bag → pick a target (auto-applies vs a single opponent).
-  /** @type {{ item:any, opponents:any[] }|null} */
-  let sabPicker = null;
-  /** @param {any} item */
-  async function openSabotagePicker(item) {
-    showBag = false;
-    const id = matchInfo?.id; if (!id) return;
-    const opps = (await getMatchOpponents(id)).filter((/** @type {any} */ o) => !o.done);
-    if (opps.length === 0) { vaultMsg = 'No opponents left to hit.'; return; }
-    if (opps.length === 1) { await matchSabotageOpponent(opps[0].id, item.id); await refreshClimbPups(); return; }
-    sabPicker = { item, opponents: opps };
-  }
-  /** @param {string} targetId */
-  async function applySabotage(targetId) {
-    if (!sabPicker) return;
-    const item = sabPicker.item; sabPicker = null;
-    await matchSabotageOpponent(targetId, item.id);
-    await refreshClimbPups();
-  }
-
-  // ℹ️ Daily explainers: ×N badge, Solve-to-Earn, 🏆 streak, or today's Twist.
-  /** @type {'mult'|'bounty'|'streak'|'twist'|null} */
-  let dailyInfo = null;
-  $: dlMult = Number($gameStore.dailyLive?.mult ?? $gameStore.bountyMult ?? 1);
-  $: dlRemaining = $gameStore.dailyLive?.remaining ?? 0;     // Prize budget left
-  $: dlWinnings = $gameStore.dailyLive?.winnings ?? Math.round(dlRemaining * dlMult); // banked if you solve now
-  $: dlNet = dlWinnings;
-  $: dlWinStreak = dailyStatus?.win_streak ?? 0;
-  $: dlStreakBonus = Math.min(0.1 * dlWinStreak, 0.5);
-  $: dlWrong = $gameStore.wrongGuesses ?? 0;
-  $: dlPenalty = Math.min(0.2 * dlWrong, Math.max(0, dlMult - 1)); // shown penalty, can't push below ×1.0 floor
-  $: dlBoost = Math.max(0, Math.round((dlMult - 1 - dlStreakBonus + dlPenalty) * 10) / 10);
-  const fmtMult = (/** @type {number} */ n) => '×' + n.toFixed(1);
-  let _prevBank = /** @type {number|null} */ (null);
-  let _floatId = 0;
-  /** @type {{id:number,text:string}[]} */
-  let spendFloaters = [];
-  $: trackSpend($gameStore.bankroll, $gameStore.gameMode, showMainMenu);
-  /** @param {number|null|undefined} b @param {string} mode @param {boolean} onMenu */
-  function trackSpend(b, mode, onMenu) {
-    if (browser && !onMenu && _prevBank != null && b != null && b < _prevBank && ['daily', 'makeup', 'climb'].includes(mode)) {
-      const amt = _prevBank - b;
-      if (amt > 0 && amt <= 300) {
-        const id = ++_floatId;
-        spendFloaters = [...spendFloaters, { id, text: '−$' + amt.toLocaleString() }];
-        setTimeout(() => { spendFloaters = spendFloaters.filter((f) => f.id !== id); }, 1100);
-      }
-    }
-    _prevBank = b;
-  }
-
-  // 💥 Dramatic bank pop on a big swing (win payout / big change).
-  let bankFlash = '';
-  let _bankFxPrev = /** @type {number|null} */ (null);
-  /** @type {ReturnType<typeof setTimeout>|undefined} */
-  let _bankFxTimer;
-  $: bankFx($gameStore.bankroll, showMainMenu);
-  /** @param {number|null|undefined} b @param {boolean} onMenu */
-  function bankFx(b, onMenu) {
-    if (!browser || b == null) { _bankFxPrev = b ?? _bankFxPrev; return; }
-    if (!onMenu && _bankFxPrev != null && Math.abs(b - _bankFxPrev) >= 150) {
-      bankFlash = b > _bankFxPrev ? 'up' : 'down';
-      clearTimeout(_bankFxTimer);
-      _bankFxTimer = setTimeout(() => { bankFlash = ''; }, 1100);
-    }
-    _bankFxPrev = b;
-  }
-
-
-  // ── Fold + broke-timer (Daily + Challenges) ──────────────────────────────
-  // You're "broke" when you can't afford the cheapest still-buyable letter →
-  // a 60s clock starts; guess it or you auto-Fold (lose the puzzle).
-  // Mirror of the server-authoritative public.letter_cost() (economy v3.2: −25%, cheapest $20).
-  const LETTER_COSTS = { Q:20,W:40,E:100,R:90,T:90,Y:50,U:60,I:80,O:70,P:60,A:100,S:90,D:60,F:50,G:50,H:50,J:20,K:40,L:60,Z:30,X:30,C:60,V:40,B:50,N:80,M:50 };
-  // foldMode = modes with a "Give up" button (Daily + Challenges).
-  $: foldMode = ($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'match');
-  // brokeMode = modes with the out-of-Cash auto-fold CLOCK. The Daily has NO timer —
-  // guesses are free + unlimited, so being broke isn't a dead end; you solve it or you
-  // don't (an unfinished Daily expires as a loss at day's end). Only live challenges,
-  // where stalling stalls a real opponent, keep the broke clock.
-  $: brokeMode = ($gameStore.gameMode === 'match');
-  $: gameActive = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
-  $: isBroke = (() => {
-    // Only while actively on a game screen — never on the menu.
-    if (!brokeMode || !gameActive || showMainMenu) return false;
-    const mod = $gameStore.modifier, discount = mod === 'discount', vowelHalf = mod === 'vowel_vision';
-    const purchased = new Set(($gameStore.purchasedLetters || []).filter(Boolean));
-    const incorrect = new Set($gameStore.incorrectLetters || []);
-    let minCost = Infinity;
-    for (const [L, base] of Object.entries(LETTER_COSTS)) {
-      if (purchased.has(L) || incorrect.has(L)) continue;
-      let c = base;
-      if (discount) c = Math.ceil(c * 0.75);
-      if (vowelHalf && 'AEIOU'.includes(L)) c = Math.ceil(c * 0.5);
-      if (c < minCost) minCost = c;
-    }
-    return minCost !== Infinity && ($gameStore.bankroll || 0) < minCost;
-  })();
-  let brokeDeadline = 0, brokeLeft = 0, brokeTimer = null, brokeFiring = false;
-  $: if (browser) manageBrokeTimer(isBroke);
-  function manageBrokeTimer(broke) {
-    if (broke && !brokeTimer) {
-      brokeDeadline = Date.now() + 60000; brokeLeft = 60;
-      brokeTimer = setInterval(() => {
-        brokeLeft = Math.max(0, Math.ceil((brokeDeadline - Date.now()) / 1000));
-        if (brokeLeft <= 0) { clearInterval(brokeTimer); brokeTimer = null; doFold(true); }
-      }, 250);
-    } else if (!broke && brokeTimer) {
-      clearInterval(brokeTimer); brokeTimer = null;
-    }
-  }
-  /** @param {boolean} auto */
-  async function doFold(auto = false) {
-    if (brokeFiring) return;
-    brokeFiring = true;
-    if (brokeTimer) { clearInterval(brokeTimer); brokeTimer = null; }
-    try {
-      fx(auto ? 'bust' : 'tap');
-      if ($gameStore.gameMode === 'daily') await dailyFold();
-      else if ($gameStore.gameMode === 'match') await matchFold();
-      else if ($gameStore.gameMode === 'climb') { await climbSkipPuzzle(); await tick(); playDailyIntroIfArmed(); } // fresh puzzle; heat resets; replay the dramatic build
-    } finally { brokeFiring = false; }
-  }
-  // Give-up confirm layer (in-app, not window.confirm).
-  let showGiveUp = false;
-  function confirmFold() { fx('tap'); showGiveUp = true; }
-  function cancelGiveUp() { fx('tap'); showGiveUp = false; }
-  function doGiveUp() { showGiveUp = false; doFold(false); }
-
-  // 💥 Double or Nothing confirm layer (Cash Game). Solve → ×2; get stuck → forfeit.
-  let showDon = false;
-  let donBusy = false;
-  function openDon() { fx('tap'); showDon = true; }
-  function cancelDon() { fx('tap'); showDon = false; }
-  async function armDon() {
-    if (donBusy) return;
-    donBusy = true;
-    try { fx('tap'); await climbArmDoubleOrNothing(); }
-    finally { donBusy = false; showDon = false; }
-  }
-
-  $: matchRemaining = (() => {
-    if (!matchBlitz || !matchInfo?.started_at) return 0;
-    const start = new Date(matchInfo.started_at).getTime();
-    const clockMs = (matchInfo.clock_seconds ?? 60) * 1000;
-    return Math.max(0, Math.ceil((start + clockMs - pressureNow) / 1000));
-  })();
-  $: if (matchBlitz && matchRemaining > 0) matchExpiredFired = false;
-  $: if (matchBlitz && matchRemaining <= 0 && !matchExpiredFired) fireMatchTimeout();
-  async function fireMatchTimeout() {
-    matchExpiredFired = true;
-    await matchTimeoutCheck();
-  }
-  $: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
-  // Heat IS the Cash Game win streak: each solve +0.1× (cap ×2.0), reset to ×1.0 when stuck.
-  $: climbStreak = Math.max(0, Math.round(((climb?.heat ?? 100) - 100) / 10));
-  // 🔥 The run: solves + cumulative profit since heat last reset (run_profit can be negative early).
-  $: climbRun = (isClimb && climb) ? { solves: climb.run_solves ?? 0, profit: climb.run_profit ?? 0, best: climb.best_run_profit ?? 0 } : null;
-  $: climbRunIsBest = climbRun != null && climbRun.profit > 0 && climbRun.profit >= climbRun.best;
-  // Owned, not-yet-used climb buffs — drives the vault badge by the Solve button.
-  $: usableClimbPups = isClimb ? selfPups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0 && !((climb?.equipped ?? []).includes(i.id))).length : 0;
-  $: usableMatchPups = (isMatch && matchInfo?.items_allowed) ? selfPups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0 && !((matchInfo?.used_powerups ?? []).includes(i.id))).length : 0;
-  /** @type {'heat'|'earn'|'streak'|null} ℹ️ Cash Game explainers (mirror of dailyInfo). */
-  let climbInfo = null;
-  $: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
-  /** @type {{rank:number, total:number}|null} */
-  let dailyPlacement = null;
-  $: if (showResultModal && isDailyResult && resultWon && dr && dailyPlacement === null) loadDailyPlacement();
-  async function loadDailyPlacement() {
-    dailyPlacement = { rank: 0, total: 0 }; // guard against re-fire
-    try {
-      const board = await getDailyBoard('friends');
-      const me = board.find((/** @type {any} */ r) => r.is_me);
-      dailyPlacement = { rank: me?.rank ?? 0, total: board.length };
-    } catch { dailyPlacement = { rank: 0, total: 0 }; }
-  }
-  /** @type {any[]} */
-  let climbPups = [];
-  const PUP_ICON = /** @type {Record<string,string>} */ ({
-    free_reveal: '🔍', half_off: '🏷️', vowel_vision: '👁️', extra_hint: '💡', reveal_word: '📖', free_vowel: '🅰️', last_letters: '🔚',
-    sabotage_tax: '💸', sabotage_fog: '🌫️', sabotage_toll: '🚧', sabotage_vowel_block: '🚫', sabotage_lock: '🔒'
-  });
-  const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({
-    tax: '💸 Taxed (letters +50%)', fog: '🌫️ Fogged (clue hidden)',
-    toll: '🚧 Tolled (next letter 3×)', vowel_block: '🚫 Vowel-blocked (vowels 3×)'
-  });
-  const DEBUFF_DESC = /** @type {Record<string,string>} */ ({
-    tax: 'Every letter you buy costs +50% while this is active.',
-    fog: 'Your clue is hidden — you have to solve it blind.',
-    toll: 'Your next letter purchase costs 3×, then it clears.',
-    vowel_block: 'Vowels cost 3× while this is active.'
-  });
-  // 💥 Tappable debuff banner → what each sabotage does + who hit you.
-  /** @type {{effect:string, by:string|null}[]|null} */
-  let debuffModal = null;
-  async function openDebuffInfo() {
-    fx('tap');
-    const id = matchInfo?.id; if (!id) return;
-    debuffModal = await getMatchDebuffs(id);
-  }
-  // ℹ️ Tappable "Left to Spend" hero → explains the challenge ante.
-  let showAnteInfo = false;
-  async function refreshClimbPups() {
-    try { const r = await getPowerups(); climbPups = r.items ?? []; } catch { /* non-fatal */ }
-  }
-  $: selfPups = climbPups.filter((/** @type {any} */ i) => i.kind === 'climb');   // buffs (use on yourself)
-  $: sabPups = climbPups.filter((/** @type {any} */ i) => i.kind === 'sabotage'); // sabotage (target an opponent)
-
-  // --- per-match chat (1v1 + group challenges) ---
-  let matchChatOpen = false;
-  let matchChatUnread = false;
-  /** @type {string|null} id of the newest message you've already seen */
-  let matchChatSeenId = null;
-  /** @type {any[]} */
-  let matchMessages = [];
-  let matchChatInput = '';
-  let matchChatBusy = false;
-  /** @type {string|null} */
-  let matchChatId = null;
-  /** @type {any} */
-  let matchChannel = null;
-  /** @type {ReturnType<typeof setInterval>|undefined} */
-  let matchChatPoll;
-  /** @type {HTMLElement|undefined} */
-  let matchChatScroll;
-
-  async function loadMatchMsgs() {
-    if (!matchChatId) return;
-    const m = await getMatchMessages(matchChatId);
-    if (matchChatId == null) return;
-    matchMessages = m;
-    const newest = m.length ? m[m.length - 1] : null;
-    if (matchChatOpen) {
-      // Reading the thread = caught up.
-      if (newest) matchChatSeenId = newest.id;
-      matchChatUnread = false;
-      tick().then(() => { if (matchChatScroll) matchChatScroll.scrollTop = matchChatScroll.scrollHeight; });
-    } else if (matchChatSeenId === null) {
-      // First sync: treat the existing backlog as already seen (don't nag).
-      if (newest) matchChatSeenId = newest.id;
-    } else if (newest && !newest.is_me && newest.id !== matchChatSeenId) {
-      // Light up only for a NEW message from someone else you haven't opened.
-      matchChatUnread = true;
-    }
-  }
-  function teardownMatchChat() {
-    if (matchChannel) { supabase.removeChannel(matchChannel); matchChannel = null; }
-    clearInterval(matchChatPoll);
-    matchChatId = null; matchMessages = []; matchChatOpen = false; matchChatUnread = false; matchChatSeenId = null;
-  }
-  /** @param {string|null|undefined} id */
-  function syncMatchChat(id) {
-    if (id === matchChatId) return;
-    teardownMatchChat();
-    if (!id) return;
-    matchChatId = id;
-    loadMatchMsgs();
-    matchChannel = supabase.channel(`match:${id}`)
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'match_messages', filter: `match_id=eq.${id}` }, loadMatchMsgs)
-      .subscribe();
-    matchChatPoll = setInterval(loadMatchMsgs, 20000);
-  }
-  $: syncMatchChat((isMatch && !showMainMenu) ? matchInfo?.id : null);
-  function openMatchChat() { matchChatOpen = true; matchChatUnread = false; loadMatchMsgs(); }
-  async function sendMatchChat() {
-    const body = matchChatInput.trim();
-    if (!body || matchChatBusy || !matchChatId) return;
-    matchChatBusy = true;
-    const res = await sendMatchMessage(matchChatId, body);
-    matchChatBusy = false;
-    if (res.ok) { matchChatInput = ''; await loadMatchMsgs(); }
-  }
-  onDestroy(teardownMatchChat);
-
-  $: makeupLabel = (() => {
-    const d = $gameStore.makeupDate;
-    if (!d) return '';
-    const dt = new Date(d + 'T00:00:00');
-    return dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-  })();
-  $: chScore = ($gameStore.challengeInfo?.score ?? Math.floor($gameStore.bankroll || 0));
-  $: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
-  $: resultMedal = medalFor(resultBankroll, resultWon);
-
-  // ⏱️ Pressure-mode challenge clock (server-authoritative; this just displays + triggers the check)
-  let pressureNow = browser ? Date.now() : 0;
-  /** @type {ReturnType<typeof setInterval>|undefined} */
-  let pressureTimer;
-  let pressureFired = false;
-  $: chInfo = $gameStore.gameMode === 'challenge' ? $gameStore.challengeInfo : null;
-  $: isPressure = chInfo?.mode === 'pressure';
-  $: pressureActive = isPressure && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
-  $: pressureRemaining = (() => {
-    if (!isPressure || !chInfo?.started_at) return 0;
-    const start = new Date(chInfo.started_at).getTime();
-    const limitMs = (chInfo.limit_seconds ?? 60) * 1000;
-    return Math.max(0, Math.ceil((start + limitMs - pressureNow) / 1000));
-  })();
-  $: if (pressureActive && pressureRemaining > 0) pressureFired = false;
-  $: if (pressureActive && pressureRemaining <= 0 && !pressureFired) firePressureTimeout();
-  async function firePressureTimeout() {
-    pressureFired = true;
-    await challengeTimeoutCheck();
-    // tolerate minor client/server clock skew — retry shortly if the play didn't settle
-    if ($gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost') {
-      setTimeout(() => { pressureFired = false; }, 1500);
-    }
-  }
-
-  let shareCopied = false;
-  function buildShareText() {
-    const br = '$' + resultBankroll.toLocaleString();
-    // Link to the live origin (never a hardcoded/deleted project URL).
-    const link = typeof window !== 'undefined' ? window.location.origin : '';
-    if (isDailyResult) {
-      if (resultWon && dr) {
-        return `🧠 WordBank Daily · ${todayLabel}\nProfit ${(dr.net ?? 0) >= 0 ? '+' : '−'}$${Math.abs(dr.net ?? 0).toLocaleString()} — beat that 👀\n${link}`;
-      }
-      return `🧠 WordBank Daily · ${todayLabel}\nDidn't crack it today 😬\n${link}`;
-    }
-    return `🏦 WordBank\n${resultMedal.emoji} ${br} banked\n${link}`;
-  }
-  async function handleShare() {
-    const text = buildShareText();
-    try {
-      if (typeof navigator !== 'undefined' && navigator.share) { await navigator.share({ text }); return; }
-    } catch { /* user cancelled native share */ }
-    try {
-      await navigator.clipboard.writeText(text);
-      shareCopied = true;
-      setTimeout(() => { shareCopied = false; }, 1800);
-    } catch { /* clipboard unavailable */ }
-  }
-
-  // ✅ Auto-save the moment a board is live (even before the first letter) so you
-  // can always resume — and keep saving as you play.
-  $: if (
-    loggedIn &&
-    $gameStore.currentPhrase &&
-    $gameStore.category &&
-    Array.isArray($gameStore.purchasedLetters)
-  ) {
-    saveGameToLocalStorage();
-  }
-
-  onMount(() => {
-    ['click', 'mousedown', 'touchstart'].forEach(event =>
-      document.addEventListener(event, removeButtonFocus, true)
-    );
-    pressureTimer = setInterval(() => { pressureNow = Date.now(); }, 250);
-  });
-  onDestroy(() => { clearInterval(pressureTimer); if (brokeTimer) clearInterval(brokeTimer); });
-
-  // Bump this key whenever the tutorial gains new content — it re-shows for
-  // everyone on next login (v3 = persistent Cash, spend-the-least, attendance, no loans).
-  const TUTORIAL_KEY = 'wb_tutorial_v3';
-  // First-run guided tutorial: show once a signed-in user is past the username/PIN
-  // gates and on the menu (not while those full-screen gates are up).
-  $: if (browser && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
-    showTutorial = true;
-  }
-
-  // One-time launch welcome for returning players (we reset everyone to a fresh
-  // Day-1 start). New users get the tutorial instead (it sets this key on dismiss).
-  const LAUNCH_KEY = 'wb_launch_welcome_v1';
-  $: if (browser && loggedIn && hasInitialized && showMainMenu && !needsUsername && !showPinUnlock && !showPinSetup
-         && !showTutorial && localStorage.getItem(TUTORIAL_KEY) === 'true' && localStorage.getItem(LAUNCH_KEY) !== '1') {
-    showLaunchWelcome = true;
-  }
-  function dismissLaunchWelcome() {
-    showLaunchWelcome = false;
-    if (browser) localStorage.setItem(LAUNCH_KEY, '1');
-  }
-
-  // Deep link from a public profile's "⚔️ Challenge" button: /?challenge=<username>
-  let challengeDeepLinkDone = false;
-  $: if (browser && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup && !challengeDeepLinkDone) {
-    challengeDeepLinkDone = true;
-    try {
-      const params = new URLSearchParams(window.location.search);
-      const ch = params.get('challenge');
-      if (ch) {
-        newChallenge().then(() => { mbTarget = 'friend'; mbOpponent = ch; });
-        params.delete('challenge');
-      }
-      // Settings/account deep link from the Profile page's ⚙️ gear (/?account=1)
-      if (params.get('account')) {
-        handleMenuMyAccount();
-        params.delete('account');
-      }
-      // Friends & Groups deep link (Profile 👥+ button → /?people=1)
-      if (params.get('people')) {
-        openCommunity('people');
-        params.delete('people');
-      }
-      const qs = params.toString();
-      window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
-    } catch { /* non-fatal */ }
-  }
-  // A tapped challenge toast / deep-link opens Community ▸ Challenges (people fallback).
-  let _inboxSeen = 0;
-  $: if (browser && $inboxRequest > _inboxSeen && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup) {
-    _inboxSeen = $inboxRequest;
-    if ($inboxTarget === 'people') { openCommunity('people'); peopleTab = 'friends'; }
-    else openCommunity('challenges');
-  }
-  function dismissTutorial() {
-    showTutorial = false;
-    // New users just onboarded — they don't also need the launch welcome.
-    if (browser) { localStorage.setItem(TUTORIAL_KEY, 'true'); localStorage.setItem(LAUNCH_KEY, '1'); }
-  }
-
-  // ===== Pre-game "How to win" objective card =====
-  // Shows the objective the moment a mode starts. Solo modes show once (per mode,
-  // localStorage); challenges show every entry. One reactive latch detects the
-  // menu→game transition so we don't have to wire every scattered start site.
-  /** @type {{ mode: string, ctx: any } | null} */
-  let objective = null;
-  let _wasMenu = true;
-  const SOLO_MODES = ['daily', 'climb', 'makeup'];
-
-  function buildObjectiveCtx(/** @type {string} */ mode) {
-    if (mode !== 'match') return {};
-    const mi = get(gameStore).matchInfo || {};
-    const opps = mi.opponents ?? [];
-    return { opponent: opps.length === 1 ? opps[0]?.name : undefined,
-      wager: mi.wager, packSize: mi.pack_size, fieldSize: opps.length + 1 };
-  }
-  // once-seen localStorage key: per-mode for solo modes, per-match for challenges
-  // (so the "How to win" card shows on the FIRST entry only, never on resume).
-  function objSeenKey(/** @type {string} */ mode) {
-    if (mode === 'match') { const id = get(gameStore).matchInfo?.id; return id ? 'wb_obj_match_' + id : null; }
-    return SOLO_MODES.includes(mode) ? 'wb_obj_' + mode : null;
-  }
-  /** @param {boolean} [forced] re-opened via the board ⓘ button — bypass the once-seen gate */
-  function showObjectiveFor(/** @type {string} */ mode, forced = false) {
-    if (!mode || showTutorial) return;
-    const key = objSeenKey(mode);
-    if (!forced && key && browser && localStorage.getItem(key) === '1') return;
-    objective = { mode, ctx: buildObjectiveCtx(mode) };
-  }
-  function dismissObjective() {
-    if (objective && browser) { const key = objSeenKey(objective.mode); if (key) localStorage.setItem(key, '1'); }
-    objective = null;
-    tick().then(playDailyIntroIfArmed); // board is now visible → play the opening reveal
-  }
-
-  // Detect entering a game from the menu (latch flips once per entry).
-  $: if (browser && loggedIn && hasInitialized && !needsUsername && !showPinUnlock && !showPinSetup) {
-    if (showMainMenu) { _wasMenu = true; }
-    else if (_wasMenu && $gameStore.gameMode && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost') {
-      _wasMenu = false;
-      showObjectiveFor($gameStore.gameMode);
-      refreshBank(); // keep the on-board "Cash" fresh (e.g. a challenge buy-in was just paid)
-    }
-  }
-
-  // Keep the menu pinned to the top. The tall menu + the login→menu height change can
-  // leave the window scrolled (browser scroll-anchoring), which then read as a "jump"
-  // when navigating to /profile. Reset to top whenever the menu becomes visible.
-  let _menuPinned = false;
-  $: if (browser) {
-    if (showMainMenu) { if (!_menuPinned) { _menuPinned = true; tick().then(() => window.scrollTo(0, 0)); } }
-    else _menuPinned = false;
-  }
-
-  /** @param {Event} e */
-  const removeButtonFocus = (e) => {
-    if (e.target && /** @type {HTMLElement} */ (e.target).tagName === 'BUTTON') /** @type {HTMLButtonElement} */ (e.target).blur();
-  };
-
-  // ✅ Log out: clear saved game so next login always shows main menu
-  const handleLogout = async () => {
-    clearSavedGame();
-    clearPin(); // forget this device's PIN so the next person can't unlock the account
-    gameWasRestored.set(false);
-    await supabase.auth.signOut();
-    user.set(null);
-    location.reload();
-  };
-
-  // 🔑 PIN: show "Change PIN" only when one is set; require the CURRENT PIN first.
-  $: hasPin = browser && $user?.id ? hasPinFor($user.id) : false;
-  async function changePin() {
-    fx('tap');
-    try { await requirePin('Enter your current PIN to set a new one'); } catch { return; }
-    showMyAccount = false;
-    clearPin(); clearPinSkipped(); pinNotSet = true; // → the create-new-PIN screen
-  }
-  // 🔓 Forgot PIN (from Settings) — verify by email + password, then set a new PIN.
-  async function forgotPin() {
-    if (!(await requireConfirm({ title: 'Reset PIN?', message: 'You’ll sign back in with your email & password, then set a new PIN.', confirmText: 'Reset PIN', danger: true }))) return;
-    showMyAccount = false;
-    clearPin(); clearPinSkipped();
-    handleLogout();
-  }
-
-  // 🗑️ Permanent account deletion (App Store 5.1.1(v)) — requires typing DELETE.
-  const APP_VERSION = '1.0.0';
-  const SUPPORT_EMAIL = 'charlieforeman77@gmail.com';
-  let showDeleteConfirm = false;
-  let deleteBusy = false;
-  let deleteInput = '';
-  $: deleteArmed = deleteInput.trim().toUpperCase() === 'DELETE';
-  async function confirmDeleteAccount() {
-    if (!deleteArmed || deleteBusy) return;
-    deleteBusy = true;
-    const { ok } = await deleteMyAccount();
-    if (!ok) { deleteBusy = false; maMsg = 'Could not delete your account — try again.'; return; }
-    clearSavedGame();
-    clearPin();
-    gameWasRestored.set(false);
-    await supabase.auth.signOut().catch(() => {});
-    user.set(null);
-    location.reload();
-  }
-
-  /** Start daily: resume if in progress, else show "already played" or fetch new daily.
-   *  Daily has no personal power-ups — everyone shares the same Daily Modifier. */
-  async function handleMenuDaily() {
-    const currentUser = get(user);
-    if (!currentUser?.id) return;
-    // Status loads non-blocking after login — make sure we know it before deciding,
-    // so an already-completed daily shows the summary instead of re-opening + "winning".
-    if (!dailyStatus) {
-      dailyStatus = await getDailyStatus(currentUser.id);
-      menuDailyPlayed = dailyStatus.has_played_today;
-    }
-    // Resume an active Daily based on SERVER truth, not the clobberable local save slot.
-    const inProgress = (dailyStatus?.daily_in_progress ?? false) || (savedGameInfo?.gameMode === 'daily' && savedGameInfo?.gameState !== 'won' && savedGameInfo?.gameState !== 'lost');
-    if (dailyStatus?.has_played_today && !inProgress) {
-      showStreakMessage = true;  // already solved today → come-back summary
-      return;
-    }
-    // Today's Twist is auto-given on the board — no pre-game popup. Just play.
-    await startDaily();
-  }
-
-  // ⚡ Power-up hotbar feed. Daily: today's Twist (mode allows only the Twist).
-  // Cash Game / Challenges will feed mode-eligible inventory power-ups here later.
-  // Daily hotbar = today's Twist (if unused) + any owned Bounty Boosts you carry.
-  /** @type {{id:string,emoji:string,name:string,blurb:string,count:number}[]} */
-  let dailyBoosts = [];
-  const BOOST_META = /** @type {Record<string,{emoji:string,blurb:string}>} */ ({
-    bounty_boost: { emoji: '💥', blurb: 'Adds ×0.5 to your bounty' },
-    jackpot_boost: { emoji: '💎', blurb: 'Adds ×1.0 to your bounty' }
-  });
-  async function loadDailyBoosts() {
-    try {
-      const r = await getPowerups();
-      dailyBoosts = (r.items ?? [])
-        .filter((/** @type {any} */ i) => i.kind === 'daily' && (i.owned ?? 0) > 0)
-        .map((/** @type {any} */ i) => ({ id: i.id, emoji: BOOST_META[i.id]?.emoji ?? '💥', name: i.name, blurb: BOOST_META[i.id]?.blurb ?? '', count: i.owned }));
-    } catch { dailyBoosts = []; }
-  }
-  $: trayPowerups = ($gameStore.gameMode === 'daily' && gameActive)
-    ? [
-        ...((dailyMod && !$gameStore.twistUsed) ? [{ id: 'twist', emoji: dailyMod.emoji, name: dailyMod.name, blurb: dailyMod.blurb, count: 1 }] : []),
-        ...dailyBoosts
-      ]
-    : [];
-  /** @param {CustomEvent<any>} e */
-  function onUsePowerup(e) {
-    const item = e.detail;
-    if (item?.id === 'twist') { useTwist(); return; }
-    if (item?.id === 'bounty_boost' || item?.id === 'jackpot_boost') { useBoost(item.id); return; }
-  }
-
-  // Use today's Daily Twist power-up (tap the tray slot).
-  let dailyTwistBusy = false;
-  let dailyBoostBusy = false;
-  async function useTwist() {
-    if (dailyTwistBusy || $gameStore.twistUsed) return;
-    dailyTwistBusy = true;
-    fx('select');
-    await useDailyTwist();
-    dailyTwistBusy = false;
-  }
-  /** @param {string} id */
-  async function useBoost(id) {
-    if (dailyBoostBusy) return;
-    dailyBoostBusy = true;
-    fx('multiplier');
-    await useDailyBoost(id);
-    await loadDailyBoosts();
-    dailyBoostBusy = false;
-  }
-  async function startDaily() {
-    localStorage.setItem('gameMode', 'daily');
-    const ok = await fetchDailyGame();
-    if (ok) {
-      hasInitialized = true;
-      showMainMenu = false;
-      loadDailyBoosts(); // surface any owned Bounty Boosts in the hotbar
-      // refresh streaks so the 📅 attendance chip includes today's check-in
-      const uid = get(user)?.id;
-      if (uid) getDailyStatus(uid).then((s) => { dailyStatus = s; }).catch(() => {});
-      // If the "How to win" card is suppressed (already seen), the board is now
-      // visible — play the opening reveal once reactives settle. If the card DOES
-      // show, this no-ops (objective set) and the reveal fires on its dismiss.
-      await tick();
-      playDailyIntroIfArmed();
-    } else {
-      initError = "Daily puzzle failed to load.";
-    }
-  }
-
-  // Today's shared Daily Modifier banner (id lives in the game store, set by fetchDailyGame).
-  $: dailyMod = ($gameStore.gameMode === 'daily' && $gameStore.modifier) ? modifierInfo($gameStore.modifier) : null;
-
-  /** Start or resume the Cash Game (the persistent real-Cash Climb). */
-  // ===== Cash Game V2 — tier select + run =====
-  let showTierSelect = false;
-  /** @type {any} */
-  let cgMeta = null;
-  let cgBusy = false;
-  /** @type {any} */
-  let cashoutResult = null; // { banked, buy_in, profit, multiple_x100, solves, tier }
-
-  async function enterClimbGame() {
-    hasInitialized = true;
-    showMainMenu = false;
-    showTierSelect = false;
-    refreshClimbPups();
-    await tick();
-    playDailyIntroIfArmed();
-  }
-  async function handleMenuClimb() {
-    const currentUser = get(user);
-    if (!currentUser?.id) return;
-    localStorage.setItem('gameMode', 'climb');
-    const res = await fetchClimbGame();
-    if (res === 'needs_tier') {
-      cgMeta = await getCashgameMeta();
-      showTierSelect = true;
-    } else if (res) {
-      await enterClimbGame();
-    } else {
-      initError = 'Cash Game failed to load.';
-    }
-  }
-  /** @param {string} tier */
-  async function pickTier(tier) {
-    if (cgBusy) return;
-    cgBusy = true;
-    const res = await startCashGame(tier);
-    cgBusy = false;
-    if (res?.ok) { await enterClimbGame(); }
-    else if (res?.reason === 'insufficient') {
-      // Can't afford the buy-in → offer the Loan Shark.
-      if (confirm(`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`)) { showTierSelect = false; goto('/bank'); }
-    } else if (res?.reason === 'locked') { fx('wrong'); }
-  }
-  async function cashOut() {
-    if (cgBusy) return;
-    cgBusy = true;
-    const res = await cashOutClimb();
-    cgBusy = false;
-    if (res?.ok) { cashoutResult = res; showResultModal = true; refreshBank(); }
-  }
-
-  // ===== ⚡ Blitz — tier select + timed run =====
-  let showBlitzTier = false;
-  /** @type {any} */
-  let bzMeta = null;
-  let bzBusy = false;
-  /** @type {any} */
-  let blitzResult = null; // { solved, winnings, buy_in, net, best_combo, tier }
-  async function handleMenuBlitz() {
-    if (!get(user)?.id) return;
-    localStorage.setItem('gameMode', 'blitz');
-    bzMeta = await getBlitzMeta();
-    showBlitzTier = true;
-  }
-  /** @param {string} tier */
-  async function pickBlitzTier(tier) {
-    if (bzBusy) return;
-    bzBusy = true;
-    const res = await startBlitz(tier);
-    bzBusy = false;
-    if (res?.ok) {
-      hasInitialized = true; showMainMenu = false; showBlitzTier = false; blitzResult = null;
-    } else if (res?.reason === 'insufficient') {
-      if (confirm(`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`)) { showBlitzTier = false; goto('/bank'); }
-    }
-  }
-  // When the run ends (clock → 0), surface the result modal.
-  $: if (isBlitz && blitz && blitz.state === 'ended' && !blitzResult) {
-    blitzResult = blitz; showResultModal = true; refreshBank();
-  }
-
-  // ===== Challenge Builder (configurable packs vs friends/groups) =====
-  let showChallenges = false; // the New-Challenge builder modal
-  /** Which Community hub tab is showing. */
-  let communityTab = /** @type {'challenges'|'leaderboard'|'activity'|'people'} */ ('challenges');
-  /** Which People sub-tab (when communityTab === 'people'). */
-  let peopleTab = /** @type {'friends'|'groups'} */ ('friends');
-  /** Start a challenge with a friend from the People list. @param {string} username */
-  function challengeFriend(username) {
-    newChallenge().then(() => { mbTarget = 'friend'; mbOpponent = username; });
-  }
-  /** @type {any[]} */
-  let myMatches = [];
-  /** @type {any[]} */
-  let myGroups = [];
-  let challengeCount = 0; // matches awaiting my play (badge on the Challenges card)
-  let friendReqCount = 0; // incoming friend requests (badge on Friends)
-  /** @type {any|null} */
-  let matchResults = null; // a settled match's results being viewed
-  // Builder form
-  let mbTarget = 'friend'; // 'friend' | 'group'
-  let mbMode = 'standard'; // 'standard' | 'blitz'
-  let mbOpponent = '';
-  let mbGroupId = '';
-  /** @type {string[]} */
-  let mbCategories = [];
-  let mbPackSize = 3;
-  let mbWager = 500;
-  let mbPayout = 'winner'; // derived from field size at settle; kept for the RPC signature
-  // Challenge tier antes (ante = stake = pot size; payout is by field size at settle).
-  const CHALLENGE_TIERS = [
-    { v: 0, label: '🤝 Friendly' }, { v: 500, label: '🥉 $500' },
-    { v: 2000, label: '🥈 $2K' }, { v: 10000, label: '🥇 $10K' }
-  ];
-  let mbWindow = 172800; // seconds
-  let mbItemsAllowed = false; // host toggle: allow power-ups in this challenge
-  let mbMsg = '';
-  let mbBusy = false;
-  /** @type {{username:string,is_friend:boolean}[]} */
-  let mbResults = [];
-  /** @type {ReturnType<typeof setTimeout>|undefined} */
-  let mbSearchTimer;
-  const WINDOWS = [{ s: 3600, l: '1 hour' }, { s: 21600, l: '6 hours' }, { s: 86400, l: '24 hours' }, { s: 172800, l: '48 hours' }, { s: 604800, l: '1 week' }];
-
-  /** Refresh the data behind the home act-now banner (matches + friend requests). */
-  async function refreshChallengeCount() {
-    if (!get(user)?.id) return;
-    try {
-      const [matches, reqs] = await Promise.all([getMyMatches(), listFriendRequests()]);
-      myMatches = matches;
-      friendRequests = reqs.incoming ?? [];
-      challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
-      friendReqCount = friendRequests.length;
-    } catch { /* non-fatal */ }
-  }
-  /** Open the New-Challenge builder modal. */
-  async function newChallenge() {
-    if (!get(user)?.id) return;
-    mbMsg = '';
-    myGroups = await getMyGroups();
-    showChallenges = true;
-  }
-  /** Go to the Community hub. @param {'challenges'|'leaderboard'|'activity'|'people'} [tab] */
-  // When the People tab is opened straight from the home menu (👥+ button), its
-  // back button returns to the main menu; when opened from inside Community, back
-  // returns to Community.
-  let peopleBackToHome = false;
-  async function openCommunity(tab) {
-    if (!get(user)?.id) return;
-    matchResults = null;
-    peopleBackToHome = tab === 'people';
-    communityTab = tab ?? 'challenges';
-    menuView = 'community';
-    showMainMenu = true;
-    [myMatches, myGroups] = await Promise.all([getMyMatches(), getMyGroups()]);
-    challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
-  }
-  /** Back-compat shim for existing callers (banner "+N more", toasts, result modal). */
-  async function openChallenges(forceTab) {
-    if (forceTab === 'new') return newChallenge();
-    return openCommunity('challenges');
-  }
-
-  function onMbOppInput() {
-    clearTimeout(mbSearchTimer);
-    const q = mbOpponent.trim();
-    if (q.length < 2) { mbResults = []; return; }
-    mbSearchTimer = setTimeout(async () => { mbResults = await searchUsers(q); }, 220);
-  }
-  /** @param {string} username */
-  function pickMbOpp(username) { mbOpponent = username; mbResults = []; }
-  /** @param {string} c */
-  function toggleCategory(c) { mbCategories = mbCategories.includes(c) ? mbCategories.filter((x) => x !== c) : [...mbCategories, c]; }
-
-  async function submitNewMatch() {
-    if (mbBusy) return;
-    if (mbTarget === 'friend' && !mbOpponent.trim()) { mbMsg = 'Pick an opponent.'; return; }
-    if (mbTarget === 'group' && !mbGroupId) { mbMsg = 'Pick a group.'; return; }
-    const w = Math.floor(Number(mbWager) || 0);
-    const createStakes = [
-      { label: mbTarget === 'group' ? 'Group' : 'Opponent', value: mbTarget === 'group' ? (myGroups.find((g) => g.id === mbGroupId)?.name || 'Group') : '@' + mbOpponent.trim() },
-      { label: 'Puzzles', value: String(mbPackSize) },
-      { label: 'Buy-in', value: w > 0 ? '$' + w.toLocaleString() : 'Friendly' },
-      { label: 'Payout', value: mbPayout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
-    ];
-    try { await requirePin(w > 0 ? 'Send & stake your buy-in' : 'Send this challenge', createStakes); } catch { return; }
-    mbBusy = true; mbMsg = 'Creating…';
-    const res = await startMatch({
-      opponent: mbTarget === 'friend' ? mbOpponent.trim() : null,
-      group_id: mbTarget === 'group' ? mbGroupId : null,
-      categories: mbCategories, pack_size: mbPackSize, mode: mbMode,
-      wager: Math.floor(Number(mbWager) || 0), payout: mbPayout, window_seconds: mbWindow,
-      items_allowed: mbItemsAllowed
-    });
-    mbBusy = false;
-    if (res?.ok) { launchMatchPlay(); }
-    else {
-      mbMsg = res?.reason === 'no_opponent' ? 'No player with that username.'
-        : res?.reason === 'insufficient' ? 'Not enough Cash for that wager.'
-        : res?.reason === 'min_wager' ? 'Minimum wager is $500 (or $0 for a friendly).'
-        : res?.reason === 'self' ? "You can't challenge yourself."
-        : res?.reason === 'not_member' ? "You're not in that group."
-        : res?.reason === 'no_puzzles' ? 'No puzzles in those categories.'
-        : 'Could not create the challenge.';
-    }
-  }
-  /** Stakes shown on the PIN confirm. @param {any} m */
-  function matchStakes(m) {
-    const s = [
-      { label: m.is_host ? 'Players' : 'Opponent', value: m.is_host ? `${m.players}` : '@' + m.host },
-      { label: 'Puzzles', value: String(m.pack_size) },
-      { label: 'Buy-in', value: Number(m.wager) > 0 ? '$' + Number(m.wager).toLocaleString() : 'Friendly' },
-      { label: 'Payout', value: m.payout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
-    ];
-    if (Number(m.wager) > 0 && netWorth != null) s.push({ label: 'Your Cash', value: '$' + Math.round(netWorth).toLocaleString() });
-    return s;
-  }
-  /** A challenge whose buy-in I can't fully afford — drives the play-or-decline sheet. */
-  let shortMatch = /** @type {any|null} */ (null);
-  /** @param {any} m */
-  async function respondToMatch(m) {
-    if (mbBusy) return;
-    if (m.status === 'settled') { matchResults = { loading: true }; matchResults = await getMatchDetail(m.id); return; }
-    // Accepting an invite commits your buy-in → confirm with PIN (resuming doesn't).
-    if (m.my_state === 'invited') {
-      // Can't afford the full buy-in → offer "play with what you have" or decline.
-      if (Number(m.wager) > 0 && netWorth != null && netWorth < Number(m.wager)) { shortMatch = m; return; }
-      try { await requirePin(`Accept @${m.host}'s challenge`, matchStakes(m)); } catch { return; }
-    }
-    mbBusy = true;
-    const ok = m.my_state === 'invited' ? await acceptAndPlayMatch(m.id) : await resumeMatch(m.id);
-    mbBusy = false;
-    if (ok) { markChallengeNotifRead(m.id); launchMatchPlay(); }
-    else mbMsg = 'Could not open that challenge.';
-  }
-  /** Play a challenge with a budget capped at your current Cash. @param {any} m */
-  async function playReduced(m) {
-    shortMatch = null;
-    const cap = Math.round(netWorth ?? 0);
-    const stakes = matchStakes(m).map((s) => s.label === 'Buy-in' ? { label: 'Buy-in (capped)', value: '$' + cap.toLocaleString() } : s);
-    try { await requirePin(`Play with $${cap.toLocaleString()}`, stakes); } catch { return; }
-    mbBusy = true;
-    const ok = await acceptAndPlayMatch(m.id, true);
-    mbBusy = false;
-    if (ok) launchMatchPlay();
-    else mbMsg = 'Could not open that challenge.';
-  }
-  /** Decline an invited challenge (refunds the host if it can't proceed). @param {any} m */
-  async function declineChallenge(m) {
-    shortMatch = null;
-    mbBusy = true;
-    await declineMatch(m.id);
-    await refreshChallengeCount();
-    mbBusy = false;
-  }
-  function launchMatchPlay() {
-    showChallenges = false;
-    localStorage.setItem('gameMode', 'match');
-    hasInitialized = true;
-    showMainMenu = false;
-    refreshClimbPups(); // load owned power-ups for the match tray
-  }
-
-  function handleMenuLeaderboard() {
-    goto('/leaderboard');
-  }
-
-  /** Return to main menu from game (saves and refreshes menu state) */
-  function goToMainMenu() {
-    const currentUser = get(user);
-    if (!currentUser?.id) return;
-    dailyPlacement = null;
-    // Leaving a make-up: clear it so we land on the menu, not back in the make-up.
-    if ($gameStore.gameMode === 'makeup') {
-      localStorage.setItem('gameMode', 'daily');
-      localStorage.removeItem('makeupDate');
-    }
-    // Leaving the Cash Game clears heat (position + Cash persist server-side).
-    if ($gameStore.gameMode === 'climb') {
-      climbLeaveGame();
-      localStorage.setItem('gameMode', 'daily');
-    }
-    // Leaving a challenge match — progress persists server-side; refresh the inbox count.
-    if ($gameStore.gameMode === 'match') {
-      localStorage.setItem('gameMode', 'daily');
-      refreshChallengeCount();
-    }
-    saveGameToLocalStorage();
-    savedGameInfo = getSavedGameInfo(currentUser.id);
-    showMainMenu = true;
-    // Refresh the daily completion indicator (e.g. just finished today's daily).
-    getDailyStatus(currentUser.id).then((s) => { dailyStatus = s; menuDailyPlayed = s.has_played_today; });
-    refreshOpenGames();
-    refreshBank();
-    refreshChallengeCount();
-    refreshNotifications();
-  }
-
-  let showMyAccount = false;
-  let showAudio = false; // in-game quick audio panel (sound / haptics / music / track)
-  let showStreakMessage = false;
-  let accountStreak = 0;
-  let accountFreezes = 0;
-  let maUsername = '';
-  /** @type {any} */ let myAvatar = null;
-  let _avatarLoaded = false;
-  $: if (browser && loggedIn && hasInitialized && !_avatarLoaded) { _avatarLoaded = true; getMyAvatar().then((a) => { myAvatar = a.config; }); }
-  let maInput = '';
-  let maEditing = false;
-  let maMsg = '';
-
-  // First-run "pick your username" gate (new accounts that have no username yet).
-  let needsUsername = false;
-  let claimInput = '';
-  let claimMsg = '';
-  let claimBusy = false;
-  async function claimUsername() {
-    const name = claimInput.trim();
-    if (!name || claimBusy) return;
-    claimBusy = true; claimMsg = '';
-    const res = await setUsername(name);
-    claimBusy = false;
-    if (res.ok) {
-      maUsername = res.username ?? name;
-      needsUsername = false;
-      track('username_set', { at: 'signup' });
-      fx('win');
-    } else {
-      claimMsg = res.reason === 'taken' ? 'That username is taken — try another.'
-        : res.reason === 'reserved' ? 'That one’s reserved — try another.'
-        : res.reason === 'invalid' ? '3–15 characters: letters, numbers, or _.'
-        : 'Could not set that username.';
-    }
-  }
-  async function handleMenuMyAccount() {
-    showMyAccount = true;
-    maMsg = '';
-    const u = get(user);
-    if (u?.id) {
-      const status = await getDailyStatus(u.id);
-      accountStreak = status.current_streak ?? 0;
-      accountFreezes = status.streak_freezes ?? 0;
-      maUsername = (await getMyUsername()) ?? '';
-      maEditing = !maUsername;
-      maInput = maUsername;
-    }
-  }
-  async function saveMaUsername() {
-    const name = maInput.trim();
-    if (!name) return;
-    maMsg = 'Saving…';
-    const res = await setUsername(name);
-    if (res.ok) { maUsername = res.username ?? name; maEditing = false; maMsg = ''; track('username_set'); }
-    else {
-      maMsg = res.reason === 'taken' ? 'That username is taken.'
-        : res.reason === 'reserved' ? 'That username is reserved.'
-        : res.reason === 'invalid' ? '3–15 letters, numbers or _ only.'
-        : 'Could not save username.';
-    }
-  }
-  /** @param {KeyboardEvent} e */
-  function handleEscape(e) {
-    if (e.key !== 'Escape') return;
-    if (showMyAccount) showMyAccount = false;
-    if (showStreakMessage) showStreakMessage = false;
-  }
-
-  // Daily result → go to the daily leaderboard.
-  const goToDailyLeaderboard = () => {
-    showResultModal = false;
-    hasTriggeredModal = false;
-    const currentUser = get(user);
-    if (!currentUser?.id) return;
-    clearSavedGame();
-    gameWasRestored.set(false);
-    goto('/leaderboard?mode=daily');
-  };
-
-  /** @type {null | { yesterday_played: boolean, yesterday_banked: number|null, yesterday_won: boolean, today_banked: number|null, today_players: number, today_percentile: number|null }} */
-  let ghost = null;
-
-  const onPhraseRevealComplete = () => {
-    if (!hasTriggeredModal && ['won', 'lost'].includes($gameStore.gameState)) {
-      hasTriggeredModal = true;
-      const won = $gameStore.gameState === 'won';
-      if ($gameStore.gameMode === 'daily' && won) {
-        resultRank = null;
-        getMyDailyRank().then((r) => { resultRank = r; }).catch(() => {});
-        const uid = get(user)?.id;
-        if (uid) getDailyStatus(uid).then((s) => { dailyStatus = s; }).catch(() => {});
-      }
-      setTimeout(() => {
-        showResultModal = true;
-        // 🏆 Win banner: count the profit up, then scroll Cash to the new total.
-        if ($gameStore.gameMode === 'daily' && won) {
-          const profit = $gameStore.dailyResult?.net ?? 0;
-          const newBank = Math.round($gameStore.bankroll ?? 0);
-          resultProfit.set(0, { duration: 0 });
-          resultBankAnim.set(newBank - profit, { duration: 0 });
-          setTimeout(() => { resultProfit.set(profit); fx('win'); }, 350);
-          setTimeout(() => { resultBankAnim.set(newBank); }, 1100);
-        } else if ($gameStore.gameMode === 'climb' && won) {
-          const c = $gameStore.climbInfo || {};
-          const profit = Math.round((c.last_gain ?? 0) - (c.spent ?? 0));
-          const newBank = Math.round($gameStore.bankroll ?? 0);
-          resultProfit.set(0, { duration: 0 });
-          resultBankAnim.set(newBank - profit, { duration: 0 });
-          setTimeout(() => { resultProfit.set(profit); fx('win'); }, 350);
-          setTimeout(() => { resultBankAnim.set(newBank); }, 1100);
-        }
-      }, 1000);
-    }
-  };
+	import { onMount, onDestroy, tick } from 'svelte';
+	import { browser } from '$app/environment';
+	import { supabase } from '$lib/supabaseClient';
+	import { get } from 'svelte/store';
+	import { tweened } from 'svelte/motion';
+	import { cubicOut } from 'svelte/easing';
+
+	import {
+		gameStore,
+		fetchDailyGame,
+		useDailyTwist,
+		useDailyBoost,
+		startChallenge,
+		acceptAndPlayChallenge,
+		resumeChallenge,
+		challengeTimeoutCheck,
+		fetchMakeupGame,
+		fetchClimbGame,
+		startCashGame,
+		cashOutClimb,
+		climbAdvance,
+		climbLeaveGame,
+		climbSkipPuzzle,
+		climbArmDoubleOrNothing,
+		climbPowerup,
+		startBlitz,
+		endBlitz,
+		blitzSkipPuzzle,
+		startMatch,
+		acceptAndPlayMatch,
+		resumeMatch,
+		matchTimeoutCheck,
+		matchPowerup,
+		matchSabotageOpponent,
+		dailyFold,
+		matchFold
+	} from '$lib/stores/GameStore.js';
+	import {
+		getMyChallenges,
+		getPowerups,
+		getDailyAvailBoosts,
+		getMyMatches,
+		getMyGroups,
+		getMatch,
+		getMatchDetail,
+		getMatchDebuffs,
+		getMatchOpponents,
+		declineMatch
+	} from '$lib/stores/statsStore.js';
+	import { CATEGORIES } from '$lib/categories.js';
+	import {
+		user,
+		userProfile,
+		fetchUserProfile,
+		ensureProfileExists
+	} from '$lib/stores/userStore.js';
+	import {
+		getDailyStatus,
+		getOpenGames,
+		expireStaleDailies,
+		getDailyGhost,
+		getMyDailyRank,
+		addFriend,
+		searchUsers,
+		getMyUsername,
+		setUsername,
+		getBank,
+		getDailyBoard,
+		getMatchMessages,
+		sendMatchMessage,
+		getFriendRequestCount,
+		respondFriendRequest,
+		listFriendRequests,
+		getDailyModifier,
+		deleteMyAccount,
+		getMyAvatar,
+		getCashgameMeta,
+		getBlitzMeta
+	} from '$lib/stores/statsStore.js';
+	import Avatar from '$lib/components/Avatar.svelte';
+	import {
+		unreadCount,
+		refreshNotifications,
+		inboxRequest,
+		inboxTarget,
+		markChallengeNotifRead,
+		markFriendNotifRead
+	} from '$lib/stores/notificationStore.js';
+	import { track } from '$lib/analytics.js';
+	import { modifierInfo } from '$lib/powerups.js';
+	import {
+		saveGameToLocalStorage,
+		clearSavedGame,
+		getSavedGameInfo
+	} from '$lib/stores/localGameUtils.js';
+	import { gameWasRestored } from '$lib/stores/GameStateFlags.js';
+	import { soundEnabled, toggleSound, hapticsEnabled, toggleHaptics, fx } from '$lib/sound.js';
+	import {
+		startMusic,
+		stopMusic,
+		musicEnabled,
+		musicVolume,
+		setMusicVolume,
+		toggleMusic,
+		TRACKS,
+		currentTrackId,
+		selectTrack
+	} from '$lib/music.js';
+	import PinGate from '$lib/components/PinGate.svelte';
+	import {
+		pinLocked,
+		hasPinFor,
+		clearPin,
+		markUnlocked,
+		sessionIsUnlocked,
+		markPinSkipped,
+		pinSkipped,
+		clearPinSkipped
+	} from '$lib/pin.js';
+	import { requirePin } from '$lib/pinConfirm.js';
+	import { requireConfirm } from '$lib/confirm.js';
+	import { goto } from '$app/navigation';
+
+	import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
+	import InventoryList from '$lib/components/InventoryList.svelte';
+	import VaultReveal from '$lib/components/VaultReveal.svelte';
+	import Keyboard from '$lib/components/Keyboard.svelte';
+	import GameButtons from '$lib/components/GameButtons.svelte';
+	import FlipDigit from '$lib/components/FlipDigit.svelte';
+	import Auth from '$lib/components/Auth.svelte';
+	import Tutorial from '$lib/components/Tutorial.svelte';
+	import ObjectiveCard from '$lib/components/ObjectiveCard.svelte';
+	import StandingStrip from '$lib/components/StandingStrip.svelte';
+	import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
+	import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
+	import FriendsPanel from '$lib/components/FriendsPanel.svelte';
+	import GroupsPanel from '$lib/components/GroupsPanel.svelte';
+
+	export let data;
+
+	// UI state
+	let showTutorial = false;
+	let showLaunchWelcome = false;
+	let menuView = 'home'; // 'home' | 'play' | 'challenge' | 'progress'
+	let blitzSoon = false;
+	let showResultModal = false;
+	let hasTriggeredModal = false;
+	let hasInitialized = false;
+	let sessionUid = ''; // current session user id (for the PIN gate)
+	let pinNotSet = false; // logged in on this device with no PIN yet → prompt setup
+	/** @type {string | null} */
+	let initError = null; // 🔍 Diagnostic: what failed during init
+	/** Show main menu (Daily / Cash Game / Leaderboard / My account) when true; game when false */
+	let showMainMenu = false;
+	/** When showing menu: can we show "Resume daily" / "Resume in-progress game"? */
+	let savedGameInfo = /** @type {{ gameMode: string, gameState: string } | null} */ (null);
+	/** When showing menu: has user already played daily today? */
+	let menuDailyPlayed = false;
+	/** Today's daily result for the menu indicator (won/lost + score). */
+	let dailyStatus =
+		/** @type {{ has_played_today: boolean, last_daily_won: boolean|null, daily_bankroll: number, bank: number, current_streak: number, streak_freezes: number, today_score: number, win_streak: number, daily_in_progress?: boolean } | null} */ (
+			null
+		);
+	// 🎮 Live solo games from SERVER truth (daily/climb), newest first. The old
+	// single localStorage save slot got overwritten whenever you played another mode, which
+	// made a live Daily show as "complete + lost". openGames lets every mode resume independently.
+	/** @type {{mode:string, updated_at:string}[]} */
+	let openGames = [];
+	async function refreshOpenGames() {
+		const u = get(user);
+		if (!u?.id) return;
+		// Filter out any legacy Free Play rows the server may still return (mode retired in V2).
+		try {
+			openGames = (await getOpenGames()).filter((/** @type {any} */ g) => g.mode !== 'freeplay');
+		} catch {
+			/* keep last */
+		}
+	}
+	// "In progress" must come from SERVER truth, not the clobberable localStorage slot.
+	$: dailyInProgress =
+		openGames.some((g) => g.mode === 'daily') || (dailyStatus?.daily_in_progress ?? false);
+	$: dailyDone = menuDailyPlayed && !dailyInProgress;
+	$: climbInProgress = openGames.some((g) => g.mode === 'climb');
+	// 🔁 Resume: every in-progress game — solo modes AND challenges you've started.
+	const RESUME_LABEL = /** @type {Record<string,string>} */ ({
+		daily: 'Daily',
+		climb: 'Cash Game'
+	});
+	$: resumables = [
+		...openGames.map((/** @type {any} */ g) => ({
+			key: 'solo-' + g.mode,
+			label: RESUME_LABEL[g.mode] ?? 'Game',
+			icon: /** @type {Record<string,string>} */ ({ daily: '📅', climb: '🎰' })[g.mode] ?? '▶',
+			go: () => resumeSolo(g.mode)
+		})),
+		...(myMatches ?? [])
+			.filter((/** @type {any} */ m) => m.status === 'open' && m.my_state === 'active')
+			.map((/** @type {any} */ m) => ({
+				key: 'match-' + m.id,
+				label: m.group_name || (m.opponent ? '@' + m.opponent : 'Challenge'),
+				icon: '⚔️',
+				go: () => respondToMatch(m)
+			}))
+	];
+	let showResumeMenu = false;
+	function resumeSolo(/** @type {string} */ mode) {
+		if (mode === 'daily') handleMenuDaily();
+		else if (mode === 'climb') handleMenuClimb();
+	}
+	function onResume() {
+		fx('tap');
+		if (resumables.length === 1) resumables[0].go();
+		else showResumeMenu = true;
+	}
+	/** Net Worth for the menu chip. */
+	let netWorth = /** @type {number|null} */ (null);
+	let menuLoan = 0; // outstanding loan → drives the menu debt banner
+	async function refreshBank() {
+		try {
+			const gb = await getBank();
+			netWorth = gb.net_worth;
+			menuLoan = gb.loan ?? 0;
+		} catch {
+			/* non-fatal */
+		}
+	}
+
+	// ✅ Load Supabase user profile and sync bankroll (creates profile if missing)
+	/** @param {string} userId */
+	async function loadUserProfile(userId) {
+		try {
+			const { data: profile, error } = await fetchUserProfile(userId);
+			if (error || !profile) {
+				console.warn('⚠️ Failed to load profile:', error?.message ?? error);
+				// Auto-create profile for new users (no profile row yet)
+				const createError = await ensureProfileExists(userId);
+				if (createError) {
+					console.error('❌ Failed to create profile:', createError);
+					return null;
+				}
+				const { data: newProfile } = await fetchUserProfile(userId);
+				if (!newProfile) return null;
+				userProfile.set(newProfile);
+				gameStore.update((state) => ({ ...state, bankroll: 2000 }));
+				console.log('✅ Profile created. Bankroll: 2000');
+				return newProfile;
+			}
+
+			userProfile.set(profile);
+			gameStore.update((state) => ({
+				...state,
+				bankroll: profile.bank ?? 2000
+			}));
+
+			console.log('✅ Profile loaded. Bankroll:', profile.current_bankroll ?? profile.bank);
+			return profile;
+		} catch (err) {
+			console.error('❌ Profile load error:', err instanceof Error ? err.message : String(err));
+			return null;
+		}
+	}
+
+	// ✅ Main logic on initial mount
+	onMount(async () => {
+		initError = null;
+		track('app_open');
+		// Safety net: never strand a logged-in user on the loading screen if a slow or
+		// failed secondary call blocks init.
+		const initFallback = setTimeout(() => {
+			if (!hasInitialized) {
+				showMainMenu = true;
+				hasInitialized = true;
+			}
+		}, 6000);
+		try {
+			const {
+				data: { session },
+				error
+			} = await supabase.auth.getSession();
+			if (!session || error) {
+				initError =
+					'No session (session: ' +
+					(session ? 'yes' : 'no') +
+					', error: ' +
+					(error?.message || 'none') +
+					')';
+				console.warn('⛔', initError);
+				return;
+			}
+
+			user.set(/** @type {{ id: string }} */ (session.user));
+			const profile = await loadUserProfile(session.user.id);
+			if (!profile) {
+				initError =
+					'Profile failed to load or create. Check Supabase profiles table and RLS policies.';
+				console.warn('⛔', initError);
+				showMainMenu = true;
+				hasInitialized = true; // surface the menu instead of hanging
+				return;
+			}
+
+			// Device PIN gate (approach A): if a PIN is set on this device, lock until it's
+			// entered; otherwise mark that we should prompt to set one (after username).
+			sessionUid = session.user.id;
+			// Lock only on a cold open (close → reopen), not on in-app navigation back
+			// to the menu — sessionIsUnlocked() persists the unlock for this app session.
+			if (hasPinFor(sessionUid)) {
+				if (!sessionIsUnlocked()) pinLocked.set(true);
+			} else pinNotSet = !pinSkipped(sessionUid); // don't re-nag if they chose "Skip for now"
+
+			// Make-up daily launched from the streak calendar → drop straight into the board.
+			if (localStorage.getItem('gameMode') === 'makeup' && localStorage.getItem('makeupDate')) {
+				showMainMenu = false;
+				hasInitialized = true;
+				await fetchMakeupGame();
+				return;
+			}
+
+			// Into the menu immediately — the loading screen only gates on auth + profile.
+			showMainMenu = true;
+			// Load any in-progress game so the menu shows "Resume" (not "Missed") after
+			// returning from another route (e.g. the Store).
+			savedGameInfo = getSavedGameInfo(session.user.id);
+			hasInitialized = true;
+
+			// Secondary menu data: must NOT block the loading screen or each other.
+			// Finalize any unfinished Daily from a prior day (no timer → it expires as a loss)
+			// BEFORE reading status/open games, so the menu reflects it.
+			expireStaleDailies()
+				.catch(() => {})
+				.finally(() => {
+					getDailyStatus(session.user.id)
+						.then((ds) => {
+							dailyStatus = ds;
+							menuDailyPlayed = ds.has_played_today;
+						})
+						.catch((e) => console.error('daily status:', e));
+					refreshOpenGames();
+				});
+			refreshBank();
+			refreshChallengeCount();
+			// First-run username gate: prompt if this account hasn't claimed one yet.
+			getMyUsername()
+				.then((u) => {
+					needsUsername = !u;
+				})
+				.catch(() => {});
+
+			// Friend invite link: ?add=USERNAME → add them, then open the Friends board.
+			try {
+				const params = new URLSearchParams(window.location.search);
+				const addName = params.get('add');
+				if (addName) {
+					const res = await addFriend(addName);
+					if (res?.ok) {
+						track('friend_add', { via: 'link' });
+						goto('/leaderboard?mode=friends');
+					}
+				} else if (params.get('challenges')) {
+					openChallenges();
+				}
+			} catch {
+				/* non-fatal */
+			}
+		} catch (err) {
+			initError = 'Init error: ' + (err instanceof Error ? err.message : String(err));
+			console.error('❌', initError);
+			showMainMenu = true;
+			hasInitialized = true; // don't hang on a transient error
+		} finally {
+			clearTimeout(initFallback);
+		}
+	});
+
+	// ✅ Reactive puzzle loader if puzzle is missing (skip when showing main menu)
+	$: if (
+		hasInitialized &&
+		loggedIn &&
+		!showMainMenu &&
+		$gameStore.currentPhrase === '' &&
+		!$gameWasRestored
+	) {
+		const gameMode = localStorage.getItem('gameMode') || 'daily';
+		if (gameMode === 'makeup') {
+			fetchMakeupGame().then((ok) => {
+				if (!ok) showMainMenu = true;
+			});
+		} else if (gameMode === 'climb') {
+			fetchClimbGame().then((ok) => {
+				if (!ok) showMainMenu = true;
+			});
+		} else if (gameMode === 'match' || gameMode === 'blitz') {
+			// Matches (need the active id) + Blitz (a live timed run) aren't deep-link restorable.
+			localStorage.setItem('gameMode', 'daily');
+			showMainMenu = true;
+		} else {
+			fetchDailyGame().then((ok) => {
+				if (!ok) initError = 'Daily puzzle failed to load.';
+			});
+		}
+	}
+
+	// ✅ Set user from SSR if present (profile load happens once in onMount)
+	$: if (data?.user) {
+		user.set(/** @type {{ id: string }} */ (data.user));
+	}
+
+	// Reactive state values
+	$: loggedIn = !!$user?.id;
+	// PIN gate: unlock screen for returning users; set-PIN after username for new ones.
+	$: showPinUnlock = loggedIn && hasInitialized && $pinLocked;
+	$: showPinSetup = loggedIn && hasInitialized && !$pinLocked && pinNotSet && !needsUsername;
+	// ===== Home "act-now" banner: the single most-urgent thing needing me =====
+	/** @type {any[]} incoming friend requests [{id,name,username}] */
+	let friendRequests = [];
+	// When a new notification lands (badge ticks up), refresh the act-now banner's
+	// matches/requests too — so a fresh challenge shows up live, not just the count.
+	let _prevUnread = 0;
+	$: handleUnreadRise($unreadCount);
+	function handleUnreadRise(/** @type {number} */ n) {
+		if (browser && loggedIn && hasInitialized && n > _prevUnread) refreshChallengeCount();
+		_prevUnread = n;
+	}
+	// (Resume + challenge-invite + friend-request notifications now live as their own
+	//  top-of-menu buttons — see resumables / challengeInvites / friendRequests.)
+	/** @param {any} r */
+	async function acceptFriend(r) {
+		fx('tap');
+		await respondFriendRequest(r.id, true);
+		markFriendNotifRead(r.id);
+		await refreshChallengeCount();
+	}
+	function onPinUnlocked() {
+		markUnlocked();
+		pinLocked.set(false);
+	}
+	function onPinSet() {
+		markUnlocked();
+		clearPinSkipped();
+		pinNotSet = false;
+	}
+	function onPinSkip() {
+		markUnlocked();
+		markPinSkipped(sessionUid);
+		pinNotSet = false;
+	} // remember the skip so it doesn't nag every open
+	function onPinLogout() {
+		clearPin();
+		clearPinSkipped();
+		pinLocked.set(false);
+		pinNotSet = false;
+		handleLogout();
+	}
+	// Background music: play continuously through the whole session — menu AND in-game
+	// (it loops seamlessly across screens) — pausing only while locked / setting a PIN.
+	$: if (browser) {
+		loggedIn && hasInitialized && !showPinUnlock && !showPinSetup ? startMusic() : stopMusic();
+	}
+	$: bankroll = $gameStore.bankroll || 0;
+	$: digits = String(bankroll).split('');
+
+	// ✨ Bankroll change reaction (pulse + floating delta)
+	let bankrollPulse = '';
+	let bankrollDelta = 0;
+	/** @type {number | null} */
+	let _prevBankroll = null;
+	$: {
+		const b = $gameStore.bankroll;
+		if (_prevBankroll !== null && typeof b === 'number' && b !== _prevBankroll) {
+			bankrollDelta = b - _prevBankroll;
+			bankrollPulse = bankrollDelta > 0 ? 'up' : 'down';
+			const token = bankrollDelta;
+			setTimeout(() => {
+				if (bankrollDelta === token) bankrollPulse = '';
+			}, 950);
+		}
+		if (typeof b === 'number') _prevBankroll = b;
+	}
+
+	// ---- Daily result: shareable card ----
+	// Each day is its own puzzle (one per date), so show the date — not a counter.
+	// Pinned to UTC — the server schedules the Daily/Twist by UTC CURRENT_DATE, so the
+	// label must match it (otherwise it disagrees near local midnight).
+	$: todayLabel = browser
+		? new Date().toLocaleDateString(undefined, {
+				weekday: 'long',
+				month: 'long',
+				day: 'numeric',
+				timeZone: 'UTC'
+			})
+		: '';
+
+	/** @param {number} br @param {boolean} won */
+	function medalFor(br, won) {
+		if (!won) return { emoji: '💀', name: 'Busted', tier: 'none' };
+		if (br >= 700) return { emoji: '🥇', name: 'Gold', tier: 'gold' };
+		if (br >= 400) return { emoji: '🥈', name: 'Silver', tier: 'silver' };
+		return { emoji: '🥉', name: 'Bronze', tier: 'bronze' };
+	}
+	$: resultWon = $gameStore.gameState === 'won';
+	$: isDailyResult = $gameStore.gameMode === 'daily';
+	// Live Daily HUD metrics (only while actively playing the daily).
+	$: dLive =
+		($gameStore.gameMode === 'daily' || $gameStore.gameMode === 'makeup') &&
+		$gameStore.gameState !== 'won' &&
+		$gameStore.gameState !== 'lost'
+			? $gameStore.dailyLive
+			: null;
+	$: isChallenge = $gameStore.gameMode === 'challenge';
+	$: isMakeup = $gameStore.gameMode === 'makeup';
+	// Auto-dismiss the Cash-earned toast after a few seconds.
+	/** @type {ReturnType<typeof setTimeout>|undefined} */
+	let _attTimer;
+	$: if ($gameStore.cashToast) {
+		clearTimeout(_attTimer);
+		_attTimer = setTimeout(() => gameStore.update((s) => ({ ...s, cashToast: null })), 4000);
+	}
+	$: isClimb = $gameStore.gameMode === 'climb';
+	$: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
+	// ⚡ Blitz — the live client clock counts down to blitzInfo.remaining_ms (server-authoritative);
+	// each action resyncs it. At 0 we call endBlitz() once.
+	$: isBlitz = $gameStore.gameMode === 'blitz';
+	$: blitz = $gameStore.blitzInfo; // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state }
+	let blitzClockMs = 0;
+	/** @type {ReturnType<typeof setInterval>|undefined} */
+	let blitzTimer;
+	let blitzEnding = false;
+	// Resync the local clock whenever the server sends a fresh remaining_ms.
+	$: if (isBlitz && blitz && blitz.state !== 'ended' && blitz.remaining_ms != null) {
+		blitzClockMs = blitz.remaining_ms;
+	}
+	$: if (isBlitz && blitz && blitz.state !== 'ended') {
+		if (!blitzTimer) {
+			blitzEnding = false;
+			blitzTimer = setInterval(() => {
+				blitzClockMs = Math.max(0, blitzClockMs - 100);
+				if (blitzClockMs <= 0 && !blitzEnding) {
+					blitzEnding = true;
+					clearInterval(blitzTimer);
+					blitzTimer = undefined;
+					endBlitz();
+				}
+			}, 100);
+		}
+	} else if (blitzTimer) {
+		clearInterval(blitzTimer);
+		blitzTimer = undefined;
+	}
+	onDestroy(() => {
+		if (blitzTimer) clearInterval(blitzTimer);
+	});
+	$: blitzSec = Math.ceil(blitzClockMs / 1000);
+	// 🏷️ Which mode you're in — a consistent pill under the wordmark on every game screen.
+	$: modeLabel =
+		{
+			daily: { emoji: '📅', name: 'Daily' },
+			climb: { emoji: '🎰', name: 'Cash Game' },
+			blitz: { emoji: '⚡', name: 'Blitz' },
+			makeup: { emoji: '📅', name: 'Make-up' },
+			match: { emoji: '⚔️', name: 'Challenge' },
+			challenge: { emoji: '⚔️', name: 'Challenge' }
+		}[$gameStore.gameMode] ?? null;
+	$: isMatch = $gameStore.gameMode === 'match';
+	$: matchInfo = $gameStore.matchInfo; // { position, pack_size, total_score, last_score, done, mode, solved, spent, budget, wager, items_allowed, used_powerups, started_at, clock_seconds, combo }
+	$: matchBlitz = isMatch && matchInfo?.mode === 'blitz' && !matchInfo?.done;
+	$: matchCombo = ((matchInfo?.combo ?? 100) / 100).toFixed(2);
+	let matchExpiredFired = false;
+	// 💥 Double or Nothing (Cash Game): server exposes don_armed + don_available (heat ≥ ×1.5).
+	$: donArmed = !!climb?.don_armed;
+	$: donAvailable = !!climb?.don_available;
+	// The doubled target payout (matches server: bounty ×2, then × heat, rounded).
+	$: donTarget =
+		isClimb && climb ? Math.round(((climb.bounty ?? 0) * 2 * (climb.heat ?? 100)) / 100) : 0;
+	// Climb live: Spent · Payout (bounty × heat, doubled while armed) · Net.
+	$: climbLive =
+		isClimb && climb && climb.state === 'active'
+			? (() => {
+					const m = climb.don_armed ? 2 : 1;
+					const pay = Math.round(((climb.bounty ?? 0) * m * (climb.heat ?? 100)) / 100);
+					const sp = climb.spent ?? 0;
+					return { spent: sp, payout: pay, net: pay - sp };
+				})()
+			: null;
+	// Win banner needs to know the solve was a Double-or-Nothing (server clears don_armed on solve).
+	let donArmedThisPuzzle = false;
+	$: if (isClimb && climb) {
+		if (climb.don_armed) donArmedThisPuzzle = true;
+		else if (climb.state === 'stuck' || (climb.state === 'active' && (climb.spent ?? 0) === 0))
+			donArmedThisPuzzle = false;
+	}
+	// Challenge live: Spent of your ante budget — lowest spend wins (standard only).
+	$: matchLive =
+		isMatch && matchInfo && !matchInfo.done && matchInfo.mode !== 'blitz'
+			? { spent: matchInfo.spent ?? 0, budget: matchInfo.budget ?? 0 }
+			: null;
+	$: matchLeft = matchLive ? Math.max(0, (matchLive.budget ?? 0) - (matchLive.spent ?? 0)) : 0;
+	// Unified money hero (Daily · Cash Game = net you keep; Challenge = ante left to spend).
+	$: soloHero = climbLive
+		? { net: climbLive.net }
+		: dLive
+			? { net: dLive.winnings }
+			: matchLive
+				? { net: matchLeft }
+				: null;
+
+	// 🎰 Slot-machine money feel: count up/down the bankroll + the green "Solve to Earn",
+	// and float a -$X by the number each time you spend.
+	const tweenBank = tweened(0, { duration: 550, easing: cubicOut });
+	const tweenNet = tweened(0, { duration: 900, easing: cubicOut });
+	// 🏆 Win-banner animations: profit counts up, then Cash scrolls to the new total.
+	const resultProfit = tweened(0, { duration: 1100, easing: cubicOut });
+	const resultBankAnim = tweened(0, { duration: 1300, easing: cubicOut });
+	/** @type {{rank:number,total:number,score:number}|null} */
+	let resultRank = null;
+	$: tweenBank.set(Math.round($gameStore.bankroll ?? 0));
+	// While the opening reveal is landing boxes, hold the bounty at $0 so it can
+	// dramatically count up at the climax (introDone).
+	$: tweenNet.set(introBuilding ? 0 : soloHero ? Math.round(soloHero.net) : 0);
+
+	// 🎰 Daily opening reveal coordination (boxes land → bounty counts up × multiplier).
+	// fetchDailyGame ARMS it (dailyIntro token); we only PLAY it once the board is
+	// actually on screen — i.e. the "How to win" card is dismissed — by bumping
+	// dailyIntroGo, which PhraseDisplay watches.
+	let introBuilding = false;
+	let _introFired = 0;
+	let introCountPop = false;
+	// Play the armed opening reveal — but only when the board is truly on screen
+	// (no objective card up, not on the menu). Called from dismissObjective and,
+	// when the card is suppressed, right after the board renders.
+	function playDailyIntroIfArmed() {
+		const st = get(gameStore);
+		const tok = st.dailyIntro;
+		// Play once per FRESH open (token). dailyIntroPlayed lives in the store so it
+		// survives remounts (e.g. back from the leaderboard); the auto-applied Twist
+		// revealing letters no longer wrongly suppresses the reveal.
+		if (!browser || !tok || tok === st.dailyIntroPlayed) return;
+		if (objective || showMainMenu) return;
+		gameStore.update((s) => ({
+			...s,
+			dailyIntroPlayed: tok,
+			dailyIntroGo: (s.dailyIntroGo || 0) + 1
+		}));
+		introBuilding = true;
+		tweenNet.set(0, { duration: 0 });
+	}
+	function onDailyIntroDone() {
+		introBuilding = false; // releases the reactive above → bounty counts 0 → net
+		introCountPop = true;
+		setTimeout(() => {
+			introCountPop = false;
+		}, 1200);
+	}
+	// 🎬 Challenges auto-advance through a pack, so play the armed opening reveal on each
+	// new puzzle (and on first entry). Resets between matches so a new pack re-triggers.
+	let _lastMatchPos = -1;
+	$: if (!isMatch) {
+		_lastMatchPos = -1;
+	} else if (matchInfo && (matchInfo.position ?? 1) !== _lastMatchPos && !showMainMenu) {
+		_lastMatchPos = matchInfo.position ?? 1;
+		tick().then(playDailyIntroIfArmed);
+	}
+
+	// 💰 In-game bank: a modal (not a route) so closing it returns to the game, not the menu.
+	let showBank = false;
+	/** @type {{ bank:number, net_worth:number, ledger:any[] }|null} */
+	let bankData = null;
+	async function openBankModal() {
+		fx('tap');
+		showBank = true;
+		try {
+			bankData = await getBank();
+		} catch {
+			bankData = null;
+		}
+	}
+	const fmtCash = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+	/** @param {string} reason */
+	const bankReason = (reason) =>
+		/** @type {Record<string,string>} */ ({
+			daily_win: 'Daily reward',
+			daily_reward: 'Daily reward',
+			attendance: 'Daily attendance reward',
+			arcade_cashout: 'Cash Game cash-out',
+			climb_bounty: 'Climb bounty',
+			freeplay_reward: 'Free Play reward',
+			cosmetic_buy: 'Shop purchase',
+			powerup_buy: 'Power-up purchase',
+			wager_win: 'Won a wager',
+			wager_stake: 'Wager staked',
+			wager_refund: 'Wager refunded'
+		})[reason] || reason;
+
+	// 🔐 My Vault — owned inventory; use power-ups in-game (mode-eligible only).
+	let showBag = false;
+	let vaultVideo = false;
+	/** @type {any[]} */ let vaultOwned = [];
+	/** @type {Record<string,number>} */ let dailyAvailBoosts = {};
+	let vaultMsg = '';
+	/** @type {ReturnType<typeof setTimeout>|undefined} */ let _vaultMsgTimer;
+	async function loadVault() {
+		try {
+			vaultOwned = ((await getPowerups()).items ?? []).filter(
+				(/** @type {any} */ i) => (i.owned ?? 0) > 0
+			);
+		} catch {
+			vaultOwned = [];
+		}
+		if (!showMainMenu && $gameStore.gameMode === 'daily') {
+			try {
+				dailyAvailBoosts = await getDailyAvailBoosts();
+			} catch {
+				dailyAvailBoosts = {};
+			}
+		}
+	}
+	function openBag() {
+		fx('tap');
+		showBag = true;
+		loadVault();
+	}
+	// From the main menu: require the device PIN (if set), play the safe-open reveal, then open.
+	async function openVaultFromMenu() {
+		fx('tap');
+		try {
+			await requirePin('Open your Vault');
+		} catch {
+			return;
+		}
+		loadVault();
+		vaultVideo = true;
+	}
+	function onVaultVideoEnd() {
+		if (vaultVideo) {
+			vaultVideo = false;
+			showBag = true;
+		}
+	}
+
+	// In-game vault contents: every item, with the mode-eligible ones usable and the
+	// rest grayed out (with a reason on tap).
+	$: vaultItems =
+		!showBag || showMainMenu
+			? []
+			: (() => {
+					const out = [];
+					if ($gameStore.gameMode === 'daily' && dailyMod && !$gameStore.twistUsed && gameActive) {
+						out.push({
+							id: 'twist',
+							emoji: dailyMod.emoji,
+							name: dailyMod.name,
+							blurb: dailyMod.blurb,
+							count: 1,
+							usable: true,
+							reason: ''
+						});
+					}
+					for (const it of vaultOwned) {
+						if (it.kind === 'daily') {
+							const avail =
+								$gameStore.gameMode === 'daily' && (dailyAvailBoosts[it.id] ?? 0) > 0 && gameActive;
+							out.push({
+								id: it.id,
+								emoji: BOOST_META[it.id]?.emoji ?? '💥',
+								name: it.name,
+								blurb: BOOST_META[it.id]?.blurb ?? '',
+								count: it.owned,
+								usable: avail,
+								reason: avail ? '' : 'Bought after you started — usable on your next puzzle.'
+							});
+						} else if (it.kind === 'climb') {
+							// Self-buffs work in BOTH the Cash Game and Challenges.
+							const climbUsed = (climb?.equipped ?? []).includes(it.id);
+							const matchUsed = (matchInfo?.used_powerups ?? []).includes(it.id);
+							const climbAvail =
+								$gameStore.gameMode === 'climb' && gameActive && !climbUsed && (it.owned ?? 0) > 0;
+							const matchAvail =
+								isMatch &&
+								!!matchInfo?.items_allowed &&
+								gameActive &&
+								!matchUsed &&
+								(it.owned ?? 0) > 0;
+							const avail = climbAvail || matchAvail;
+							out.push({
+								id: it.id,
+								emoji: PUP_ICON[it.id] ?? '✨',
+								name: it.name,
+								blurb: avail ? 'Tap to use now' : '',
+								count: it.owned,
+								usable: avail,
+								reason:
+									climbUsed || matchUsed
+										? 'Already used on this puzzle.'
+										: $gameStore.gameMode === 'climb' || isMatch
+											? ''
+											: 'For the Cash Game or Challenges — not this mode.'
+							});
+						} else if (it.kind === 'sabotage') {
+							const sabAvail =
+								isMatch && !!matchInfo?.items_allowed && gameActive && (it.owned ?? 0) > 0;
+							out.push({
+								id: it.id,
+								emoji: PUP_ICON[it.id] ?? '😈',
+								name: it.name,
+								blurb: sabAvail ? '😈 Tap to aim at an opponent' : '',
+								count: it.owned,
+								usable: sabAvail,
+								kind: 'sabotage',
+								reason: sabAvail ? '' : 'For Challenges — use it during a challenge.'
+							});
+						} else {
+							out.push({
+								id: it.id,
+								emoji: PUP_ICON[it.id] ?? '✨',
+								name: it.name,
+								blurb: '',
+								count: it.owned,
+								usable: false,
+								reason: 'For the Cash Game or Challenges — not this mode.'
+							});
+						}
+					}
+					return out;
+				})();
+	/** @param {any} item */
+	function tapVaultItem(item) {
+		if (item.usable) {
+			useFromBag(item);
+			return;
+		}
+		vaultMsg = item.reason || "This item can't be used for this puzzle.";
+		clearTimeout(_vaultMsgTimer);
+		_vaultMsgTimer = setTimeout(() => {
+			vaultMsg = '';
+		}, 2600);
+	}
+	/** @param {any} item */
+	function useFromBag(item) {
+		if (item?.id === 'twist') useTwist();
+		else if (item?.id === 'bounty_boost' || item?.id === 'jackpot_boost') {
+			useBoost(item.id);
+			loadVault();
+		} else if ($gameStore.gameMode === 'climb') {
+			climbPowerup(item.id).then(() => {
+				refreshClimbPups();
+				loadVault();
+			});
+		} else if (isMatch && item?.kind === 'sabotage') {
+			openSabotagePicker(item);
+			return;
+		} // keeps flow for the target step
+		else if (isMatch) {
+			matchPowerup(item.id).then(() => {
+				refreshClimbPups();
+				loadVault();
+			});
+		}
+		showBag = false;
+	}
+	// 😈 Sabotage from the bag → pick a target (auto-applies vs a single opponent).
+	/** @type {{ item:any, opponents:any[] }|null} */
+	let sabPicker = null;
+	/** @param {any} item */
+	async function openSabotagePicker(item) {
+		showBag = false;
+		const id = matchInfo?.id;
+		if (!id) return;
+		const opps = (await getMatchOpponents(id)).filter((/** @type {any} */ o) => !o.done);
+		if (opps.length === 0) {
+			vaultMsg = 'No opponents left to hit.';
+			return;
+		}
+		if (opps.length === 1) {
+			await matchSabotageOpponent(opps[0].id, item.id);
+			await refreshClimbPups();
+			return;
+		}
+		sabPicker = { item, opponents: opps };
+	}
+	/** @param {string} targetId */
+	async function applySabotage(targetId) {
+		if (!sabPicker) return;
+		const item = sabPicker.item;
+		sabPicker = null;
+		await matchSabotageOpponent(targetId, item.id);
+		await refreshClimbPups();
+	}
+
+	// ℹ️ Daily explainers: ×N badge, Solve-to-Earn, 🏆 streak, or today's Twist.
+	/** @type {'mult'|'bounty'|'streak'|'twist'|null} */
+	let dailyInfo = null;
+	$: dlMult = Number($gameStore.dailyLive?.mult ?? $gameStore.bountyMult ?? 1);
+	$: dlRemaining = $gameStore.dailyLive?.remaining ?? 0; // Prize budget left
+	$: dlWinnings = $gameStore.dailyLive?.winnings ?? Math.round(dlRemaining * dlMult); // banked if you solve now
+	$: dlNet = dlWinnings;
+	$: dlWinStreak = dailyStatus?.win_streak ?? 0;
+	$: dlStreakBonus = Math.min(0.1 * dlWinStreak, 0.5);
+	$: dlWrong = $gameStore.wrongGuesses ?? 0;
+	$: dlPenalty = Math.min(0.2 * dlWrong, Math.max(0, dlMult - 1)); // shown penalty, can't push below ×1.0 floor
+	$: dlBoost = Math.max(0, Math.round((dlMult - 1 - dlStreakBonus + dlPenalty) * 10) / 10);
+	const fmtMult = (/** @type {number} */ n) => '×' + n.toFixed(1);
+	let _prevBank = /** @type {number|null} */ (null);
+	let _floatId = 0;
+	/** @type {{id:number,text:string}[]} */
+	let spendFloaters = [];
+	$: trackSpend($gameStore.bankroll, $gameStore.gameMode, showMainMenu);
+	/** @param {number|null|undefined} b @param {string} mode @param {boolean} onMenu */
+	function trackSpend(b, mode, onMenu) {
+		if (
+			browser &&
+			!onMenu &&
+			_prevBank != null &&
+			b != null &&
+			b < _prevBank &&
+			['daily', 'makeup', 'climb'].includes(mode)
+		) {
+			const amt = _prevBank - b;
+			if (amt > 0 && amt <= 300) {
+				const id = ++_floatId;
+				spendFloaters = [...spendFloaters, { id, text: '−$' + amt.toLocaleString() }];
+				setTimeout(() => {
+					spendFloaters = spendFloaters.filter((f) => f.id !== id);
+				}, 1100);
+			}
+		}
+		_prevBank = b ?? null;
+	}
+
+	// 💥 Dramatic bank pop on a big swing (win payout / big change).
+	let bankFlash = '';
+	let _bankFxPrev = /** @type {number|null} */ (null);
+	/** @type {ReturnType<typeof setTimeout>|undefined} */
+	let _bankFxTimer;
+	$: bankFx($gameStore.bankroll, showMainMenu);
+	/** @param {number|null|undefined} b @param {boolean} onMenu */
+	function bankFx(b, onMenu) {
+		if (!browser || b == null) {
+			_bankFxPrev = b ?? _bankFxPrev;
+			return;
+		}
+		if (!onMenu && _bankFxPrev != null && Math.abs(b - _bankFxPrev) >= 150) {
+			bankFlash = b > _bankFxPrev ? 'up' : 'down';
+			clearTimeout(_bankFxTimer);
+			_bankFxTimer = setTimeout(() => {
+				bankFlash = '';
+			}, 1100);
+		}
+		_bankFxPrev = b;
+	}
+
+	// ── Fold + broke-timer (Daily + Challenges) ──────────────────────────────
+	// You're "broke" when you can't afford the cheapest still-buyable letter →
+	// a 60s clock starts; guess it or you auto-Fold (lose the puzzle).
+	// Mirror of the server-authoritative public.letter_cost() (economy v3.2: −25%, cheapest $20).
+	const LETTER_COSTS = {
+		Q: 20,
+		W: 40,
+		E: 100,
+		R: 90,
+		T: 90,
+		Y: 50,
+		U: 60,
+		I: 80,
+		O: 70,
+		P: 60,
+		A: 100,
+		S: 90,
+		D: 60,
+		F: 50,
+		G: 50,
+		H: 50,
+		J: 20,
+		K: 40,
+		L: 60,
+		Z: 30,
+		X: 30,
+		C: 60,
+		V: 40,
+		B: 50,
+		N: 80,
+		M: 50
+	};
+	// foldMode = modes with a "Give up" button (Daily + Challenges).
+	$: foldMode = $gameStore.gameMode === 'daily' || $gameStore.gameMode === 'match';
+	// brokeMode = modes with the out-of-Cash auto-fold CLOCK. The Daily has NO timer —
+	// guesses are free + unlimited, so being broke isn't a dead end; you solve it or you
+	// don't (an unfinished Daily expires as a loss at day's end). Only live challenges,
+	// where stalling stalls a real opponent, keep the broke clock.
+	$: brokeMode = $gameStore.gameMode === 'match';
+	$: gameActive = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
+	$: isBroke = (() => {
+		// Only while actively on a game screen — never on the menu.
+		if (!brokeMode || !gameActive || showMainMenu) return false;
+		const mod = $gameStore.modifier,
+			discount = mod === 'discount',
+			vowelHalf = mod === 'vowel_vision';
+		const purchased = new Set(($gameStore.purchasedLetters || []).filter(Boolean));
+		const incorrect = new Set($gameStore.incorrectLetters || []);
+		let minCost = Infinity;
+		for (const [L, base] of Object.entries(LETTER_COSTS)) {
+			if (purchased.has(L) || incorrect.has(L)) continue;
+			let c = base;
+			if (discount) c = Math.ceil(c * 0.75);
+			if (vowelHalf && 'AEIOU'.includes(L)) c = Math.ceil(c * 0.5);
+			if (c < minCost) minCost = c;
+		}
+		return minCost !== Infinity && ($gameStore.bankroll || 0) < minCost;
+	})();
+	let brokeDeadline = 0,
+		brokeLeft = 0,
+		brokeFiring = false;
+	/** @type {ReturnType<typeof setInterval>|null} */
+	let brokeTimer = null;
+	$: if (browser) manageBrokeTimer(isBroke);
+	/** @param {boolean} broke */
+	function manageBrokeTimer(broke) {
+		if (broke && !brokeTimer) {
+			brokeDeadline = Date.now() + 60000;
+			brokeLeft = 60;
+			brokeTimer = setInterval(() => {
+				brokeLeft = Math.max(0, Math.ceil((brokeDeadline - Date.now()) / 1000));
+				if (brokeLeft <= 0) {
+					if (brokeTimer) clearInterval(brokeTimer);
+					brokeTimer = null;
+					doFold(true);
+				}
+			}, 250);
+		} else if (!broke && brokeTimer) {
+			if (brokeTimer) clearInterval(brokeTimer);
+			brokeTimer = null;
+		}
+	}
+	/** @param {boolean} auto */
+	async function doFold(auto = false) {
+		if (brokeFiring) return;
+		brokeFiring = true;
+		if (brokeTimer) {
+			if (brokeTimer) clearInterval(brokeTimer);
+			brokeTimer = null;
+		}
+		try {
+			fx(auto ? 'bust' : 'tap');
+			if ($gameStore.gameMode === 'daily') await dailyFold();
+			else if ($gameStore.gameMode === 'match') await matchFold();
+			else if ($gameStore.gameMode === 'climb') {
+				await climbSkipPuzzle();
+				await tick();
+				playDailyIntroIfArmed();
+			} // fresh puzzle; heat resets; replay the dramatic build
+		} finally {
+			brokeFiring = false;
+		}
+	}
+	// Give-up confirm layer (in-app, not window.confirm).
+	let showGiveUp = false;
+	function confirmFold() {
+		fx('tap');
+		showGiveUp = true;
+	}
+	function cancelGiveUp() {
+		fx('tap');
+		showGiveUp = false;
+	}
+	function doGiveUp() {
+		showGiveUp = false;
+		doFold(false);
+	}
+
+	// 💥 Double or Nothing confirm layer (Cash Game). Solve → ×2; get stuck → forfeit.
+	let showDon = false;
+	let donBusy = false;
+	function openDon() {
+		fx('tap');
+		showDon = true;
+	}
+	function cancelDon() {
+		fx('tap');
+		showDon = false;
+	}
+	async function armDon() {
+		if (donBusy) return;
+		donBusy = true;
+		try {
+			fx('tap');
+			await climbArmDoubleOrNothing();
+		} finally {
+			donBusy = false;
+			showDon = false;
+		}
+	}
+
+	$: matchRemaining = (() => {
+		if (!matchBlitz || !matchInfo?.started_at) return 0;
+		const start = new Date(matchInfo.started_at).getTime();
+		const clockMs = (matchInfo.clock_seconds ?? 60) * 1000;
+		return Math.max(0, Math.ceil((start + clockMs - pressureNow) / 1000));
+	})();
+	$: if (matchBlitz && matchRemaining > 0) matchExpiredFired = false;
+	$: if (matchBlitz && matchRemaining <= 0 && !matchExpiredFired) fireMatchTimeout();
+	async function fireMatchTimeout() {
+		matchExpiredFired = true;
+		await matchTimeoutCheck();
+	}
+	$: climbHeat = ((climb?.heat ?? 100) / 100).toFixed(1);
+	// Heat IS the Cash Game win streak: each solve +0.1× (cap ×2.0), reset to ×1.0 when stuck.
+	$: climbStreak = Math.max(0, Math.round(((climb?.heat ?? 100) - 100) / 10));
+	// 🔥 The run: solves + cumulative profit since heat last reset (run_profit can be negative early).
+	$: climbRun =
+		isClimb && climb
+			? {
+					solves: climb.run_solves ?? 0,
+					profit: climb.run_profit ?? 0,
+					best: climb.best_run_profit ?? 0
+				}
+			: null;
+	$: climbRunIsBest = climbRun != null && climbRun.profit > 0 && climbRun.profit >= climbRun.best;
+	// Owned, not-yet-used climb buffs — drives the vault badge by the Solve button.
+	$: usableClimbPups = isClimb
+		? selfPups.filter(
+				(/** @type {any} */ i) => (i.owned ?? 0) > 0 && !(climb?.equipped ?? []).includes(i.id)
+			).length
+		: 0;
+	$: usableMatchPups =
+		isMatch && matchInfo?.items_allowed
+			? selfPups.filter(
+					(/** @type {any} */ i) =>
+						(i.owned ?? 0) > 0 && !(matchInfo?.used_powerups ?? []).includes(i.id)
+				).length
+			: 0;
+	/** @type {'heat'|'earn'|'streak'|null} ℹ️ Cash Game explainers (mirror of dailyInfo). */
+	let climbInfo = null;
+	$: dr = $gameStore.dailyResult; // { score, clean, no_vowels, first_try, no_reveals }
+	/** @type {{rank:number, total:number}|null} */
+	let dailyPlacement = null;
+	$: if (showResultModal && isDailyResult && resultWon && dr && dailyPlacement === null)
+		loadDailyPlacement();
+	async function loadDailyPlacement() {
+		dailyPlacement = { rank: 0, total: 0 }; // guard against re-fire
+		try {
+			const board = await getDailyBoard('friends');
+			const me = board.find((/** @type {any} */ r) => r.is_me);
+			dailyPlacement = { rank: me?.rank ?? 0, total: board.length };
+		} catch {
+			dailyPlacement = { rank: 0, total: 0 };
+		}
+	}
+	/** @type {any[]} */
+	let climbPups = [];
+	const PUP_ICON = /** @type {Record<string,string>} */ ({
+		free_reveal: '🔍',
+		half_off: '🏷️',
+		vowel_vision: '👁️',
+		extra_hint: '💡',
+		reveal_word: '📖',
+		free_vowel: '🅰️',
+		last_letters: '🔚',
+		sabotage_tax: '💸',
+		sabotage_fog: '🌫️',
+		sabotage_toll: '🚧',
+		sabotage_vowel_block: '🚫',
+		sabotage_lock: '🔒'
+	});
+	const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({
+		tax: '💸 Taxed (letters +50%)',
+		fog: '🌫️ Fogged (clue hidden)',
+		toll: '🚧 Tolled (next letter 3×)',
+		vowel_block: '🚫 Vowel-blocked (vowels 3×)'
+	});
+	const DEBUFF_DESC = /** @type {Record<string,string>} */ ({
+		tax: 'Every letter you buy costs +50% while this is active.',
+		fog: 'Your clue is hidden — you have to solve it blind.',
+		toll: 'Your next letter purchase costs 3×, then it clears.',
+		vowel_block: 'Vowels cost 3× while this is active.'
+	});
+	// 💥 Tappable debuff banner → what each sabotage does + who hit you.
+	/** @type {{effect:string, by:string|null}[]|null} */
+	let debuffModal = null;
+	async function openDebuffInfo() {
+		fx('tap');
+		const id = matchInfo?.id;
+		if (!id) return;
+		debuffModal = await getMatchDebuffs(id);
+	}
+	// ℹ️ Tappable "Left to Spend" hero → explains the challenge ante.
+	let showAnteInfo = false;
+	async function refreshClimbPups() {
+		try {
+			const r = await getPowerups();
+			climbPups = r.items ?? [];
+		} catch {
+			/* non-fatal */
+		}
+	}
+	$: selfPups = climbPups.filter((/** @type {any} */ i) => i.kind === 'climb'); // buffs (use on yourself)
+	$: sabPups = climbPups.filter((/** @type {any} */ i) => i.kind === 'sabotage'); // sabotage (target an opponent)
+
+	// --- per-match chat (1v1 + group challenges) ---
+	let matchChatOpen = false;
+	let matchChatUnread = false;
+	/** @type {string|null} id of the newest message you've already seen */
+	let matchChatSeenId = null;
+	/** @type {any[]} */
+	let matchMessages = [];
+	let matchChatInput = '';
+	let matchChatBusy = false;
+	/** @type {string|null} */
+	let matchChatId = null;
+	/** @type {any} */
+	let matchChannel = null;
+	/** @type {ReturnType<typeof setInterval>|undefined} */
+	let matchChatPoll;
+	/** @type {HTMLElement|undefined} */
+	let matchChatScroll;
+
+	async function loadMatchMsgs() {
+		if (!matchChatId) return;
+		const m = await getMatchMessages(matchChatId);
+		if (matchChatId == null) return;
+		matchMessages = m;
+		const newest = m.length ? m[m.length - 1] : null;
+		if (matchChatOpen) {
+			// Reading the thread = caught up.
+			if (newest) matchChatSeenId = newest.id;
+			matchChatUnread = false;
+			tick().then(() => {
+				if (matchChatScroll) matchChatScroll.scrollTop = matchChatScroll.scrollHeight;
+			});
+		} else if (matchChatSeenId === null) {
+			// First sync: treat the existing backlog as already seen (don't nag).
+			if (newest) matchChatSeenId = newest.id;
+		} else if (newest && !newest.is_me && newest.id !== matchChatSeenId) {
+			// Light up only for a NEW message from someone else you haven't opened.
+			matchChatUnread = true;
+		}
+	}
+	function teardownMatchChat() {
+		if (matchChannel) {
+			supabase.removeChannel(matchChannel);
+			matchChannel = null;
+		}
+		clearInterval(matchChatPoll);
+		matchChatId = null;
+		matchMessages = [];
+		matchChatOpen = false;
+		matchChatUnread = false;
+		matchChatSeenId = null;
+	}
+	/** @param {string|null|undefined} id */
+	function syncMatchChat(id) {
+		if (id === matchChatId) return;
+		teardownMatchChat();
+		if (!id) return;
+		matchChatId = id;
+		loadMatchMsgs();
+		matchChannel = supabase
+			.channel(`match:${id}`)
+			.on(
+				'postgres_changes',
+				{ event: 'INSERT', schema: 'public', table: 'match_messages', filter: `match_id=eq.${id}` },
+				loadMatchMsgs
+			)
+			.subscribe();
+		matchChatPoll = setInterval(loadMatchMsgs, 20000);
+	}
+	$: syncMatchChat(isMatch && !showMainMenu ? matchInfo?.id : null);
+	function openMatchChat() {
+		matchChatOpen = true;
+		matchChatUnread = false;
+		loadMatchMsgs();
+	}
+	async function sendMatchChat() {
+		const body = matchChatInput.trim();
+		if (!body || matchChatBusy || !matchChatId) return;
+		matchChatBusy = true;
+		const res = await sendMatchMessage(matchChatId, body);
+		matchChatBusy = false;
+		if (res.ok) {
+			matchChatInput = '';
+			await loadMatchMsgs();
+		}
+	}
+	onDestroy(teardownMatchChat);
+
+	$: makeupLabel = (() => {
+		const d = $gameStore.makeupDate;
+		if (!d) return '';
+		const dt = new Date(d + 'T00:00:00');
+		return dt.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	})();
+	$: chScore = $gameStore.challengeInfo?.score ?? Math.floor($gameStore.bankroll || 0);
+	$: resultBankroll = Math.max(0, Math.floor($gameStore.bankroll || 0));
+	$: resultMedal = medalFor(resultBankroll, resultWon);
+
+	// ⏱️ Pressure-mode challenge clock (server-authoritative; this just displays + triggers the check)
+	let pressureNow = browser ? Date.now() : 0;
+	/** @type {ReturnType<typeof setInterval>|undefined} */
+	let pressureTimer;
+	let pressureFired = false;
+	$: chInfo = $gameStore.gameMode === 'challenge' ? $gameStore.challengeInfo : null;
+	$: isPressure = chInfo?.mode === 'pressure';
+	$: pressureActive =
+		isPressure && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
+	$: pressureRemaining = (() => {
+		if (!isPressure || !chInfo?.started_at) return 0;
+		const start = new Date(chInfo.started_at).getTime();
+		const limitMs = (chInfo.limit_seconds ?? 60) * 1000;
+		return Math.max(0, Math.ceil((start + limitMs - pressureNow) / 1000));
+	})();
+	$: if (pressureActive && pressureRemaining > 0) pressureFired = false;
+	$: if (pressureActive && pressureRemaining <= 0 && !pressureFired) firePressureTimeout();
+	async function firePressureTimeout() {
+		pressureFired = true;
+		await challengeTimeoutCheck();
+		// tolerate minor client/server clock skew — retry shortly if the play didn't settle
+		if ($gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost') {
+			setTimeout(() => {
+				pressureFired = false;
+			}, 1500);
+		}
+	}
+
+	let shareCopied = false;
+	function buildShareText() {
+		const br = '$' + resultBankroll.toLocaleString();
+		// Link to the live origin (never a hardcoded/deleted project URL).
+		const link = typeof window !== 'undefined' ? window.location.origin : '';
+		if (isDailyResult) {
+			if (resultWon && dr) {
+				return `🧠 WordBank Daily · ${todayLabel}\nProfit ${(dr.net ?? 0) >= 0 ? '+' : '−'}$${Math.abs(dr.net ?? 0).toLocaleString()} — beat that 👀\n${link}`;
+			}
+			return `🧠 WordBank Daily · ${todayLabel}\nDidn't crack it today 😬\n${link}`;
+		}
+		return `🏦 WordBank\n${resultMedal.emoji} ${br} banked\n${link}`;
+	}
+	async function handleShare() {
+		const text = buildShareText();
+		try {
+			if (typeof navigator !== 'undefined' && navigator.share) {
+				await navigator.share({ text });
+				return;
+			}
+		} catch {
+			/* user cancelled native share */
+		}
+		try {
+			await navigator.clipboard.writeText(text);
+			shareCopied = true;
+			setTimeout(() => {
+				shareCopied = false;
+			}, 1800);
+		} catch {
+			/* clipboard unavailable */
+		}
+	}
+
+	// ✅ Auto-save the moment a board is live (even before the first letter) so you
+	// can always resume — and keep saving as you play.
+	$: if (
+		loggedIn &&
+		$gameStore.currentPhrase &&
+		$gameStore.category &&
+		Array.isArray($gameStore.purchasedLetters)
+	) {
+		saveGameToLocalStorage();
+	}
+
+	onMount(() => {
+		['click', 'mousedown', 'touchstart'].forEach((event) =>
+			document.addEventListener(event, removeButtonFocus, true)
+		);
+		pressureTimer = setInterval(() => {
+			pressureNow = Date.now();
+		}, 250);
+	});
+	onDestroy(() => {
+		clearInterval(pressureTimer);
+		if (brokeTimer) if (brokeTimer) clearInterval(brokeTimer);
+	});
+
+	// Bump this key whenever the tutorial gains new content — it re-shows for
+	// everyone on next login (v3 = persistent Cash, spend-the-least, attendance, no loans).
+	const TUTORIAL_KEY = 'wb_tutorial_v3';
+	// First-run guided tutorial: show once a signed-in user is past the username/PIN
+	// gates and on the menu (not while those full-screen gates are up).
+	$: if (
+		browser &&
+		loggedIn &&
+		hasInitialized &&
+		!needsUsername &&
+		!showPinUnlock &&
+		!showPinSetup &&
+		localStorage.getItem(TUTORIAL_KEY) !== 'true'
+	) {
+		showTutorial = true;
+	}
+
+	// One-time launch welcome for returning players (we reset everyone to a fresh
+	// Day-1 start). New users get the tutorial instead (it sets this key on dismiss).
+	const LAUNCH_KEY = 'wb_launch_welcome_v1';
+	$: if (
+		browser &&
+		loggedIn &&
+		hasInitialized &&
+		showMainMenu &&
+		!needsUsername &&
+		!showPinUnlock &&
+		!showPinSetup &&
+		!showTutorial &&
+		localStorage.getItem(TUTORIAL_KEY) === 'true' &&
+		localStorage.getItem(LAUNCH_KEY) !== '1'
+	) {
+		showLaunchWelcome = true;
+	}
+	function dismissLaunchWelcome() {
+		showLaunchWelcome = false;
+		if (browser) localStorage.setItem(LAUNCH_KEY, '1');
+	}
+
+	// Deep link from a public profile's "⚔️ Challenge" button: /?challenge=<username>
+	let challengeDeepLinkDone = false;
+	$: if (
+		browser &&
+		loggedIn &&
+		hasInitialized &&
+		!needsUsername &&
+		!showPinUnlock &&
+		!showPinSetup &&
+		!challengeDeepLinkDone
+	) {
+		challengeDeepLinkDone = true;
+		try {
+			const params = new URLSearchParams(window.location.search);
+			const ch = params.get('challenge');
+			if (ch) {
+				newChallenge().then(() => {
+					mbTarget = 'friend';
+					mbOpponent = ch;
+				});
+				params.delete('challenge');
+			}
+			// Settings/account deep link from the Profile page's ⚙️ gear (/?account=1)
+			if (params.get('account')) {
+				handleMenuMyAccount();
+				params.delete('account');
+			}
+			// Friends & Groups deep link (Profile 👥+ button → /?people=1)
+			if (params.get('people')) {
+				openCommunity('people');
+				params.delete('people');
+			}
+			const qs = params.toString();
+			window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
+		} catch {
+			/* non-fatal */
+		}
+	}
+	// A tapped challenge toast / deep-link opens Community ▸ Challenges (people fallback).
+	let _inboxSeen = 0;
+	$: if (
+		browser &&
+		$inboxRequest > _inboxSeen &&
+		loggedIn &&
+		hasInitialized &&
+		!needsUsername &&
+		!showPinUnlock &&
+		!showPinSetup
+	) {
+		_inboxSeen = $inboxRequest;
+		if ($inboxTarget === 'people') {
+			openCommunity('people');
+			peopleTab = 'friends';
+		} else openCommunity('challenges');
+	}
+	function dismissTutorial() {
+		showTutorial = false;
+		// New users just onboarded — they don't also need the launch welcome.
+		if (browser) {
+			localStorage.setItem(TUTORIAL_KEY, 'true');
+			localStorage.setItem(LAUNCH_KEY, '1');
+		}
+	}
+
+	// ===== Pre-game "How to win" objective card =====
+	// Shows the objective the moment a mode starts. Solo modes show once (per mode,
+	// localStorage); challenges show every entry. One reactive latch detects the
+	// menu→game transition so we don't have to wire every scattered start site.
+	/** @type {{ mode: string, ctx: any } | null} */
+	let objective = null;
+	let _wasMenu = true;
+	const SOLO_MODES = ['daily', 'climb', 'makeup'];
+
+	function buildObjectiveCtx(/** @type {string} */ mode) {
+		if (mode !== 'match') return {};
+		const mi = get(gameStore).matchInfo || {};
+		const opps = mi.opponents ?? [];
+		return {
+			opponent: opps.length === 1 ? opps[0]?.name : undefined,
+			wager: mi.wager,
+			packSize: mi.pack_size,
+			fieldSize: opps.length + 1
+		};
+	}
+	// once-seen localStorage key: per-mode for solo modes, per-match for challenges
+	// (so the "How to win" card shows on the FIRST entry only, never on resume).
+	function objSeenKey(/** @type {string} */ mode) {
+		if (mode === 'match') {
+			const id = get(gameStore).matchInfo?.id;
+			return id ? 'wb_obj_match_' + id : null;
+		}
+		return SOLO_MODES.includes(mode) ? 'wb_obj_' + mode : null;
+	}
+	/** @param {boolean} [forced] re-opened via the board ⓘ button — bypass the once-seen gate */
+	function showObjectiveFor(/** @type {string} */ mode, forced = false) {
+		if (!mode || showTutorial) return;
+		const key = objSeenKey(mode);
+		if (!forced && key && browser && localStorage.getItem(key) === '1') return;
+		objective = { mode, ctx: buildObjectiveCtx(mode) };
+	}
+	function dismissObjective() {
+		if (objective && browser) {
+			const key = objSeenKey(objective.mode);
+			if (key) localStorage.setItem(key, '1');
+		}
+		objective = null;
+		tick().then(playDailyIntroIfArmed); // board is now visible → play the opening reveal
+	}
+
+	// Detect entering a game from the menu (latch flips once per entry).
+	$: if (
+		browser &&
+		loggedIn &&
+		hasInitialized &&
+		!needsUsername &&
+		!showPinUnlock &&
+		!showPinSetup
+	) {
+		if (showMainMenu) {
+			_wasMenu = true;
+		} else if (
+			_wasMenu &&
+			$gameStore.gameMode &&
+			$gameStore.gameState !== 'won' &&
+			$gameStore.gameState !== 'lost'
+		) {
+			_wasMenu = false;
+			showObjectiveFor($gameStore.gameMode);
+			refreshBank(); // keep the on-board "Cash" fresh (e.g. a challenge buy-in was just paid)
+		}
+	}
+
+	// Keep the menu pinned to the top. The tall menu + the login→menu height change can
+	// leave the window scrolled (browser scroll-anchoring), which then read as a "jump"
+	// when navigating to /profile. Reset to top whenever the menu becomes visible.
+	let _menuPinned = false;
+	$: if (browser) {
+		if (showMainMenu) {
+			if (!_menuPinned) {
+				_menuPinned = true;
+				tick().then(() => window.scrollTo(0, 0));
+			}
+		} else _menuPinned = false;
+	}
+
+	/** @param {Event} e */
+	const removeButtonFocus = (e) => {
+		if (e.target && /** @type {HTMLElement} */ (e.target).tagName === 'BUTTON')
+			/** @type {HTMLButtonElement} */ (e.target).blur();
+	};
+
+	// ✅ Log out: clear saved game so next login always shows main menu
+	const handleLogout = async () => {
+		clearSavedGame();
+		clearPin(); // forget this device's PIN so the next person can't unlock the account
+		gameWasRestored.set(false);
+		await supabase.auth.signOut();
+		user.set(null);
+		location.reload();
+	};
+
+	// 🔑 PIN: show "Change PIN" only when one is set; require the CURRENT PIN first.
+	$: hasPin = browser && $user?.id ? hasPinFor($user.id) : false;
+	async function changePin() {
+		fx('tap');
+		try {
+			await requirePin('Enter your current PIN to set a new one');
+		} catch {
+			return;
+		}
+		showMyAccount = false;
+		clearPin();
+		clearPinSkipped();
+		pinNotSet = true; // → the create-new-PIN screen
+	}
+	// 🔓 Forgot PIN (from Settings) — verify by email + password, then set a new PIN.
+	async function forgotPin() {
+		if (
+			!(await requireConfirm({
+				title: 'Reset PIN?',
+				message: 'You’ll sign back in with your email & password, then set a new PIN.',
+				confirmText: 'Reset PIN',
+				danger: true
+			}))
+		)
+			return;
+		showMyAccount = false;
+		clearPin();
+		clearPinSkipped();
+		handleLogout();
+	}
+
+	// 🗑️ Permanent account deletion (App Store 5.1.1(v)) — requires typing DELETE.
+	const APP_VERSION = '1.0.0';
+	const SUPPORT_EMAIL = 'charlieforeman77@gmail.com';
+	let showDeleteConfirm = false;
+	let deleteBusy = false;
+	let deleteInput = '';
+	$: deleteArmed = deleteInput.trim().toUpperCase() === 'DELETE';
+	async function confirmDeleteAccount() {
+		if (!deleteArmed || deleteBusy) return;
+		deleteBusy = true;
+		const { ok } = await deleteMyAccount();
+		if (!ok) {
+			deleteBusy = false;
+			maMsg = 'Could not delete your account — try again.';
+			return;
+		}
+		clearSavedGame();
+		clearPin();
+		gameWasRestored.set(false);
+		await supabase.auth.signOut().catch(() => {});
+		user.set(null);
+		location.reload();
+	}
+
+	/** Start daily: resume if in progress, else show "already played" or fetch new daily.
+	 *  Daily has no personal power-ups — everyone shares the same Daily Modifier. */
+	async function handleMenuDaily() {
+		const currentUser = get(user);
+		if (!currentUser?.id) return;
+		// Status loads non-blocking after login — make sure we know it before deciding,
+		// so an already-completed daily shows the summary instead of re-opening + "winning".
+		if (!dailyStatus) {
+			dailyStatus = await getDailyStatus(currentUser.id);
+			menuDailyPlayed = dailyStatus.has_played_today;
+		}
+		// Resume an active Daily based on SERVER truth, not the clobberable local save slot.
+		const inProgress =
+			(dailyStatus?.daily_in_progress ?? false) ||
+			(savedGameInfo?.gameMode === 'daily' &&
+				savedGameInfo?.gameState !== 'won' &&
+				savedGameInfo?.gameState !== 'lost');
+		if (dailyStatus?.has_played_today && !inProgress) {
+			showStreakMessage = true; // already solved today → come-back summary
+			return;
+		}
+		// Today's Twist is auto-given on the board — no pre-game popup. Just play.
+		await startDaily();
+	}
+
+	// ⚡ Power-up hotbar feed. Daily: today's Twist (mode allows only the Twist).
+	// Cash Game / Challenges will feed mode-eligible inventory power-ups here later.
+	// Daily hotbar = today's Twist (if unused) + any owned Bounty Boosts you carry.
+	/** @type {{id:string,emoji:string,name:string,blurb:string,count:number}[]} */
+	let dailyBoosts = [];
+	const BOOST_META = /** @type {Record<string,{emoji:string,blurb:string}>} */ ({
+		bounty_boost: { emoji: '💥', blurb: 'Adds ×0.5 to your bounty' },
+		jackpot_boost: { emoji: '💎', blurb: 'Adds ×1.0 to your bounty' }
+	});
+	async function loadDailyBoosts() {
+		try {
+			const r = await getPowerups();
+			dailyBoosts = (r.items ?? [])
+				.filter((/** @type {any} */ i) => i.kind === 'daily' && (i.owned ?? 0) > 0)
+				.map((/** @type {any} */ i) => ({
+					id: i.id,
+					emoji: BOOST_META[i.id]?.emoji ?? '💥',
+					name: i.name,
+					blurb: BOOST_META[i.id]?.blurb ?? '',
+					count: i.owned
+				}));
+		} catch {
+			dailyBoosts = [];
+		}
+	}
+	$: trayPowerups =
+		$gameStore.gameMode === 'daily' && gameActive
+			? [
+					...(dailyMod && !$gameStore.twistUsed
+						? [
+								{
+									id: 'twist',
+									emoji: dailyMod.emoji,
+									name: dailyMod.name,
+									blurb: dailyMod.blurb,
+									count: 1
+								}
+							]
+						: []),
+					...dailyBoosts
+				]
+			: [];
+	/** @param {CustomEvent<any>} e */
+	function onUsePowerup(e) {
+		const item = e.detail;
+		if (item?.id === 'twist') {
+			useTwist();
+			return;
+		}
+		if (item?.id === 'bounty_boost' || item?.id === 'jackpot_boost') {
+			useBoost(item.id);
+			return;
+		}
+	}
+
+	// Use today's Daily Twist power-up (tap the tray slot).
+	let dailyTwistBusy = false;
+	let dailyBoostBusy = false;
+	async function useTwist() {
+		if (dailyTwistBusy || $gameStore.twistUsed) return;
+		dailyTwistBusy = true;
+		fx('select');
+		await useDailyTwist();
+		dailyTwistBusy = false;
+	}
+	/** @param {string} id */
+	async function useBoost(id) {
+		if (dailyBoostBusy) return;
+		dailyBoostBusy = true;
+		fx('multiplier');
+		await useDailyBoost(id);
+		await loadDailyBoosts();
+		dailyBoostBusy = false;
+	}
+	async function startDaily() {
+		localStorage.setItem('gameMode', 'daily');
+		const ok = await fetchDailyGame();
+		if (ok) {
+			hasInitialized = true;
+			showMainMenu = false;
+			loadDailyBoosts(); // surface any owned Bounty Boosts in the hotbar
+			// refresh streaks so the 📅 attendance chip includes today's check-in
+			const uid = get(user)?.id;
+			if (uid)
+				getDailyStatus(uid)
+					.then((s) => {
+						dailyStatus = s;
+					})
+					.catch(() => {});
+			// If the "How to win" card is suppressed (already seen), the board is now
+			// visible — play the opening reveal once reactives settle. If the card DOES
+			// show, this no-ops (objective set) and the reveal fires on its dismiss.
+			await tick();
+			playDailyIntroIfArmed();
+		} else {
+			initError = 'Daily puzzle failed to load.';
+		}
+	}
+
+	// Today's shared Daily Modifier banner (id lives in the game store, set by fetchDailyGame).
+	$: dailyMod =
+		$gameStore.gameMode === 'daily' && $gameStore.modifier
+			? modifierInfo($gameStore.modifier)
+			: null;
+
+	/** Start or resume the Cash Game (the persistent real-Cash Climb). */
+	// ===== Cash Game V2 — tier select + run =====
+	let showTierSelect = false;
+	/** @type {any} */
+	let cgMeta = null;
+	let cgBusy = false;
+	/** @type {any} */
+	let cashoutResult = null; // { banked, buy_in, profit, multiple_x100, solves, tier }
+
+	async function enterClimbGame() {
+		hasInitialized = true;
+		showMainMenu = false;
+		showTierSelect = false;
+		refreshClimbPups();
+		await tick();
+		playDailyIntroIfArmed();
+	}
+	async function handleMenuClimb() {
+		const currentUser = get(user);
+		if (!currentUser?.id) return;
+		localStorage.setItem('gameMode', 'climb');
+		const res = await fetchClimbGame();
+		if (res === 'needs_tier') {
+			cgMeta = await getCashgameMeta();
+			showTierSelect = true;
+		} else if (res) {
+			await enterClimbGame();
+		} else {
+			initError = 'Cash Game failed to load.';
+		}
+	}
+	/** @param {string} tier */
+	async function pickTier(tier) {
+		if (cgBusy) return;
+		cgBusy = true;
+		const res = await startCashGame(tier);
+		cgBusy = false;
+		if (res?.ok) {
+			await enterClimbGame();
+		} else if (res?.reason === 'insufficient') {
+			// Can't afford the buy-in → offer the Loan Shark.
+			if (
+				confirm(
+					`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`
+				)
+			) {
+				showTierSelect = false;
+				goto('/bank');
+			}
+		} else if (res?.reason === 'locked') {
+			fx('wrong');
+		}
+	}
+	async function cashOut() {
+		if (cgBusy) return;
+		cgBusy = true;
+		const res = await cashOutClimb();
+		cgBusy = false;
+		if (res?.ok) {
+			cashoutResult = res;
+			showResultModal = true;
+			refreshBank();
+		}
+	}
+
+	// ===== ⚡ Blitz — tier select + timed run =====
+	let showBlitzTier = false;
+	/** @type {any} */
+	let bzMeta = null;
+	let bzBusy = false;
+	/** @type {any} */
+	let blitzResult = null; // { solved, winnings, buy_in, net, best_combo, tier }
+	async function handleMenuBlitz() {
+		if (!get(user)?.id) return;
+		localStorage.setItem('gameMode', 'blitz');
+		bzMeta = await getBlitzMeta();
+		showBlitzTier = true;
+	}
+	/** @param {string} tier */
+	async function pickBlitzTier(tier) {
+		if (bzBusy) return;
+		bzBusy = true;
+		const res = await startBlitz(tier);
+		bzBusy = false;
+		if (res?.ok) {
+			hasInitialized = true;
+			showMainMenu = false;
+			showBlitzTier = false;
+			blitzResult = null;
+		} else if (res?.reason === 'insufficient') {
+			if (
+				confirm(
+					`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`
+				)
+			) {
+				showBlitzTier = false;
+				goto('/bank');
+			}
+		}
+	}
+	// When the run ends (clock → 0), surface the result modal.
+	$: if (isBlitz && blitz && blitz.state === 'ended' && !blitzResult) {
+		blitzResult = blitz;
+		showResultModal = true;
+		refreshBank();
+	}
+
+	// ===== Challenge Builder (configurable packs vs friends/groups) =====
+	let showChallenges = false; // the New-Challenge builder modal
+	/** Which Community hub tab is showing. */
+	let communityTab = /** @type {'challenges'|'leaderboard'|'activity'|'people'} */ ('challenges');
+	/** Which People sub-tab (when communityTab === 'people'). */
+	let peopleTab = /** @type {'friends'|'groups'} */ ('friends');
+	/** Start a challenge with a friend from the People list. @param {string} username */
+	function challengeFriend(username) {
+		newChallenge().then(() => {
+			mbTarget = 'friend';
+			mbOpponent = username;
+		});
+	}
+	/** @type {any[]} */
+	let myMatches = [];
+	/** @type {any[]} */
+	let myGroups = [];
+	let challengeCount = 0; // matches awaiting my play (badge on the Challenges card)
+	let friendReqCount = 0; // incoming friend requests (badge on Friends)
+	/** @type {any|null} */
+	let matchResults = null; // a settled match's results being viewed
+	// Builder form
+	let mbTarget = 'friend'; // 'friend' | 'group'
+	let mbMode = 'standard'; // 'standard' | 'blitz'
+	let mbOpponent = '';
+	let mbGroupId = '';
+	/** @type {string[]} */
+	let mbCategories = [];
+	let mbPackSize = 3;
+	let mbWager = 500;
+	let mbPayout = 'winner'; // derived from field size at settle; kept for the RPC signature
+	// Challenge tier antes (ante = stake = pot size; payout is by field size at settle).
+	const CHALLENGE_TIERS = [
+		{ v: 0, label: '🤝 Friendly' },
+		{ v: 500, label: '🥉 $500' },
+		{ v: 2000, label: '🥈 $2K' },
+		{ v: 10000, label: '🥇 $10K' }
+	];
+	let mbWindow = 172800; // seconds
+	let mbItemsAllowed = false; // host toggle: allow power-ups in this challenge
+	let mbMsg = '';
+	let mbBusy = false;
+	/** @type {{username:string,is_friend:boolean}[]} */
+	let mbResults = [];
+	/** @type {ReturnType<typeof setTimeout>|undefined} */
+	let mbSearchTimer;
+	const WINDOWS = [
+		{ s: 3600, l: '1 hour' },
+		{ s: 21600, l: '6 hours' },
+		{ s: 86400, l: '24 hours' },
+		{ s: 172800, l: '48 hours' },
+		{ s: 604800, l: '1 week' }
+	];
+
+	/** Refresh the data behind the home act-now banner (matches + friend requests). */
+	async function refreshChallengeCount() {
+		if (!get(user)?.id) return;
+		try {
+			const [matches, reqs] = await Promise.all([getMyMatches(), listFriendRequests()]);
+			myMatches = matches;
+			friendRequests = reqs.incoming ?? [];
+			challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
+			friendReqCount = friendRequests.length;
+		} catch {
+			/* non-fatal */
+		}
+	}
+	/** Open the New-Challenge builder modal. */
+	async function newChallenge() {
+		if (!get(user)?.id) return;
+		mbMsg = '';
+		myGroups = await getMyGroups();
+		showChallenges = true;
+	}
+	/** Go to the Community hub. @param {'challenges'|'leaderboard'|'activity'|'people'} [tab] */
+	// When the People tab is opened straight from the home menu (👥+ button), its
+	// back button returns to the main menu; when opened from inside Community, back
+	// returns to Community.
+	let peopleBackToHome = false;
+	/** @param {string} tab */
+	async function openCommunity(tab) {
+		if (!get(user)?.id) return;
+		matchResults = null;
+		peopleBackToHome = tab === 'people';
+		communityTab = /** @type {any} */ (tab ?? 'challenges');
+		menuView = 'community';
+		showMainMenu = true;
+		[myMatches, myGroups] = await Promise.all([getMyMatches(), getMyGroups()]);
+		challengeCount = myMatches.filter((m) => m.status === 'open' && m.my_state !== 'done').length;
+	}
+	/** Back-compat shim for existing callers (banner "+N more", toasts, result modal). */
+	/** @param {string} [forceTab] */
+	async function openChallenges(forceTab) {
+		if (forceTab === 'new') return newChallenge();
+		return openCommunity('challenges');
+	}
+
+	function onMbOppInput() {
+		clearTimeout(mbSearchTimer);
+		const q = mbOpponent.trim();
+		if (q.length < 2) {
+			mbResults = [];
+			return;
+		}
+		mbSearchTimer = setTimeout(async () => {
+			mbResults = await searchUsers(q);
+		}, 220);
+	}
+	/** @param {string} username */
+	function pickMbOpp(username) {
+		mbOpponent = username;
+		mbResults = [];
+	}
+	/** @param {string} c */
+	function toggleCategory(c) {
+		mbCategories = mbCategories.includes(c)
+			? mbCategories.filter((x) => x !== c)
+			: [...mbCategories, c];
+	}
+
+	async function submitNewMatch() {
+		if (mbBusy) return;
+		if (mbTarget === 'friend' && !mbOpponent.trim()) {
+			mbMsg = 'Pick an opponent.';
+			return;
+		}
+		if (mbTarget === 'group' && !mbGroupId) {
+			mbMsg = 'Pick a group.';
+			return;
+		}
+		const w = Math.floor(Number(mbWager) || 0);
+		const createStakes = [
+			{
+				label: mbTarget === 'group' ? 'Group' : 'Opponent',
+				value:
+					mbTarget === 'group'
+						? myGroups.find((g) => g.id === mbGroupId)?.name || 'Group'
+						: '@' + mbOpponent.trim()
+			},
+			{ label: 'Puzzles', value: String(mbPackSize) },
+			{ label: 'Buy-in', value: w > 0 ? '$' + w.toLocaleString() : 'Friendly' },
+			{ label: 'Payout', value: mbPayout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
+		];
+		try {
+			await requirePin(w > 0 ? 'Send & stake your buy-in' : 'Send this challenge', createStakes);
+		} catch {
+			return;
+		}
+		mbBusy = true;
+		mbMsg = 'Creating…';
+		const res = await startMatch({
+			opponent: mbTarget === 'friend' ? mbOpponent.trim() : null,
+			group_id: mbTarget === 'group' ? mbGroupId : null,
+			categories: mbCategories,
+			pack_size: mbPackSize,
+			mode: mbMode,
+			wager: Math.floor(Number(mbWager) || 0),
+			payout: mbPayout,
+			window_seconds: mbWindow,
+			items_allowed: mbItemsAllowed
+		});
+		mbBusy = false;
+		if (res?.ok) {
+			launchMatchPlay();
+		} else {
+			mbMsg =
+				res?.reason === 'no_opponent'
+					? 'No player with that username.'
+					: res?.reason === 'insufficient'
+						? 'Not enough Cash for that wager.'
+						: res?.reason === 'min_wager'
+							? 'Minimum wager is $500 (or $0 for a friendly).'
+							: res?.reason === 'self'
+								? "You can't challenge yourself."
+								: res?.reason === 'not_member'
+									? "You're not in that group."
+									: res?.reason === 'no_puzzles'
+										? 'No puzzles in those categories.'
+										: 'Could not create the challenge.';
+		}
+	}
+	/** Stakes shown on the PIN confirm. @param {any} m */
+	function matchStakes(m) {
+		const s = [
+			{
+				label: m.is_host ? 'Players' : 'Opponent',
+				value: m.is_host ? `${m.players}` : '@' + m.host
+			},
+			{ label: 'Puzzles', value: String(m.pack_size) },
+			{
+				label: 'Buy-in',
+				value: Number(m.wager) > 0 ? '$' + Number(m.wager).toLocaleString() : 'Friendly'
+			},
+			{ label: 'Payout', value: m.payout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
+		];
+		if (Number(m.wager) > 0 && netWorth != null)
+			s.push({ label: 'Your Cash', value: '$' + Math.round(netWorth).toLocaleString() });
+		return s;
+	}
+	/** A challenge whose buy-in I can't fully afford — drives the play-or-decline sheet. */
+	let shortMatch = /** @type {any|null} */ (null);
+	/** @param {any} m */
+	async function respondToMatch(m) {
+		if (mbBusy) return;
+		if (m.status === 'settled') {
+			matchResults = { loading: true };
+			matchResults = await getMatchDetail(m.id);
+			return;
+		}
+		// Accepting an invite commits your buy-in → confirm with PIN (resuming doesn't).
+		if (m.my_state === 'invited') {
+			// Can't afford the full buy-in → offer "play with what you have" or decline.
+			if (Number(m.wager) > 0 && netWorth != null && netWorth < Number(m.wager)) {
+				shortMatch = m;
+				return;
+			}
+			try {
+				await requirePin(`Accept @${m.host}'s challenge`, matchStakes(m));
+			} catch {
+				return;
+			}
+		}
+		mbBusy = true;
+		const ok = m.my_state === 'invited' ? await acceptAndPlayMatch(m.id) : await resumeMatch(m.id);
+		mbBusy = false;
+		if (ok) {
+			markChallengeNotifRead(m.id);
+			launchMatchPlay();
+		} else mbMsg = 'Could not open that challenge.';
+	}
+	/** Play a challenge with a budget capped at your current Cash. @param {any} m */
+	async function playReduced(m) {
+		shortMatch = null;
+		const cap = Math.round(netWorth ?? 0);
+		const stakes = matchStakes(m).map((s) =>
+			s.label === 'Buy-in' ? { label: 'Buy-in (capped)', value: '$' + cap.toLocaleString() } : s
+		);
+		try {
+			await requirePin(`Play with $${cap.toLocaleString()}`, stakes);
+		} catch {
+			return;
+		}
+		mbBusy = true;
+		const ok = await acceptAndPlayMatch(m.id, true);
+		mbBusy = false;
+		if (ok) launchMatchPlay();
+		else mbMsg = 'Could not open that challenge.';
+	}
+	/** Decline an invited challenge (refunds the host if it can't proceed). @param {any} m */
+	async function declineChallenge(m) {
+		shortMatch = null;
+		mbBusy = true;
+		await declineMatch(m.id);
+		await refreshChallengeCount();
+		mbBusy = false;
+	}
+	function launchMatchPlay() {
+		showChallenges = false;
+		localStorage.setItem('gameMode', 'match');
+		hasInitialized = true;
+		showMainMenu = false;
+		refreshClimbPups(); // load owned power-ups for the match tray
+	}
+
+	function handleMenuLeaderboard() {
+		goto('/leaderboard');
+	}
+
+	/** Return to main menu from game (saves and refreshes menu state) */
+	function goToMainMenu() {
+		const currentUser = get(user);
+		if (!currentUser?.id) return;
+		dailyPlacement = null;
+		// Leaving a make-up: clear it so we land on the menu, not back in the make-up.
+		if ($gameStore.gameMode === 'makeup') {
+			localStorage.setItem('gameMode', 'daily');
+			localStorage.removeItem('makeupDate');
+		}
+		// Leaving the Cash Game clears heat (position + Cash persist server-side).
+		if ($gameStore.gameMode === 'climb') {
+			climbLeaveGame();
+			localStorage.setItem('gameMode', 'daily');
+		}
+		// Leaving a challenge match — progress persists server-side; refresh the inbox count.
+		if ($gameStore.gameMode === 'match') {
+			localStorage.setItem('gameMode', 'daily');
+			refreshChallengeCount();
+		}
+		saveGameToLocalStorage();
+		savedGameInfo = getSavedGameInfo(currentUser.id);
+		showMainMenu = true;
+		// Refresh the daily completion indicator (e.g. just finished today's daily).
+		getDailyStatus(currentUser.id).then((s) => {
+			dailyStatus = s;
+			menuDailyPlayed = s.has_played_today;
+		});
+		refreshOpenGames();
+		refreshBank();
+		refreshChallengeCount();
+		refreshNotifications();
+	}
+
+	let showMyAccount = false;
+	let showAudio = false; // in-game quick audio panel (sound / haptics / music / track)
+	let showStreakMessage = false;
+	let accountStreak = 0;
+	let accountFreezes = 0;
+	let maUsername = '';
+	/** @type {any} */ let myAvatar = null;
+	let _avatarLoaded = false;
+	$: if (browser && loggedIn && hasInitialized && !_avatarLoaded) {
+		_avatarLoaded = true;
+		getMyAvatar().then((a) => {
+			myAvatar = a.config;
+		});
+	}
+	let maInput = '';
+	let maEditing = false;
+	let maMsg = '';
+
+	// First-run "pick your username" gate (new accounts that have no username yet).
+	let needsUsername = false;
+	let claimInput = '';
+	let claimMsg = '';
+	let claimBusy = false;
+	async function claimUsername() {
+		const name = claimInput.trim();
+		if (!name || claimBusy) return;
+		claimBusy = true;
+		claimMsg = '';
+		const res = await setUsername(name);
+		claimBusy = false;
+		if (res.ok) {
+			maUsername = res.username ?? name;
+			needsUsername = false;
+			track('username_set', { at: 'signup' });
+			fx('win');
+		} else {
+			claimMsg =
+				res.reason === 'taken'
+					? 'That username is taken — try another.'
+					: res.reason === 'reserved'
+						? 'That one’s reserved — try another.'
+						: res.reason === 'invalid'
+							? '3–15 characters: letters, numbers, or _.'
+							: 'Could not set that username.';
+		}
+	}
+	async function handleMenuMyAccount() {
+		showMyAccount = true;
+		maMsg = '';
+		const u = get(user);
+		if (u?.id) {
+			const status = await getDailyStatus(u.id);
+			accountStreak = status.current_streak ?? 0;
+			accountFreezes = status.streak_freezes ?? 0;
+			maUsername = (await getMyUsername()) ?? '';
+			maEditing = !maUsername;
+			maInput = maUsername;
+		}
+	}
+	async function saveMaUsername() {
+		const name = maInput.trim();
+		if (!name) return;
+		maMsg = 'Saving…';
+		const res = await setUsername(name);
+		if (res.ok) {
+			maUsername = res.username ?? name;
+			maEditing = false;
+			maMsg = '';
+			track('username_set');
+		} else {
+			maMsg =
+				res.reason === 'taken'
+					? 'That username is taken.'
+					: res.reason === 'reserved'
+						? 'That username is reserved.'
+						: res.reason === 'invalid'
+							? '3–15 letters, numbers or _ only.'
+							: 'Could not save username.';
+		}
+	}
+	/** @param {KeyboardEvent} e */
+	function handleEscape(e) {
+		if (e.key !== 'Escape') return;
+		if (showMyAccount) showMyAccount = false;
+		if (showStreakMessage) showStreakMessage = false;
+	}
+
+	// Daily result → go to the daily leaderboard.
+	const goToDailyLeaderboard = () => {
+		showResultModal = false;
+		hasTriggeredModal = false;
+		const currentUser = get(user);
+		if (!currentUser?.id) return;
+		clearSavedGame();
+		gameWasRestored.set(false);
+		goto('/leaderboard?mode=daily');
+	};
+
+	/** @type {null | { yesterday_played: boolean, yesterday_banked: number|null, yesterday_won: boolean, today_banked: number|null, today_players: number, today_percentile: number|null }} */
+	let ghost = null;
+
+	const onPhraseRevealComplete = () => {
+		if (!hasTriggeredModal && ['won', 'lost'].includes($gameStore.gameState)) {
+			hasTriggeredModal = true;
+			const won = $gameStore.gameState === 'won';
+			if ($gameStore.gameMode === 'daily' && won) {
+				resultRank = null;
+				getMyDailyRank()
+					.then((r) => {
+						resultRank = r;
+					})
+					.catch(() => {});
+				const uid = get(user)?.id;
+				if (uid)
+					getDailyStatus(uid)
+						.then((s) => {
+							dailyStatus = s;
+						})
+						.catch(() => {});
+			}
+			setTimeout(() => {
+				showResultModal = true;
+				// 🏆 Win banner: count the profit up, then scroll Cash to the new total.
+				if ($gameStore.gameMode === 'daily' && won) {
+					const profit = $gameStore.dailyResult?.net ?? 0;
+					const newBank = Math.round($gameStore.bankroll ?? 0);
+					resultProfit.set(0, { duration: 0 });
+					resultBankAnim.set(newBank - profit, { duration: 0 });
+					setTimeout(() => {
+						resultProfit.set(profit);
+						fx('win');
+					}, 350);
+					setTimeout(() => {
+						resultBankAnim.set(newBank);
+					}, 1100);
+				} else if ($gameStore.gameMode === 'climb' && won) {
+					const c = $gameStore.climbInfo || {};
+					const profit = Math.round((c.last_gain ?? 0) - (c.spent ?? 0));
+					const newBank = Math.round($gameStore.bankroll ?? 0);
+					resultProfit.set(0, { duration: 0 });
+					resultBankAnim.set(newBank - profit, { duration: 0 });
+					setTimeout(() => {
+						resultProfit.set(profit);
+						fx('win');
+					}, 350);
+					setTimeout(() => {
+						resultBankAnim.set(newBank);
+					}, 1100);
+				}
+			}, 1000);
+		}
+	};
 </script>
+
 <svelte:window on:keydown={handleEscape} />
 <!-- ☰ Main menu (top-left) -->
 {#if loggedIn && hasInitialized && !showMainMenu}
-  <button class="menu-back-btn" title="Main menu" aria-label="Main menu" on:click={goToMainMenu}><span class="hamburger"></span></button>
+	<button class="menu-back-btn" title="Main menu" aria-label="Main menu" on:click={goToMainMenu}
+		><span class="hamburger"></span></button
+	>
 {/if}
 <!-- ❓ How to play THIS game type (top-center) -->
 {#if loggedIn && hasInitialized && !showMainMenu && $gameStore.gameMode}
-  <button class="help-btn" title="How to play" aria-label="How to play this game" on:click={() => showObjectiveFor($gameStore.gameMode, true)}>?</button>
+	<button
+		class="help-btn"
+		title="How to play"
+		aria-label="How to play this game"
+		on:click={() => showObjectiveFor($gameStore.gameMode, true)}>?</button
+	>
 {/if}
 <!-- 🔊 In-game audio controls (sound / haptics / music) -->
 {#if loggedIn && hasInitialized && !showMainMenu}
-  <button class="audio-btn" title="Sound & music" aria-label="Sound and music settings" on:click={() => { fx('tap'); showAudio = true; }}>{$soundEnabled || $musicEnabled ? '🔊' : '🔇'}</button>
+	<button
+		class="audio-btn"
+		title="Sound & music"
+		aria-label="Sound and music settings"
+		on:click={() => {
+			fx('tap');
+			showAudio = true;
+		}}>{$soundEnabled || $musicEnabled ? '🔊' : '🔇'}</button
+	>
 {/if}
 <!-- 🏳️ Give up (top-right) — Daily / Challenges -->
 {#if loggedIn && hasInitialized && !showMainMenu && foldMode && gameActive}
-  <button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
+	<button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
 {/if}
 <!-- ⏭️ Skip (top-right) — Cash Game only; resets heat. Hidden once Double-or-Nothing is armed (committed). -->
 {#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && !donArmed && (climb?.state === 'active' || climb?.state === 'stuck')}
-  <button class="giveup-btn" title="Skip this puzzle" aria-label="Skip this puzzle" on:click={confirmFold}>↪</button>
+	<button
+		class="giveup-btn"
+		title="Skip this puzzle"
+		aria-label="Skip this puzzle"
+		on:click={confirmFold}>↪</button
+	>
 {/if}
 
 <!-- 💬 Match chat (1v1 + group challenges) — only inside a live match, never on the menu -->
 {#if isMatch && matchInfo && !showMainMenu}
-  <button class="match-chat-btn" class:unread={matchChatUnread} title="Trash talk" on:click={openMatchChat}>
-    💬 <span class="mcb-label">Chat</span>{#if matchChatUnread}<span class="mc-dot"></span>{/if}
-  </button>
+	<button
+		class="match-chat-btn"
+		class:unread={matchChatUnread}
+		title="Trash talk"
+		on:click={openMatchChat}
+	>
+		💬 <span class="mcb-label">Chat</span>{#if matchChatUnread}<span class="mc-dot"></span>{/if}
+	</button>
 {/if}
 {#if matchChatOpen && !showMainMenu}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Match chat">
-    <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => matchChatOpen = false}></button>
-    <div class="modal-content chat-modal">
-      <button class="close-btn" on:click={() => matchChatOpen = false}>❌</button>
-      <h2 class="chat-h">💬 Trash talk</h2>
-      <div class="chat-msgs" bind:this={matchChatScroll}>
-        {#if matchMessages.length}
-          {#each matchMessages as m}
-            <div class="cmsg" class:mine={m.is_me}>
-              <span class="cm-name">{m.is_me ? 'You' : m.name}</span>
-              <span class="cm-body">{m.body}</span>
-            </div>
-          {/each}
-        {:else}
-          <p class="chat-empty">No messages yet — start the smack talk 👀</p>
-        {/if}
-      </div>
-      <div class="chat-input-row">
-        <input class="chat-input" placeholder="Message…" maxlength="500" bind:value={matchChatInput}
-          on:keydown={(e) => { if (e.key === 'Enter') sendMatchChat(); }} />
-        <button class="chat-send" on:click={sendMatchChat} disabled={matchChatBusy || !matchChatInput.trim()}>Send</button>
-      </div>
-    </div>
-  </div>
+	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Match chat">
+		<button
+			type="button"
+			class="modal-backdrop"
+			aria-label="Close"
+			on:click={() => (matchChatOpen = false)}
+		></button>
+		<div class="modal-content chat-modal">
+			<button class="close-btn" on:click={() => (matchChatOpen = false)}>❌</button>
+			<h2 class="chat-h">💬 Trash talk</h2>
+			<div class="chat-msgs" bind:this={matchChatScroll}>
+				{#if matchMessages.length}
+					{#each matchMessages as m}
+						<div class="cmsg" class:mine={m.is_me}>
+							<span class="cm-name">{m.is_me ? 'You' : m.name}</span>
+							<span class="cm-body">{m.body}</span>
+						</div>
+					{/each}
+				{:else}
+					<p class="chat-empty">No messages yet — start the smack talk 👀</p>
+				{/if}
+			</div>
+			<div class="chat-input-row">
+				<input
+					class="chat-input"
+					placeholder="Message…"
+					maxlength="500"
+					bind:value={matchChatInput}
+					on:keydown={(e) => {
+						if (e.key === 'Enter') sendMatchChat();
+					}}
+				/>
+				<button
+					class="chat-send"
+					on:click={sendMatchChat}
+					disabled={matchChatBusy || !matchChatInput.trim()}>Send</button
+				>
+			</div>
+		</div>
+	</div>
 {/if}
 
 <!-- 🏳️ Give-up confirm layer -->
 {#if showGiveUp}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Give up">
-    <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelGiveUp}></button>
-    <div class="modal-content giveup-modal">
-      <h2 class="gu-title">{isClimb ? 'Skip this puzzle?' : `Give up ${$gameStore.gameMode === 'match' ? 'this puzzle' : "today's Daily"}?`}</h2>
-      <p class="gu-text">{isClimb
-        ? `Your heat resets to ×1.0${(climb?.spent ?? 0) > 0 ? ` and you forfeit the $${(climb?.spent ?? 0).toLocaleString()} spent on this one` : ''} — then a fresh puzzle.`
-        : $gameStore.gameMode === 'match'
-        ? 'Skip this puzzle — you pay its full price and move on.'
-        : 'It counts as a loss and reveals the answer.'}</p>
-      <div class="gu-actions">
-        <button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
-        <button class="gu-confirm" on:click={doGiveUp}>{isClimb ? '⏭️ Skip' : '🏳️ Give up'}</button>
-      </div>
-    </div>
-  </div>
+	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Give up">
+		<button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelGiveUp}
+		></button>
+		<div class="modal-content giveup-modal">
+			<h2 class="gu-title">
+				{isClimb
+					? 'Skip this puzzle?'
+					: `Give up ${$gameStore.gameMode === 'match' ? 'this puzzle' : "today's Daily"}?`}
+			</h2>
+			<p class="gu-text">
+				{isClimb
+					? `Your heat resets to ×1.0${(climb?.spent ?? 0) > 0 ? ` and you forfeit the $${(climb?.spent ?? 0).toLocaleString()} spent on this one` : ''} — then a fresh puzzle.`
+					: $gameStore.gameMode === 'match'
+						? 'Skip this puzzle — you pay its full price and move on.'
+						: 'It counts as a loss and reveals the answer.'}
+			</p>
+			<div class="gu-actions">
+				<button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
+				<button class="gu-confirm" on:click={doGiveUp}>{isClimb ? '⏭️ Skip' : '🏳️ Give up'}</button>
+			</div>
+		</div>
+	</div>
 {/if}
 
 <!-- 💥 Double or Nothing confirm layer (Cash Game) -->
 {#if showDon}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Double or Nothing">
-    <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelDon}></button>
-    <div class="modal-content giveup-modal don-modal">
-      <h2 class="gu-title">💥 Double or Nothing?</h2>
-      <p class="gu-text">
-        Solve this puzzle and your payout <b>doubles</b> to <b class="don-win">${donTarget.toLocaleString()}</b>.
-        But you're all in — you <b>can't skip</b>, and if you get stuck you walk away with <b class="don-loss">$0</b>{(climb?.spent ?? 0) > 0 ? ` and forfeit the $${(climb?.spent ?? 0).toLocaleString()} you've spent` : ''}.
-      </p>
-      <div class="gu-actions">
-        <button class="gu-cancel" on:click={cancelDon}>Not now</button>
-        <button class="gu-confirm don-confirm" on:click={armDon} disabled={donBusy}>💥 Double it</button>
-      </div>
-    </div>
-  </div>
+	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Double or Nothing">
+		<button type="button" class="modal-backdrop" aria-label="Cancel" on:click={cancelDon}></button>
+		<div class="modal-content giveup-modal don-modal">
+			<h2 class="gu-title">💥 Double or Nothing?</h2>
+			<p class="gu-text">
+				Solve this puzzle and your payout <b>doubles</b> to
+				<b class="don-win">${donTarget.toLocaleString()}</b>. But you're all in — you
+				<b>can't skip</b>, and if you get stuck you walk away with
+				<b class="don-loss">$0</b>{(climb?.spent ?? 0) > 0
+					? ` and forfeit the $${(climb?.spent ?? 0).toLocaleString()} you've spent`
+					: ''}.
+			</p>
+			<div class="gu-actions">
+				<button class="gu-cancel" on:click={cancelDon}>Not now</button>
+				<button class="gu-confirm don-confirm" on:click={armDon} disabled={donBusy}
+					>💥 Double it</button
+				>
+			</div>
+		</div>
+	</div>
 {/if}
 
 <!-- 🎉 One-time launch welcome (returning players after the fresh-start reset) -->
 {#if showLaunchWelcome}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Welcome to WordBank">
-    <div class="modal-content welcome-modal">
-      <img class="wc-coin" src="/logo-coin.png" alt="" width="76" height="76" />
-      <h2 class="wc-title">Welcome to WordBank 🎉</h2>
-      <p class="wc-sub">We’ve officially launched — and everyone’s starting fresh.</p>
-      <ul class="wc-list">
-        <li><span>💰</span> <b>$2,000</b> in the bank to play with</li>
-        <li><span>📅</span> Today is <b>Day 1</b> of the Daily</li>
-        <li><span>🎰</span> Fresh puzzles waiting in the Cash Game</li>
-        <li><span>🏆</span> Leaderboards are wide open — go claim a spot</li>
-      </ul>
-      <button class="wc-btn" on:click={dismissLaunchWelcome}>Let’s play →</button>
-    </div>
-  </div>
+	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Welcome to WordBank">
+		<div class="modal-content welcome-modal">
+			<img class="wc-coin" src="/logo-coin.png" alt="" width="76" height="76" />
+			<h2 class="wc-title">Welcome to WordBank 🎉</h2>
+			<p class="wc-sub">We’ve officially launched — and everyone’s starting fresh.</p>
+			<ul class="wc-list">
+				<li><span>💰</span> <b>$2,000</b> in the bank to play with</li>
+				<li><span>📅</span> Today is <b>Day 1</b> of the Daily</li>
+				<li><span>🎰</span> Fresh puzzles waiting in the Cash Game</li>
+				<li><span>🏆</span> Leaderboards are wide open — go claim a spot</li>
+			</ul>
+			<button class="wc-btn" on:click={dismissLaunchWelcome}>Let’s play →</button>
+		</div>
+	</div>
 {/if}
 
 <!-- 📜 Guided tutorial (first run + replayable from ❓) -->
 {#if showTutorial}
-  <Tutorial on:close={dismissTutorial} />
+	<Tutorial on:close={dismissTutorial} />
 {/if}
 
 {#if objective && !showTutorial}
-  <ObjectiveCard mode={objective.mode} ctx={objective.ctx} on:close={dismissObjective} />
+	<ObjectiveCard mode={objective.mode} ctx={objective.ctx} on:close={dismissObjective} />
 {/if}
 
 {#if $gameStore.cashToast}
-  <button class="attendance-toast" on:click={() => gameStore.update(s => ({ ...s, cashToast: null }))}>
-    {#if $gameStore.cashToast.amount > 0}<strong>+${$gameStore.cashToast.amount.toLocaleString()}</strong> · {/if}{$gameStore.cashToast.label}
-  </button>
+	<button
+		class="attendance-toast"
+		on:click={() => gameStore.update((s) => ({ ...s, cashToast: null }))}
+	>
+		{#if $gameStore.cashToast.amount > 0}<strong
+				>+${$gameStore.cashToast.amount.toLocaleString()}</strong
+			> ·
+		{/if}{$gameStore.cashToast.label}
+	</button>
 {/if}
 
 <!-- 🎰 Pure-solve ×1.5 multiplier fly-in -->
 <!-- 💰 In-game bank modal: same info as /bank, but closing returns to the game -->
 {#if showBank}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => showBank = false} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') showBank = false; }}>
-    <div class="info-card bank-card" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => showBank = false} aria-label="Close">✕</button>
-      <p class="bm-label">Net Worth</p>
-      <div class="info-big">{fmtCash(bankData?.bank ?? netWorth ?? 0)}</div>
-      <p class="info-sub">Your Cash — this is your score</p>
-      {#if bankData}
-        <div class="bm-hist-h">Recent activity</div>
-        {#if (bankData.ledger ?? []).length === 0}
-          <p class="info-note" style="text-align:center">No transactions yet. Win the Daily, show up for attendance, or climb the Cash Game to grow your Cash.</p>
-        {:else}
-          <div class="bm-ledger">
-            {#each bankData.ledger.slice(0, 8) as e}
-              <div class="bm-row">
-                <span class="bm-reason">{bankReason(e.reason)}</span>
-                <span class="bm-delta" class:pos={e.delta > 0} class:neg={e.delta < 0}>{e.delta > 0 ? '+' : '−'}{fmtCash(Math.abs(e.delta))}</span>
-              </div>
-            {/each}
-          </div>
-        {/if}
-      {/if}
-      <button class="info-close" on:click={() => showBank = false}>Back to game</button>
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (showBank = false)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape' || e.key === 'Enter') showBank = false;
+		}}
+	>
+		<div class="info-card bank-card" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (showBank = false)} aria-label="Close">✕</button>
+			<p class="bm-label">Net Worth</p>
+			<div class="info-big">{fmtCash(bankData?.bank ?? netWorth ?? 0)}</div>
+			<p class="info-sub">Your Cash — this is your score</p>
+			{#if bankData}
+				<div class="bm-hist-h">Recent activity</div>
+				{#if (bankData.ledger ?? []).length === 0}
+					<p class="info-note" style="text-align:center">
+						No transactions yet. Win the Daily, show up for attendance, or climb the Cash Game to
+						grow your Cash.
+					</p>
+				{:else}
+					<div class="bm-ledger">
+						{#each bankData.ledger.slice(0, 8) as e}
+							<div class="bm-row">
+								<span class="bm-reason">{bankReason(e.reason)}</span>
+								<span class="bm-delta" class:pos={e.delta > 0} class:neg={e.delta < 0}
+									>{e.delta > 0 ? '+' : '−'}{fmtCash(Math.abs(e.delta))}</span
+								>
+							</div>
+						{/each}
+					</div>
+				{/if}
+			{/if}
+			<button class="info-close" on:click={() => (showBank = false)}>Back to game</button>
+		</div>
+	</div>
 {/if}
 
 <!-- 🔐 Vault door-open animation (from the main menu, after the PIN) → then items -->
 {#if vaultVideo}
-  <VaultReveal on:done={onVaultVideoEnd} />
+	<VaultReveal on:done={onVaultVideoEnd} />
 {/if}
 
 <!-- 🔐 My Vault: use power-ups in-game + view inventory + Store link -->
 {#if showBag}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => showBag = false} on:keydown={(e) => { if (e.key === 'Escape') showBag = false; }}>
-    <div class="info-card bag-modal" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => showBag = false} aria-label="Close">✕</button>
-      <h3 class="info-title"><img src="/vault.png" alt="" class="vault-ic-xs" /> My Vault</h3>
-      {#if showMainMenu}
-        <div class="bag-inv"><InventoryList /></div>
-        <button class="bag-store" on:click={() => goto('/shop')}>🛍️ Go to the Store →</button>
-      {:else}
-        <div class="bag-use-h">Your items</div>
-        {#if vaultItems.length}
-          <div class="bag-use-grid">
-            {#each vaultItems as it}
-              <button class="bag-use" class:locked={!it.usable} disabled={(dailyTwistBusy || dailyBoostBusy) && it.usable} on:click={() => tapVaultItem(it)} title={it.usable ? it.blurb : it.reason}>
-                <span class="bag-use-e">{it.emoji}</span>
-                {#if (it.count ?? 1) > 1}<span class="bag-use-n">×{it.count}</span>{/if}
-                <span class="bag-use-name">{it.name}</span>
-                <span class="bag-use-d">{it.usable ? it.blurb : '🔒 tap for why'}</span>
-              </button>
-            {/each}
-          </div>
-        {:else}
-          <p class="bag-note">Nothing usable here right now.</p>
-        {/if}
-      {/if}
-      {#if vaultMsg}<div class="bag-msg">{vaultMsg}</div>{/if}
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (showBag = false)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape') showBag = false;
+		}}
+	>
+		<div class="info-card bag-modal" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (showBag = false)} aria-label="Close">✕</button>
+			<h3 class="info-title"><img src="/vault.png" alt="" class="vault-ic-xs" /> My Vault</h3>
+			{#if showMainMenu}
+				<div class="bag-inv"><InventoryList /></div>
+				<button class="bag-store" on:click={() => goto('/shop')}>🛍️ Go to the Store →</button>
+			{:else}
+				<div class="bag-use-h">Your items</div>
+				{#if vaultItems.length}
+					<div class="bag-use-grid">
+						{#each vaultItems as it}
+							<button
+								class="bag-use"
+								class:locked={!it.usable}
+								disabled={(dailyTwistBusy || dailyBoostBusy) && it.usable}
+								on:click={() => tapVaultItem(it)}
+								title={it.usable ? it.blurb : it.reason}
+							>
+								<span class="bag-use-e">{it.emoji}</span>
+								{#if (it.count ?? 1) > 1}<span class="bag-use-n">×{it.count}</span>{/if}
+								<span class="bag-use-name">{it.name}</span>
+								<span class="bag-use-d">{it.usable ? it.blurb : '🔒 tap for why'}</span>
+							</button>
+						{/each}
+					</div>
+				{:else}
+					<p class="bag-note">Nothing usable here right now.</p>
+				{/if}
+			{/if}
+			{#if vaultMsg}<div class="bag-msg">{vaultMsg}</div>{/if}
+		</div>
+	</div>
 {/if}
 
 <!-- ℹ️ Daily explainers: multiplier breakdown / Solve-to-Earn calculation -->
 {#if dailyInfo}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => dailyInfo = null} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') dailyInfo = null; }}>
-    <div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => dailyInfo = null} aria-label="Close">✕</button>
-      {#if dailyInfo === 'mult'}
-        <div class="info-big">{fmtMult(dlMult)}</div>
-        <h3 class="info-title">Bounty Multiplier</h3>
-        <p class="info-sub">Everything you can earn from this puzzle is multiplied by this.</p>
-        <div class="info-rows">
-          <div class="info-row"><span>Base</span><b>×1.0</b></div>
-          {#if dlStreakBonus > 0}<div class="info-row"><span>🏆 Win streak ({dlWinStreak} in a row)</span><b class="pos">+{dlStreakBonus.toFixed(1)}</b></div>{/if}
-          {#if dlBoost > 0}<div class="info-row"><span>💥 Boosts</span><b class="pos">+{dlBoost.toFixed(1)}</b></div>{/if}
-          {#if dlWrong > 0}<div class="info-row"><span>❌ Wrong guesses ({dlWrong})</span><b class="neg">−{dlPenalty.toFixed(1)}</b></div>{/if}
-          <div class="info-row total"><span>Your multiplier</span><b>{fmtMult(dlMult)}</b></div>
-        </div>
-        <p class="info-note">Grows with your <button class="info-inline" on:click|stopPropagation={() => dailyInfo = 'streak'}>win streak</button> (<b>+0.1×</b>/solve, up to <b>×1.5</b>). Each wrong guess costs <b>−0.2×</b> (never below ×1.0).</p>
-      {:else if dailyInfo === 'twist'}
-        <div class="info-big">{dailyMod?.emoji ?? '🎁'}</div>
-        <h3 class="info-title">{dailyMod?.name ?? "Today's Twist"}</h3>
-        <p class="info-sub">Today's special — applied automatically. ✓</p>
-        <p class="info-twist-do">{dailyMod?.blurb ?? ''}</p>
-        <p class="info-note">A different special each weekday — same for everyone.</p>
-      {:else if dailyInfo === 'streak'}
-        <div class="info-big">🏆 {dlWinStreak}</div>
-        <h3 class="info-title">Win Streak</h3>
-        <p class="info-sub">Daily puzzles you've solved in a row.</p>
-        <div class="info-rows">
-          <div class="info-row"><span>Solve today's Daily</span><b class="pos">+1</b></div>
-          <div class="info-row"><span>Lose or give up</span><b class="neg">back to 0</b></div>
-        </div>
-        <p class="info-note">Also boosts your <button class="info-inline" on:click|stopPropagation={() => dailyInfo = 'mult'}>multiplier</button> — <b>+0.1×</b> per win.</p>
-      {:else}
-        <div class="info-big green">${Math.max(0, dlWinnings).toLocaleString()}</div>
-        <h3 class="info-title">You'll bank</h3>
-        <p class="info-sub">What you'd bank if you solve right now. Your Cash never drops — playing only adds to it.</p>
-        <div class="info-rows">
-          <div class="info-row"><span>🏆 Prize left</span><b class="pos">${dlRemaining.toLocaleString()}</b></div>
-          {#if dlMult > 1}<div class="info-row"><span>× Streak bonus</span><b>{fmtMult(dlMult)}</b></div>{/if}
-          <div class="info-row total"><span>You bank</span><b class="green">${dlWinnings.toLocaleString()}</b></div>
-        </div>
-        <p class="info-note">Deduce letters instead of buying them — keep more of the Prize. Grows your <button class="info-inline" on:click|stopPropagation={() => dailyInfo = 'mult'}>multiplier</button> too.</p>
-      {/if}
-      <button class="info-close" on:click={() => dailyInfo = null}>Got it</button>
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (dailyInfo = null)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape' || e.key === 'Enter') dailyInfo = null;
+		}}
+	>
+		<div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (dailyInfo = null)} aria-label="Close">✕</button>
+			{#if dailyInfo === 'mult'}
+				<div class="info-big">{fmtMult(dlMult)}</div>
+				<h3 class="info-title">Bounty Multiplier</h3>
+				<p class="info-sub">Everything you can earn from this puzzle is multiplied by this.</p>
+				<div class="info-rows">
+					<div class="info-row"><span>Base</span><b>×1.0</b></div>
+					{#if dlStreakBonus > 0}<div class="info-row">
+							<span>🏆 Win streak ({dlWinStreak} in a row)</span><b class="pos"
+								>+{dlStreakBonus.toFixed(1)}</b
+							>
+						</div>{/if}
+					{#if dlBoost > 0}<div class="info-row">
+							<span>💥 Boosts</span><b class="pos">+{dlBoost.toFixed(1)}</b>
+						</div>{/if}
+					{#if dlWrong > 0}<div class="info-row">
+							<span>❌ Wrong guesses ({dlWrong})</span><b class="neg">−{dlPenalty.toFixed(1)}</b>
+						</div>{/if}
+					<div class="info-row total"><span>Your multiplier</span><b>{fmtMult(dlMult)}</b></div>
+				</div>
+				<p class="info-note">
+					Grows with your <button
+						class="info-inline"
+						on:click|stopPropagation={() => (dailyInfo = 'streak')}>win streak</button
+					>
+					(<b>+0.1×</b>/solve, up to <b>×1.5</b>). Each wrong guess costs <b>−0.2×</b> (never below ×1.0).
+				</p>
+			{:else if dailyInfo === 'twist'}
+				<div class="info-big">{dailyMod?.emoji ?? '🎁'}</div>
+				<h3 class="info-title">{dailyMod?.name ?? "Today's Twist"}</h3>
+				<p class="info-sub">Today's special — applied automatically. ✓</p>
+				<p class="info-twist-do">{dailyMod?.blurb ?? ''}</p>
+				<p class="info-note">A different special each weekday — same for everyone.</p>
+			{:else if dailyInfo === 'streak'}
+				<div class="info-big">🏆 {dlWinStreak}</div>
+				<h3 class="info-title">Win Streak</h3>
+				<p class="info-sub">Daily puzzles you've solved in a row.</p>
+				<div class="info-rows">
+					<div class="info-row"><span>Solve today's Daily</span><b class="pos">+1</b></div>
+					<div class="info-row"><span>Lose or give up</span><b class="neg">back to 0</b></div>
+				</div>
+				<p class="info-note">
+					Also boosts your <button
+						class="info-inline"
+						on:click|stopPropagation={() => (dailyInfo = 'mult')}>multiplier</button
+					>
+					— <b>+0.1×</b> per win.
+				</p>
+			{:else}
+				<div class="info-big green">${Math.max(0, dlWinnings).toLocaleString()}</div>
+				<h3 class="info-title">You'll bank</h3>
+				<p class="info-sub">
+					What you'd bank if you solve right now. Your Cash never drops — playing only adds to it.
+				</p>
+				<div class="info-rows">
+					<div class="info-row">
+						<span>🏆 Prize left</span><b class="pos">${dlRemaining.toLocaleString()}</b>
+					</div>
+					{#if dlMult > 1}<div class="info-row">
+							<span>× Streak bonus</span><b>{fmtMult(dlMult)}</b>
+						</div>{/if}
+					<div class="info-row total">
+						<span>You bank</span><b class="green">${dlWinnings.toLocaleString()}</b>
+					</div>
+				</div>
+				<p class="info-note">
+					Deduce letters instead of buying them — keep more of the Prize. Grows your <button
+						class="info-inline"
+						on:click|stopPropagation={() => (dailyInfo = 'mult')}>multiplier</button
+					> too.
+				</p>
+			{/if}
+			<button class="info-close" on:click={() => (dailyInfo = null)}>Got it</button>
+		</div>
+	</div>
 {/if}
 
 <!-- ℹ️ Cash Game explainers: heat (= win streak) / Solve-to-Earn calculation -->
 {#if climbInfo}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => climbInfo = null} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') climbInfo = null; }}>
-    <div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => climbInfo = null} aria-label="Close">✕</button>
-      {#if climbInfo === 'heat'}
-        <div class="info-big">🔥 ×{climbHeat}</div>
-        <h3 class="info-title">Heat — your multiplier</h3>
-        <p class="info-sub">Everything you earn from a puzzle is multiplied by your heat.</p>
-        <div class="info-rows">
-          <div class="info-row"><span>Base</span><b>×1.0</b></div>
-          <div class="info-row"><span>Each solve in a row</span><b class="pos">+0.1×</b></div>
-          <div class="info-row"><span>Maxes out at</span><b>×2.0</b></div>
-          <div class="info-row total"><span>Your heat</span><b>×{climbHeat}</b></div>
-        </div>
-        <p class="info-note">Heat climbs with your <button class="info-inline" on:click|stopPropagation={() => climbInfo = 'streak'}>win streak</button> and resets to ×1.0 if you get stuck or skip.</p>
-      {:else if climbInfo === 'streak'}
-        <div class="info-big">🏆 {climbStreak}</div>
-        <h3 class="info-title">Win Streak</h3>
-        <p class="info-sub">Cash Game puzzles you've solved in a row.</p>
-        <div class="info-rows">
-          <div class="info-row"><span>Solve a puzzle</span><b class="pos">+1</b></div>
-          <div class="info-row"><span>Get stuck or skip</span><b class="neg">back to 0</b></div>
-        </div>
-        <p class="info-note">Powers your <button class="info-inline" on:click|stopPropagation={() => climbInfo = 'heat'}>heat</button> — <b>+0.1×</b> per win.</p>
-      {:else}
-        <div class="info-big green">${Math.max(0, climbLive?.net ?? 0).toLocaleString()}</div>
-        <h3 class="info-title">Solve to Earn</h3>
-        <p class="info-sub">What you pocket if you solve right now.</p>
-        <div class="info-rows">
-          <div class="info-row"><span>Bounty × heat ({fmtMult(Number(climbHeat))})</span><b class="pos">${(climbLive?.payout ?? 0).toLocaleString()}</b></div>
-          <div class="info-row"><span>− Spent on letters</span><b class="neg">−${(climbLive?.spent ?? 0).toLocaleString()}</b></div>
-          <div class="info-row total"><span>You keep</span><b class="green">${(climbLive?.net ?? 0).toLocaleString()}</b></div>
-        </div>
-        <p class="info-note">Spend less on letters to keep more — and grow your <button class="info-inline" on:click|stopPropagation={() => climbInfo = 'heat'}>heat</button>.</p>
-      {/if}
-      <button class="info-close" on:click={() => climbInfo = null}>Got it</button>
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (climbInfo = null)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape' || e.key === 'Enter') climbInfo = null;
+		}}
+	>
+		<div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (climbInfo = null)} aria-label="Close">✕</button>
+			{#if climbInfo === 'heat'}
+				<div class="info-big">🔥 ×{climbHeat}</div>
+				<h3 class="info-title">Heat — your multiplier</h3>
+				<p class="info-sub">Everything you earn from a puzzle is multiplied by your heat.</p>
+				<div class="info-rows">
+					<div class="info-row"><span>Base</span><b>×1.0</b></div>
+					<div class="info-row"><span>Each solve in a row</span><b class="pos">+0.1×</b></div>
+					<div class="info-row"><span>Maxes out at</span><b>×2.0</b></div>
+					<div class="info-row total"><span>Your heat</span><b>×{climbHeat}</b></div>
+				</div>
+				<p class="info-note">
+					Heat climbs with your <button
+						class="info-inline"
+						on:click|stopPropagation={() => (climbInfo = 'streak')}>win streak</button
+					> and resets to ×1.0 if you get stuck or skip.
+				</p>
+			{:else if climbInfo === 'streak'}
+				<div class="info-big">🏆 {climbStreak}</div>
+				<h3 class="info-title">Win Streak</h3>
+				<p class="info-sub">Cash Game puzzles you've solved in a row.</p>
+				<div class="info-rows">
+					<div class="info-row"><span>Solve a puzzle</span><b class="pos">+1</b></div>
+					<div class="info-row"><span>Get stuck or skip</span><b class="neg">back to 0</b></div>
+				</div>
+				<p class="info-note">
+					Powers your <button
+						class="info-inline"
+						on:click|stopPropagation={() => (climbInfo = 'heat')}>heat</button
+					>
+					— <b>+0.1×</b> per win.
+				</p>
+			{:else}
+				<div class="info-big green">${Math.max(0, climbLive?.net ?? 0).toLocaleString()}</div>
+				<h3 class="info-title">Solve to Earn</h3>
+				<p class="info-sub">What you pocket if you solve right now.</p>
+				<div class="info-rows">
+					<div class="info-row">
+						<span>Bounty × heat ({fmtMult(Number(climbHeat))})</span><b class="pos"
+							>${(climbLive?.payout ?? 0).toLocaleString()}</b
+						>
+					</div>
+					<div class="info-row">
+						<span>− Spent on letters</span><b class="neg"
+							>−${(climbLive?.spent ?? 0).toLocaleString()}</b
+						>
+					</div>
+					<div class="info-row total">
+						<span>You keep</span><b class="green">${(climbLive?.net ?? 0).toLocaleString()}</b>
+					</div>
+				</div>
+				<p class="info-note">
+					Spend less on letters to keep more — and grow your <button
+						class="info-inline"
+						on:click|stopPropagation={() => (climbInfo = 'heat')}>heat</button
+					>.
+				</p>
+			{/if}
+			<button class="info-close" on:click={() => (climbInfo = null)}>Got it</button>
+		</div>
+	</div>
 {/if}
 
 <!-- ℹ️ Challenge "Left to Spend" explainer -->
 {#if showAnteInfo}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => showAnteInfo = false} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') showAnteInfo = false; }}>
-    <div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => showAnteInfo = false} aria-label="Close">✕</button>
-      <div class="info-big green">${Math.max(0, matchLeft).toLocaleString()}</div>
-      <h3 class="info-title">Left to Spend</h3>
-      <p class="info-sub">Your buy-in — real Cash, all of it at stake. Buying letters spends it; your wallet up top is the rest of your Cash and it's safe.</p>
-      <div class="info-rows">
-        <div class="info-row"><span>Most Cash left at the end</span><b class="pos">takes the whole pot</b></div>
-        <div class="info-row"><span>Lose</span><b class="neg">forfeit your buy-in</b></div>
-        <div class="info-row"><span>Skip a puzzle</span><b class="neg">pays full price</b></div>
-      </div>
-      <p class="info-note">Most Cash left wins the pot. Duel = winner-take-all (tie splits 50/50); groups pay a podium (3 → 70/30, 4+ → 60/30/10). Wrong guesses waste your ante, so guess only when you're sure.</p>
-      <button class="info-close" on:click={() => showAnteInfo = false}>Got it</button>
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (showAnteInfo = false)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape' || e.key === 'Enter') showAnteInfo = false;
+		}}
+	>
+		<div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (showAnteInfo = false)} aria-label="Close">✕</button>
+			<div class="info-big green">${Math.max(0, matchLeft).toLocaleString()}</div>
+			<h3 class="info-title">Left to Spend</h3>
+			<p class="info-sub">
+				Your buy-in — real Cash, all of it at stake. Buying letters spends it; your wallet up top is
+				the rest of your Cash and it's safe.
+			</p>
+			<div class="info-rows">
+				<div class="info-row">
+					<span>Most Cash left at the end</span><b class="pos">takes the whole pot</b>
+				</div>
+				<div class="info-row"><span>Lose</span><b class="neg">forfeit your buy-in</b></div>
+				<div class="info-row"><span>Skip a puzzle</span><b class="neg">pays full price</b></div>
+			</div>
+			<p class="info-note">
+				Most Cash left wins the pot. Duel = winner-take-all (tie splits 50/50); groups pay a podium
+				(3 → 70/30, 4+ → 60/30/10). Wrong guesses waste your ante, so guess only when you're sure.
+			</p>
+			<button class="info-close" on:click={() => (showAnteInfo = false)}>Got it</button>
+		</div>
+	</div>
 {/if}
 
 <!-- 💥 Sabotage debuff explainer: what it does + who hit you -->
 {#if debuffModal}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => debuffModal = null} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') debuffModal = null; }}>
-    <div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => debuffModal = null} aria-label="Close">✕</button>
-      <div class="info-big">💥</div>
-      <h3 class="info-title">You got hit</h3>
-      {#if debuffModal.length}
-        <div class="info-rows">
-          {#each debuffModal as d}
-            <div class="info-row debuff-row">
-              <span>{DEBUFF_LABEL[d.effect] ?? d.effect}<small class="db-desc">{DEBUFF_DESC[d.effect] ?? ''}</small></span>
-              <b>{d.by ? 'by ' + d.by : ''}</b>
-            </div>
-          {/each}
-        </div>
-      {:else}
-        <p class="info-sub">No active sabotage right now.</p>
-      {/if}
-      <button class="info-close" on:click={() => debuffModal = null}>Got it</button>
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (debuffModal = null)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape' || e.key === 'Enter') debuffModal = null;
+		}}
+	>
+		<div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (debuffModal = null)} aria-label="Close">✕</button>
+			<div class="info-big">💥</div>
+			<h3 class="info-title">You got hit</h3>
+			{#if debuffModal.length}
+				<div class="info-rows">
+					{#each debuffModal as d}
+						<div class="info-row debuff-row">
+							<span
+								>{DEBUFF_LABEL[d.effect] ?? d.effect}<small class="db-desc"
+									>{DEBUFF_DESC[d.effect] ?? ''}</small
+								></span
+							>
+							<b>{d.by ? 'by ' + d.by : ''}</b>
+						</div>
+					{/each}
+				</div>
+			{:else}
+				<p class="info-sub">No active sabotage right now.</p>
+			{/if}
+			<button class="info-close" on:click={() => (debuffModal = null)}>Got it</button>
+		</div>
+	</div>
 {/if}
 
 <!-- 😈 Sabotage target picker (group play): each opponent's puzzle + ante left -->
 {#if sabPicker}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Cancel"
-    on:click={() => sabPicker = null} on:keydown={(e) => { if (e.key === 'Escape') sabPicker = null; }}>
-    <div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => sabPicker = null} aria-label="Cancel">✕</button>
-      <div class="info-big">{PUP_ICON[sabPicker.item.id] ?? '😈'}</div>
-      <h3 class="info-title">{sabPicker.item.name} — hit who?</h3>
-      <div class="sab-target-list">
-        {#each sabPicker.opponents as o}
-          <button class="sab-target-row" on:click={() => applySabotage(o.id)}>
-            <span class="st-name">{o.name}</span>
-            <span class="st-stat">🧩 Puzzle {o.position} · ${Number(o.ante_left ?? 0).toLocaleString()}</span>
-          </button>
-        {/each}
-      </div>
-      <button class="info-close" on:click={() => sabPicker = null}>Cancel</button>
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Cancel"
+		on:click={() => (sabPicker = null)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape') sabPicker = null;
+		}}
+	>
+		<div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (sabPicker = null)} aria-label="Cancel">✕</button>
+			<div class="info-big">{PUP_ICON[sabPicker.item.id] ?? '😈'}</div>
+			<h3 class="info-title">{sabPicker.item.name} — hit who?</h3>
+			<div class="sab-target-list">
+				{#each sabPicker.opponents as o}
+					<button class="sab-target-row" on:click={() => applySabotage(o.id)}>
+						<span class="st-name">{o.name}</span>
+						<span class="st-stat"
+							>🧩 Puzzle {o.position} · ${Number(o.ante_left ?? 0).toLocaleString()}</span
+						>
+					</button>
+				{/each}
+			</div>
+			<button class="info-close" on:click={() => (sabPicker = null)}>Cancel</button>
+		</div>
+	</div>
 {/if}
 
 <!-- ▶ Resume menu — pick which in-progress game to jump back into -->
 {#if showResumeMenu}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Resume a game">
-    <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showResumeMenu = false}></button>
-    <div class="info-card resume-menu" role="document">
-      <button class="modal-x" on:click={() => showResumeMenu = false} aria-label="Close">✕</button>
-      <h3 class="info-title">Resume a game</h3>
-      <div class="rm-list">
-        {#each resumables as r (r.key)}
-          <button class="rm-row" on:click={() => { showResumeMenu = false; r.go(); }}>
-            <span class="rm-ic">{r.icon}</span><span class="rm-label">{r.label}</span><span class="rm-arrow">▶</span>
-          </button>
-        {/each}
-      </div>
-    </div>
-  </div>
+	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Resume a game">
+		<button
+			type="button"
+			class="modal-backdrop"
+			aria-label="Close"
+			on:click={() => (showResumeMenu = false)}
+		></button>
+		<div class="info-card resume-menu" role="document">
+			<button class="modal-x" on:click={() => (showResumeMenu = false)} aria-label="Close">✕</button
+			>
+			<h3 class="info-title">Resume a game</h3>
+			<div class="rm-list">
+				{#each resumables as r (r.key)}
+					<button
+						class="rm-row"
+						on:click={() => {
+							showResumeMenu = false;
+							r.go();
+						}}
+					>
+						<span class="rm-ic">{r.icon}</span><span class="rm-label">{r.label}</span><span
+							class="rm-arrow">▶</span
+						>
+					</button>
+				{/each}
+			</div>
+		</div>
+	</div>
 {/if}
 
 <!-- 🔊 In-game audio panel — sound / haptics / music + track, adjustable mid-puzzle -->
 {#if showAudio}
-  <div class="modal-overlay info-overlay" role="button" tabindex="0" aria-label="Close"
-    on:click={() => showAudio = false} on:keydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') showAudio = false; }}>
-    <div class="info-card audio-panel" on:click|stopPropagation role="dialog" aria-modal="true">
-      <button class="modal-x" on:click={() => showAudio = false} aria-label="Close">✕</button>
-      <h3 class="info-title">Sound &amp; Music</h3>
-      <div class="ap-rows">
-        <button class="ap-toggle" on:click={() => { toggleSound(); if ($soundEnabled) fx('select'); }}>
-          <span>{$soundEnabled ? '🔊' : '🔇'} Sound</span><span class="ap-state" class:on={$soundEnabled}>{$soundEnabled ? 'On' : 'Off'}</span>
-        </button>
-        <button class="ap-toggle" on:click={() => { toggleHaptics(); if ($hapticsEnabled) fx('tap'); }}>
-          <span>{$hapticsEnabled ? '📳' : '📴'} Haptics</span><span class="ap-state" class:on={$hapticsEnabled}>{$hapticsEnabled ? 'On' : 'Off'}</span>
-        </button>
-        <button class="ap-toggle" on:click={toggleMusic}>
-          <span>{$musicEnabled ? '🎵' : '🔕'} Music</span><span class="ap-state" class:on={$musicEnabled}>{$musicEnabled ? 'On' : 'Off'}</span>
-        </button>
-      </div>
-      {#if $musicEnabled}
-        <div class="ma-music-ctl">
-          <span class="mmc-ic">🔈</span>
-          <input class="mmc-slider" type="range" min="0" max="100" step="1" value={Math.round($musicVolume * 100)} on:input={(e) => setMusicVolume(Number(e.currentTarget.value) / 100)} />
-          <span class="mmc-pct">{Math.round($musicVolume * 100)}%</span>
-        </div>
-        <div class="ma-tracks">
-          {#each TRACKS as t, i}
-            <button class="ma-track" class:on={$currentTrackId === t.id} on:click={() => selectTrack(t.id)}>Track {i + 1}</button>
-          {/each}
-        </div>
-      {/if}
-    </div>
-  </div>
+	<div
+		class="modal-overlay info-overlay"
+		role="button"
+		tabindex="0"
+		aria-label="Close"
+		on:click={() => (showAudio = false)}
+		on:keydown={(e) => {
+			if (e.key === 'Escape' || e.key === 'Enter') showAudio = false;
+		}}
+	>
+		<div class="info-card audio-panel" on:click|stopPropagation role="dialog" aria-modal="true">
+			<button class="modal-x" on:click={() => (showAudio = false)} aria-label="Close">✕</button>
+			<h3 class="info-title">Sound &amp; Music</h3>
+			<div class="ap-rows">
+				<button
+					class="ap-toggle"
+					on:click={() => {
+						toggleSound();
+						if ($soundEnabled) fx('select');
+					}}
+				>
+					<span>{$soundEnabled ? '🔊' : '🔇'} Sound</span><span
+						class="ap-state"
+						class:on={$soundEnabled}>{$soundEnabled ? 'On' : 'Off'}</span
+					>
+				</button>
+				<button
+					class="ap-toggle"
+					on:click={() => {
+						toggleHaptics();
+						if ($hapticsEnabled) fx('tap');
+					}}
+				>
+					<span>{$hapticsEnabled ? '📳' : '📴'} Haptics</span><span
+						class="ap-state"
+						class:on={$hapticsEnabled}>{$hapticsEnabled ? 'On' : 'Off'}</span
+					>
+				</button>
+				<button class="ap-toggle" on:click={toggleMusic}>
+					<span>{$musicEnabled ? '🎵' : '🔕'} Music</span><span
+						class="ap-state"
+						class:on={$musicEnabled}>{$musicEnabled ? 'On' : 'Off'}</span
+					>
+				</button>
+			</div>
+			{#if $musicEnabled}
+				<div class="ma-music-ctl">
+					<span class="mmc-ic">🔈</span>
+					<input
+						class="mmc-slider"
+						type="range"
+						min="0"
+						max="100"
+						step="1"
+						value={Math.round($musicVolume * 100)}
+						on:input={(e) => setMusicVolume(Number(e.currentTarget.value) / 100)}
+					/>
+					<span class="mmc-pct">{Math.round($musicVolume * 100)}%</span>
+				</div>
+				<div class="ma-tracks">
+					{#each TRACKS as t, i}
+						<button
+							class="ma-track"
+							class:on={$currentTrackId === t.id}
+							on:click={() => selectTrack(t.id)}>Track {i + 1}</button
+						>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
 {/if}
 
 <main>
-  <!-- 👤 First-run: pick a username (required to play socially) -->
-  {#if loggedIn && hasInitialized && needsUsername}
-    <div class="modal-overlay username-gate" role="dialog" aria-modal="true" aria-label="Pick your username">
-      <div class="modal-content main-menu-modal claim-card">
-        <img class="claim-coin" src="/logo-coin.png" alt="" width="84" height="84" />
-        <h2>Pick your username</h2>
-        <p class="claim-sub">This is your @handle — how friends find you and challenge you. You can change it later in My Account.</p>
-        <div class="claim-row">
-          <span class="claim-at">@</span>
-          <input class="claim-input" placeholder="username" bind:value={claimInput} maxlength="15" autocomplete="off"
-            on:keydown={(e) => { if (e.key === 'Enter') claimUsername(); }} />
-        </div>
-        {#if claimMsg}<p class="claim-msg">{claimMsg}</p>{/if}
-        <button class="claim-btn" disabled={claimBusy || !claimInput.trim()} on:click={claimUsername}>
-          {claimBusy ? 'Claiming…' : 'Claim username'}
-        </button>
-        <p class="claim-hint">3–15 characters · letters, numbers, or _</p>
-      </div>
-    </div>
-  {/if}
+	<!-- 👤 First-run: pick a username (required to play socially) -->
+	{#if loggedIn && hasInitialized && needsUsername}
+		<div
+			class="modal-overlay username-gate"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Pick your username"
+		>
+			<div class="modal-content main-menu-modal claim-card">
+				<img class="claim-coin" src="/logo-coin.png" alt="" width="84" height="84" />
+				<h2>Pick your username</h2>
+				<p class="claim-sub">
+					This is your @handle — how friends find you and challenge you. You can change it later in
+					My Account.
+				</p>
+				<div class="claim-row">
+					<span class="claim-at">@</span>
+					<input
+						class="claim-input"
+						placeholder="username"
+						bind:value={claimInput}
+						maxlength="15"
+						autocomplete="off"
+						on:keydown={(e) => {
+							if (e.key === 'Enter') claimUsername();
+						}}
+					/>
+				</div>
+				{#if claimMsg}<p class="claim-msg">{claimMsg}</p>{/if}
+				<button
+					class="claim-btn"
+					disabled={claimBusy || !claimInput.trim()}
+					on:click={claimUsername}
+				>
+					{claimBusy ? 'Claiming…' : 'Claim username'}
+				</button>
+				<p class="claim-hint">3–15 characters · letters, numbers, or _</p>
+			</div>
+		</div>
+	{/if}
 
-  <!-- 🔐 PIN gate: unlock (returning) or set (new), full-screen over everything -->
-  {#if showPinUnlock}
-    <PinGate mode="unlock" uid={sessionUid} name={maUsername} balance={netWorth}
-      on:unlocked={onPinUnlocked} on:logout={onPinLogout} />
-  {:else if showPinSetup}
-    <PinGate mode="set" uid={sessionUid} name={maUsername}
-      on:pinset={onPinSet} on:skip={onPinSkip} on:logout={onPinLogout} />
-  {/if}
+	<!-- 🔐 PIN gate: unlock (returning) or set (new), full-screen over everything -->
+	{#if showPinUnlock}
+		<PinGate
+			mode="unlock"
+			uid={sessionUid}
+			name={maUsername}
+			balance={netWorth}
+			on:unlocked={onPinUnlocked}
+			on:logout={onPinLogout}
+		/>
+	{:else if showPinSetup}
+		<PinGate
+			mode="set"
+			uid={sessionUid}
+			name={maUsername}
+			on:pinset={onPinSet}
+			on:skip={onPinSkip}
+			on:logout={onPinLogout}
+		/>
+	{/if}
 
-  {#if !loggedIn}
-    <!-- 🔐 Login Screen -->
-    <div class="auth-screen">
-      <Auth />
-    </div>
-  {:else if !hasInitialized}
-    <!-- ⏳ Loading (prevents flash of game UI / diagnostic before we know menu vs game) -->
-    <div class="init-loading">Loading…</div>
-  {:else if showMainMenu}
-    <!-- 🏠 Main Menu (after sign-in) -->
-    <div class="main-menu fade-up">
-      <div class="menu-hero">
-        <div class="hero-top">
-          <button class="bell-ic" on:click={() => goto('/profile?tab=alerts')} title="Notifications" aria-label="Notifications">
-            🔔{#if $unreadCount > 0}<span class="account-count" title="{$unreadCount} new">{$unreadCount > 99 ? '99+' : $unreadCount}</span>{/if}
-          </button>
-          <button class="bank-chip" on:click={() => goto('/bank')} title="Your Cash">
-            <span class="bc-coin">💰</span>{netWorth == null ? '—' : '$' + Math.round(netWorth).toLocaleString()}
-          </button>
-          <button class="account-ic has-av" on:click={() => goto('/profile')} title="Profile" aria-label="Profile">
-            <Avatar config={myAvatar} mode="head" fx size={50} />
-          </button>
-        </div>
-        <video class="menu-mark" src="/coin.mp4" poster="/coin-poster.jpg" autoplay loop muted playsinline disablepictureinpicture></video>
-        <img class="menu-wordmark" src="/wordmark-slogan.png" alt="WordBank — Spend Less. Think More." />
-      </div>
-      {#if menuView === 'home'}
-        <div class="main-menu-buttons stagger">
-          <!-- 🦈 Debt banner — you owe the Loan Shark; Store locked + payouts auto-skim. -->
-          {#if menuLoan > 0}
-            <button class="debt-banner" style="--i: 0" on:click={() => { fx('tap'); goto('/bank'); }}>
-              🦈 <span class="db-text">You owe <b>${Math.round(menuLoan).toLocaleString()}</b> — half of every payout auto-repays it</span>
-              <span class="db-go">Repay ›</span>
-            </button>
-          {/if}
-          <!-- ▶ Resume — any in-progress game (solo + started challenges). One → straight in; many → the Resume menu. -->
-          {#if resumables.length}
-            <button class="resume-strip" style="--i: 0" on:click={onResume}>
-              <span class="rs-dot">▸</span>
-              <span class="rs-label">Resume{resumables.length === 1 ? ' — ' + resumables[0].label : ''}</span>
-              {#if resumables.length > 1}<span class="rs-count">{resumables.length}</span>{/if}
-              <span class="rs-go">›</span>
-            </button>
-          {/if}
-          <button class="menu-card primary" style="--i: 0" on:click={() => { menuView = 'play'; fx('tap'); }}>
-            <span class="mc-title">Play Now!</span>
-          </button>
-          <!-- ⚔️ Challenges hub (list + New). Incoming invites alert via the bell → tap routes here. -->
-          <div class="vs-cta-group">
-            <button class="vs-main" on:click={() => { fx('tap'); openCommunity('challenges'); }}>
-              ⚔️ Challenge Friends
-            </button>
-            <button class="vs-people" title="Friends &amp; Groups" aria-label="Friends and groups" on:click={() => { fx('tap'); openCommunity('people'); }}>
-              <span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span>
-            </button>
-          </div>
-          <button class="menu-card" style="--i: 1" on:click={() => { fx('tap'); openCommunity('leaderboard'); }}>
-            <span class="mc-title">🏆 Leaderboard</span>
-          </button>
-          <button class="menu-card" style="--i: 2" on:click={() => goto('/shop')}>
-            <span class="mc-title">Store</span>
-          </button>
-        </div>
+	{#if !loggedIn}
+		<!-- 🔐 Login Screen -->
+		<div class="auth-screen">
+			<Auth />
+		</div>
+	{:else if !hasInitialized}
+		<!-- ⏳ Loading (prevents flash of game UI / diagnostic before we know menu vs game) -->
+		<div class="init-loading">Loading…</div>
+	{:else if showMainMenu}
+		<!-- 🏠 Main Menu (after sign-in) -->
+		<div class="main-menu fade-up">
+			<div class="menu-hero">
+				<div class="hero-top">
+					<button
+						class="bell-ic"
+						on:click={() => goto('/profile?tab=alerts')}
+						title="Notifications"
+						aria-label="Notifications"
+					>
+						🔔{#if $unreadCount > 0}<span class="account-count" title="{$unreadCount} new"
+								>{$unreadCount > 99 ? '99+' : $unreadCount}</span
+							>{/if}
+					</button>
+					<button class="bank-chip" on:click={() => goto('/bank')} title="Your Cash">
+						<span class="bc-coin">💰</span>{netWorth == null
+							? '—'
+							: '$' + Math.round(netWorth).toLocaleString()}
+					</button>
+					<button
+						class="account-ic has-av"
+						on:click={() => goto('/profile')}
+						title="Profile"
+						aria-label="Profile"
+					>
+						<Avatar config={myAvatar} mode="head" fx size={50} />
+					</button>
+				</div>
+				<video
+					class="menu-mark"
+					src="/coin.mp4"
+					poster="/coin-poster.jpg"
+					autoplay
+					loop
+					muted
+					playsinline
+					disablepictureinpicture
+				></video>
+				<img
+					class="menu-wordmark"
+					src="/wordmark-slogan.png"
+					alt="WordBank — Spend Less. Think More."
+				/>
+			</div>
+			{#if menuView === 'home'}
+				<div class="main-menu-buttons stagger">
+					<!-- 🦈 Debt banner — you owe the Loan Shark; Store locked + payouts auto-skim. -->
+					{#if menuLoan > 0}
+						<button
+							class="debt-banner"
+							style="--i: 0"
+							on:click={() => {
+								fx('tap');
+								goto('/bank');
+							}}
+						>
+							🦈 <span class="db-text"
+								>You owe <b>${Math.round(menuLoan).toLocaleString()}</b> — half of every payout auto-repays
+								it</span
+							>
+							<span class="db-go">Repay ›</span>
+						</button>
+					{/if}
+					<!-- ▶ Resume — any in-progress game (solo + started challenges). One → straight in; many → the Resume menu. -->
+					{#if resumables.length}
+						<button class="resume-strip" style="--i: 0" on:click={onResume}>
+							<span class="rs-dot">▸</span>
+							<span class="rs-label"
+								>Resume{resumables.length === 1 ? ' — ' + resumables[0].label : ''}</span
+							>
+							{#if resumables.length > 1}<span class="rs-count">{resumables.length}</span>{/if}
+							<span class="rs-go">›</span>
+						</button>
+					{/if}
+					<button
+						class="menu-card primary"
+						style="--i: 0"
+						on:click={() => {
+							menuView = 'play';
+							fx('tap');
+						}}
+					>
+						<span class="mc-title">Play Now!</span>
+					</button>
+					<!-- ⚔️ Challenges hub (list + New). Incoming invites alert via the bell → tap routes here. -->
+					<div class="vs-cta-group">
+						<button
+							class="vs-main"
+							on:click={() => {
+								fx('tap');
+								openCommunity('challenges');
+							}}
+						>
+							⚔️ Challenge Friends
+						</button>
+						<button
+							class="vs-people"
+							title="Friends &amp; Groups"
+							aria-label="Friends and groups"
+							on:click={() => {
+								fx('tap');
+								openCommunity('people');
+							}}
+						>
+							<span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span>
+						</button>
+					</div>
+					<button
+						class="menu-card"
+						style="--i: 1"
+						on:click={() => {
+							fx('tap');
+							openCommunity('leaderboard');
+						}}
+					>
+						<span class="mc-title">🏆 Leaderboard</span>
+					</button>
+					<button class="menu-card" style="--i: 2" on:click={() => goto('/shop')}>
+						<span class="mc-title">Store</span>
+					</button>
+				</div>
+			{:else if menuView === 'play'}
+				<div class="sub-head">
+					<button
+						class="sub-back"
+						on:click={() => {
+							menuView = 'home';
+							fx('tap');
+						}}>← Back</button
+					>
+					<h2 class="sub-title">Play</h2>
+				</div>
+				<div class="main-menu-buttons stagger">
+					<button
+						class="menu-card"
+						class:done={dailyDone}
+						class:resumable={dailyInProgress}
+						class:fresh={!dailyDone && !dailyInProgress}
+						style="--i: 0"
+						on:click={handleMenuDaily}
+					>
+						<span class="mc-streak left" title="Play streak — days in a row"
+							>📅 {dailyStatus?.current_streak ?? 0}</span
+						>
+						<span class="mc-title">{dailyInProgress ? 'Resume Daily' : 'Daily'}</span>
+						<span class="mc-streak right" title="Win streak — solves in a row"
+							>🏆 {dailyStatus?.win_streak ?? 0}</span
+						>
+						{#if dailyDone}
+							{#if dailyStatus?.last_daily_won}
+								<span class="daily-chip won"
+									>✅ +${(dailyStatus?.today_score ?? 0).toLocaleString()}</span
+								>
+							{:else}
+								<span class="daily-chip lost"
+									>❌{dailyStatus?.today_score
+										? ' −$' + Math.abs(dailyStatus.today_score).toLocaleString()
+										: ''}</span
+								>
+							{/if}
+						{:else if dailyInProgress}
+							<span class="daily-chip prog">▶ Resume</span>
+						{/if}
+					</button>
+					<button
+						class="menu-card"
+						class:resumable={climbInProgress}
+						style="--i: 1"
+						on:click={handleMenuClimb}
+					>
+						<span class="mc-title">Cash Game</span>
+						{#if climbInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
+					</button>
+					<button class="menu-card" style="--i: 2" on:click={handleMenuBlitz}>
+						<span class="mc-title">⚡ Blitz</span><span class="mc-stat">Beat the clock</span>
+					</button>
+				</div>
+			{:else if menuView === 'community'}
+				<div class="sub-head">
+					{#if communityTab === 'people'}
+						{#if peopleBackToHome}
+							<button
+								class="sub-back"
+								on:click={() => {
+									menuView = 'home';
+									fx('tap');
+								}}>← Back</button
+							>
+						{:else}
+							<button
+								class="sub-back"
+								on:click={() => {
+									communityTab = 'challenges';
+									fx('tap');
+								}}>← Community</button
+							>
+						{/if}
+						<h2 class="sub-title">People</h2>
+					{:else}
+						<button
+							class="sub-back"
+							on:click={() => {
+								menuView = 'home';
+								fx('tap');
+							}}>← Back</button
+						>
+						<h2 class="sub-title">
+							{communityTab === 'leaderboard' ? '🏆 Leaderboard' : '⚔️ Challenges'}
+						</h2>
+						{#if communityTab === 'challenges'}
+							<button
+								class="sub-people"
+								title="Friends & Groups"
+								aria-label="Friends & Groups"
+								on:click={() => {
+									communityTab = 'people';
+									peopleBackToHome = false;
+									fx('tap');
+								}}><span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span></button
+							>
+						{/if}
+					{/if}
+				</div>
+				{#if communityTab === 'people'}
+					<div class="comm-tabs">
+						<button
+							class="comm-tab"
+							class:active={peopleTab === 'friends'}
+							on:click={() => {
+								peopleTab = 'friends';
+								fx('tap');
+							}}
+							>Friends{#if friendReqCount > 0}
+								· {friendReqCount}{/if}</button
+						>
+						<button
+							class="comm-tab"
+							class:active={peopleTab === 'groups'}
+							on:click={() => {
+								peopleTab = 'groups';
+								fx('tap');
+							}}>Groups</button
+						>
+					</div>
+				{/if}
 
-      {:else if menuView === 'play'}
-        <div class="sub-head">
-          <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
-          <h2 class="sub-title">Play</h2>
-        </div>
-        <div class="main-menu-buttons stagger">
-          <button class="menu-card" class:done={dailyDone} class:resumable={dailyInProgress} class:fresh={!dailyDone && !dailyInProgress} style="--i: 0" on:click={handleMenuDaily}>
-            <span class="mc-streak left" title="Play streak — days in a row">📅 {dailyStatus?.current_streak ?? 0}</span>
-            <span class="mc-title">{dailyInProgress ? 'Resume Daily' : 'Daily'}</span>
-            <span class="mc-streak right" title="Win streak — solves in a row">🏆 {dailyStatus?.win_streak ?? 0}</span>
-            {#if dailyDone}
-              {#if dailyStatus?.last_daily_won}
-                <span class="daily-chip won">✅ +${(dailyStatus?.today_score ?? 0).toLocaleString()}</span>
-              {:else}
-                <span class="daily-chip lost">❌{dailyStatus?.today_score ? ' −$' + Math.abs(dailyStatus.today_score).toLocaleString() : ''}</span>
-              {/if}
-            {:else if dailyInProgress}
-              <span class="daily-chip prog">▶ Resume</span>
-            {/if}
-          </button>
-          <button class="menu-card" class:resumable={climbInProgress} style="--i: 1" on:click={handleMenuClimb}>
-            <span class="mc-title">Cash Game</span>
-            {#if climbInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
-          </button>
-          <button class="menu-card" style="--i: 2" on:click={handleMenuBlitz}>
-            <span class="mc-title">⚡ Blitz</span><span class="mc-stat">Beat the clock</span>
-          </button>
-        </div>
+				{#if communityTab === 'challenges'}
+					<div class="comm-body">
+						<button class="ch-new-btn" on:click={newChallenge}>＋ New Challenge</button>
+						{#if myMatches.length}
+							<div class="ch-list">
+								{#each myMatches as m}
+									<div class="ch-item">
+										<div class="ch-info">
+											<span class="ch-vs">{m.is_host ? 'You hosted' : m.host + ' invited you'}</span
+											>
+											<span class="ch-meta"
+												>{m.pack_size} puzzle{m.pack_size === 1 ? '' : 's'} · {m.players} players{#if m.wager > 0}
+													· ${m.wager?.toLocaleString()}{/if}</span
+											>
+										</div>
+										{#if m.status === 'settled'}
+											<button
+												class="ch-play ghost"
+												disabled={mbBusy}
+												on:click={() => respondToMatch(m)}>Results</button
+											>
+										{:else if m.my_state !== 'done'}
+											<button class="ch-play" disabled={mbBusy} on:click={() => respondToMatch(m)}
+												>{m.my_state === 'invited' ? 'Play' : 'Resume'}</button
+											>
+										{:else}
+											<span class="ch-waiting">Waiting…</span>
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{:else}
+							<p class="ch-empty">No challenges yet. Tap <b>＋ New Challenge</b> to start one.</p>
+						{/if}
+					</div>
+				{:else if communityTab === 'leaderboard'}
+					<div class="comm-body"><LeaderboardPanel /></div>
+				{:else}
+					<div class="comm-body">
+						{#if peopleTab === 'friends'}
+							<FriendsPanel onChallenge={challengeFriend} />
+						{:else}
+							<GroupsPanel />
+						{/if}
+					</div>
+				{/if}
+			{/if}
+		</div>
 
-      {:else if menuView === 'community'}
-        <div class="sub-head">
-          {#if communityTab === 'people'}
-            {#if peopleBackToHome}
-              <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
-            {:else}
-              <button class="sub-back" on:click={() => { communityTab = 'challenges'; fx('tap'); }}>← Community</button>
-            {/if}
-            <h2 class="sub-title">People</h2>
-          {:else}
-            <button class="sub-back" on:click={() => { menuView = 'home'; fx('tap'); }}>← Back</button>
-            <h2 class="sub-title">{communityTab === 'leaderboard' ? '🏆 Leaderboard' : '⚔️ Challenges'}</h2>
-            {#if communityTab === 'challenges'}
-              <button class="sub-people" title="Friends & Groups" aria-label="Friends & Groups" on:click={() => { communityTab = 'people'; peopleBackToHome = false; fx('tap'); }}><span class="vs-ppl">👥</span><span class="vs-ppl-plus">+</span></button>
-            {/if}
-          {/if}
-        </div>
-        {#if communityTab === 'people'}
-          <div class="comm-tabs">
-            <button class="comm-tab" class:active={peopleTab === 'friends'} on:click={() => { peopleTab = 'friends'; fx('tap'); }}>Friends{#if friendReqCount > 0} · {friendReqCount}{/if}</button>
-            <button class="comm-tab" class:active={peopleTab === 'groups'} on:click={() => { peopleTab = 'groups'; fx('tap'); }}>Groups</button>
-          </div>
-        {/if}
+		<!-- 🎰 Cash Game: tier select (buy-in run) -->
+		{#if showTierSelect}
+			<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a tier">
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Close"
+					on:click={() => (showTierSelect = false)}
+				></button>
+				<div class="modal-content main-menu-modal tier-modal">
+					<button class="close-btn" on:click={() => (showTierSelect = false)}>❌</button>
+					<h2>🎰 Cash Game</h2>
+					<p class="cat-sub">
+						Stake a buy-in, grow the run, cash out — or bust. Higher tiers = bigger stakes, thinner
+						margins, bigger jackpots.
+					</p>
+					<div class="tier-grid">
+						{#each cgMeta?.tiers ?? [] as t}
+							<button
+								class="tier-tile"
+								class:locked={!t.unlocked}
+								disabled={cgBusy || !t.unlocked || (cgMeta?.bank ?? 0) < t.buy_in}
+								on:click={() => pickTier(t.tier)}
+							>
+								<span class="tt-label">{t.label}</span>
+								<span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
+								<span class="tt-meta"
+									>k {Number(t.k).toFixed(2)} · heat ×{(t.heat_cap / 100).toFixed(1)}</span
+								>
+								{#if !t.unlocked}<span class="tt-lock"
+										>🔒 {t.tier === 'silver'
+											? '3 Bronze wins'
+											: t.tier === 'gold'
+												? '3 Silver wins'
+												: 'locked'}</span
+									>
+								{:else if (cgMeta?.bank ?? 0) < t.buy_in}<span class="tt-lock"
+										>Need ${t.buy_in.toLocaleString()}</span
+									>{/if}
+							</button>
+						{/each}
+					</div>
+					{#if (cgMeta?.best_run ?? 0) > 0}
+						<p class="tier-stats">
+							Best run <b>${cgMeta.best_run.toLocaleString()}</b> · best multiple
+							<b>{((cgMeta.best_multiple_x100 ?? 0) / 100).toFixed(1)}×</b>
+							· run streak <b>{cgMeta.run_streak ?? 0}</b>
+						</p>
+					{/if}
+				</div>
+			</div>
+		{/if}
 
-        {#if communityTab === 'challenges'}
-          <div class="comm-body">
-            <button class="ch-new-btn" on:click={newChallenge}>＋ New Challenge</button>
-            {#if myMatches.length}
-              <div class="ch-list">
-                {#each myMatches as m}
-                  <div class="ch-item">
-                    <div class="ch-info">
-                      <span class="ch-vs">{m.is_host ? 'You hosted' : m.host + ' invited you'}</span>
-                      <span class="ch-meta">{m.pack_size} puzzle{m.pack_size === 1 ? '' : 's'} · {m.players} players{#if m.wager > 0} · ${m.wager?.toLocaleString()}{/if}</span>
-                    </div>
-                    {#if m.status === 'settled'}
-                      <button class="ch-play ghost" disabled={mbBusy} on:click={() => respondToMatch(m)}>Results</button>
-                    {:else if m.my_state !== 'done'}
-                      <button class="ch-play" disabled={mbBusy} on:click={() => respondToMatch(m)}>{m.my_state === 'invited' ? 'Play' : 'Resume'}</button>
-                    {:else}
-                      <span class="ch-waiting">Waiting…</span>
-                    {/if}
-                  </div>
-                {/each}
-              </div>
-            {:else}
-              <p class="ch-empty">No challenges yet. Tap <b>＋ New Challenge</b> to start one.</p>
-            {/if}
-          </div>
-        {:else if communityTab === 'leaderboard'}
-          <div class="comm-body"><LeaderboardPanel /></div>
-        {:else}
-          <div class="comm-body">
-            {#if peopleTab === 'friends'}
-              <FriendsPanel onChallenge={challengeFriend} />
-            {:else}
-              <GroupsPanel />
-            {/if}
-          </div>
-        {/if}
-      {/if}
-    </div>
+		<!-- ⚡ Blitz: tier select (timed run) -->
+		{#if showBlitzTier}
+			<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a Blitz tier">
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Close"
+					on:click={() => (showBlitzTier = false)}
+				></button>
+				<div class="modal-content main-menu-modal tier-modal">
+					<button class="close-btn" on:click={() => (showBlitzTier = false)}>❌</button>
+					<h2>⚡ Blitz</h2>
+					<p class="cat-sub">
+						Beat the clock. 45s to start — reveal costs 3s, a wrong guess costs 5s, each solve adds
+						8s + a combo-boosted payout. Bank whatever you win.
+					</p>
+					<div class="tier-grid tier-grid-3">
+						{#each bzMeta?.tiers ?? [] as t}
+							<button
+								class="tier-tile"
+								disabled={bzBusy || !t.affordable}
+								on:click={() => pickBlitzTier(t.tier)}
+							>
+								<span class="tt-label">{t.label}</span>
+								<span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
+								<span class="tt-meta">~${t.base}/solve × combo</span>
+								{#if !t.affordable}<span class="tt-lock">Need ${t.buy_in.toLocaleString()}</span
+									>{/if}
+							</button>
+						{/each}
+					</div>
+					{#if (bzMeta?.best_run ?? 0) > 0}
+						<p class="tier-stats">
+							Best run <b>{bzMeta.best_run}</b> solved · best combo
+							<b>×{((bzMeta.best_combo_x100 ?? 100) / 100).toFixed(2)}</b>
+							· biggest payout <b>${(bzMeta.best_payout ?? 0).toLocaleString()}</b>
+						</p>
+					{/if}
+				</div>
+			</div>
+		{/if}
 
-    <!-- 🎰 Cash Game: tier select (buy-in run) -->
-    {#if showTierSelect}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a tier">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showTierSelect = false}></button>
-        <div class="modal-content main-menu-modal tier-modal">
-          <button class="close-btn" on:click={() => showTierSelect = false}>❌</button>
-          <h2>🎰 Cash Game</h2>
-          <p class="cat-sub">Stake a buy-in, grow the run, cash out — or bust. Higher tiers = bigger stakes, thinner margins, bigger jackpots.</p>
-          <div class="tier-grid">
-            {#each (cgMeta?.tiers ?? []) as t}
-              <button class="tier-tile" class:locked={!t.unlocked} disabled={cgBusy || !t.unlocked || (cgMeta?.bank ?? 0) < t.buy_in}
-                on:click={() => pickTier(t.tier)}>
-                <span class="tt-label">{t.label}</span>
-                <span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
-                <span class="tt-meta">k {Number(t.k).toFixed(2)} · heat ×{(t.heat_cap/100).toFixed(1)}</span>
-                {#if !t.unlocked}<span class="tt-lock">🔒 {t.tier === 'silver' ? '3 Bronze wins' : t.tier === 'gold' ? '3 Silver wins' : 'locked'}</span>
-                {:else if (cgMeta?.bank ?? 0) < t.buy_in}<span class="tt-lock">Need ${t.buy_in.toLocaleString()}</span>{/if}
-              </button>
-            {/each}
-          </div>
-          {#if (cgMeta?.best_run ?? 0) > 0}
-            <p class="tier-stats">Best run <b>${(cgMeta.best_run).toLocaleString()}</b> · best multiple <b>{((cgMeta.best_multiple_x100 ?? 0)/100).toFixed(1)}×</b> · run streak <b>{cgMeta.run_streak ?? 0}</b></p>
-          {/if}
-        </div>
-      </div>
-    {/if}
+		<!-- Challenges: wager vs friends -->
+		{#if showChallenges}
+			<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Challenge Friends">
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Close"
+					on:click={() => (showChallenges = false)}
+				></button>
+				<div class="modal-content main-menu-modal ch-modal">
+					<button class="close-btn" on:click={() => (showChallenges = false)}>❌</button>
 
-    <!-- ⚡ Blitz: tier select (timed run) -->
-    {#if showBlitzTier}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Pick a Blitz tier">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showBlitzTier = false}></button>
-        <div class="modal-content main-menu-modal tier-modal">
-          <button class="close-btn" on:click={() => showBlitzTier = false}>❌</button>
-          <h2>⚡ Blitz</h2>
-          <p class="cat-sub">Beat the clock. 45s to start — reveal costs 3s, a wrong guess costs 5s, each solve adds 8s + a combo-boosted payout. Bank whatever you win.</p>
-          <div class="tier-grid tier-grid-3">
-            {#each (bzMeta?.tiers ?? []) as t}
-              <button class="tier-tile" disabled={bzBusy || !t.affordable}
-                on:click={() => pickBlitzTier(t.tier)}>
-                <span class="tt-label">{t.label}</span>
-                <span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
-                <span class="tt-meta">~${t.base}/solve × combo</span>
-                {#if !t.affordable}<span class="tt-lock">Need ${t.buy_in.toLocaleString()}</span>{/if}
-              </button>
-            {/each}
-          </div>
-          {#if (bzMeta?.best_run ?? 0) > 0}
-            <p class="tier-stats">Best run <b>{bzMeta.best_run}</b> solved · best combo <b>×{((bzMeta.best_combo_x100 ?? 100)/100).toFixed(2)}</b> · biggest payout <b>${(bzMeta.best_payout ?? 0).toLocaleString()}</b></p>
-          {/if}
-        </div>
-      </div>
-    {/if}
+					<h2>⚔️ New Challenge</h2>
+					<p class="cat-sub">
+						Build a match — a pack of puzzles vs a friend or a group. Same puzzles for everyone.
+					</p>
 
-    <!-- Challenges: wager vs friends -->
-    {#if showChallenges}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Challenge Friends">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showChallenges = false}></button>
-        <div class="modal-content main-menu-modal ch-modal">
-          <button class="close-btn" on:click={() => showChallenges = false}>❌</button>
+					<div class="ch-new">
+						<!-- Opponent: friend or group -->
+						<div class="ch-modes">
+							<button
+								type="button"
+								class="ch-mode"
+								class:active={mbTarget === 'friend'}
+								on:click={() => (mbTarget = 'friend')}>👤 A friend<small>by username</small></button
+							>
+							<button
+								type="button"
+								class="ch-mode"
+								class:active={mbTarget === 'group'}
+								on:click={() => (mbTarget = 'group')}
+								>👥 A group<small>everyone in it</small></button
+							>
+						</div>
+						{#if mbTarget === 'friend'}
+							<div class="ch-search-wrap">
+								<input
+									class="ch-input"
+									placeholder="Opponent username"
+									bind:value={mbOpponent}
+									on:input={onMbOppInput}
+									autocomplete="off"
+								/>
+								{#if mbResults.length}
+									<div class="ch-results">
+										{#each mbResults as r}
+											<button
+												type="button"
+												class="ch-result-item"
+												on:click={() => pickMbOpp(r.username)}
+												>@{r.username}{#if r.is_friend}
+													<span class="ch-friend-tag">friend</span>{/if}</button
+											>
+										{/each}
+									</div>
+								{/if}
+							</div>
+						{:else}
+							<select class="ch-input" bind:value={mbGroupId}>
+								<option value="" disabled selected>Pick a group</option>
+								{#each myGroups as g}<option value={g.id}>{g.name} ({g.members})</option>{/each}
+							</select>
+						{/if}
 
-          <h2>⚔️ New Challenge</h2>
-          <p class="cat-sub">Build a match — a pack of puzzles vs a friend or a group. Same puzzles for everyone.</p>
+						<!-- Standard vs Blitz -->
+						<div class="ch-modes">
+							<button
+								type="button"
+								class="ch-mode"
+								class:active={mbMode === 'standard'}
+								on:click={() => (mbMode = 'standard')}
+								>🧠 Standard<small>efficiency · spend less</small></button
+							>
+							<button
+								type="button"
+								class="ch-mode"
+								class:active={mbMode === 'blitz'}
+								on:click={() => (mbMode = 'blitz')}
+								>⚡ Blitz<small>timed · combo speed</small></button
+							>
+						</div>
 
-          <div class="ch-new">
-              <!-- Opponent: friend or group -->
-              <div class="ch-modes">
-                <button type="button" class="ch-mode" class:active={mbTarget === 'friend'} on:click={() => mbTarget = 'friend'}>👤 A friend<small>by username</small></button>
-                <button type="button" class="ch-mode" class:active={mbTarget === 'group'} on:click={() => mbTarget = 'group'}>👥 A group<small>everyone in it</small></button>
-              </div>
-              {#if mbTarget === 'friend'}
-                <div class="ch-search-wrap">
-                  <input class="ch-input" placeholder="Opponent username" bind:value={mbOpponent} on:input={onMbOppInput} autocomplete="off" />
-                  {#if mbResults.length}
-                    <div class="ch-results">
-                      {#each mbResults as r}
-                        <button type="button" class="ch-result-item" on:click={() => pickMbOpp(r.username)}>@{r.username}{#if r.is_friend} <span class="ch-friend-tag">friend</span>{/if}</button>
-                      {/each}
-                    </div>
-                  {/if}
-                </div>
-              {:else}
-                <select class="ch-input" bind:value={mbGroupId}>
-                  <option value="" disabled selected>Pick a group</option>
-                  {#each myGroups as g}<option value={g.id}>{g.name} ({g.members})</option>{/each}
-                </select>
-              {/if}
+						<!-- Categories (optional) -->
+						<div class="ch-cats">
+							{#each CATEGORIES as c}
+								<button
+									type="button"
+									class="ch-cat"
+									class:on={mbCategories.includes(c.value)}
+									on:click={() => toggleCategory(c.value)}>{c.emoji}</button
+								>
+							{/each}
+						</div>
+						<p class="ch-hint">
+							{mbCategories.length ? mbCategories.length + ' categories' : 'Any category'}
+						</p>
 
-              <!-- Standard vs Blitz -->
-              <div class="ch-modes">
-                <button type="button" class="ch-mode" class:active={mbMode === 'standard'} on:click={() => mbMode = 'standard'}>🧠 Standard<small>efficiency · spend less</small></button>
-                <button type="button" class="ch-mode" class:active={mbMode === 'blitz'} on:click={() => mbMode = 'blitz'}>⚡ Blitz<small>timed · combo speed</small></button>
-              </div>
+						<!-- Pack size + payout + window -->
+						<div class="ch-row">
+							<label class="ch-field"
+								><span>Puzzles</span>
+								<select class="ch-input" bind:value={mbPackSize}
+									>{#each [1, 3, 5, 10] as n}<option value={n}>{n}</option>{/each}</select
+								>
+							</label>
+							<label class="ch-field"
+								><span>Respond within</span>
+								<select class="ch-input" bind:value={mbWindow}
+									>{#each WINDOWS as w}<option value={w.s}>{w.l}</option>{/each}</select
+								>
+							</label>
+						</div>
+						<div class="ch-field ch-ante">
+							<span>Ante — the stakes</span>
+							<div class="ante-chips">
+								{#each CHALLENGE_TIERS as t}
+									<button
+										class="ante-chip"
+										class:on={mbWager === t.v}
+										type="button"
+										on:click={() => {
+											mbWager = t.v;
+											fx('tap');
+										}}>{t.label}</button
+									>
+								{/each}
+							</div>
+							<p class="ch-hint">
+								{mbWager > 0
+									? 'Each player antes this → the pot. Duel: winner takes all. Group: podium (3 → 70/30 · 4+ → 60/30/10). Spend less to keep more — that’s your score.'
+									: 'Friendly — no stakes, just bragging rights.'}
+							</p>
+						</div>
+						<button
+							class="ch-toggle"
+							class:on={mbItemsAllowed}
+							on:click={() => {
+								mbItemsAllowed = !mbItemsAllowed;
+								fx('tap');
+							}}
+						>
+							<span class="ch-tog-box">{mbItemsAllowed ? '✓' : ''}</span>
+							⚡ Allow power-ups
+						</button>
+						<p class="ch-objective"><strong>Spend the least — winner takes the pot.</strong></p>
+						<button
+							class="ch-create"
+							disabled={mbBusy}
+							on:click={submitNewMatch}
+							style="width:100%;">Send challenge ⚔️</button
+						>
+						{#if mbMsg}<p class="add-msg">{mbMsg}</p>{/if}
+					</div>
+				</div>
+			</div>
+		{/if}
 
-              <!-- Categories (optional) -->
-              <div class="ch-cats">
-                {#each CATEGORIES as c}
-                  <button type="button" class="ch-cat" class:on={mbCategories.includes(c.value)} on:click={() => toggleCategory(c.value)}>{c.emoji}</button>
-                {/each}
-              </div>
-              <p class="ch-hint">{mbCategories.length ? mbCategories.length + ' categories' : 'Any category'}</p>
+		<!-- Settled-challenge results (shared with /history) -->
+		<MatchDetailModal detail={matchResults} on:close={() => (matchResults = null)} />
 
-              <!-- Pack size + payout + window -->
-              <div class="ch-row">
-                <label class="ch-field"><span>Puzzles</span>
-                  <select class="ch-input" bind:value={mbPackSize}>{#each [1, 3, 5, 10] as n}<option value={n}>{n}</option>{/each}</select>
-                </label>
-                <label class="ch-field"><span>Respond within</span>
-                  <select class="ch-input" bind:value={mbWindow}>{#each WINDOWS as w}<option value={w.s}>{w.l}</option>{/each}</select>
-                </label>
-              </div>
-              <div class="ch-field ch-ante">
-                <span>Ante — the stakes</span>
-                <div class="ante-chips">
-                  {#each CHALLENGE_TIERS as t}
-                    <button class="ante-chip" class:on={mbWager === t.v} type="button" on:click={() => { mbWager = t.v; fx('tap'); }}>{t.label}</button>
-                  {/each}
-                </div>
-                <p class="ch-hint">{mbWager > 0 ? 'Each player antes this → the pot. Duel: winner takes all. Group: podium (3 → 70/30 · 4+ → 60/30/10). Spend less to keep more — that’s your score.' : 'Friendly — no stakes, just bragging rights.'}</p>
-              </div>
-              <button class="ch-toggle" class:on={mbItemsAllowed} on:click={() => { mbItemsAllowed = !mbItemsAllowed; fx('tap'); }}>
-                <span class="ch-tog-box">{mbItemsAllowed ? '✓' : ''}</span>
-                ⚡ Allow power-ups
-              </button>
-              <p class="ch-objective"><strong>Spend the least — winner takes the pot.</strong></p>
-              <button class="ch-create" disabled={mbBusy} on:click={submitNewMatch} style="width:100%;">Send challenge ⚔️</button>
-              {#if mbMsg}<p class="add-msg">{mbMsg}</p>{/if}
-            </div>
-        </div>
-      </div>
-    {/if}
+		<!-- 💸 Can't afford the full buy-in: play with what you have, or decline -->
+		{#if shortMatch}
+			<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Not enough Cash">
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Close"
+					on:click={() => (shortMatch = null)}
+				></button>
+				<div class="modal-content sm-modal">
+					<div class="sm-icon">💸</div>
+					<h2>Not enough for the full buy-in</h2>
+					<div class="sm-rows">
+						<div class="sm-row">
+							<span>This challenge</span><b>${Number(shortMatch.wager).toLocaleString()} buy-in</b>
+						</div>
+						<div class="sm-row">
+							<span>You have</span><b>${Math.round(netWorth ?? 0).toLocaleString()}</b>
+						</div>
+					</div>
+					<p class="sm-note">
+						Your whole buy-in is at stake — winner takes the pot. Play with a smaller buy-in, or
+						decline.
+					</p>
+					<button class="sm-play" disabled={mbBusy} on:click={() => playReduced(shortMatch)}
+						>Play with ${Math.round(netWorth ?? 0).toLocaleString()}</button
+					>
+					<button class="sm-decline" disabled={mbBusy} on:click={() => declineChallenge(shortMatch)}
+						>Decline challenge</button
+					>
+				</div>
+			</div>
+		{/if}
 
-    <!-- Settled-challenge results (shared with /history) -->
-    <MatchDetailModal detail={matchResults} on:close={() => matchResults = null} />
+		<!-- Streak message (when Daily is disabled and user taps it) -->
+		{#if showStreakMessage}
+			<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Come back tomorrow">
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Close"
+					on:click={() => (showStreakMessage = false)}
+				></button>
+				<div class="modal-content main-menu-modal">
+					<button class="close-btn" on:click={() => (showStreakMessage = false)}>❌</button>
+					<div class="cbt-medal">{dailyStatus?.last_daily_won ? '✅' : '🏁'}</div>
+					<h2>{dailyStatus?.last_daily_won ? 'Daily Solved!' : "Today's Daily Done"}</h2>
+					<p class="cbt-result">
+						{dailyStatus?.last_daily_won
+							? "Nice work — you've finished today's puzzle."
+							: "You've already played today's puzzle."}
+					</p>
+					<div class="cbt-stats">
+						<div class="cbt-stat">
+							<span class="cbt-val">+${dailyStatus?.today_score?.toLocaleString() ?? 0}</span><span
+								class="cbt-cap">Profit</span
+							>
+						</div>
+						{#if (dailyStatus?.current_streak ?? 0) > 0}
+							<div class="cbt-stat">
+								<span class="cbt-val">🔥 {dailyStatus?.current_streak}</span><span class="cbt-cap"
+									>Play streak</span
+								>
+							</div>
+						{/if}
+					</div>
+					<p class="streak-message">
+						{#if (dailyStatus?.current_streak ?? 0) > 0}Come back tomorrow for a new puzzle to keep
+							your 🔥 {dailyStatus?.current_streak}-day streak alive!{:else}Come back tomorrow for a
+							fresh puzzle and start a streak!{/if}
+					</p>
+					<button
+						class="main-menu-btn"
+						on:click={() => {
+							showStreakMessage = false;
+							goToDailyLeaderboard();
+						}}>View Leaderboard</button
+					>
+					<button class="main-menu-btn ghost-btn" on:click={() => (showStreakMessage = false)}
+						>Close</button
+					>
+				</div>
+			</div>
+		{/if}
+		<!-- My Account modal -->
+		{#if showMyAccount}
+			<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="My Account">
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Close"
+					on:click={() => (showMyAccount = false)}
+				></button>
+				<div class="modal-content main-menu-modal settings-modal">
+					<button class="close-btn" on:click={() => (showMyAccount = false)}>❌</button>
+					<h2>Settings</h2>
 
-    <!-- 💸 Can't afford the full buy-in: play with what you have, or decline -->
-    {#if shortMatch}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Not enough Cash">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => shortMatch = null}></button>
-        <div class="modal-content sm-modal">
-          <div class="sm-icon">💸</div>
-          <h2>Not enough for the full buy-in</h2>
-          <div class="sm-rows">
-            <div class="sm-row"><span>This challenge</span><b>${Number(shortMatch.wager).toLocaleString()} buy-in</b></div>
-            <div class="sm-row"><span>You have</span><b>${Math.round(netWorth ?? 0).toLocaleString()}</b></div>
-          </div>
-          <p class="sm-note">Your whole buy-in is at stake — winner takes the pot. Play with a smaller buy-in, or decline.</p>
-          <button class="sm-play" disabled={mbBusy} on:click={() => playReduced(shortMatch)}>Play with ${Math.round(netWorth ?? 0).toLocaleString()}</button>
-          <button class="sm-decline" disabled={mbBusy} on:click={() => declineChallenge(shortMatch)}>Decline challenge</button>
-        </div>
-      </div>
-    {/if}
+					<!-- Profile -->
+					<div class="set-profile">
+						<button
+							class="set-av"
+							on:click={() => {
+								showMyAccount = false;
+								goto('/avatar');
+							}}
+							aria-label="Edit avatar"
+						>
+							<Avatar config={myAvatar} fx size={68} />
+							<span class="set-av-edit">Edit</span>
+						</button>
+						<div class="set-id">
+							{#if maUsername && !maEditing}
+								<div class="set-uname">
+									@{maUsername}<button
+										class="ma-edit"
+										on:click={() => {
+											maEditing = true;
+											maInput = maUsername;
+											maMsg = '';
+										}}>edit</button
+									>
+								</div>
+							{:else}
+								<div class="set-uname-edit">
+									<input
+										class="ma-input"
+										placeholder="pick a username"
+										bind:value={maInput}
+										maxlength="15"
+										on:keydown={(e) => {
+											if (e.key === 'Enter') saveMaUsername();
+										}}
+									/>
+									<button class="ma-save" on:click={saveMaUsername}>Save</button>
+								</div>
+							{/if}
+							{#if $user?.email}<div class="set-email">{$user.email}</div>{/if}
+						</div>
+					</div>
+					{#if maMsg}<p class="ma-msg">{maMsg}</p>{/if}
 
-    <!-- Streak message (when Daily is disabled and user taps it) -->
-    {#if showStreakMessage}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Come back tomorrow">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showStreakMessage = false}></button>
-        <div class="modal-content main-menu-modal">
-          <button class="close-btn" on:click={() => showStreakMessage = false}>❌</button>
-          <div class="cbt-medal">{dailyStatus?.last_daily_won ? '✅' : '🏁'}</div>
-          <h2>{dailyStatus?.last_daily_won ? 'Daily Solved!' : "Today's Daily Done"}</h2>
-          <p class="cbt-result">
-            {dailyStatus?.last_daily_won ? "Nice work — you've finished today's puzzle." : "You've already played today's puzzle."}
-          </p>
-          <div class="cbt-stats">
-            <div class="cbt-stat"><span class="cbt-val">+${dailyStatus?.today_score?.toLocaleString() ?? 0}</span><span class="cbt-cap">Profit</span></div>
-            {#if (dailyStatus?.current_streak ?? 0) > 0}
-              <div class="cbt-stat"><span class="cbt-val">🔥 {dailyStatus?.current_streak}</span><span class="cbt-cap">Play streak</span></div>
-            {/if}
-          </div>
-          <p class="streak-message">
-            {#if (dailyStatus?.current_streak ?? 0) > 0}Come back tomorrow for a new puzzle to keep your 🔥 {dailyStatus?.current_streak}-day streak alive!{:else}Come back tomorrow for a fresh puzzle and start a streak!{/if}
-          </p>
-          <button class="main-menu-btn" on:click={() => { showStreakMessage = false; goToDailyLeaderboard(); }}>View Leaderboard</button>
-          <button class="main-menu-btn ghost-btn" on:click={() => showStreakMessage = false}>Close</button>
-        </div>
-      </div>
-    {/if}
-    <!-- My Account modal -->
-    {#if showMyAccount}
-      <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="My Account">
-        <button type="button" class="modal-backdrop" aria-label="Close" on:click={() => showMyAccount = false}></button>
-        <div class="modal-content main-menu-modal settings-modal">
-          <button class="close-btn" on:click={() => showMyAccount = false}>❌</button>
-          <h2>Settings</h2>
+					<!-- Preferences -->
+					<div class="set-label">Preferences</div>
+					<div class="set-group">
+						<button
+							class="set-row"
+							on:click={() => {
+								toggleSound();
+								if ($soundEnabled) fx('select');
+							}}
+						>
+							<span>🔊 Sound</span><span class="set-state" class:on={$soundEnabled}
+								>{$soundEnabled ? 'On' : 'Off'}</span
+							>
+						</button>
+						<button
+							class="set-row"
+							on:click={() => {
+								toggleHaptics();
+								if ($hapticsEnabled) fx('tap');
+							}}
+						>
+							<span>📳 Haptics</span><span class="set-state" class:on={$hapticsEnabled}
+								>{$hapticsEnabled ? 'On' : 'Off'}</span
+							>
+						</button>
+						<button class="set-row" on:click={toggleMusic}>
+							<span>🎵 Music</span><span class="set-state" class:on={$musicEnabled}
+								>{$musicEnabled ? 'On' : 'Off'}</span
+							>
+						</button>
+						{#if $musicEnabled}
+							<div class="set-row sub">
+								<span class="mmc-ic">🔈</span>
+								<input
+									class="mmc-slider"
+									type="range"
+									min="0"
+									max="100"
+									step="1"
+									value={Math.round($musicVolume * 100)}
+									on:input={(e) => setMusicVolume(Number(e.currentTarget.value) / 100)}
+								/>
+								<span class="mmc-pct">{Math.round($musicVolume * 100)}%</span>
+							</div>
+							{#if TRACKS.length > 1}
+								<div class="set-row sub tracks">
+									{#each TRACKS as t, i}<button
+											class="ma-track"
+											class:on={$currentTrackId === t.id}
+											on:click={() => selectTrack(t.id)}>Track {i + 1}</button
+										>{/each}
+								</div>
+							{/if}
+						{/if}
+					</div>
 
-          <!-- Profile -->
-          <div class="set-profile">
-            <button class="set-av" on:click={() => { showMyAccount = false; goto('/avatar'); }} aria-label="Edit avatar">
-              <Avatar config={myAvatar} fx size={68} />
-              <span class="set-av-edit">Edit</span>
-            </button>
-            <div class="set-id">
-              {#if maUsername && !maEditing}
-                <div class="set-uname">@{maUsername}<button class="ma-edit" on:click={() => { maEditing = true; maInput = maUsername; maMsg = ''; }}>edit</button></div>
-              {:else}
-                <div class="set-uname-edit">
-                  <input class="ma-input" placeholder="pick a username" bind:value={maInput} maxlength="15" on:keydown={(e) => { if (e.key === 'Enter') saveMaUsername(); }} />
-                  <button class="ma-save" on:click={saveMaUsername}>Save</button>
-                </div>
-              {/if}
-              {#if $user?.email}<div class="set-email">{$user.email}</div>{/if}
-            </div>
-          </div>
-          {#if maMsg}<p class="ma-msg">{maMsg}</p>{/if}
+					<!-- Social -->
+					<div class="set-label">Social</div>
+					<div class="set-group">
+						<button
+							class="set-row nav"
+							on:click={() => {
+								showMyAccount = false;
+								peopleTab = 'friends';
+								openCommunity('people');
+							}}><span>👋 Friends</span><span class="chev">›</span></button
+						>
+						<button
+							class="set-row nav"
+							on:click={() => {
+								showMyAccount = false;
+								peopleTab = 'groups';
+								openCommunity('people');
+							}}><span>👥 Groups</span><span class="chev">›</span></button
+						>
+					</div>
 
-          <!-- Preferences -->
-          <div class="set-label">Preferences</div>
-          <div class="set-group">
-            <button class="set-row" on:click={() => { toggleSound(); if ($soundEnabled) fx('select'); }}>
-              <span>🔊 Sound</span><span class="set-state" class:on={$soundEnabled}>{$soundEnabled ? 'On' : 'Off'}</span>
-            </button>
-            <button class="set-row" on:click={() => { toggleHaptics(); if ($hapticsEnabled) fx('tap'); }}>
-              <span>📳 Haptics</span><span class="set-state" class:on={$hapticsEnabled}>{$hapticsEnabled ? 'On' : 'Off'}</span>
-            </button>
-            <button class="set-row" on:click={toggleMusic}>
-              <span>🎵 Music</span><span class="set-state" class:on={$musicEnabled}>{$musicEnabled ? 'On' : 'Off'}</span>
-            </button>
-            {#if $musicEnabled}
-              <div class="set-row sub">
-                <span class="mmc-ic">🔈</span>
-                <input class="mmc-slider" type="range" min="0" max="100" step="1" value={Math.round($musicVolume * 100)} on:input={(e) => setMusicVolume(Number(e.currentTarget.value) / 100)} />
-                <span class="mmc-pct">{Math.round($musicVolume * 100)}%</span>
-              </div>
-              {#if TRACKS.length > 1}
-                <div class="set-row sub tracks">
-                  {#each TRACKS as t, i}<button class="ma-track" class:on={$currentTrackId === t.id} on:click={() => selectTrack(t.id)}>Track {i + 1}</button>{/each}
-                </div>
-              {/if}
-            {/if}
-          </div>
+					<!-- Security -->
+					{#if hasPin}
+						<div class="set-label">Security</div>
+						<div class="set-group">
+							<button class="set-row nav" on:click={changePin}
+								><span>🔑 Change PIN</span><span class="chev">›</span></button
+							>
+							<button class="set-row nav" on:click={forgotPin}
+								><span>🔓 Forgot PIN?</span><span class="chev">›</span></button
+							>
+						</div>
+					{/if}
 
-          <!-- Social -->
-          <div class="set-label">Social</div>
-          <div class="set-group">
-            <button class="set-row nav" on:click={() => { showMyAccount = false; peopleTab = 'friends'; openCommunity('people'); }}><span>👋 Friends</span><span class="chev">›</span></button>
-            <button class="set-row nav" on:click={() => { showMyAccount = false; peopleTab = 'groups'; openCommunity('people'); }}><span>👥 Groups</span><span class="chev">›</span></button>
-          </div>
+					<!-- Help & Legal -->
+					<div class="set-label">Help &amp; Legal</div>
+					<div class="set-group">
+						<button
+							class="set-row nav"
+							on:click={() => {
+								showMyAccount = false;
+								showTutorial = true;
+							}}><span>❓ How to Play</span><span class="chev">›</span></button
+						>
+						<a class="set-row nav" href="/privacy" target="_blank" rel="noopener noreferrer"
+							><span>🔒 Privacy Policy</span><span class="chev">↗</span></a
+						>
+						<a class="set-row nav" href="/terms" target="_blank" rel="noopener noreferrer"
+							><span>📄 Terms of Service</span><span class="chev">↗</span></a
+						>
+						<a class="set-row nav" href={`mailto:${SUPPORT_EMAIL}`}
+							><span>✉️ Contact Support</span><span class="chev">↗</span></a
+						>
+					</div>
 
-          <!-- Security -->
-          {#if hasPin}
-            <div class="set-label">Security</div>
-            <div class="set-group">
-              <button class="set-row nav" on:click={changePin}><span>🔑 Change PIN</span><span class="chev">›</span></button>
-              <button class="set-row nav" on:click={forgotPin}><span>🔓 Forgot PIN?</span><span class="chev">›</span></button>
-            </div>
-          {/if}
+					<!-- Account -->
+					<div class="set-label">Account</div>
+					<div class="set-group">
+						<button
+							class="set-row nav"
+							on:click={() => {
+								showMyAccount = false;
+								handleLogout();
+							}}><span>🚪 Log Out</span><span class="chev">›</span></button
+						>
+						<button
+							class="set-row nav danger"
+							on:click={() => {
+								deleteInput = '';
+								maMsg = '';
+								showDeleteConfirm = true;
+							}}><span>🗑️ Delete Account</span><span class="chev">›</span></button
+						>
+					</div>
 
-          <!-- Help & Legal -->
-          <div class="set-label">Help &amp; Legal</div>
-          <div class="set-group">
-            <button class="set-row nav" on:click={() => { showMyAccount = false; showTutorial = true; }}><span>❓ How to Play</span><span class="chev">›</span></button>
-            <a class="set-row nav" href="/privacy" target="_blank" rel="noopener noreferrer"><span>🔒 Privacy Policy</span><span class="chev">↗</span></a>
-            <a class="set-row nav" href="/terms" target="_blank" rel="noopener noreferrer"><span>📄 Terms of Service</span><span class="chev">↗</span></a>
-            <a class="set-row nav" href={`mailto:${SUPPORT_EMAIL}`}><span>✉️ Contact Support</span><span class="chev">↗</span></a>
-          </div>
+					<p class="ma-version">WordBank v{APP_VERSION}</p>
+				</div>
+			</div>
+		{/if}
 
-          <!-- Account -->
-          <div class="set-label">Account</div>
-          <div class="set-group">
-            <button class="set-row nav" on:click={() => { showMyAccount = false; handleLogout(); }}><span>🚪 Log Out</span><span class="chev">›</span></button>
-            <button class="set-row nav danger" on:click={() => { deleteInput = ''; maMsg = ''; showDeleteConfirm = true; }}><span>🗑️ Delete Account</span><span class="chev">›</span></button>
-          </div>
+		<!-- 🗑️ Delete-account confirmation — permanent, requires typing DELETE -->
+		{#if showDeleteConfirm}
+			<div
+				class="modal-overlay danger-overlay"
+				role="dialog"
+				aria-modal="true"
+				aria-label="Delete account"
+			>
+				<button
+					type="button"
+					class="modal-backdrop"
+					aria-label="Cancel"
+					on:click={() => {
+						if (!deleteBusy) showDeleteConfirm = false;
+					}}
+				></button>
+				<div class="info-card del-card" role="document">
+					<div class="info-big">🗑️</div>
+					<h3 class="info-title">Delete your account?</h3>
+					<p class="del-body">
+						This permanently erases your account, Cash, stats, streaks, badges and history. <b
+							>It can't be undone.</b
+						>
+					</p>
+					<input
+						class="ma-input del-input"
+						placeholder="Type DELETE to confirm"
+						bind:value={deleteInput}
+						autocomplete="off"
+						autocapitalize="characters"
+						spellcheck="false"
+					/>
+					<button
+						class="main-menu-btn ma-danger"
+						disabled={!deleteArmed || deleteBusy}
+						on:click={confirmDeleteAccount}
+					>
+						{deleteBusy ? 'Deleting…' : 'Delete forever'}
+					</button>
+					<button
+						class="main-menu-btn ghost-btn"
+						disabled={deleteBusy}
+						on:click={() => (showDeleteConfirm = false)}>Cancel</button
+					>
+				</div>
+			</div>
+		{/if}
+	{:else}
+		<!-- ✅ GAME UI (Visible only when logged in) -->
 
-          <p class="ma-version">WordBank v{APP_VERSION}</p>
-        </div>
-      </div>
-    {/if}
+		<!-- 🧠 Game Logo -->
+		<img class="game-logo" src="/wordmark.png" alt="WordBank" />
 
-    <!-- 🗑️ Delete-account confirmation — permanent, requires typing DELETE -->
-    {#if showDeleteConfirm}
-      <div class="modal-overlay danger-overlay" role="dialog" aria-modal="true" aria-label="Delete account">
-        <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={() => { if (!deleteBusy) showDeleteConfirm = false; }}></button>
-        <div class="info-card del-card" role="document">
-          <div class="info-big">🗑️</div>
-          <h3 class="info-title">Delete your account?</h3>
-          <p class="del-body">This permanently erases your account, Cash, stats, streaks, badges and history. <b>It can't be undone.</b></p>
-          <input class="ma-input del-input" placeholder="Type DELETE to confirm" bind:value={deleteInput}
-            autocomplete="off" autocapitalize="characters" spellcheck="false" />
-          <button class="main-menu-btn ma-danger" disabled={!deleteArmed || deleteBusy} on:click={confirmDeleteAccount}>
-            {deleteBusy ? 'Deleting…' : 'Delete forever'}
-          </button>
-          <button class="main-menu-btn ghost-btn" disabled={deleteBusy} on:click={() => showDeleteConfirm = false}>Cancel</button>
-        </div>
-      </div>
-    {/if}
-  {:else}
-    <!-- ✅ GAME UI (Visible only when logged in) -->
+		<!-- 🏷️ Game-mode pill — same spot & style for every mode; tap to see the rules -->
+		{#if $gameStore.currentPhrase && $gameStore.gameMode && modeLabel}
+			<button
+				class="mode-pill"
+				title="How {modeLabel.name} works"
+				on:click={() => {
+					fx('tap');
+					showObjectiveFor($gameStore.gameMode, true);
+				}}
+			>
+				<span class="mp-emoji">{modeLabel.emoji}</span>{modeLabel.name}<span class="mp-info">ⓘ</span
+				>
+			</button>
+		{/if}
 
-    <!-- 🧠 Game Logo -->
-    <img class="game-logo" src="/wordmark.png" alt="WordBank" />
+		<!-- 💰 Bankroll — top of every mode. Challenge ante now lives in the bounty hero below. -->
+		{#if $gameStore.currentPhrase && $gameStore.gameMode}
+			{#if isBlitz && blitz && blitz.state !== 'ended'}
+				<!-- ⚡ Blitz HUD: big countdown clock + combo + live winnings -->
+				<div class="blitz-hud">
+					<div class="bz-clock" class:danger={blitzSec <= 10}>
+						⏱️ {blitzSec}<span class="bz-clock-s">s</span>
+					</div>
+					<div class="bz-row">
+						<span class="bz-stat"
+							><b class="bz-combo">×{((blitz.combo ?? 100) / 100).toFixed(2)}</b><small>combo</small
+							></span
+						>
+						<span class="bz-stat"
+							><b class="bz-win">${Math.round(blitz.winnings ?? 0).toLocaleString()}</b><small
+								>winnings</small
+							></span
+						>
+						<span class="bz-stat"><b>{blitz.solved ?? 0}</b><small>solved</small></span>
+					</div>
+					<button
+						class="bz-skip"
+						on:click={() => {
+							fx('tap');
+							blitzSkipPuzzle();
+						}}>Skip (−3s, combo resets)</button
+					>
+				</div>
+			{:else if !matchBlitz}
+				{@const isDailyLike = $gameStore.gameMode === 'daily' || isMakeup}
+				<button
+					class="top-bank solo"
+					class:pop-up={bankFlash === 'up'}
+					class:pop-down={bankFlash === 'down'}
+					title={isDailyLike ? 'Prize remaining — spend it, keep the rest' : 'Your Cash'}
+					on:click={openBankModal}
+				>
+					{#if isMatch}<span class="tb-wallet-cap">💰 Wallet</span>{:else if isDailyLike}<span
+							class="tb-wallet-cap">🏆 Prize</span
+						>{/if}
+					<span class="tb-solo"
+						>{#if isMatch}💰
+						{:else if !isDailyLike}💰
+						{/if}${Math.round($tweenBank).toLocaleString()}</span
+					>
+				</button>
+			{/if}
+		{/if}
 
-    <!-- 🏷️ Game-mode pill — same spot & style for every mode; tap to see the rules -->
-    {#if $gameStore.currentPhrase && $gameStore.gameMode && modeLabel}
-      <button class="mode-pill" title="How {modeLabel.name} works" on:click={() => { fx('tap'); showObjectiveFor($gameStore.gameMode, true); }}>
-        <span class="mp-emoji">{modeLabel.emoji}</span>{modeLabel.name}<span class="mp-info">ⓘ</span>
-      </button>
-    {/if}
+		<!-- 🔍 Diagnostic banner (shows when init failed) -->
+		{#if initError}
+			<div class="diagnostic-banner">
+				<strong>⚠️ Diagnostic:</strong>
+				{initError}
+				<br />
+				<small>Open DevTools (F12) → Console for details.</small>
+				<button
+					class="diagnostic-retry"
+					on:click={() => {
+						initError = null;
+						location.reload();
+					}}
+				>
+					Retry
+				</button>
+			</div>
+		{:else if loggedIn && hasInitialized && !$gameStore.currentPhrase && !$gameWasRestored}
+			<div class="diagnostic-banner info">
+				Loading puzzle… If this persists, check Console (F12).
+			</div>
+		{/if}
 
-    <!-- 💰 Bankroll — top of every mode. Challenge ante now lives in the bounty hero below. -->
-    {#if $gameStore.currentPhrase && $gameStore.gameMode}
-      {#if isBlitz && blitz && blitz.state !== 'ended'}
-        <!-- ⚡ Blitz HUD: big countdown clock + combo + live winnings -->
-        <div class="blitz-hud">
-          <div class="bz-clock" class:danger={blitzSec <= 10}>⏱️ {blitzSec}<span class="bz-clock-s">s</span></div>
-          <div class="bz-row">
-            <span class="bz-stat"><b class="bz-combo">×{((blitz.combo ?? 100)/100).toFixed(2)}</b><small>combo</small></span>
-            <span class="bz-stat"><b class="bz-win">${Math.round(blitz.winnings ?? 0).toLocaleString()}</b><small>winnings</small></span>
-            <span class="bz-stat"><b>{blitz.solved ?? 0}</b><small>solved</small></span>
-          </div>
-          <button class="bz-skip" on:click={() => { fx('tap'); blitzSkipPuzzle(); }}>Skip (−3s, combo resets)</button>
-        </div>
-      {:else if !matchBlitz}
-        {@const isDailyLike = $gameStore.gameMode === 'daily' || isMakeup}
-        <button class="top-bank solo" class:pop-up={bankFlash === 'up'} class:pop-down={bankFlash === 'down'} title={isDailyLike ? 'Prize remaining — spend it, keep the rest' : 'Your Cash'} on:click={openBankModal}>
-          {#if isMatch}<span class="tb-wallet-cap">💰 Wallet</span>{:else if isDailyLike}<span class="tb-wallet-cap">🏆 Prize</span>{/if}
-          <span class="tb-solo">{#if isMatch}💰 {:else if !isDailyLike}💰 {/if}${Math.round($tweenBank).toLocaleString()}</span>
-        </button>
-      {/if}
-    {/if}
+		<!-- ⏱️ Pressure-mode challenge clock -->
+		{#if pressureActive}
+			<div class="pressure-hud" class:danger={pressureRemaining <= 10}>
+				<span class="ph-clock">⏱️ {pressureRemaining}s</span>
+				<span class="ph-label">Pressure — solve fast for a bigger score</span>
+			</div>
+		{/if}
 
-    <!-- 🔍 Diagnostic banner (shows when init failed) -->
-    {#if initError}
-      <div class="diagnostic-banner">
-        <strong>⚠️ Diagnostic:</strong> {initError}
-        <br />
-        <small>Open DevTools (F12) → Console for details.</small>
-        <button class="diagnostic-retry" on:click={() => { initError = null; location.reload(); }}>
-          Retry
-        </button>
-      </div>
-    {:else if loggedIn && hasInitialized && !$gameStore.currentPhrase && !$gameWasRestored}
-      <div class="diagnostic-banner info">
-        Loading puzzle… If this persists, check Console (F12).
-      </div>
-    {/if}
+		<!-- 🗓️ Make-up daily banner -->
+		{#if isMakeup}
+			<div class="makeup-banner">
+				<span class="mb-tag">🗓️ Make-up</span>
+				<span class="mb-text">{makeupLabel}</span>
+			</div>
+		{/if}
 
-    <!-- ⏱️ Pressure-mode challenge clock -->
-    {#if pressureActive}
-      <div class="pressure-hud" class:danger={pressureRemaining <= 10}>
-        <span class="ph-clock">⏱️ {pressureRemaining}s</span>
-        <span class="ph-label">Pressure — solve fast for a bigger score</span>
-      </div>
-    {/if}
-
-    <!-- 🗓️ Make-up daily banner -->
-    {#if isMakeup}
-      <div class="makeup-banner">
-        <span class="mb-tag">🗓️ Make-up</span>
-        <span class="mb-text">{makeupLabel}</span>
-      </div>
-    {/if}
-
-    <!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
+		<!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
          Solve-to-Earn box; power-ups live in the vault beside Solve. -->
-    {#if isClimb && climb}
-      {#if climb.stuck && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
-        <div class="climb-stuck">
-          <span class="cs-text">🎯 Final guess — solve it or bust the run</span>
-        </div>
-      {/if}
-      <!-- 🏦 Cash Out — bank the run bankroll anytime (the press-your-luck valve). -->
-      {#if (climb.state === 'active' || climb.state === 'stuck') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
-        {@const bankroll = Math.round(climb.bankroll ?? 0)}
-        {@const profit = bankroll - Math.round(climb.buy_in ?? 0)}
-        <button class="cashout-btn" class:up={profit > 0} disabled={cgBusy || bankroll <= 0} on:click={cashOut}>
-          🏦 Cash Out <b>${bankroll.toLocaleString()}</b>
-          {#if profit !== 0}<span class="co-profit" class:neg={profit < 0}>{profit > 0 ? '+' : '−'}${Math.abs(profit).toLocaleString()}</span>{/if}
-        </button>
-      {/if}
-    {/if}
+		{#if isClimb && climb}
+			{#if climb.stuck && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+				<div class="climb-stuck">
+					<span class="cs-text">🎯 Final guess — solve it or bust the run</span>
+				</div>
+			{/if}
+			<!-- 🏦 Cash Out — bank the run bankroll anytime (the press-your-luck valve). -->
+			{#if (climb.state === 'active' || climb.state === 'stuck') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+				{@const bankroll = Math.round(climb.bankroll ?? 0)}
+				{@const profit = bankroll - Math.round(climb.buy_in ?? 0)}
+				<button
+					class="cashout-btn"
+					class:up={profit > 0}
+					disabled={cgBusy || bankroll <= 0}
+					on:click={cashOut}
+				>
+					🏦 Cash Out <b>${bankroll.toLocaleString()}</b>
+					{#if profit !== 0}<span class="co-profit" class:neg={profit < 0}
+							>{profit > 0 ? '+' : '−'}${Math.abs(profit).toLocaleString()}</span
+						>{/if}
+				</button>
+			{/if}
+		{/if}
 
-    <!-- ⚔️ Challenge match HUD -->
-    {#if isMatch && matchInfo && !matchInfo.done}
-      {#if matchBlitz}
-        <div class="climb-hud">
-          <div class="ch-cell"><span class="ch-val">{matchInfo.position}/{matchInfo.pack_size}</span><span class="ch-label">Puzzle</span></div>
-          <div class="ch-cell"><span class="ch-val ch-gold">{(matchInfo.total_score ?? 0).toLocaleString()}</span><span class="ch-label">Score</span></div>
-          <div class="ch-cell"><span class="ch-val">×{matchCombo}</span><span class="ch-label">Combo</span></div>
-          <div class="ch-cell" class:hot={matchRemaining <= 10}><span class="ch-val">⏱️{matchRemaining}</span><span class="ch-label">Time</span></div>
-        </div>
-      {:else}
-        {#if matchInfo.pack_size > 1}<p class="match-pos">Puzzle {matchInfo.position}/{matchInfo.pack_size}</p>{/if}
-        <StandingStrip standing={matchInfo.standing ?? null} />
-      {/if}
-      {#if (matchInfo.my_debuffs ?? []).length}
-        <button type="button" class="debuff-banner" on:click={openDebuffInfo} title="Who hit you & what it does">
-          {(matchInfo.my_debuffs ?? []).map((/** @type {string} */ d) => DEBUFF_LABEL[d] ?? d).join(' · ')} <span class="db-info">ⓘ</span>
-        </button>
-      {/if}
-      <!-- Power-ups & sabotage all live in the 🔐 vault beside Solve now. -->
-    {/if}
+		<!-- ⚔️ Challenge match HUD -->
+		{#if isMatch && matchInfo && !matchInfo.done}
+			{#if matchBlitz}
+				<div class="climb-hud">
+					<div class="ch-cell">
+						<span class="ch-val">{matchInfo.position}/{matchInfo.pack_size}</span><span
+							class="ch-label">Puzzle</span
+						>
+					</div>
+					<div class="ch-cell">
+						<span class="ch-val ch-gold">{(matchInfo.total_score ?? 0).toLocaleString()}</span><span
+							class="ch-label">Score</span
+						>
+					</div>
+					<div class="ch-cell">
+						<span class="ch-val">×{matchCombo}</span><span class="ch-label">Combo</span>
+					</div>
+					<div class="ch-cell" class:hot={matchRemaining <= 10}>
+						<span class="ch-val">⏱️{matchRemaining}</span><span class="ch-label">Time</span>
+					</div>
+				</div>
+			{:else}
+				{#if matchInfo.pack_size > 1}<p class="match-pos">
+						Puzzle {matchInfo.position}/{matchInfo.pack_size}
+					</p>{/if}
+				<StandingStrip standing={matchInfo.standing ?? null} />
+			{/if}
+			{#if (matchInfo.my_debuffs ?? []).length}
+				<button
+					type="button"
+					class="debuff-banner"
+					on:click={openDebuffInfo}
+					title="Who hit you & what it does"
+				>
+					{(matchInfo.my_debuffs ?? [])
+						.map((/** @type {string} */ d) => DEBUFF_LABEL[d] ?? d)
+						.join(' · ')} <span class="db-info">ⓘ</span>
+				</button>
+			{/if}
+			<!-- Power-ups & sabotage all live in the 🔐 vault beside Solve now. -->
+		{/if}
 
-    <!-- 🌍 Category + today's auto-applied Twist chip + witty clue -->
-    <div class="puzzle-meta">
-      {#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
-      {#if $gameStore.gameMode === 'daily' && dailyMod}
-        <button class="twist-chip" title="Today's special — tap to see" on:click={() => { fx('tap'); dailyInfo = 'twist'; }}>{dailyMod.emoji}</button>
-      {/if}
-    </div>
-    {#if $gameStore.clue}
-      <p class="puzzle-clue">{$gameStore.clue}</p>
-    {/if}
+		<!-- 🌍 Category + today's auto-applied Twist chip + witty clue -->
+		<div class="puzzle-meta">
+			{#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
+			{#if $gameStore.gameMode === 'daily' && dailyMod}
+				<button
+					class="twist-chip"
+					title="Today's special — tap to see"
+					on:click={() => {
+						fx('tap');
+						dailyInfo = 'twist';
+					}}>{dailyMod.emoji}</button
+				>
+			{/if}
+		</div>
+		{#if $gameStore.clue}
+			<p class="puzzle-clue">{$gameStore.clue}</p>
+		{/if}
 
+		<!-- 🎁 Announce today's auto-applied Twist during the dramatic load -->
+		{#if introBuilding && $gameStore.gameMode === 'daily' && dailyMod}
+			<div class="twist-announce" aria-hidden="true">
+				<span class="ta-label">Today's special</span>
+				<span class="ta-name">{dailyMod.emoji} {dailyMod.name}</span>
+				<span class="ta-blurb">{dailyMod.blurb} · applied automatically</span>
+			</div>
+		{/if}
 
-    <!-- 🎁 Announce today's auto-applied Twist during the dramatic load -->
-    {#if introBuilding && $gameStore.gameMode === 'daily' && dailyMod}
-      <div class="twist-announce" aria-hidden="true">
-        <span class="ta-label">Today's special</span>
-        <span class="ta-name">{dailyMod.emoji} {dailyMod.name}</span>
-        <span class="ta-blurb">{dailyMod.blurb} · applied automatically</span>
-      </div>
-    {/if}
+		<!-- 🔤 Phrase Display -->
+		<section class="phrase-section">
+			<PhraseDisplay on:revealComplete={onPhraseRevealComplete} on:introDone={onDailyIntroDone} />
+		</section>
 
-    <!-- 🔤 Phrase Display -->
-    <section class="phrase-section">
-      <PhraseDisplay on:revealComplete={onPhraseRevealComplete} on:introDone={onDailyIntroDone} />
-    </section>
+		<!-- ⏱ Out-of-Cash broke-timer — live Challenges only (Daily has no timer) -->
+		{#if brokeMode && gameActive && isBroke}
+			<div class="fold-bar broke">
+				<span class="fold-timer">⏱ 0:{String(brokeLeft).padStart(2, '0')}</span>
+				<span class="fold-warn">Out of Cash — guess in time or you give up this one</span>
+			</div>
+		{/if}
 
-    <!-- ⏱ Out-of-Cash broke-timer — live Challenges only (Daily has no timer) -->
-    {#if brokeMode && gameActive && isBroke}
-      <div class="fold-bar broke">
-        <span class="fold-timer">⏱ 0:{String(brokeLeft).padStart(2, '0')}</span>
-        <span class="fold-warn">Out of Cash — guess in time or you give up this one</span>
-      </div>
-    {/if}
+		<!-- 💰 Money hero -->
+		<section class="stats-section">
+			{#if soloHero}
+				<!-- Daily · Cash Game = the number you keep if you solve now. Challenge = ante left to spend (depletes). -->
+				<div
+					class="bounty-panel"
+					class:loss={!isMatch && soloHero.net < 0}
+					class:ante-empty={isMatch && matchLeft <= 0}
+					class:count-pop={introCountPop}
+				>
+					{#if $gameStore.gameMode === 'daily'}
+						<button
+							class="bp-mult-badge"
+							title="How your multiplier works"
+							on:click={() => {
+								fx('tap');
+								dailyInfo = 'mult';
+							}}>×{Number($gameStore.bountyMult ?? 1).toFixed(1)}</button
+						>
+						<button
+							class="bp-winstreak"
+							title="Win streak"
+							on:click={() => {
+								fx('tap');
+								dailyInfo = 'streak';
+							}}>🏆 {dailyStatus?.win_streak ?? 0}</button
+						>
+					{:else if isClimb}
+						<button
+							class="bp-mult-badge"
+							title="Heat — your payout multiplier"
+							on:click={() => {
+								fx('tap');
+								climbInfo = 'heat';
+							}}>🔥 ×{climbHeat}</button
+						>
+						<button
+							class="bp-winstreak"
+							title="Win streak"
+							on:click={() => {
+								fx('tap');
+								climbInfo = 'streak';
+							}}>🏆 {climbStreak}</button
+						>
+					{/if}
+					<span class="bp-label"
+						>{isMatch
+							? matchLeft > 0
+								? '💰 Left to Spend'
+								: '🪙 Out of ante'
+							: $gameStore.gameMode === 'daily'
+								? "You'll bank"
+								: soloHero.net >= 0
+									? 'Solve to Earn'
+									: '⚠️ You’re losing money'}</span
+					>
+					{#if $gameStore.gameMode === 'daily'}
+						<button
+							class="bp-amount bp-amount-btn"
+							title="How this is calculated"
+							on:click={() => {
+								fx('tap');
+								dailyInfo = 'bounty';
+							}}
+							>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(
+								Math.round($tweenNet)
+							).toLocaleString()}</button
+						>
+					{:else if isClimb}
+						<button
+							class="bp-amount bp-amount-btn"
+							title="How this is calculated"
+							on:click={() => {
+								fx('tap');
+								climbInfo = 'earn';
+							}}
+							>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(
+								Math.round($tweenNet)
+							).toLocaleString()}</button
+						>
+					{:else if isMatch}
+						<button
+							class="bp-amount bp-amount-btn"
+							title="What is this?"
+							on:click={() => {
+								fx('tap');
+								showAnteInfo = true;
+							}}>${Math.max(0, Math.round($tweenNet)).toLocaleString()}</button
+						>
+					{:else}
+						<span class="bp-amount"
+							>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</span
+						>
+					{/if}
+					{#each spendFloaters as f (f.id)}<span class="spend-float">{f.text}</span>{/each}
+				</div>
+				{#if isMatch && matchLive}
+					<div class="ante-bar">
+						<span
+							class="ante-fill"
+							style="width:{(matchLive.budget ?? 0) > 0
+								? Math.max(0, Math.min(100, (matchLeft / matchLive.budget) * 100))
+								: 100}%"
+						></span>
+					</div>
+				{/if}
+				{#if isClimb && climbRun && climbRun.solves >= 2}
+					<p class="climb-run-line" class:best={climbRunIsBest}>
+						🔥 {climbRun.solves}-solve run ·
+						<b class="run-profit" class:neg={climbRun.profit < 0}
+							>{climbRun.profit >= 0 ? '+' : '−'}${Math.abs(climbRun.profit).toLocaleString()}</b
+						>
+						this run{#if climbRunIsBest}
+							· 🏆 personal best{/if}
+					</p>
+				{/if}
+			{/if}
+		</section>
 
-    <!-- 💰 Money hero -->
-    <section class="stats-section">
-      {#if soloHero}
-        <!-- Daily · Cash Game = the number you keep if you solve now. Challenge = ante left to spend (depletes). -->
-        <div class="bounty-panel" class:loss={!isMatch && soloHero.net < 0} class:ante-empty={isMatch && matchLeft <= 0} class:count-pop={introCountPop}>
-          {#if $gameStore.gameMode === 'daily'}
-            <button class="bp-mult-badge" title="How your multiplier works" on:click={() => { fx('tap'); dailyInfo = 'mult'; }}>×{Number($gameStore.bountyMult ?? 1).toFixed(1)}</button>
-            <button class="bp-winstreak" title="Win streak" on:click={() => { fx('tap'); dailyInfo = 'streak'; }}>🏆 {dailyStatus?.win_streak ?? 0}</button>
-          {:else if isClimb}
-            <button class="bp-mult-badge" title="Heat — your payout multiplier" on:click={() => { fx('tap'); climbInfo = 'heat'; }}>🔥 ×{climbHeat}</button>
-            <button class="bp-winstreak" title="Win streak" on:click={() => { fx('tap'); climbInfo = 'streak'; }}>🏆 {climbStreak}</button>
-          {/if}
-          <span class="bp-label">{isMatch ? (matchLeft > 0 ? '💰 Left to Spend' : '🪙 Out of ante') : ($gameStore.gameMode === 'daily' ? "You'll bank" : (soloHero.net >= 0 ? 'Solve to Earn' : '⚠️ You’re losing money'))}</span>
-          {#if $gameStore.gameMode === 'daily'}
-            <button class="bp-amount bp-amount-btn" title="How this is calculated" on:click={() => { fx('tap'); dailyInfo = 'bounty'; }}>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</button>
-          {:else if isClimb}
-            <button class="bp-amount bp-amount-btn" title="How this is calculated" on:click={() => { fx('tap'); climbInfo = 'earn'; }}>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</button>
-          {:else if isMatch}
-            <button class="bp-amount bp-amount-btn" title="What is this?" on:click={() => { fx('tap'); showAnteInfo = true; }}>${Math.max(0, Math.round($tweenNet)).toLocaleString()}</button>
-          {:else}
-            <span class="bp-amount">{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(Math.round($tweenNet)).toLocaleString()}</span>
-          {/if}
-          {#each spendFloaters as f (f.id)}<span class="spend-float">{f.text}</span>{/each}
-        </div>
-        {#if isMatch && matchLive}
-          <div class="ante-bar"><span class="ante-fill" style="width:{(matchLive.budget ?? 0) > 0 ? Math.max(0, Math.min(100, (matchLeft / matchLive.budget) * 100)) : 100}%"></span></div>
-        {/if}
-        {#if isClimb && climbRun && climbRun.solves >= 2}
-          <p class="climb-run-line" class:best={climbRunIsBest}>
-            🔥 {climbRun.solves}-solve run · <b class="run-profit" class:neg={climbRun.profit < 0}>{climbRun.profit >= 0 ? '+' : '−'}${Math.abs(climbRun.profit).toLocaleString()}</b> this run{#if climbRunIsBest} · 🏆 personal best{/if}
-          </p>
-        {/if}
-      {/if}
-    </section>
+		<!-- 💥 Double or Nothing — Cash Game only, when heat ≥ ×1.5. Arm to double the payout. -->
+		{#if isClimb && climb && $gameStore.gameState !== 'won'}
+			{#if donAvailable}
+				<button class="don-cta" on:click={openDon}>
+					<span class="don-cta-title">💥 Double or Nothing</span>
+					<span class="don-cta-sub">Solve for <b>${donTarget.toLocaleString()}</b> · all-in</span>
+				</button>
+			{:else if donArmed}
+				<div class="don-armed" role="status">
+					<span class="don-armed-title">💥 Doubled — all in</span>
+					<span class="don-armed-sub">Solve for <b>${donTarget.toLocaleString()}</b></span>
+				</div>
+			{/if}
+		{/if}
 
-    <!-- 💥 Double or Nothing — Cash Game only, when heat ≥ ×1.5. Arm to double the payout. -->
-    {#if isClimb && climb && $gameStore.gameState !== 'won'}
-      {#if donAvailable}
-        <button class="don-cta" on:click={openDon}>
-          <span class="don-cta-title">💥 Double or Nothing</span>
-          <span class="don-cta-sub">Solve for <b>${donTarget.toLocaleString()}</b> · all-in</span>
-        </button>
-      {:else if donArmed}
-        <div class="don-armed" role="status">
-          <span class="don-armed-title">💥 Doubled — all in</span>
-          <span class="don-armed-sub">Solve for <b>${donTarget.toLocaleString()}</b></span>
-        </div>
-      {/if}
-    {/if}
+		<!-- 🎮 Solve / Cancel Buttons (Cash Game gets a vault to the left for power-ups) -->
+		<section class="buttons-section">
+			<GameButtons>
+				<svelte:fragment slot="left">
+					{#if isClimb && climb?.state === 'active'}
+						<button
+							class="solve-vault"
+							on:click={openBag}
+							title="Your power-ups"
+							aria-label="Open your vault"
+						>
+							<img src="/vault.png" alt="" />
+							{#if usableClimbPups > 0}<span class="solve-vault-badge">{usableClimbPups}</span>{/if}
+						</button>
+					{:else if isMatch && matchInfo?.items_allowed && !matchInfo?.done && gameActive}
+						<button
+							class="solve-vault"
+							on:click={openBag}
+							title="Your power-ups"
+							aria-label="Open your vault"
+						>
+							<img src="/vault.png" alt="" />
+							{#if usableMatchPups > 0}<span class="solve-vault-badge">{usableMatchPups}</span>{/if}
+						</button>
+					{/if}
+				</svelte:fragment>
+			</GameButtons>
+		</section>
 
-    <!-- 🎮 Solve / Cancel Buttons (Cash Game gets a vault to the left for power-ups) -->
-    <section class="buttons-section">
-      <GameButtons>
-        <svelte:fragment slot="left">
-          {#if isClimb && climb?.state === 'active'}
-            <button class="solve-vault" on:click={openBag} title="Your power-ups" aria-label="Open your vault">
-              <img src="/vault.png" alt="" />
-              {#if usableClimbPups > 0}<span class="solve-vault-badge">{usableClimbPups}</span>{/if}
-            </button>
-          {:else if isMatch && matchInfo?.items_allowed && !matchInfo?.done && gameActive}
-            <button class="solve-vault" on:click={openBag} title="Your power-ups" aria-label="Open your vault">
-              <img src="/vault.png" alt="" />
-              {#if usableMatchPups > 0}<span class="solve-vault-badge">{usableMatchPups}</span>{/if}
-            </button>
-          {/if}
-        </svelte:fragment>
-      </GameButtons>
-    </section>
+		<!-- ⌨️ Keyboard Section (keyboard disables itself via gameStore state) -->
+		<section class="keyboard-section">
+			<Keyboard />
+		</section>
 
-    <!-- ⌨️ Keyboard Section (keyboard disables itself via gameStore state) -->
-    <section class="keyboard-section">
-      <Keyboard />
-    </section>
+		<!-- 🏆 Game Outcome Banner (win celebration handled by the slot-machine reveal) -->
+		{#if $gameStore.gameState === 'lost'}
+			<div class="banner lose">Bankrupt!</div>
+		{/if}
 
-    <!-- 🏆 Game Outcome Banner (win celebration handled by the slot-machine reveal) -->
-    {#if $gameStore.gameState === "lost"}
-      <div class="banner lose">Bankrupt!</div>
-    {/if}
-
-    <!-- 🎯 Result Modal -->
-    {#if showResultModal && ['won', 'lost'].includes($gameStore.gameState)}
-      <div class="modal-overlay">
-        <div class="modal-content result-modal">
-          {#if isDailyResult && resultWon && dr}
-            {@const mult = Number(dr.mult ?? $gameStore.bountyMult ?? 1)}
-            {@const prize = Number(dr.base ?? 0)}
-            {@const kept = Number(dr.kept ?? Math.max(0, prize - (dr.spent ?? 0)))}
-            {@const banked = Number(dr.winnings ?? dr.banked ?? dr.reward ?? Math.round(kept * mult))}
-            <h2 class="win-h">🎉 Solved!</h2>
-            <p class="result-sub">{todayLabel}</p>
-            <!-- Prize − Spent = Kept ×mult = Banked -->
-            <div class="win-math">
-              <div class="wm-row"><span>🏆 Prize</span><b>${prize.toLocaleString()}</b></div>
-              <div class="wm-row"><span>− Spent on letters</span><b class="neg">−${(dr.spent ?? 0).toLocaleString()}</b></div>
-              <div class="wm-row"><span>= Kept</span><b>${kept.toLocaleString()}</b></div>
-              {#if mult > 1}<div class="wm-row"><span>× Streak bonus</span><b>{fmtMult(mult)}</b></div>{/if}
-              <div class="wm-row total"><span>💰 Banked</span><b class="profit">+${banked.toLocaleString()}</b></div>
-            </div>
-            {#if dailyMod}
-              <p class="win-twist">{dailyMod.emoji} <b>{dailyMod.name}</b> — applied for everyone</p>
-            {/if}
-            <!-- bankroll scrolls to the new total -->
-            <div class="win-bank">
-              <span class="wb-label">💰 Your Cash</span>
-              <span class="wb-amount">${Math.round($resultBankAnim).toLocaleString()}</span>
-            </div>
-            <p class="win-rank">
-              {#if resultRank && resultRank.total > 0}<b>🏆 #{resultRank.rank}</b> of {resultRank.total.toLocaleString()} today{/if}
-              {#if (dailyStatus?.win_streak ?? 0) > 0} · 🔥 {dailyStatus?.win_streak} win streak{/if}
-            </p>
-            <div class="result-actions">
-              <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
-              <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
-            </div>
-            <button class="win-menu" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Back to menu</button>
-          {:else if isDailyResult}
-            <div class="result-medal lose">😖</div>
-            <h2>Busted</h2>
-            <p class="result-sub">{todayLabel}</p>
-            <div class="result-bankroll">
-              <span class="rb-label">Your Cash</span>
-              <span class="rb-amount">${resultBankroll.toLocaleString()}</span>
-            </div>
-            <p class="win-rank">No profit this time — your win streak resets. Come back tomorrow.</p>
-            <div class="result-actions">
-              <button class="share-btn" on:click={handleShare}>{shareCopied ? '✓ Copied!' : 'Share'}</button>
-              <button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button>
-            </div>
-          {:else if isClimb && cashoutResult}
-            <!-- 🏦 Cash Game: cashed out — banked the run bankroll -->
-            {@const co = cashoutResult}
-            <h2 class="win-h">🏦 Cashed Out!</h2>
-            <p class="result-sub">{(co.tier ?? '').charAt(0).toUpperCase() + (co.tier ?? '').slice(1)} run · {co.solves ?? 0} solve{co.solves === 1 ? '' : 's'}</p>
-            <div class="win-math">
-              <div class="wm-row"><span>Banked</span><b>${(co.banked ?? 0).toLocaleString()}</b></div>
-              <div class="wm-row"><span>− Buy-in</span><b class="neg">−${(co.buy_in ?? 0).toLocaleString()}</b></div>
-              <div class="wm-row total"><span>Profit</span><b class="profit">{(co.profit ?? 0) >= 0 ? '+' : '−'}${Math.abs(co.profit ?? 0).toLocaleString()}</b></div>
-            </div>
-            <p class="win-twist">{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× your buy-in · 🔥 peak ×{((co.heat ?? 100) / 100).toFixed(1)} — banked to your Cash</p>
-            <div class="result-actions">
-              <button class="share-btn" on:click={() => { cashoutResult = null; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Done</button>
-              <button class="next-puzzle-button" on:click={() => { cashoutResult = null; showResultModal = false; hasTriggeredModal = false; handleMenuClimb(); }}>New Run</button>
-            </div>
-          {:else if isClimb && resultWon}
-            <!-- 🎰 Solved a puzzle → the payout grew your RUN bankroll (not Cash yet) -->
-            {@const payout = climb?.last_gain ?? 0}
-            {@const bankroll = Math.round(climb?.bankroll ?? 0)}
-            <h2 class="win-h">🎉 Solved!</h2>
-            <p class="result-sub">{$gameStore.currentPhrase}</p>
-            <div class="win-math">
-              <div class="wm-row"><span>Payout <small>(🔥 ×{climbHeat} heat)</small></span><b class="profit">+${payout.toLocaleString()}</b></div>
-              <div class="wm-row total"><span>🎰 Run bankroll</span><b>${bankroll.toLocaleString()}</b></div>
-            </div>
-            <p class="win-twist">🔥 Heat now ×{climbHeat}{#if (climb?.run_solves ?? 0) > 1} · {climb.run_solves}-solve run{/if} — bank it or push on?</p>
-            <div class="result-actions">
-              <button class="share-btn co-inline" disabled={cgBusy} on:click={() => { showResultModal = false; hasTriggeredModal = false; cashOut(); }}>🏦 Cash Out ${bankroll.toLocaleString()}</button>
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; climbAdvance().then(() => tick().then(playDailyIntroIfArmed)); }}>Next →</button>
-            </div>
-          {:else if isClimb}
-            <!-- 💥 Busted — lost the buy-in -->
-            <div class="result-medal">💥</div>
-            <h2>Busted</h2>
-            <p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
-            <p class="arcade-gain">You lost your ${(climb?.buy_in ?? 0).toLocaleString()} buy-in. The Daily always refills your Cash — come back for another run.</p>
-            <div class="result-actions">
-              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Leave</button>
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; handleMenuClimb(); }}>New Run</button>
-            </div>
-          {:else if isBlitz && blitzResult}
-            <!-- ⚡ Blitz: time's up -->
-            {@const br = blitzResult}
-            <h2 class="win-h">⚡ Time!</h2>
-            <p class="result-sub">{br.solved ?? 0} solved · best combo ×{((br.best_combo ?? 100)/100).toFixed(2)}</p>
-            <div class="win-math">
-              <div class="wm-row"><span>Winnings</span><b>${(br.winnings ?? 0).toLocaleString()}</b></div>
-              <div class="wm-row"><span>− Buy-in</span><b class="neg">−${(br.buy_in ?? 0).toLocaleString()}</b></div>
-              <div class="wm-row total"><span>Net</span><b class="profit">{(br.net ?? 0) >= 0 ? '+' : '−'}${Math.abs(br.net ?? 0).toLocaleString()}</b></div>
-            </div>
-            <p class="win-twist">{(br.net ?? 0) >= 0 ? '🔥 You beat the clock — banked to your Cash.' : 'Whiffed the bet — the Daily always refills your Cash.'}</p>
-            <div class="result-actions">
-              <button class="share-btn" on:click={() => { blitzResult = null; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Done</button>
-              <button class="next-puzzle-button" on:click={() => { blitzResult = null; showResultModal = false; hasTriggeredModal = false; handleMenuBlitz(); }}>New Run</button>
-            </div>
-          {:else if isMatch}
-            <!-- Challenge match: finished the whole pack -->
-            <div class="result-medal">⚔️</div>
-            <h2>Challenge complete!</h2>
-            <p class="result-sub">{#if matchInfo?.mode === 'blitz'}You scored {(matchInfo?.total_score ?? 0).toLocaleString()} across {matchInfo?.pack_size} puzzle{matchInfo?.pack_size === 1 ? '' : 's'}{:else}You solved {matchInfo?.solved ?? 0}/{matchInfo?.pack_size} spending ${(matchInfo?.spent ?? 0).toLocaleString()}{/if}</p>
-            <p class="arcade-gain">{matchInfo?.status === 'settled' ? 'Settled — check the results.' : "Most Cash left wins — we'll settle once everyone plays."}</p>
-            <div class="result-actions">
-              {#if matchInfo?.status === 'settled'}
-                <button class="share-btn" on:click={async () => { const id = matchInfo?.id; showResultModal = false; hasTriggeredModal = false; goToMainMenu(); matchResults = { loading: true }; matchResults = await getMatchDetail(id); }}>View Results</button>
-              {:else}
-                <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); newChallenge(); }}>Challenge Friends</button>
-              {/if}
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
-            </div>
-          {:else if isMakeup}
-            <!-- Make-up daily result (calendar fill; no streak/Bank) -->
-            {#if resultWon}
-              <div class="result-medal">🗓️</div>
-              <h2>Made it up!</h2>
-              <p class="result-sub">{makeupLabel} is on your calendar · {$gameStore.currentPhrase}</p>
-              <p class="arcade-gain">Counts toward 🗓️ Perfect Week / 📅 Perfect Month.</p>
-            {:else}
-              <div class="result-medal">💸</div>
-              <h2>Out of Cash</h2>
-              <p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
-            {/if}
-            <div class="result-actions">
-              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); goto('/streak'); }}>Calendar</button>
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
-            </div>
-          {:else if isChallenge}
-            <!-- Challenge result (settles when the friend plays) -->
-            <div class="result-medal">{resultWon ? (isPressure ? '⏱️' : '⚔️') : '⌛'}</div>
-            <h2>{resultWon ? 'Challenge played!' : "Time's up!"}</h2>
-            {#if resultWon}
-              <p class="result-sub">You scored ${chScore.toLocaleString()} · {$gameStore.currentPhrase}</p>
-              {#if isPressure}<p class="arcade-earn">Bankroll ${resultBankroll.toLocaleString()} + speed bonus</p>{/if}
-            {:else}
-              <p class="result-sub">Ran out of time — scored $0 · {$gameStore.currentPhrase}</p>
-            {/if}
-            <p class="arcade-gain">We'll settle the pot once your friend plays.</p>
-            <div class="result-actions">
-              <button class="share-btn" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); newChallenge(); }}>Challenge Friends</button>
-              <button class="next-puzzle-button" on:click={() => { showResultModal = false; hasTriggeredModal = false; goToMainMenu(); }}>Menu</button>
-            </div>
-          {/if}
-        </div>
-      </div>
-    {/if}
-  {/if}
+		<!-- 🎯 Result Modal -->
+		{#if showResultModal && ['won', 'lost'].includes($gameStore.gameState)}
+			<div class="modal-overlay">
+				<div class="modal-content result-modal">
+					{#if isDailyResult && resultWon && dr}
+						{@const mult = Number(dr.mult ?? $gameStore.bountyMult ?? 1)}
+						{@const prize = Number(dr.base ?? 0)}
+						{@const kept = Number(dr.kept ?? Math.max(0, prize - (dr.spent ?? 0)))}
+						{@const banked = Number(
+							dr.winnings ?? dr.banked ?? dr.reward ?? Math.round(kept * mult)
+						)}
+						<h2 class="win-h">🎉 Solved!</h2>
+						<p class="result-sub">{todayLabel}</p>
+						<!-- Prize − Spent = Kept ×mult = Banked -->
+						<div class="win-math">
+							<div class="wm-row"><span>🏆 Prize</span><b>${prize.toLocaleString()}</b></div>
+							<div class="wm-row">
+								<span>− Spent on letters</span><b class="neg"
+									>−${(dr.spent ?? 0).toLocaleString()}</b
+								>
+							</div>
+							<div class="wm-row"><span>= Kept</span><b>${kept.toLocaleString()}</b></div>
+							{#if mult > 1}<div class="wm-row">
+									<span>× Streak bonus</span><b>{fmtMult(mult)}</b>
+								</div>{/if}
+							<div class="wm-row total">
+								<span>💰 Banked</span><b class="profit">+${banked.toLocaleString()}</b>
+							</div>
+						</div>
+						{#if dailyMod}
+							<p class="win-twist">
+								{dailyMod.emoji} <b>{dailyMod.name}</b> — applied for everyone
+							</p>
+						{/if}
+						<!-- bankroll scrolls to the new total -->
+						<div class="win-bank">
+							<span class="wb-label">💰 Your Cash</span>
+							<span class="wb-amount">${Math.round($resultBankAnim).toLocaleString()}</span>
+						</div>
+						<p class="win-rank">
+							{#if resultRank && resultRank.total > 0}<b>🏆 #{resultRank.rank}</b> of {resultRank.total.toLocaleString()}
+								today{/if}
+							{#if (dailyStatus?.win_streak ?? 0) > 0}
+								· 🔥 {dailyStatus?.win_streak} win streak{/if}
+						</p>
+						<div class="result-actions">
+							<button class="share-btn" on:click={handleShare}
+								>{shareCopied ? '✓ Copied!' : 'Share'}</button
+							>
+							<button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button
+							>
+						</div>
+						<button
+							class="win-menu"
+							on:click={() => {
+								showResultModal = false;
+								hasTriggeredModal = false;
+								goToMainMenu();
+							}}>Back to menu</button
+						>
+					{:else if isDailyResult}
+						<div class="result-medal lose">😖</div>
+						<h2>Busted</h2>
+						<p class="result-sub">{todayLabel}</p>
+						<div class="result-bankroll">
+							<span class="rb-label">Your Cash</span>
+							<span class="rb-amount">${resultBankroll.toLocaleString()}</span>
+						</div>
+						<p class="win-rank">
+							No profit this time — your win streak resets. Come back tomorrow.
+						</p>
+						<div class="result-actions">
+							<button class="share-btn" on:click={handleShare}
+								>{shareCopied ? '✓ Copied!' : 'Share'}</button
+							>
+							<button class="next-puzzle-button" on:click={goToDailyLeaderboard}>Leaderboard</button
+							>
+						</div>
+					{:else if isClimb && cashoutResult}
+						<!-- 🏦 Cash Game: cashed out — banked the run bankroll -->
+						{@const co = cashoutResult}
+						<h2 class="win-h">🏦 Cashed Out!</h2>
+						<p class="result-sub">
+							{(co.tier ?? '').charAt(0).toUpperCase() + (co.tier ?? '').slice(1)} run · {co.solves ??
+								0} solve{co.solves === 1 ? '' : 's'}
+						</p>
+						<div class="win-math">
+							<div class="wm-row">
+								<span>Banked</span><b>${(co.banked ?? 0).toLocaleString()}</b>
+							</div>
+							<div class="wm-row">
+								<span>− Buy-in</span><b class="neg">−${(co.buy_in ?? 0).toLocaleString()}</b>
+							</div>
+							<div class="wm-row total">
+								<span>Profit</span><b class="profit"
+									>{(co.profit ?? 0) >= 0 ? '+' : '−'}${Math.abs(
+										co.profit ?? 0
+									).toLocaleString()}</b
+								>
+							</div>
+						</div>
+						<p class="win-twist">
+							{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× your buy-in · 🔥 peak ×{(
+								(co.heat ?? 100) / 100
+							).toFixed(1)} — banked to your Cash
+						</p>
+						<div class="result-actions">
+							<button
+								class="share-btn"
+								on:click={() => {
+									cashoutResult = null;
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+								}}>Done</button
+							>
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									cashoutResult = null;
+									showResultModal = false;
+									hasTriggeredModal = false;
+									handleMenuClimb();
+								}}>New Run</button
+							>
+						</div>
+					{:else if isClimb && resultWon}
+						<!-- 🎰 Solved a puzzle → the payout grew your RUN bankroll (not Cash yet) -->
+						{@const payout = climb?.last_gain ?? 0}
+						{@const bankroll = Math.round(climb?.bankroll ?? 0)}
+						<h2 class="win-h">🎉 Solved!</h2>
+						<p class="result-sub">{$gameStore.currentPhrase}</p>
+						<div class="win-math">
+							<div class="wm-row">
+								<span>Payout <small>(🔥 ×{climbHeat} heat)</small></span><b class="profit"
+									>+${payout.toLocaleString()}</b
+								>
+							</div>
+							<div class="wm-row total">
+								<span>🎰 Run bankroll</span><b>${bankroll.toLocaleString()}</b>
+							</div>
+						</div>
+						<p class="win-twist">
+							🔥 Heat now ×{climbHeat}{#if (climb?.run_solves ?? 0) > 1}
+								· {climb.run_solves}-solve run{/if} — bank it or push on?
+						</p>
+						<div class="result-actions">
+							<button
+								class="share-btn co-inline"
+								disabled={cgBusy}
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									cashOut();
+								}}>🏦 Cash Out ${bankroll.toLocaleString()}</button
+							>
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									climbAdvance().then(() => tick().then(playDailyIntroIfArmed));
+								}}>Next →</button
+							>
+						</div>
+					{:else if isClimb}
+						<!-- 💥 Busted — lost the buy-in -->
+						<div class="result-medal">💥</div>
+						<h2>Busted</h2>
+						<p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
+						<p class="arcade-gain">
+							You lost your ${(climb?.buy_in ?? 0).toLocaleString()} buy-in. The Daily always refills
+							your Cash — come back for another run.
+						</p>
+						<div class="result-actions">
+							<button
+								class="share-btn"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+								}}>Leave</button
+							>
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									handleMenuClimb();
+								}}>New Run</button
+							>
+						</div>
+					{:else if isBlitz && blitzResult}
+						<!-- ⚡ Blitz: time's up -->
+						{@const br = blitzResult}
+						<h2 class="win-h">⚡ Time!</h2>
+						<p class="result-sub">
+							{br.solved ?? 0} solved · best combo ×{((br.best_combo ?? 100) / 100).toFixed(2)}
+						</p>
+						<div class="win-math">
+							<div class="wm-row">
+								<span>Winnings</span><b>${(br.winnings ?? 0).toLocaleString()}</b>
+							</div>
+							<div class="wm-row">
+								<span>− Buy-in</span><b class="neg">−${(br.buy_in ?? 0).toLocaleString()}</b>
+							</div>
+							<div class="wm-row total">
+								<span>Net</span><b class="profit"
+									>{(br.net ?? 0) >= 0 ? '+' : '−'}${Math.abs(br.net ?? 0).toLocaleString()}</b
+								>
+							</div>
+						</div>
+						<p class="win-twist">
+							{(br.net ?? 0) >= 0
+								? '🔥 You beat the clock — banked to your Cash.'
+								: 'Whiffed the bet — the Daily always refills your Cash.'}
+						</p>
+						<div class="result-actions">
+							<button
+								class="share-btn"
+								on:click={() => {
+									blitzResult = null;
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+								}}>Done</button
+							>
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									blitzResult = null;
+									showResultModal = false;
+									hasTriggeredModal = false;
+									handleMenuBlitz();
+								}}>New Run</button
+							>
+						</div>
+					{:else if isMatch}
+						<!-- Challenge match: finished the whole pack -->
+						<div class="result-medal">⚔️</div>
+						<h2>Challenge complete!</h2>
+						<p class="result-sub">
+							{#if matchInfo?.mode === 'blitz'}You scored {(
+									matchInfo?.total_score ?? 0
+								).toLocaleString()} across {matchInfo?.pack_size} puzzle{matchInfo?.pack_size === 1
+									? ''
+									: 's'}{:else}You solved {matchInfo?.solved ?? 0}/{matchInfo?.pack_size} spending ${(
+									matchInfo?.spent ?? 0
+								).toLocaleString()}{/if}
+						</p>
+						<p class="arcade-gain">
+							{matchInfo?.status === 'settled'
+								? 'Settled — check the results.'
+								: "Most Cash left wins — we'll settle once everyone plays."}
+						</p>
+						<div class="result-actions">
+							{#if matchInfo?.status === 'settled'}
+								<button
+									class="share-btn"
+									on:click={async () => {
+										const id = matchInfo?.id;
+										showResultModal = false;
+										hasTriggeredModal = false;
+										goToMainMenu();
+										matchResults = { loading: true };
+										matchResults = await getMatchDetail(id);
+									}}>View Results</button
+								>
+							{:else}
+								<button
+									class="share-btn"
+									on:click={() => {
+										showResultModal = false;
+										hasTriggeredModal = false;
+										goToMainMenu();
+										newChallenge();
+									}}>Challenge Friends</button
+								>
+							{/if}
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+								}}>Menu</button
+							>
+						</div>
+					{:else if isMakeup}
+						<!-- Make-up daily result (calendar fill; no streak/Bank) -->
+						{#if resultWon}
+							<div class="result-medal">🗓️</div>
+							<h2>Made it up!</h2>
+							<p class="result-sub">
+								{makeupLabel} is on your calendar · {$gameStore.currentPhrase}
+							</p>
+							<p class="arcade-gain">Counts toward 🗓️ Perfect Week / 📅 Perfect Month.</p>
+						{:else}
+							<div class="result-medal">💸</div>
+							<h2>Out of Cash</h2>
+							<p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
+						{/if}
+						<div class="result-actions">
+							<button
+								class="share-btn"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+									goto('/streak');
+								}}>Calendar</button
+							>
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+								}}>Menu</button
+							>
+						</div>
+					{:else if isChallenge}
+						<!-- Challenge result (settles when the friend plays) -->
+						<div class="result-medal">{resultWon ? (isPressure ? '⏱️' : '⚔️') : '⌛'}</div>
+						<h2>{resultWon ? 'Challenge played!' : "Time's up!"}</h2>
+						{#if resultWon}
+							<p class="result-sub">
+								You scored ${chScore.toLocaleString()} · {$gameStore.currentPhrase}
+							</p>
+							{#if isPressure}<p class="arcade-earn">
+									Bankroll ${resultBankroll.toLocaleString()} + speed bonus
+								</p>{/if}
+						{:else}
+							<p class="result-sub">Ran out of time — scored $0 · {$gameStore.currentPhrase}</p>
+						{/if}
+						<p class="arcade-gain">We'll settle the pot once your friend plays.</p>
+						<div class="result-actions">
+							<button
+								class="share-btn"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+									newChallenge();
+								}}>Challenge Friends</button
+							>
+							<button
+								class="next-puzzle-button"
+								on:click={() => {
+									showResultModal = false;
+									hasTriggeredModal = false;
+									goToMainMenu();
+								}}>Menu</button
+							>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	{/if}
 </main>
 
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap');
+	@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+	@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap');
 
-  .attendance-toast {
-    position: fixed; top: 14px; left: 50%; transform: translateX(-50%);
-    z-index: 2000; padding: 0.6rem 1.1rem; border-radius: 999px; cursor: pointer;
-    font-family: var(--font-ui); font-size: 0.85rem; color: #3a2a00;
-    background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047));
-    border: none; box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36,0.4));
-    animation: attDrop 0.4s var(--ease-spring, ease) both;
-  }
-  .attendance-toast strong { font-family: var(--font-display); }
-  /* 🎰 Pure-solve ×1.5 multiplier fly-in */
-  @keyframes attDrop { from { transform: translate(-50%, -60px); opacity: 0; } to { transform: translate(-50%, 0); opacity: 1; } }
-  @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
+	.attendance-toast {
+		position: fixed;
+		top: 14px;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 2000;
+		padding: 0.6rem 1.1rem;
+		border-radius: 999px;
+		cursor: pointer;
+		font-family: var(--font-ui);
+		font-size: 0.85rem;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		border: none;
+		box-shadow: var(--glow-brand, 0 8px 24px rgba(251, 191, 36, 0.4));
+		animation: attDrop 0.4s var(--ease-spring, ease) both;
+	}
+	.attendance-toast strong {
+		font-family: var(--font-display);
+	}
+	/* 🎰 Pure-solve ×1.5 multiplier fly-in */
+	@keyframes attDrop {
+		from {
+			transform: translate(-50%, -60px);
+			opacity: 0;
+		}
+		to {
+			transform: translate(-50%, 0);
+			opacity: 1;
+		}
+	}
+	@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
+	@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
 
-  main {
-    max-width: 600px;
-    margin: 0 auto;
-    text-align: center;
-    font-family: var(--font-ui);
-    padding: 16px 12px calc(env(safe-area-inset-bottom, 0px) + 244px); /* space so content stays above fixed Solve + keyboard */
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    /* "safe center": center when content fits, but top-align when it's taller than the
+	main {
+		max-width: 600px;
+		margin: 0 auto;
+		text-align: center;
+		font-family: var(--font-ui);
+		padding: 16px 12px calc(env(safe-area-inset-bottom, 0px) + 244px); /* space so content stays above fixed Solve + keyboard */
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		/* "safe center": center when content fits, but top-align when it's taller than the
        viewport (e.g. the menu) so the page doesn't load pre-scrolled and jump on nav. */
-    justify-content: safe center;
-  }
+		justify-content: safe center;
+	}
 
-  .pressure-hud {
-    display: flex; flex-direction: column; align-items: center; gap: 2px;
-    width: 100%; max-width: 360px; margin: 0 auto 14px; padding: 0.5rem 1rem;
-    border: 1px solid rgba(251,191,36,0.4); border-radius: 14px;
-    background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.03));
-  }
-  .pressure-hud .ph-clock { font-family: var(--font-display); font-weight: 800; font-size: 1.5rem; color: #fbbf24; line-height: 1; font-variant-numeric: tabular-nums; }
-  .pressure-hud .ph-label { font-size: 0.72rem; color: var(--text-muted); }
-  .pressure-hud.danger { border-color: rgba(248,113,113,0.6); background: linear-gradient(135deg, rgba(248,113,113,0.16), rgba(248,113,113,0.04)); animation: pressurePulse 1s ease-in-out infinite; }
-  .pressure-hud.danger .ph-clock { color: #f87171; }
-  @keyframes pressurePulse { 0%,100% { box-shadow: 0 0 0 rgba(248,113,113,0); } 50% { box-shadow: 0 0 16px rgba(248,113,113,0.35); } }
-  .makeup-banner {
-    display: flex; align-items: center; gap: 8px; justify-content: center;
-    width: 100%; max-width: 360px; margin: 0 auto 12px; padding: 0.5rem 0.9rem;
-    border: 1px solid rgba(56,189,248,0.4); border-radius: 12px;
-    background: linear-gradient(135deg, rgba(56,189,248,0.12), rgba(56,189,248,0.03));
-  }
-  .makeup-banner .mb-tag { font-family: var(--font-display); font-weight: 800; font-size: 0.8rem; color: #38bdf8; white-space: nowrap; }
-  .makeup-banner .mb-text { font-size: 0.74rem; color: var(--text-muted); }
-  /* Cash Game (Climb) HUD */
-  .climb-hud { display: flex; gap: 8px; width: 100%; max-width: 360px; margin: 0 auto 12px; }
-  .match-pos { text-align: center; font-family: var(--font-display); font-weight: 700; font-size: 0.8rem; color: var(--text-muted); margin: 0 0 8px; }
-  .ch-cell {
-    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px; padding: 10px 6px;
-    background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md, 12px);
-  }
-  .ch-cell.hot { border-color: rgba(251,191,36,0.5); background: linear-gradient(135deg, rgba(251,191,36,0.14), rgba(251,191,36,0.04)); }
-  .ch-val { font-family: var(--font-display); font-weight: 700; font-size: 1.15rem; color: var(--text); font-variant-numeric: tabular-nums; }
-  .ch-cell.hot .ch-val { color: #fbbf24; }
-  .ch-gold { color: #fcd34d; }
-  .ch-label { font-size: 0.55rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-faint); font-weight: 600; }
-  .cp-hint { font-size: 0.66rem; color: var(--text-faint); text-align: center; margin: 0 0 5px; }
-  .climb-pups { display: flex; gap: 6px; width: 100%; max-width: 360px; margin: 0 auto 12px; justify-content: space-between; }
-  .cp {
-    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; padding: 7px 2px;
-    border-radius: 10px; cursor: pointer; border: 1px solid var(--border); background: var(--surface);
-    transition: transform 0.1s, border-color 0.15s;
-  }
-  .cp:hover:not(:disabled) { transform: translateY(-1px); border-color: rgba(251,191,36,0.5); }
-  .cp:disabled { opacity: 0.4; cursor: default; }
-  .cp.equipped { border-color: var(--brand-2); background: rgba(253, 224, 71,0.12); opacity: 1; }
-  .cp.equipped .cp-tag { color: var(--brand-2); }
-  .cp.empty { opacity: 0.35; }
-  .debuff-banner {
-    display: block; text-align: center; font-size: 0.76rem; font-weight: 700; color: #fb7185; margin: 0 auto 8px;
-    max-width: 340px; padding: 5px 10px; border-radius: 999px; cursor: pointer;
-    background: rgba(251,113,133,0.1); border: 1px solid rgba(251,113,133,0.3);
-  }
-  .debuff-banner:active { transform: scale(0.97); }
-  .db-info { opacity: 0.7; font-size: 0.7rem; }
-  .debuff-row { align-items: flex-start; }
-  .db-desc { display: block; font-size: 0.72rem; font-weight: 500; color: var(--text-muted); margin-top: 2px; }
-  /* 😈 Sabotage target picker (in the bag flow) */
-  .sab-target-list { display: flex; flex-direction: column; gap: 8px; margin: 4px 0 12px; }
-  .sab-target-row {
-    display: flex; justify-content: space-between; align-items: center; gap: 10px;
-    padding: 11px 14px; border-radius: 12px; cursor: pointer;
-    background: rgba(244,114,182,0.1); border: 1px solid rgba(244,114,182,0.4); color: var(--text);
-  }
-  .sab-target-row:active { transform: scale(0.98); }
-  .st-name { font-weight: 800; font-size: 0.95rem; }
-  .st-stat { font-size: 0.82rem; color: #f9a8d4; font-variant-numeric: tabular-nums; white-space: nowrap; }
-  .cp-ic { font-size: 1.1rem; line-height: 1; }
-  .cp-tag { font-size: 0.6rem; font-weight: 700; color: var(--text-faint); }
-  .climb-stuck {
-    display: flex; flex-direction: column; gap: 8px; width: 100%; max-width: 360px; margin: 0 auto 12px; padding: 0.8rem;
-    border: 1px solid rgba(248,113,113,0.45); border-radius: 14px; background: rgba(248,113,113,0.08); text-align: center;
-  }
-  .cs-text { font-size: 0.82rem; color: #fca5a5; }
-  .cs-actions { display: flex; gap: 8px; justify-content: center; }
-  .cs-leave { padding: 0.5rem 1rem; border: 1px solid var(--border); border-radius: 10px; cursor: pointer; font-weight: 700; color: var(--text-muted); background: transparent; }
-  /* 🏦 Cash Out button (during a run) */
-  .cashout-btn {
-    display: flex; align-items: center; justify-content: center; gap: 8px; width: 100%; max-width: 360px;
-    margin: 0 auto 12px; padding: 0.7rem 1rem; border-radius: 14px; cursor: pointer;
-    border: 1px solid rgba(110,231,183,0.5); background: linear-gradient(135deg, rgba(110,231,183,0.14), rgba(52,211,153,0.05));
-    color: #6ee7b7; font-family: var(--font-display); font-weight: 800; font-size: 1rem;
-  }
-  .cashout-btn.up { border-color: rgba(110,231,183,0.8); box-shadow: 0 0 16px rgba(52,211,153,0.25); }
-  .cashout-btn:disabled { opacity: 0.45; cursor: default; }
-  .cashout-btn b { color: #d1fae5; }
-  .co-profit { font-size: 0.85rem; color: #34d399; font-weight: 700; }
-  .co-profit.neg { color: #fb7185; }
-  .co-inline { background: linear-gradient(135deg, #6ee7b7, #34d399) !important; color: #06281d !important; }
-  /* 🎰 Cash Game tier select */
-  .tier-modal { max-width: 460px; }
-  .tier-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 4px 0 12px; }
-  .tier-tile {
-    display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 14px 10px; border-radius: 16px;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer;
-    transition: transform 0.15s, border-color 0.2s;
-  }
-  .tier-tile:hover:not(:disabled) { transform: translateY(-2px); border-color: var(--brand-2); }
-  .tier-tile:disabled { opacity: 0.5; cursor: default; }
-  .tier-tile.locked { border-style: dashed; }
-  .tt-label { font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; }
-  .tt-buyin { font-family: 'Orbitron', var(--font-display); font-weight: 800; color: var(--brand-2); font-size: 1.1rem; }
-  .tt-buyin small { font-family: var(--font-ui); font-weight: 500; font-size: 0.62rem; color: var(--text-faint); }
-  .tt-meta { font-size: 0.66rem; color: var(--text-faint); }
-  .tt-lock { font-size: 0.66rem; color: #fca5a5; margin-top: 2px; }
-  .tier-stats { text-align: center; font-size: 0.78rem; color: var(--text-muted); margin: 0; }
-  .tier-stats b { color: var(--brand-2); }
-  .tier-grid-3 { grid-template-columns: repeat(3, 1fr); }
-  /* ⚡ Blitz HUD */
-  .blitz-hud { display: flex; flex-direction: column; align-items: center; gap: 6px; width: 100%; max-width: 360px; margin: 0 auto 12px; }
-  .bz-clock { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.6rem; line-height: 1; color: #fde047; font-variant-numeric: tabular-nums; }
-  .bz-clock-s { font-size: 1.1rem; color: var(--text-faint); margin-left: 2px; }
-  .bz-clock.danger { color: #fb7185; animation: pressurePulse 1s ease-in-out infinite; }
-  .bz-row { display: flex; gap: 10px; }
-  .bz-stat { display: flex; flex-direction: column; align-items: center; gap: 0; padding: 5px 14px; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); }
-  .bz-stat b { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--text); }
-  .bz-stat small { font-size: 0.58rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-faint); }
-  .bz-combo { color: #fbbf24 !important; }
-  .bz-win { color: #6ee7b7 !important; }
-  .bz-skip { padding: 0.4rem 0.9rem; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--text-muted); font-weight: 700; font-size: 0.74rem; cursor: pointer; }
-  .bz-skip:hover { border-color: #fb7185; color: #fca5a5; }
-  .arcade-gain { font-family: var(--font-display); font-weight: 700; color: var(--brand-2); margin: -8px 0 14px; font-size: 1rem; }
-  .arcade-earn {
-    font-family: var(--font-display); font-weight: 700; font-size: 0.95rem;
-    color: #fcd34d; margin: 10px auto 0; padding: 7px 14px;
-    background: rgba(251, 191, 36, 0.12); border: 1px solid rgba(251, 191, 36, 0.4);
-    border-radius: 999px; display: inline-block;
-  }
-  .arcade-earn { font-family: var(--font-display); font-weight: 700; color: #fcd34d; margin: -6px 0 14px; font-size: 0.95rem; text-shadow: 0 0 14px rgba(251, 191, 36, 0.35); }
+	.pressure-hud {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 14px;
+		padding: 0.5rem 1rem;
+		border: 1px solid rgba(251, 191, 36, 0.4);
+		border-radius: 14px;
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.03));
+	}
+	.pressure-hud .ph-clock {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.5rem;
+		color: #fbbf24;
+		line-height: 1;
+		font-variant-numeric: tabular-nums;
+	}
+	.pressure-hud .ph-label {
+		font-size: 0.72rem;
+		color: var(--text-muted);
+	}
+	.pressure-hud.danger {
+		border-color: rgba(248, 113, 113, 0.6);
+		background: linear-gradient(135deg, rgba(248, 113, 113, 0.16), rgba(248, 113, 113, 0.04));
+		animation: pressurePulse 1s ease-in-out infinite;
+	}
+	.pressure-hud.danger .ph-clock {
+		color: #f87171;
+	}
+	@keyframes pressurePulse {
+		0%,
+		100% {
+			box-shadow: 0 0 0 rgba(248, 113, 113, 0);
+		}
+		50% {
+			box-shadow: 0 0 16px rgba(248, 113, 113, 0.35);
+		}
+	}
+	.makeup-banner {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		justify-content: center;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 12px;
+		padding: 0.5rem 0.9rem;
+		border: 1px solid rgba(56, 189, 248, 0.4);
+		border-radius: 12px;
+		background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(56, 189, 248, 0.03));
+	}
+	.makeup-banner .mb-tag {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.8rem;
+		color: #38bdf8;
+		white-space: nowrap;
+	}
+	.makeup-banner .mb-text {
+		font-size: 0.74rem;
+		color: var(--text-muted);
+	}
+	/* Cash Game (Climb) HUD */
+	.climb-hud {
+		display: flex;
+		gap: 8px;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 12px;
+	}
+	.match-pos {
+		text-align: center;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		margin: 0 0 8px;
+	}
+	.ch-cell {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		padding: 10px 6px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--r-md, 12px);
+	}
+	.ch-cell.hot {
+		border-color: rgba(251, 191, 36, 0.5);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.04));
+	}
+	.ch-val {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.15rem;
+		color: var(--text);
+		font-variant-numeric: tabular-nums;
+	}
+	.ch-cell.hot .ch-val {
+		color: #fbbf24;
+	}
+	.ch-gold {
+		color: #fcd34d;
+	}
+	.ch-label {
+		font-size: 0.55rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+		font-weight: 600;
+	}
+	.cp-hint {
+		font-size: 0.66rem;
+		color: var(--text-faint);
+		text-align: center;
+		margin: 0 0 5px;
+	}
+	.climb-pups {
+		display: flex;
+		gap: 6px;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 12px;
+		justify-content: space-between;
+	}
+	.cp {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1px;
+		padding: 7px 2px;
+		border-radius: 10px;
+		cursor: pointer;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		transition:
+			transform 0.1s,
+			border-color 0.15s;
+	}
+	.cp:hover:not(:disabled) {
+		transform: translateY(-1px);
+		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.cp:disabled {
+		opacity: 0.4;
+		cursor: default;
+	}
+	.cp.equipped {
+		border-color: var(--brand-2);
+		background: rgba(253, 224, 71, 0.12);
+		opacity: 1;
+	}
+	.cp.equipped .cp-tag {
+		color: var(--brand-2);
+	}
+	.cp.empty {
+		opacity: 0.35;
+	}
+	.debuff-banner {
+		display: block;
+		text-align: center;
+		font-size: 0.76rem;
+		font-weight: 700;
+		color: #fb7185;
+		margin: 0 auto 8px;
+		max-width: 340px;
+		padding: 5px 10px;
+		border-radius: 999px;
+		cursor: pointer;
+		background: rgba(251, 113, 133, 0.1);
+		border: 1px solid rgba(251, 113, 133, 0.3);
+	}
+	.debuff-banner:active {
+		transform: scale(0.97);
+	}
+	.db-info {
+		opacity: 0.7;
+		font-size: 0.7rem;
+	}
+	.debuff-row {
+		align-items: flex-start;
+	}
+	.db-desc {
+		display: block;
+		font-size: 0.72rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		margin-top: 2px;
+	}
+	/* 😈 Sabotage target picker (in the bag flow) */
+	.sab-target-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin: 4px 0 12px;
+	}
+	.sab-target-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+		padding: 11px 14px;
+		border-radius: 12px;
+		cursor: pointer;
+		background: rgba(244, 114, 182, 0.1);
+		border: 1px solid rgba(244, 114, 182, 0.4);
+		color: var(--text);
+	}
+	.sab-target-row:active {
+		transform: scale(0.98);
+	}
+	.st-name {
+		font-weight: 800;
+		font-size: 0.95rem;
+	}
+	.st-stat {
+		font-size: 0.82rem;
+		color: #f9a8d4;
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+	.cp-ic {
+		font-size: 1.1rem;
+		line-height: 1;
+	}
+	.cp-tag {
+		font-size: 0.6rem;
+		font-weight: 700;
+		color: var(--text-faint);
+	}
+	.climb-stuck {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 12px;
+		padding: 0.8rem;
+		border: 1px solid rgba(248, 113, 113, 0.45);
+		border-radius: 14px;
+		background: rgba(248, 113, 113, 0.08);
+		text-align: center;
+	}
+	.cs-text {
+		font-size: 0.82rem;
+		color: #fca5a5;
+	}
+	.cs-actions {
+		display: flex;
+		gap: 8px;
+		justify-content: center;
+	}
+	.cs-leave {
+		padding: 0.5rem 1rem;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		cursor: pointer;
+		font-weight: 700;
+		color: var(--text-muted);
+		background: transparent;
+	}
+	/* 🏦 Cash Out button (during a run) */
+	.cashout-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 12px;
+		padding: 0.7rem 1rem;
+		border-radius: 14px;
+		cursor: pointer;
+		border: 1px solid rgba(110, 231, 183, 0.5);
+		background: linear-gradient(135deg, rgba(110, 231, 183, 0.14), rgba(52, 211, 153, 0.05));
+		color: #6ee7b7;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1rem;
+	}
+	.cashout-btn.up {
+		border-color: rgba(110, 231, 183, 0.8);
+		box-shadow: 0 0 16px rgba(52, 211, 153, 0.25);
+	}
+	.cashout-btn:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.cashout-btn b {
+		color: #d1fae5;
+	}
+	.co-profit {
+		font-size: 0.85rem;
+		color: #34d399;
+		font-weight: 700;
+	}
+	.co-profit.neg {
+		color: #fb7185;
+	}
+	.co-inline {
+		background: linear-gradient(135deg, #6ee7b7, #34d399) !important;
+		color: #06281d !important;
+	}
+	/* 🎰 Cash Game tier select */
+	.tier-modal {
+		max-width: 460px;
+	}
+	.tier-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 10px;
+		margin: 4px 0 12px;
+	}
+	.tier-tile {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 3px;
+		padding: 14px 10px;
+		border-radius: 16px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		cursor: pointer;
+		transition:
+			transform 0.15s,
+			border-color 0.2s;
+	}
+	.tier-tile:hover:not(:disabled) {
+		transform: translateY(-2px);
+		border-color: var(--brand-2);
+	}
+	.tier-tile:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.tier-tile.locked {
+		border-style: dashed;
+	}
+	.tt-label {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+	}
+	.tt-buyin {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		color: var(--brand-2);
+		font-size: 1.1rem;
+	}
+	.tt-buyin small {
+		font-family: var(--font-ui);
+		font-weight: 500;
+		font-size: 0.62rem;
+		color: var(--text-faint);
+	}
+	.tt-meta {
+		font-size: 0.66rem;
+		color: var(--text-faint);
+	}
+	.tt-lock {
+		font-size: 0.66rem;
+		color: #fca5a5;
+		margin-top: 2px;
+	}
+	.tier-stats {
+		text-align: center;
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		margin: 0;
+	}
+	.tier-stats b {
+		color: var(--brand-2);
+	}
+	.tier-grid-3 {
+		grid-template-columns: repeat(3, 1fr);
+	}
+	/* ⚡ Blitz HUD */
+	.blitz-hud {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 6px;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 12px;
+	}
+	.bz-clock {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2.6rem;
+		line-height: 1;
+		color: #fde047;
+		font-variant-numeric: tabular-nums;
+	}
+	.bz-clock-s {
+		font-size: 1.1rem;
+		color: var(--text-faint);
+		margin-left: 2px;
+	}
+	.bz-clock.danger {
+		color: #fb7185;
+		animation: pressurePulse 1s ease-in-out infinite;
+	}
+	.bz-row {
+		display: flex;
+		gap: 10px;
+	}
+	.bz-stat {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0;
+		padding: 5px 14px;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.bz-stat b {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		color: var(--text);
+	}
+	.bz-stat small {
+		font-size: 0.58rem;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
+	.bz-combo {
+		color: #fbbf24 !important;
+	}
+	.bz-win {
+		color: #6ee7b7 !important;
+	}
+	.bz-skip {
+		padding: 0.4rem 0.9rem;
+		border-radius: 999px;
+		border: 1px solid var(--border);
+		background: transparent;
+		color: var(--text-muted);
+		font-weight: 700;
+		font-size: 0.74rem;
+		cursor: pointer;
+	}
+	.bz-skip:hover {
+		border-color: #fb7185;
+		color: #fca5a5;
+	}
+	.arcade-gain {
+		font-family: var(--font-display);
+		font-weight: 700;
+		color: var(--brand-2);
+		margin: -8px 0 14px;
+		font-size: 1rem;
+	}
+	.arcade-earn {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+		color: #fcd34d;
+		margin: 10px auto 0;
+		padding: 7px 14px;
+		background: rgba(251, 191, 36, 0.12);
+		border: 1px solid rgba(251, 191, 36, 0.4);
+		border-radius: 999px;
+		display: inline-block;
+	}
+	.arcade-earn {
+		font-family: var(--font-display);
+		font-weight: 700;
+		color: #fcd34d;
+		margin: -6px 0 14px;
+		font-size: 0.95rem;
+		text-shadow: 0 0 14px rgba(251, 191, 36, 0.35);
+	}
 
-  .puzzle-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    justify-content: center;
-    margin: 0 0 12px;
-  }
-  .category-chip {
-    font-family: var(--font-display);
-    font-weight: 600;
-    font-size: 0.8rem;
-    color: var(--brand-2);
-    background: rgba(253, 224, 71, 0.10);
-    border: 1px solid rgba(253, 224, 71, 0.28);
-    padding: 6px 13px;
-    border-radius: var(--r-pill);
-  }
-  /* 🎁 today's auto-applied Twist chip (tap to see what it does) */
-  .twist-chip { display: inline-grid; place-items: center; width: 32px; height: 32px; border-radius: 999px; cursor: pointer;
-    border: 1px solid rgba(253,224,71,0.55); background: rgba(251,191,36,0.16); font-size: 1.1rem; line-height: 1;
-    box-shadow: 0 0 10px rgba(251,191,36,0.25); }
-  .twist-chip:active { transform: scale(0.92); }
-  /* ⓘ re-open the "How to win" card */
-  .fold-bar { display: flex; align-items: center; justify-content: center; gap: 10px; flex-wrap: wrap; margin: 6px auto 2px; }
-  .fold-bar.broke {
-    padding: 8px 14px; border-radius: 12px; max-width: 340px;
-    background: rgba(248,113,113,0.12); border: 1px solid rgba(248,113,113,0.5);
-    animation: pressurePulse 1s ease-in-out infinite;
-  }
-  .fold-timer { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.25rem; color: #f87171; }
-  .fold-warn { font-size: 0.76rem; color: #fca5a5; flex: 1 1 140px; text-align: left; }
-  .puzzle-clue {
-    max-width: 340px;
-    margin: 8px auto 12px;
-    font-family: var(--font-ui);
-    font-size: 0.98rem;
-    font-style: italic;
-    line-height: 1.4;
-    color: var(--text);
-    text-wrap: balance;
-  }
+	.puzzle-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		justify-content: center;
+		margin: 0 0 12px;
+	}
+	.category-chip {
+		font-family: var(--font-display);
+		font-weight: 600;
+		font-size: 0.8rem;
+		color: var(--brand-2);
+		background: rgba(253, 224, 71, 0.1);
+		border: 1px solid rgba(253, 224, 71, 0.28);
+		padding: 6px 13px;
+		border-radius: var(--r-pill);
+	}
+	/* 🎁 today's auto-applied Twist chip (tap to see what it does) */
+	.twist-chip {
+		display: inline-grid;
+		place-items: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 999px;
+		cursor: pointer;
+		border: 1px solid rgba(253, 224, 71, 0.55);
+		background: rgba(251, 191, 36, 0.16);
+		font-size: 1.1rem;
+		line-height: 1;
+		box-shadow: 0 0 10px rgba(251, 191, 36, 0.25);
+	}
+	.twist-chip:active {
+		transform: scale(0.92);
+	}
+	/* ⓘ re-open the "How to win" card */
+	.fold-bar {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		flex-wrap: wrap;
+		margin: 6px auto 2px;
+	}
+	.fold-bar.broke {
+		padding: 8px 14px;
+		border-radius: 12px;
+		max-width: 340px;
+		background: rgba(248, 113, 113, 0.12);
+		border: 1px solid rgba(248, 113, 113, 0.5);
+		animation: pressurePulse 1s ease-in-out infinite;
+	}
+	.fold-timer {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.25rem;
+		color: #f87171;
+	}
+	.fold-warn {
+		font-size: 0.76rem;
+		color: #fca5a5;
+		flex: 1 1 140px;
+		text-align: left;
+	}
+	.puzzle-clue {
+		max-width: 340px;
+		margin: 8px auto 12px;
+		font-family: var(--font-ui);
+		font-size: 0.98rem;
+		font-style: italic;
+		line-height: 1.4;
+		color: var(--text);
+		text-wrap: balance;
+	}
 
-  /* Today's shared modifier — a small chip next to the category */
-  .mod-chip {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 0.74rem;
-    color: #fcd34d;
-    background: rgba(251, 191, 36, 0.12);
-    border: 1px solid rgba(251, 191, 36, 0.32);
-    padding: 5px 11px;
-    border-radius: var(--r-pill, 999px);
-    white-space: nowrap;
-  }
-  .mod-chip.pure { color: #6ee7b7; background: rgba(16, 185, 129, 0.12); border-color: rgba(110, 231, 183, 0.4); }
+	/* Today's shared modifier — a small chip next to the category */
+	.mod-chip {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.74rem;
+		color: #fcd34d;
+		background: rgba(251, 191, 36, 0.12);
+		border: 1px solid rgba(251, 191, 36, 0.32);
+		padding: 5px 11px;
+		border-radius: var(--r-pill, 999px);
+		white-space: nowrap;
+	}
+	.mod-chip.pure {
+		color: #6ee7b7;
+		background: rgba(16, 185, 129, 0.12);
+		border-color: rgba(110, 231, 183, 0.4);
+	}
 
-  .phrase-section {
-    width: 100%;
-    padding: 0;
-    margin-bottom: 0;
-    padding-bottom: min(1rem, 3vw);
-    min-height: 0;
-  }
+	.phrase-section {
+		width: 100%;
+		padding: 0;
+		margin-bottom: 0;
+		padding-bottom: min(1rem, 3vw);
+		min-height: 0;
+	}
 
-  .stats-section {
-    width: 100%;
-    padding: 0;
-    margin-top: 0.6rem;
-    margin-bottom: 0.4rem;
-    flex-shrink: 0;
-  }
+	.stats-section {
+		width: 100%;
+		padding: 0;
+		margin-top: 0.6rem;
+		margin-bottom: 0.4rem;
+		flex-shrink: 0;
+	}
 
-  @media (max-width: 600px) {
-    .phrase-section {
-      padding-bottom: 0.75rem;
-    }
-    .stats-section {
-      margin-top: 0.75rem;
-    }
-  }
+	@media (max-width: 600px) {
+		.phrase-section {
+			padding-bottom: 0.75rem;
+		}
+		.stats-section {
+			margin-top: 0.75rem;
+		}
+	}
 
-  .keyboard-section,
-  .buttons-section {
-    width: 100%;
-    padding: 0;
-  }
-  /* ⚡ Power-up tray (above the keyboard) */
+	.keyboard-section,
+	.buttons-section {
+		width: 100%;
+		padding: 0;
+	}
+	/* ⚡ Power-up tray (above the keyboard) */
 
-  .diagnostic-banner {
-    background: #ffebee;
-    border: 2px solid #c62828;
-    border-radius: 8px;
-    padding: 12px 16px;
-    margin: 12px 0;
-    text-align: left;
-    font-size: 0.9rem;
-    color: #b71c1c;
-    max-width: 100%;
-  }
-  .diagnostic-banner.info {
-    background: #e3f2fd;
-    border-color: #1976d2;
-    color: #0d47a1;
-  }
-  .diagnostic-retry {
-    margin-top: 8px;
-    padding: 6px 12px;
-    background: #c62828;
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-weight: bold;
-  }
-  .diagnostic-retry:hover {
-    background: #b71c1c;
-  }
+	.diagnostic-banner {
+		background: #ffebee;
+		border: 2px solid #c62828;
+		border-radius: 8px;
+		padding: 12px 16px;
+		margin: 12px 0;
+		text-align: left;
+		font-size: 0.9rem;
+		color: #b71c1c;
+		max-width: 100%;
+	}
+	.diagnostic-banner.info {
+		background: #e3f2fd;
+		border-color: #1976d2;
+		color: #0d47a1;
+	}
+	.diagnostic-retry {
+		margin-top: 8px;
+		padding: 6px 12px;
+		background: #c62828;
+		color: white;
+		border: none;
+		border-radius: 6px;
+		cursor: pointer;
+		font-weight: bold;
+	}
+	.diagnostic-retry:hover {
+		background: #b71c1c;
+	}
 
-  .init-loading {
-    min-height: 200px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1rem;
-    color: #666;
-  }
+	.init-loading {
+		min-height: 200px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1rem;
+		color: #666;
+	}
 
-  /* Main menu (after sign-in) — premium dark */
-  .main-menu {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    padding: 2rem 1.1rem 1.2rem;
-    gap: 1.2rem;
-  }
-  .sub-head {
-    width: 100%; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 0.6rem; margin-bottom: 0.2rem;
-  }
-  .sub-head .sub-back { justify-self: start; }
-  .sub-back {
-    display: inline-flex; align-items: center; gap: 4px; padding: 0.5rem 0.9rem;
-    background: var(--surface); border: 1px solid var(--border); border-radius: 12px;
-    color: var(--text); font-weight: 700; font-size: 0.9rem; cursor: pointer;
-    transition: transform 0.15s, border-color 0.2s, background 0.2s;
-  }
-  .sub-back:hover { transform: translateX(-2px); border-color: var(--border-strong); background: var(--surface-2); }
-  .sub-title { font-family: var(--font-display); font-size: 1.15rem; font-weight: 800; text-align: center; grid-column: 2; }
-  .sub-people {
-    position: relative; justify-self: end; width: 40px; height: 40px; display: grid; place-items: center; font-size: 1.1rem;
-    background: var(--surface); border: 1px solid var(--border); border-radius: 12px; cursor: pointer;
-  }
-  .sub-people:hover { border-color: var(--brand-2); }
-  /* Community hub tabs + body */
-  .comm-tabs { display: flex; gap: 8px; width: 100%; margin: 12px 0 14px; }
-  .comm-tab { flex: 1; padding: 9px 0; border-radius: 12px; border: 1px solid var(--border); background: var(--surface);
-    color: var(--text-muted); font-family: var(--font-display); font-weight: 700; font-size: 0.86rem; cursor: pointer; }
-  .comm-tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
-  /* Unread-count badges (Activity tab + Community card) */
-  .comm-count { display: inline-grid; place-items: center; min-width: 18px; height: 18px; padding: 0 5px;
-    border-radius: 999px; background: #f43f5e; color: #fff; font-family: var(--font-display);
-    font-weight: 800; font-size: 0.68rem; margin-left: 6px; vertical-align: middle; }
-  .menu-card .mc-count { position: absolute; top: 10px; right: 12px; display: grid; place-items: center;
-    min-width: 20px; height: 20px; padding: 0 6px; border-radius: 999px; background: #f43f5e; color: #fff;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.72rem; box-shadow: 0 0 0 2px var(--bg, #0a0e14); }
-  .act-sec { font-family: var(--font-display); font-size: 0.72rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--gold); text-align: left; margin: 6px 2px 8px; }
-  .act-sec:not(:first-child) { margin-top: 20px; }
-  .comm-body { width: 100%; }
-  .comm-body.people { display: flex; flex-direction: column; gap: 0.6rem; }
-  /* Subtle "play with friends" nudge under the solo modes */
-  /* Challenge A Friend — one on-brand gold pill, split by a divider into CTA + friends */
-  .vs-cta-group { display: flex; width: 100%; margin-top: 8px;
-    border-radius: 12px; overflow: hidden;
-    box-shadow: 0 3px 10px rgba(245,158,11,0.3), inset 0 1px 0 rgba(255,255,255,0.4); }
-  .vs-main, .vs-people { border: none; cursor: pointer; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b); }
-  .vs-main { flex: 1; padding: 12px 14px 12px 72px; text-align: center; /* left pad offsets the people button so the label centers over the whole group */
-    font-family: var(--font-display); font-weight: 800; font-size: 0.94rem; letter-spacing: 0.01em; }
-  .vs-main:hover { filter: brightness(1.05); }
-  .vs-main:active { transform: scale(0.99); }
-  .vs-badge { display: inline-grid; place-items: center; min-width: 20px; height: 20px; margin-left: 7px; padding: 0 5px; vertical-align: middle;
-    border-radius: 999px; background: #dc2626; color: #fff; font-size: 0.72rem; font-weight: 800; }
-  .vs-people { position: relative; width: 58px; flex: none; display: grid; place-items: center;
-    border-left: 1.5px solid rgba(120,80,0,0.45); } /* just the vertical divider line */
-  .vs-people:hover { filter: brightness(1.06); }
-  .vs-people:active { transform: scale(0.97); }
-  .vs-ppl { font-size: 1.35rem; line-height: 1; }
-  .vs-ppl-plus { position: absolute; top: 7px; right: 9px; width: 14px; height: 14px; border-radius: 50%;
-    background: #3a2a00; color: #fde047; font-weight: 900; font-size: 0.6rem; line-height: 1; display: grid; place-items: center;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.4); }
-  .ch-new-btn {
-    width: 100%; margin-bottom: 12px; padding: 12px; border-radius: 14px; border: none; cursor: pointer;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.95rem; color: #3a2a00;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
-    box-shadow: 0 6px 18px rgba(251, 191, 36, 0.25);
-  }
-  .ch-new-btn:hover { filter: brightness(1.05); }
-  /* Short-on-Cash sheet */
-  .sm-modal { max-width: 360px; text-align: center; }
-  .sm-icon { font-size: 2.4rem; margin-bottom: 6px; }
-  .sm-modal h2 { font-family: var(--font-display); font-size: 1.2rem; margin: 0 0 14px; }
-  .sm-rows { display: flex; flex-direction: column; gap: 6px; margin: 0 0 12px; padding: 12px 14px;
-    border-radius: 14px; border: 1px solid var(--border); background: var(--surface); }
-  .sm-row { display: flex; justify-content: space-between; align-items: center; gap: 12px; font-size: 0.88rem; color: var(--text-muted); }
-  .sm-row b { font-family: var(--font-display); color: var(--text); }
-  .sm-note { font-size: 0.8rem; color: var(--text-faint); margin: 0 0 16px; }
-  .sm-play { width: 100%; padding: 13px; border: none; border-radius: 14px; cursor: pointer; margin-bottom: 8px;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.98rem; color: #3a2a00;
-    background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047)); box-shadow: 0 6px 18px rgba(251,191,36,0.25); }
-  .sm-play:disabled { opacity: 0.5; }
-  .sm-decline { width: 100%; padding: 11px; border-radius: 14px; cursor: pointer;
-    border: 1px solid rgba(251,113,133,0.4); background: transparent; color: #fb7185; font-weight: 700; font-size: 0.9rem; }
-  .sm-decline:disabled { opacity: 0.5; }
-  .menu-hero {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    width: 100%;
-  }
-  .hero-top {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    align-items: center;
-    width: 100%;
-    max-width: 360px;
-    margin-bottom: 1.4rem;
-  }
-  .hero-top .streak-chip { justify-self: start; }
-  .hero-top .bank-chip { justify-self: center; }
-  .hero-top .bell-ic { justify-self: start; }
-  .bell-ic { position: relative; width: 42px; height: 42px; border-radius: 50%; display: grid; place-items: center; cursor: pointer;
-    background: var(--surface, rgba(255,255,255,0.05)); border: 1px solid var(--border); font-size: 1.15rem;
-    transition: transform 0.15s, border-color 0.2s; }
-  .bell-ic:hover { transform: translateY(-1px); border-color: rgba(251,191,36,0.5); }
-  .bell-ic:active { transform: scale(0.94); }
-  .account-ic {
-    position: relative;
-    justify-self: end;
-    display: inline-grid; place-items: center;
-    width: 54px; height: 54px; border-radius: 50%;
-    background: var(--surface, rgba(255,255,255,0.05)); border: 1px solid var(--border);
-    cursor: pointer; font-size: 1.7rem; transition: transform 0.15s, border-color 0.2s;
-  }
-  .account-ic:hover { transform: translateY(-1px); border-color: rgba(251,191,36,0.5); }
-  .account-ic.has-av { overflow: visible; padding: 0; }
-  .account-ic.has-av :global(.wb-avatar) { width: 100%; height: 100%; border: none; border-radius: 50%; overflow: hidden; }
-  /* My Account → avatar / edit-avatar entry */
-  .ma-avatar-btn { display: flex; flex-direction: column; align-items: center; gap: 6px; margin: 6px auto 10px; background: none; border: none; cursor: pointer; }
-  .ma-avatar-btn :global(.wb-avatar) { box-shadow: 0 6px 18px rgba(0,0,0,0.4); }
-  .ma-avatar-edit { font-size: 0.82rem; font-weight: 700; color: var(--brand-2); }
-  .account-ic:active { transform: scale(0.94); }
-  /* unread notification count, off the top-right of the avatar */
-  .account-count {
-    position: absolute; top: -4px; right: -4px; display: grid; place-items: center;
-    min-width: 19px; height: 19px; padding: 0 5px; border-radius: 999px;
-    background: #f43f5e; color: #fff; font-family: var(--font-display); font-weight: 800; font-size: 0.68rem;
-    box-shadow: 0 0 0 2px var(--bg, #0a0e14);
-  }
-  .bank-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    padding: 8px 16px;
-    border-radius: 12px;
-    background: rgba(0, 0, 0, 0.38);
-    border: 1px solid rgba(251, 191, 36, 0.5);
-    color: #fde047;
-    font-family: 'Orbitron', var(--font-display);
-    font-weight: 700;
-    font-size: 1.25rem;
-    letter-spacing: 0.04em;
-    font-variant-numeric: tabular-nums;
-    text-shadow: 0 0 10px rgba(251, 191, 36, 0.65), 0 0 22px rgba(251, 191, 36, 0.35);
-    box-shadow: inset 0 0 14px rgba(251, 191, 36, 0.1);
-    cursor: pointer;
-    transition: transform 0.15s, box-shadow 0.2s;
-  }
-  .bank-chip:hover { transform: translateY(-1px); }
-  .bank-chip:active { transform: scale(0.96); }
-  .bank-chip .bc-coin { font-size: 1.1rem; text-shadow: none; }
-  .streak-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    padding: 6px 12px;
-    border-radius: 999px;
-    background: var(--surface, rgba(255,255,255,0.05));
-    border: 1px solid var(--border);
-    color: var(--text-muted);
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 0.95rem;
-    cursor: pointer;
-    transition: transform 0.15s, border-color 0.2s, box-shadow 0.2s;
-  }
-  .streak-chip:hover { transform: translateY(-1px); }
-  .streak-chip:active { transform: scale(0.96); }
-  .menu-mark {
-    width: min(46vw, 172px);
-    aspect-ratio: 1;
-    height: auto;
-    object-fit: cover;
-    border-radius: 50%;
-    margin-bottom: 4px;
-    box-shadow: 0 0 26px rgba(251, 191, 36, 0.55), 0 10px 44px rgba(251, 191, 36, 0.4);
-  }
-  /* Mario-style coin spin: flat horizontal flip (edge-on at 90°/270°) + a gentle bob */
-  .menu-mark.spin { animation: coinSpin 2.6s linear infinite; will-change: transform; backface-visibility: visible; }
-  @keyframes coinSpin {
-    0%   { transform: translateY(0)    rotateY(0deg); }
-    25%  { transform: translateY(-5px) rotateY(90deg); }
-    50%  { transform: translateY(-7px) rotateY(180deg); }
-    75%  { transform: translateY(-5px) rotateY(270deg); }
-    100% { transform: translateY(0)    rotateY(360deg); }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .menu-mark.spin { animation: none; }
-  }
-  .menu-wordmark {
-    width: min(80vw, 300px);
-    height: auto;
-    margin: 2px 0 0;
-    filter: drop-shadow(0 2px 14px rgba(0, 0, 0, 0.5));
-  }
-  .main-menu-buttons {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    width: 100%;
-    max-width: 360px;
-  }
-  /* ── Gold bullion bars ─────────────────────────────────────────────── */
-  .menu-card {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    text-align: center;
-    padding: 17px 22px;
-    border-radius: 14px;
-    /* brushed-silver chrome plate (CSS) with a beveled chrome frame + gold engraved label */
-    background: linear-gradient(180deg, #fdfefe 0%, #e7ecf1 10%, #c4cdd7 50%, #9ba7b4 78%, #c1cad4 100%);
-    border: 1px solid #8794a2;
-    color: #b8860b;
-    cursor: pointer;
-    overflow: hidden;
-    box-shadow:
-      inset 0 0 0 1.5px rgba(255, 255, 255, 0.85),   /* bright chrome inner edge */
-      inset 0 0 0 3.5px rgba(92, 106, 122, 0.28),     /* groove → recessed brushed panel */
-      inset 0 2px 2px rgba(255, 255, 255, 0.9),       /* top catch-light */
-      inset 0 -3px 6px rgba(70, 85, 100, 0.45),       /* bottom depth */
-      0 5px 12px rgba(0, 0, 0, 0.55),                 /* drop shadow */
-      0 0 16px rgba(205, 222, 240, 0.25);             /* soft glow */
-    transition: transform 0.16s var(--ease-spring), box-shadow 0.2s, filter 0.2s;
-  }
-  /* glossy chrome sheen */
-  .menu-card::before {
-    content: ''; position: absolute; inset: 0; border-radius: inherit; z-index: 0; pointer-events: none;
-    background:
-      linear-gradient(180deg, rgba(255,255,255,0.7) 0%, rgba(255,255,255,0.15) 14%, rgba(255,255,255,0) 42%, rgba(255,255,255,0.1) 100%),
-      radial-gradient(130% 60% at 50% -10%, rgba(255,255,255,0.55), rgba(255,255,255,0) 60%);
-    mix-blend-mode: screen;
-  }
-  /* moving shine streak */
-  .menu-card::after {
-    content: ''; position: absolute; top: 0; bottom: 0; left: 0; width: 55%;
-    background: linear-gradient(105deg, transparent 25%, rgba(255,255,255,0.25) 42%, rgba(255,255,255,0.95) 50%, rgba(255,255,255,0.25) 58%, transparent 75%);
-    transform: translateX(-180%) skewX(-12deg);
-    animation: barShine 5s ease-in-out infinite;
-    animation-delay: calc(var(--i, 0) * 0.45s);
-    pointer-events: none;
-  }
-  @keyframes barShine {
-    0%, 58% { transform: translateX(-180%) skewX(-12deg); }
-    78%, 100% { transform: translateX(330%) skewX(-12deg); }
-  }
-  @media (hover: hover) and (pointer: fine) {
-    .menu-card:hover:not(.disabled) {
-      transform: translateY(-2px);
-      filter: brightness(1.05);
-      box-shadow:
-        inset 0 0 0 1.5px rgba(255, 255, 255, 0.9),
-        inset 0 0 0 3.5px rgba(92, 106, 122, 0.28),
-        inset 0 -3px 6px rgba(70, 85, 100, 0.45),
-        0 7px 16px rgba(0, 0, 0, 0.55), 0 0 24px rgba(210, 225, 240, 0.4);
-    }
-  }
-  .menu-card.gold-flash:not(.disabled) { transform: translateY(1px) scale(0.99); }
-  .menu-card.gold-flash:not(.disabled),
-  .menu-card:focus-visible:not(.disabled) {
-    outline: none;
-    box-shadow:
-      inset 0 0 0 1.5px rgba(255, 255, 255, 0.85),
-      0 0 0 2px rgba(255, 240, 190, 0.9), 0 0 22px rgba(255, 220, 110, 0.7), 0 6px 14px rgba(0, 0, 0, 0.5);
-  }
-  .menu-card.primary {
-    filter: brightness(1.04);
-    box-shadow:
-      inset 0 0 0 1.5px rgba(255, 255, 255, 0.9),
-      inset 0 0 0 3.5px rgba(92, 106, 122, 0.28),
-      inset 0 2px 2px rgba(255, 255, 255, 0.9),
-      inset 0 -3px 6px rgba(70, 85, 100, 0.45),
-      0 6px 14px rgba(0, 0, 0, 0.55), 0 0 22px rgba(210, 225, 240, 0.4);
-  }
-  .menu-card.disabled { opacity: 0.5; cursor: not-allowed; }
-  .mc-title {
-    position: relative; z-index: 1;
-    font-family: var(--font-display); font-weight: 800; font-size: 1.2rem; letter-spacing: 0.02em;
-    /* embossed gold to match the reference button */
-    background: linear-gradient(180deg, #fff1a8 0%, #f6cd4d 38%, #dd9c1b 66%, #b3760b 100%);
-    -webkit-background-clip: text; background-clip: text;
-    -webkit-text-fill-color: transparent; color: transparent;
-    text-shadow: 0 1px 1px rgba(70, 44, 0, 0.45), 0 0 1px rgba(120, 80, 0, 0.4);
-  }
-  .mc-stat { position: relative; z-index: 1; font-family: var(--font-display); font-weight: 800; font-size: 0.9rem; color: #b8860b; }
-  /* notification badge — top-right corner of the bar */
-  .mc-badge {
-    position: absolute; top: -7px; right: -6px; z-index: 3;
-    min-width: 22px; height: 22px; padding: 0 6px; border-radius: 999px;
-    display: inline-grid; place-items: center;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.76rem; line-height: 1;
-    color: #fff; background: #ef4444; border: 2px solid #1a1407;
-    box-shadow: 0 0 10px rgba(239, 68, 68, 0.6);
-  }
-  .mc-badge.gift { background: transparent; border: none; box-shadow: none; font-size: 1.1rem; top: -10px; right: -8px; }
-  /* home "you've been challenged" banner */
-  /* Home act-now banner: most-urgent item + optional "+N more" chip */
-  .ab-main {
-    width: 100%; min-width: 0; display: flex; align-items: center; gap: 12px;
-    padding: 13px 16px; border-radius: 14px; cursor: pointer; text-align: left;
-    background: linear-gradient(135deg, rgba(251, 191, 36, 0.18), rgba(251, 191, 36, 0.12));
-    border: 1px solid rgba(251, 191, 36, 0.5);
-    animation: invitePulse 1.8s ease-in-out infinite;
-  }
-  @keyframes invitePulse { 0%,100% { box-shadow: 0 0 16px rgba(251, 191, 36, 0.18); } 50% { box-shadow: 0 0 30px rgba(251, 191, 36, 0.42); } }
-  .ab-icon { font-size: 1.6rem; flex: none; }
-  .ab-text { flex: 1; display: flex; flex-direction: column; gap: 1px; min-width: 0; }
-  .ab-text strong { font-family: var(--font-display); font-weight: 800; font-size: 1rem; color: var(--text);
-    overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .ab-text small { font-size: 0.78rem; color: var(--text-muted); }
-  .ab-cta { font-family: var(--font-display); font-weight: 800; color: var(--brand-2); font-size: 0.9rem; white-space: nowrap; flex: none; }
-  /* Empty state = subtle CTA, no pulse/glow */
-  /* Daily status chip on the Play Now card */
-  .daily-chip {
-    font-size: 0.68rem; font-weight: 800; padding: 3px 9px; border-radius: 999px; white-space: nowrap;
-    border: 1px solid var(--border); background: rgba(0,0,0,0.25); color: var(--text);
-  }
-  /* 📅 / 🏆 streak chips on the Daily card */
-  .mc-streak { position: absolute; top: 50%; transform: translateY(-50%); z-index: 1;
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.82rem; color: #463413;
-    text-shadow: 0 1px 0 rgba(255,255,255,0.35); }
-  .mc-streak.left { left: 13px; }
-  .mc-streak.right { right: 13px; }
-  .menu-card.done .mc-streak, .menu-card.resumable .mc-streak { color: rgba(255,255,255,0.85); text-shadow: none; }
-  /* solid fills so chips read clearly */
-  .daily-chip.won   { color: #052e16; border-color: rgba(22,163,74,0.85); background: linear-gradient(135deg, #4ade80, #16a34a); box-shadow: 0 1px 6px rgba(22,163,74,0.5); }
-  .daily-chip.lost  { color: #fff; border-color: rgba(225,80,100,0.85); background: linear-gradient(135deg, #fb7185, #e11d48); box-shadow: 0 1px 6px rgba(225,29,72,0.45); text-shadow: 0 1px 1px rgba(0,0,0,0.25); }
-  .daily-chip.prog  { color: #fff; border-color: rgba(5,150,105,0.85); background: linear-gradient(135deg, #34d399, #059669); box-shadow: 0 1px 6px rgba(5,150,105,0.5); text-shadow: 0 1px 1px rgba(0,0,0,0.25); }
+	/* Main menu (after sign-in) — premium dark */
+	.main-menu {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: 2rem 1.1rem 1.2rem;
+		gap: 1.2rem;
+	}
+	.sub-head {
+		width: 100%;
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
+		align-items: center;
+		gap: 0.6rem;
+		margin-bottom: 0.2rem;
+	}
+	.sub-head .sub-back {
+		justify-self: start;
+	}
+	.sub-back {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 0.5rem 0.9rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		color: var(--text);
+		font-weight: 700;
+		font-size: 0.9rem;
+		cursor: pointer;
+		transition:
+			transform 0.15s,
+			border-color 0.2s,
+			background 0.2s;
+	}
+	.sub-back:hover {
+		transform: translateX(-2px);
+		border-color: var(--border-strong);
+		background: var(--surface-2);
+	}
+	.sub-title {
+		font-family: var(--font-display);
+		font-size: 1.15rem;
+		font-weight: 800;
+		text-align: center;
+		grid-column: 2;
+	}
+	.sub-people {
+		position: relative;
+		justify-self: end;
+		width: 40px;
+		height: 40px;
+		display: grid;
+		place-items: center;
+		font-size: 1.1rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+	}
+	.sub-people:hover {
+		border-color: var(--brand-2);
+	}
+	/* Community hub tabs + body */
+	.comm-tabs {
+		display: flex;
+		gap: 8px;
+		width: 100%;
+		margin: 12px 0 14px;
+	}
+	.comm-tab {
+		flex: 1;
+		padding: 9px 0;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text-muted);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.86rem;
+		cursor: pointer;
+	}
+	.comm-tab.active {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		border-color: transparent;
+	}
+	/* Unread-count badges (Activity tab + Community card) */
+	.comm-count {
+		display: inline-grid;
+		place-items: center;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 5px;
+		border-radius: 999px;
+		background: #f43f5e;
+		color: #fff;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.68rem;
+		margin-left: 6px;
+		vertical-align: middle;
+	}
+	.menu-card .mc-count {
+		position: absolute;
+		top: 10px;
+		right: 12px;
+		display: grid;
+		place-items: center;
+		min-width: 20px;
+		height: 20px;
+		padding: 0 6px;
+		border-radius: 999px;
+		background: #f43f5e;
+		color: #fff;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.72rem;
+		box-shadow: 0 0 0 2px var(--bg, #0a0e14);
+	}
+	.act-sec {
+		font-family: var(--font-display);
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--gold);
+		text-align: left;
+		margin: 6px 2px 8px;
+	}
+	.act-sec:not(:first-child) {
+		margin-top: 20px;
+	}
+	.comm-body {
+		width: 100%;
+	}
+	.comm-body.people {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	/* Subtle "play with friends" nudge under the solo modes */
+	/* Challenge A Friend — one on-brand gold pill, split by a divider into CTA + friends */
+	.vs-cta-group {
+		display: flex;
+		width: 100%;
+		margin-top: 8px;
+		border-radius: 12px;
+		overflow: hidden;
+		box-shadow:
+			0 3px 10px rgba(245, 158, 11, 0.3),
+			inset 0 1px 0 rgba(255, 255, 255, 0.4);
+	}
+	.vs-main,
+	.vs-people {
+		border: none;
+		cursor: pointer;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.vs-main {
+		flex: 1;
+		padding: 12px 14px 12px 72px;
+		text-align: center; /* left pad offsets the people button so the label centers over the whole group */
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.94rem;
+		letter-spacing: 0.01em;
+	}
+	.vs-main:hover {
+		filter: brightness(1.05);
+	}
+	.vs-main:active {
+		transform: scale(0.99);
+	}
+	.vs-badge {
+		display: inline-grid;
+		place-items: center;
+		min-width: 20px;
+		height: 20px;
+		margin-left: 7px;
+		padding: 0 5px;
+		vertical-align: middle;
+		border-radius: 999px;
+		background: #dc2626;
+		color: #fff;
+		font-size: 0.72rem;
+		font-weight: 800;
+	}
+	.vs-people {
+		position: relative;
+		width: 58px;
+		flex: none;
+		display: grid;
+		place-items: center;
+		border-left: 1.5px solid rgba(120, 80, 0, 0.45);
+	} /* just the vertical divider line */
+	.vs-people:hover {
+		filter: brightness(1.06);
+	}
+	.vs-people:active {
+		transform: scale(0.97);
+	}
+	.vs-ppl {
+		font-size: 1.35rem;
+		line-height: 1;
+	}
+	.vs-ppl-plus {
+		position: absolute;
+		top: 7px;
+		right: 9px;
+		width: 14px;
+		height: 14px;
+		border-radius: 50%;
+		background: #3a2a00;
+		color: #fde047;
+		font-weight: 900;
+		font-size: 0.6rem;
+		line-height: 1;
+		display: grid;
+		place-items: center;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+	}
+	.ch-new-btn {
+		width: 100%;
+		margin-bottom: 12px;
+		padding: 12px;
+		border-radius: 14px;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.95rem;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		box-shadow: 0 6px 18px rgba(251, 191, 36, 0.25);
+	}
+	.ch-new-btn:hover {
+		filter: brightness(1.05);
+	}
+	/* Short-on-Cash sheet */
+	.sm-modal {
+		max-width: 360px;
+		text-align: center;
+	}
+	.sm-icon {
+		font-size: 2.4rem;
+		margin-bottom: 6px;
+	}
+	.sm-modal h2 {
+		font-family: var(--font-display);
+		font-size: 1.2rem;
+		margin: 0 0 14px;
+	}
+	.sm-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		margin: 0 0 12px;
+		padding: 12px 14px;
+		border-radius: 14px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.sm-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 12px;
+		font-size: 0.88rem;
+		color: var(--text-muted);
+	}
+	.sm-row b {
+		font-family: var(--font-display);
+		color: var(--text);
+	}
+	.sm-note {
+		font-size: 0.8rem;
+		color: var(--text-faint);
+		margin: 0 0 16px;
+	}
+	.sm-play {
+		width: 100%;
+		padding: 13px;
+		border: none;
+		border-radius: 14px;
+		cursor: pointer;
+		margin-bottom: 8px;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.98rem;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		box-shadow: 0 6px 18px rgba(251, 191, 36, 0.25);
+	}
+	.sm-play:disabled {
+		opacity: 0.5;
+	}
+	.sm-decline {
+		width: 100%;
+		padding: 11px;
+		border-radius: 14px;
+		cursor: pointer;
+		border: 1px solid rgba(251, 113, 133, 0.4);
+		background: transparent;
+		color: #fb7185;
+		font-weight: 700;
+		font-size: 0.9rem;
+	}
+	.sm-decline:disabled {
+		opacity: 0.5;
+	}
+	.menu-hero {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		width: 100%;
+	}
+	.hero-top {
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
+		align-items: center;
+		width: 100%;
+		max-width: 360px;
+		margin-bottom: 1.4rem;
+	}
+	.hero-top .streak-chip {
+		justify-self: start;
+	}
+	.hero-top .bank-chip {
+		justify-self: center;
+	}
+	.hero-top .bell-ic {
+		justify-self: start;
+	}
+	.bell-ic {
+		position: relative;
+		width: 42px;
+		height: 42px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+		font-size: 1.15rem;
+		transition:
+			transform 0.15s,
+			border-color 0.2s;
+	}
+	.bell-ic:hover {
+		transform: translateY(-1px);
+		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.bell-ic:active {
+		transform: scale(0.94);
+	}
+	.account-ic {
+		position: relative;
+		justify-self: end;
+		display: inline-grid;
+		place-items: center;
+		width: 54px;
+		height: 54px;
+		border-radius: 50%;
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+		cursor: pointer;
+		font-size: 1.7rem;
+		transition:
+			transform 0.15s,
+			border-color 0.2s;
+	}
+	.account-ic:hover {
+		transform: translateY(-1px);
+		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.account-ic.has-av {
+		overflow: visible;
+		padding: 0;
+	}
+	.account-ic.has-av :global(.wb-avatar) {
+		width: 100%;
+		height: 100%;
+		border: none;
+		border-radius: 50%;
+		overflow: hidden;
+	}
+	/* My Account → avatar / edit-avatar entry */
+	.ma-avatar-btn {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 6px;
+		margin: 6px auto 10px;
+		background: none;
+		border: none;
+		cursor: pointer;
+	}
+	.ma-avatar-btn :global(.wb-avatar) {
+		box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+	}
+	.ma-avatar-edit {
+		font-size: 0.82rem;
+		font-weight: 700;
+		color: var(--brand-2);
+	}
+	.account-ic:active {
+		transform: scale(0.94);
+	}
+	/* unread notification count, off the top-right of the avatar */
+	.account-count {
+		position: absolute;
+		top: -4px;
+		right: -4px;
+		display: grid;
+		place-items: center;
+		min-width: 19px;
+		height: 19px;
+		padding: 0 5px;
+		border-radius: 999px;
+		background: #f43f5e;
+		color: #fff;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.68rem;
+		box-shadow: 0 0 0 2px var(--bg, #0a0e14);
+	}
+	.bank-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 7px;
+		padding: 8px 16px;
+		border-radius: 12px;
+		background: rgba(0, 0, 0, 0.38);
+		border: 1px solid rgba(251, 191, 36, 0.5);
+		color: #fde047;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 700;
+		font-size: 1.25rem;
+		letter-spacing: 0.04em;
+		font-variant-numeric: tabular-nums;
+		text-shadow:
+			0 0 10px rgba(251, 191, 36, 0.65),
+			0 0 22px rgba(251, 191, 36, 0.35);
+		box-shadow: inset 0 0 14px rgba(251, 191, 36, 0.1);
+		cursor: pointer;
+		transition:
+			transform 0.15s,
+			box-shadow 0.2s;
+	}
+	.bank-chip:hover {
+		transform: translateY(-1px);
+	}
+	.bank-chip:active {
+		transform: scale(0.96);
+	}
+	.bank-chip .bc-coin {
+		font-size: 1.1rem;
+		text-shadow: none;
+	}
+	.streak-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 6px 12px;
+		border-radius: 999px;
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+		color: var(--text-muted);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+		cursor: pointer;
+		transition:
+			transform 0.15s,
+			border-color 0.2s,
+			box-shadow 0.2s;
+	}
+	.streak-chip:hover {
+		transform: translateY(-1px);
+	}
+	.streak-chip:active {
+		transform: scale(0.96);
+	}
+	.menu-mark {
+		width: min(46vw, 172px);
+		aspect-ratio: 1;
+		height: auto;
+		object-fit: cover;
+		border-radius: 50%;
+		margin-bottom: 4px;
+		box-shadow:
+			0 0 26px rgba(251, 191, 36, 0.55),
+			0 10px 44px rgba(251, 191, 36, 0.4);
+	}
+	/* Mario-style coin spin: flat horizontal flip (edge-on at 90°/270°) + a gentle bob */
+	.menu-mark.spin {
+		animation: coinSpin 2.6s linear infinite;
+		will-change: transform;
+		backface-visibility: visible;
+	}
+	@keyframes coinSpin {
+		0% {
+			transform: translateY(0) rotateY(0deg);
+		}
+		25% {
+			transform: translateY(-5px) rotateY(90deg);
+		}
+		50% {
+			transform: translateY(-7px) rotateY(180deg);
+		}
+		75% {
+			transform: translateY(-5px) rotateY(270deg);
+		}
+		100% {
+			transform: translateY(0) rotateY(360deg);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.menu-mark.spin {
+			animation: none;
+		}
+	}
+	.menu-wordmark {
+		width: min(80vw, 300px);
+		height: auto;
+		margin: 2px 0 0;
+		filter: drop-shadow(0 2px 14px rgba(0, 0, 0, 0.5));
+	}
+	.main-menu-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+		width: 100%;
+		max-width: 360px;
+	}
+	/* ── Gold bullion bars ─────────────────────────────────────────────── */
+	.menu-card {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 10px;
+		text-align: center;
+		padding: 17px 22px;
+		border-radius: 14px;
+		/* brushed-silver chrome plate (CSS) with a beveled chrome frame + gold engraved label */
+		background: linear-gradient(
+			180deg,
+			#fdfefe 0%,
+			#e7ecf1 10%,
+			#c4cdd7 50%,
+			#9ba7b4 78%,
+			#c1cad4 100%
+		);
+		border: 1px solid #8794a2;
+		color: #b8860b;
+		cursor: pointer;
+		overflow: hidden;
+		box-shadow:
+			inset 0 0 0 1.5px rgba(255, 255, 255, 0.85),
+			/* bright chrome inner edge */ inset 0 0 0 3.5px rgba(92, 106, 122, 0.28),
+			/* groove → recessed brushed panel */ inset 0 2px 2px rgba(255, 255, 255, 0.9),
+			/* top catch-light */ inset 0 -3px 6px rgba(70, 85, 100, 0.45),
+			/* bottom depth */ 0 5px 12px rgba(0, 0, 0, 0.55),
+			/* drop shadow */ 0 0 16px rgba(205, 222, 240, 0.25); /* soft glow */
+		transition:
+			transform 0.16s var(--ease-spring),
+			box-shadow 0.2s,
+			filter 0.2s;
+	}
+	/* glossy chrome sheen */
+	.menu-card::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		border-radius: inherit;
+		z-index: 0;
+		pointer-events: none;
+		background:
+			linear-gradient(
+				180deg,
+				rgba(255, 255, 255, 0.7) 0%,
+				rgba(255, 255, 255, 0.15) 14%,
+				rgba(255, 255, 255, 0) 42%,
+				rgba(255, 255, 255, 0.1) 100%
+			),
+			radial-gradient(130% 60% at 50% -10%, rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0) 60%);
+		mix-blend-mode: screen;
+	}
+	/* moving shine streak */
+	.menu-card::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: 55%;
+		background: linear-gradient(
+			105deg,
+			transparent 25%,
+			rgba(255, 255, 255, 0.25) 42%,
+			rgba(255, 255, 255, 0.95) 50%,
+			rgba(255, 255, 255, 0.25) 58%,
+			transparent 75%
+		);
+		transform: translateX(-180%) skewX(-12deg);
+		animation: barShine 5s ease-in-out infinite;
+		animation-delay: calc(var(--i, 0) * 0.45s);
+		pointer-events: none;
+	}
+	@keyframes barShine {
+		0%,
+		58% {
+			transform: translateX(-180%) skewX(-12deg);
+		}
+		78%,
+		100% {
+			transform: translateX(330%) skewX(-12deg);
+		}
+	}
+	@media (hover: hover) and (pointer: fine) {
+		.menu-card:hover:not(.disabled) {
+			transform: translateY(-2px);
+			filter: brightness(1.05);
+			box-shadow:
+				inset 0 0 0 1.5px rgba(255, 255, 255, 0.9),
+				inset 0 0 0 3.5px rgba(92, 106, 122, 0.28),
+				inset 0 -3px 6px rgba(70, 85, 100, 0.45),
+				0 7px 16px rgba(0, 0, 0, 0.55),
+				0 0 24px rgba(210, 225, 240, 0.4);
+		}
+	}
+	.menu-card.gold-flash:not(.disabled) {
+		transform: translateY(1px) scale(0.99);
+	}
+	.menu-card.gold-flash:not(.disabled),
+	.menu-card:focus-visible:not(.disabled) {
+		outline: none;
+		box-shadow:
+			inset 0 0 0 1.5px rgba(255, 255, 255, 0.85),
+			0 0 0 2px rgba(255, 240, 190, 0.9),
+			0 0 22px rgba(255, 220, 110, 0.7),
+			0 6px 14px rgba(0, 0, 0, 0.5);
+	}
+	.menu-card.primary {
+		filter: brightness(1.04);
+		box-shadow:
+			inset 0 0 0 1.5px rgba(255, 255, 255, 0.9),
+			inset 0 0 0 3.5px rgba(92, 106, 122, 0.28),
+			inset 0 2px 2px rgba(255, 255, 255, 0.9),
+			inset 0 -3px 6px rgba(70, 85, 100, 0.45),
+			0 6px 14px rgba(0, 0, 0, 0.55),
+			0 0 22px rgba(210, 225, 240, 0.4);
+	}
+	.menu-card.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.mc-title {
+		position: relative;
+		z-index: 1;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.2rem;
+		letter-spacing: 0.02em;
+		/* embossed gold to match the reference button */
+		background: linear-gradient(180deg, #fff1a8 0%, #f6cd4d 38%, #dd9c1b 66%, #b3760b 100%);
+		-webkit-background-clip: text;
+		background-clip: text;
+		-webkit-text-fill-color: transparent;
+		color: transparent;
+		text-shadow:
+			0 1px 1px rgba(70, 44, 0, 0.45),
+			0 0 1px rgba(120, 80, 0, 0.4);
+	}
+	.mc-stat {
+		position: relative;
+		z-index: 1;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.9rem;
+		color: #b8860b;
+	}
+	/* notification badge — top-right corner of the bar */
+	.mc-badge {
+		position: absolute;
+		top: -7px;
+		right: -6px;
+		z-index: 3;
+		min-width: 22px;
+		height: 22px;
+		padding: 0 6px;
+		border-radius: 999px;
+		display: inline-grid;
+		place-items: center;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.76rem;
+		line-height: 1;
+		color: #fff;
+		background: #ef4444;
+		border: 2px solid #1a1407;
+		box-shadow: 0 0 10px rgba(239, 68, 68, 0.6);
+	}
+	.mc-badge.gift {
+		background: transparent;
+		border: none;
+		box-shadow: none;
+		font-size: 1.1rem;
+		top: -10px;
+		right: -8px;
+	}
+	/* home "you've been challenged" banner */
+	/* Home act-now banner: most-urgent item + optional "+N more" chip */
+	.ab-main {
+		width: 100%;
+		min-width: 0;
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 13px 16px;
+		border-radius: 14px;
+		cursor: pointer;
+		text-align: left;
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.18), rgba(251, 191, 36, 0.12));
+		border: 1px solid rgba(251, 191, 36, 0.5);
+		animation: invitePulse 1.8s ease-in-out infinite;
+	}
+	@keyframes invitePulse {
+		0%,
+		100% {
+			box-shadow: 0 0 16px rgba(251, 191, 36, 0.18);
+		}
+		50% {
+			box-shadow: 0 0 30px rgba(251, 191, 36, 0.42);
+		}
+	}
+	.ab-icon {
+		font-size: 1.6rem;
+		flex: none;
+	}
+	.ab-text {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		min-width: 0;
+	}
+	.ab-text strong {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1rem;
+		color: var(--text);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.ab-text small {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+	}
+	.ab-cta {
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: var(--brand-2);
+		font-size: 0.9rem;
+		white-space: nowrap;
+		flex: none;
+	}
+	/* Empty state = subtle CTA, no pulse/glow */
+	/* Daily status chip on the Play Now card */
+	.daily-chip {
+		font-size: 0.68rem;
+		font-weight: 800;
+		padding: 3px 9px;
+		border-radius: 999px;
+		white-space: nowrap;
+		border: 1px solid var(--border);
+		background: rgba(0, 0, 0, 0.25);
+		color: var(--text);
+	}
+	/* 📅 / 🏆 streak chips on the Daily card */
+	.mc-streak {
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		z-index: 1;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 0.82rem;
+		color: #463413;
+		text-shadow: 0 1px 0 rgba(255, 255, 255, 0.35);
+	}
+	.mc-streak.left {
+		left: 13px;
+	}
+	.mc-streak.right {
+		right: 13px;
+	}
+	.menu-card.done .mc-streak,
+	.menu-card.resumable .mc-streak {
+		color: rgba(255, 255, 255, 0.85);
+		text-shadow: none;
+	}
+	/* solid fills so chips read clearly */
+	.daily-chip.won {
+		color: #052e16;
+		border-color: rgba(22, 163, 74, 0.85);
+		background: linear-gradient(135deg, #4ade80, #16a34a);
+		box-shadow: 0 1px 6px rgba(22, 163, 74, 0.5);
+	}
+	.daily-chip.lost {
+		color: #fff;
+		border-color: rgba(225, 80, 100, 0.85);
+		background: linear-gradient(135deg, #fb7185, #e11d48);
+		box-shadow: 0 1px 6px rgba(225, 29, 72, 0.45);
+		text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
+	}
+	.daily-chip.prog {
+		color: #fff;
+		border-color: rgba(5, 150, 105, 0.85);
+		background: linear-gradient(135deg, #34d399, #059669);
+		box-shadow: 0 1px 6px rgba(5, 150, 105, 0.5);
+		text-shadow: 0 1px 1px rgba(0, 0, 0, 0.25);
+	}
 
-  /* ✅ Completed Daily — grayed-out plate (no chrome shine), result chip shows the score */
-  .menu-card.done {
-    background: linear-gradient(180deg, #39414c 0%, #2b323b 100%);
-    border-color: #49525e;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.06), inset 0 -2px 4px rgba(0,0,0,0.4), 0 3px 8px rgba(0,0,0,0.45);
-  }
-  .menu-card.done::before, .menu-card.done::after { display: none; } /* kill chrome sheen + shine streak */
-  .menu-card.done .mc-title {
-    background: linear-gradient(180deg, #aeb7c2, #7f8893); -webkit-background-clip: text; background-clip: text;
-    -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
-  }
-  /* ▶ Resumable mode — clean green accent instead of the gold chrome */
-  .menu-card.resumable {
-    background: linear-gradient(180deg, #16352b 0%, #0f2a22 100%);
-    border-color: rgba(16,185,129,0.55);
-    box-shadow: inset 0 1px 0 rgba(110,231,183,0.18), inset 0 0 0 1px rgba(16,185,129,0.25), 0 4px 12px rgba(0,0,0,0.5), 0 0 16px rgba(16,185,129,0.18);
-  }
-  .menu-card.resumable::before, .menu-card.resumable::after { display: none; }
-  .menu-card.resumable .mc-title {
-    background: linear-gradient(180deg, #d1fae5, #6ee7b7); -webkit-background-clip: text; background-clip: text;
-    -webkit-text-fill-color: transparent; color: transparent; text-shadow: none;
-  }
-  /* 📅 Fresh Daily (not started today) — solid gold, "play me" */
-  .menu-card.fresh {
-    background: linear-gradient(135deg, #fde047, #f59e0b); border-color: transparent;
-    box-shadow: 0 4px 16px rgba(245,158,11,0.45), 0 0 24px rgba(251,191,36,0.3);
-  }
-  .menu-card.fresh::before, .menu-card.fresh::after { display: none; }
-  .menu-card.fresh .mc-title { color: #3a2a00; -webkit-text-fill-color: #3a2a00; background: none; text-shadow: none; }
-  .menu-card.fresh .mc-streak { color: #5a4200; text-shadow: none; }
-  /* ▶ Resume shortcut card (home menu) — green, mirrors the in-progress accent */
-  /* ▸ slim "Continue" strip — lighter than the Play button, so it reads as a resume
+	/* ✅ Completed Daily — grayed-out plate (no chrome shine), result chip shows the score */
+	.menu-card.done {
+		background: linear-gradient(180deg, #39414c 0%, #2b323b 100%);
+		border-color: #49525e;
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.06),
+			inset 0 -2px 4px rgba(0, 0, 0, 0.4),
+			0 3px 8px rgba(0, 0, 0, 0.45);
+	}
+	.menu-card.done::before,
+	.menu-card.done::after {
+		display: none;
+	} /* kill chrome sheen + shine streak */
+	.menu-card.done .mc-title {
+		background: linear-gradient(180deg, #aeb7c2, #7f8893);
+		-webkit-background-clip: text;
+		background-clip: text;
+		-webkit-text-fill-color: transparent;
+		color: transparent;
+		text-shadow: none;
+	}
+	/* ▶ Resumable mode — clean green accent instead of the gold chrome */
+	.menu-card.resumable {
+		background: linear-gradient(180deg, #16352b 0%, #0f2a22 100%);
+		border-color: rgba(16, 185, 129, 0.55);
+		box-shadow:
+			inset 0 1px 0 rgba(110, 231, 183, 0.18),
+			inset 0 0 0 1px rgba(16, 185, 129, 0.25),
+			0 4px 12px rgba(0, 0, 0, 0.5),
+			0 0 16px rgba(16, 185, 129, 0.18);
+	}
+	.menu-card.resumable::before,
+	.menu-card.resumable::after {
+		display: none;
+	}
+	.menu-card.resumable .mc-title {
+		background: linear-gradient(180deg, #d1fae5, #6ee7b7);
+		-webkit-background-clip: text;
+		background-clip: text;
+		-webkit-text-fill-color: transparent;
+		color: transparent;
+		text-shadow: none;
+	}
+	/* 📅 Fresh Daily (not started today) — solid gold, "play me" */
+	.menu-card.fresh {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		border-color: transparent;
+		box-shadow:
+			0 4px 16px rgba(245, 158, 11, 0.45),
+			0 0 24px rgba(251, 191, 36, 0.3);
+	}
+	.menu-card.fresh::before,
+	.menu-card.fresh::after {
+		display: none;
+	}
+	.menu-card.fresh .mc-title {
+		color: #3a2a00;
+		-webkit-text-fill-color: #3a2a00;
+		background: none;
+		text-shadow: none;
+	}
+	.menu-card.fresh .mc-streak {
+		color: #5a4200;
+		text-shadow: none;
+	}
+	/* ▶ Resume shortcut card (home menu) — green, mirrors the in-progress accent */
+	/* ▸ slim "Continue" strip — lighter than the Play button, so it reads as a resume
      prompt rather than a second primary action. */
-  .resume-strip {
-    display: flex; align-items: center; gap: 9px; width: 100%; margin-bottom: 2px;
-    padding: 9px 14px; border-radius: 12px; cursor: pointer;
-    background: linear-gradient(180deg, rgba(16,53,43,0.65), rgba(15,42,34,0.65));
-    border: 1px solid rgba(16,185,129,0.4);
-    font-family: var(--font-display); font-weight: 700; font-size: 0.85rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-  }
-  .resume-strip:hover { border-color: rgba(16,185,129,0.65); }
-  .resume-strip:active { transform: scale(0.99); }
-  .debt-banner {
-    display: flex; align-items: center; gap: 9px; width: 100%; margin-bottom: 2px;
-    padding: 9px 14px; border-radius: 12px; cursor: pointer;
-    background: linear-gradient(180deg, rgba(53,16,16,0.7), rgba(42,15,15,0.7));
-    border: 1px solid rgba(248,113,113,0.5);
-    font-family: var(--font-display); font-weight: 700; font-size: 0.82rem;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.3);
-  }
-  .debt-banner:hover { border-color: rgba(248,113,113,0.75); }
-  .debt-banner:active { transform: scale(0.99); }
-  .db-text { flex: 1; text-align: left; color: #fecaca; font-weight: 600; }
-  .db-text b { color: #fb7185; }
-  .db-go { color: rgba(251,113,133,0.85); }
-  .rs-dot { color: #34d399; font-size: 0.8rem; }
-  .rs-label { flex: 1; text-align: left; color: #d1fae5; }
-  .rs-go { color: rgba(110,231,183,0.7); }
-  .rs-count {
-    min-width: 20px; height: 20px; padding: 0 6px; border-radius: 999px; display: grid; place-items: center;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.72rem; color: #0f2a22; background: #6ee7b7;
-  }
-  .invite-count { color: #1c1730; background: #c4b5fd; }
-  /* ▶ Resume menu modal */
-  .resume-menu { text-align: left; }
-  .rm-list { display: flex; flex-direction: column; gap: 8px; margin: 10px 0 4px; }
-  .rm-row {
-    display: flex; align-items: center; gap: 10px; padding: 12px 14px; border-radius: 12px; cursor: pointer;
-    background: rgba(16,185,129,0.1); border: 1px solid rgba(16,185,129,0.4); color: var(--text);
-  }
-  .rm-row:active { transform: scale(0.98); }
-  .rm-ic { font-size: 1.2rem; }
-  .rm-label { flex: 1; font-weight: 800; font-size: 0.98rem; }
-  .rm-arrow { color: #6ee7b7; font-size: 0.85rem; }
-  .progress-modes { border-left-color: rgba(251,191,36,0.3); }
-  .mc-arrow { color: var(--text-faint); font-size: 1.1rem; transition: transform 0.2s, color 0.2s; }
-  .mc-count {
-    min-width: 22px; height: 22px; padding: 0 6px; border-radius: 999px;
-    display: inline-grid; place-items: center; font-family: var(--font-display);
-    font-weight: 800; font-size: 0.78rem; color: #3a2a00; line-height: 1;
-    background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047));
-    box-shadow: 0 0 12px rgba(251, 191, 36,0.4);
-  }
-  /* Play accordion */
-  .menu-card.open .mc-arrow { color: var(--brand-2); }
-  .play-modes { display: flex; flex-direction: column; gap: 0.5rem; margin: -0.35rem 0 0.3rem; padding-left: 0.5rem; border-left: 2px solid rgba(253, 224, 71,0.25); }
-  .play-mode {
-    display: flex; align-items: center; gap: 0.8rem; width: 100%; padding: 0.75rem 0.95rem;
-    border-radius: 12px; cursor: pointer; text-align: left;
-    background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.14);
-    transition: transform 0.12s, border-color 0.15s, background 0.15s;
-  }
-  .play-mode:hover:not(:disabled) { transform: translateX(2px); background: rgba(255,255,255,0.11); }
-  .play-mode:disabled { cursor: not-allowed; }
-  .play-mode.done { opacity: 0.7; }
-  /* per-mode accent so they pop on the dark background */
-  .play-mode.daily { border-left: 3px solid #fbbf24; }
-  .play-mode.cash  { border-left: 3px solid #fbbf24; }
-  .play-mode.free  { border-left: 3px solid #60a5fa; }
-  .play-mode.blitz { border-left: 3px solid #f472b6; }
-  .play-mode:hover.daily { border-color: #fbbf24; }
-  .play-mode:hover.cash  { border-color: #fbbf24; }
-  .play-mode:hover.free  { border-color: #60a5fa; }
-  .play-mode:hover.blitz { border-color: #f472b6; }
-  .pm-ic { font-size: 1.3rem; width: 1.6rem; text-align: center; }
-  .pm-t { flex: 1; font-family: var(--font-display); font-weight: 600; font-size: 0.98rem; color: #fff; }
-  .pm-tag { font-size: 0.65rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: #f472b6; border: 1px solid rgba(244,114,182,0.4); border-radius: 999px; padding: 2px 7px; }
-  .pm-soon-note { text-align: center; font-size: 0.78rem; color: #f472b6; margin: 2px 0 0; }
-  /* utility footer (replaces the old floating icon cluster) */
-  .menu-footer { display: flex; justify-content: center; gap: 1.2rem; margin-top: 0.4rem; }
-  .menu-footer button {
-    background: none; border: none; cursor: pointer; color: var(--text-faint);
-    font-size: 0.78rem; font-weight: 600; padding: 4px;
-  }
-  .menu-footer button:hover { color: var(--text-muted); }
-  /* back-to-menu button on game/sub screens */
-  /* ☰ hamburger main-menu (top-left) */
-  .menu-back-btn {
-    position: fixed; top: 14px; left: 14px; z-index: 1000;
-    width: 38px; height: 38px; border-radius: 999px; cursor: pointer;
-    display: grid; place-items: center; color: var(--text);
-    background: var(--surface-strong, rgba(20,28,40,0.85)); border: 1px solid var(--border-strong, var(--border)); backdrop-filter: blur(10px);
-  }
-  .menu-back-btn:hover { border-color: var(--brand-2); color: var(--brand-2); }
-  .hamburger, .hamburger::before, .hamburger::after {
-    content: ''; display: block; width: 18px; height: 2px; border-radius: 2px; background: currentColor;
-  }
-  .hamburger { position: relative; }
-  .hamburger::before { position: absolute; top: -6px; left: 0; }
-  .hamburger::after { position: absolute; top: 6px; left: 0; }
-  /* how-to-play (top-center) */
-  .help-btn {
-    position: fixed; top: 14px; left: 50%; transform: translateX(-50%); z-index: 1000;
-    width: 38px; height: 38px; border-radius: 999px; cursor: pointer; font-weight: 800; font-size: 1.1rem; line-height: 1;
-    display: grid; place-items: center; color: var(--text);
-    background: var(--surface-strong, rgba(20,28,40,0.85)); border: 1px solid var(--border-strong, var(--border)); backdrop-filter: blur(10px);
-  }
-  .help-btn:hover { border-color: var(--brand-2); color: var(--brand-2); }
-  /* 🔊 in-game audio button — sits just right of the help button */
-  .audio-btn {
-    position: fixed; top: 14px; left: calc(50% + 46px); transform: translateX(-50%); z-index: 1000;
-    width: 38px; height: 38px; border-radius: 999px; cursor: pointer; font-size: 1.05rem; line-height: 1;
-    display: grid; place-items: center; color: var(--text);
-    background: var(--surface-strong, rgba(20,28,40,0.85)); border: 1px solid var(--border-strong, var(--border)); backdrop-filter: blur(10px);
-  }
-  .audio-btn:hover { border-color: var(--brand-2); }
-  .audio-btn:active { transform: translateX(-50%) scale(0.92); }
-  /* audio panel */
-  .audio-panel { text-align: left; }
-  .ap-rows { display: flex; flex-direction: column; gap: 8px; margin: 10px 0; }
-  .ap-toggle {
-    display: flex; justify-content: space-between; align-items: center; gap: 10px;
-    padding: 11px 14px; border-radius: 12px; cursor: pointer; font-weight: 700; font-size: 0.95rem; color: var(--text);
-    background: var(--surface-2, rgba(255,255,255,0.05)); border: 1px solid var(--border);
-  }
-  .ap-toggle:active { transform: scale(0.98); }
-  .ap-state { font-size: 0.8rem; font-weight: 800; color: var(--text-faint); }
-  .ap-state.on { color: #4ade80; }
-  .ma-tracks { display: flex; gap: 6px; margin-top: 8px; }
-  .ma-track {
-    flex: 1; padding: 8px 4px; border-radius: 10px; cursor: pointer; font-weight: 800; font-size: 0.8rem;
-    color: var(--text-muted); background: var(--surface-2, rgba(255,255,255,0.05)); border: 1px solid var(--border);
-  }
-  .ma-track.on { color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border-color: transparent; }
-  /* 🏳️ give up (top-right) — red exit arrow */
-  .giveup-btn {
-    position: fixed; top: 14px; right: 14px; z-index: 1000;
-    width: 38px; height: 38px; border-radius: 999px; cursor: pointer; font-size: 1.25rem; line-height: 1; font-weight: 800;
-    display: grid; place-items: center; color: #f87171;
-    background: var(--surface-strong, rgba(20,28,40,0.85)); border: 1px solid rgba(248,113,113,0.5); backdrop-filter: blur(10px);
-  }
-  .giveup-btn:hover { border-color: #f87171; background: rgba(248,113,113,0.16); }
-  .giveup-btn:active { transform: scale(0.93); }
-  /* match chat — sits just below the help button so they never overlap */
-  .match-chat-btn {
-    position: fixed; top: 60px; right: 14px; z-index: 1000;
-    display: flex; align-items: center; gap: 5px; padding: 9px 14px; border-radius: 999px; cursor: pointer;
-    font-size: 1.02rem; font-weight: 700; color: var(--text);
-    background: var(--surface-strong, rgba(20,28,40,0.9)); border: 1px solid rgba(251,191,36,0.5); backdrop-filter: blur(10px);
-    box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 12px rgba(251,191,36,0.15);
-  }
-  .match-chat-btn:hover { border-color: var(--brand-2); }
-  .match-chat-btn.unread { border-color: #f43f5e; animation: chatPulse 1.6s ease-in-out infinite; }
-  @keyframes chatPulse { 0%,100% { box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 0 rgba(244,63,94,0.5); } 50% { box-shadow: 0 2px 12px rgba(0,0,0,0.4), 0 0 0 6px rgba(244,63,94,0); } }
-  .mcb-label { font-family: var(--font-display); font-size: 0.84rem; }
-  .mc-dot { position: absolute; top: 3px; right: 3px; width: 10px; height: 10px; border-radius: 999px; background: #f43f5e; box-shadow: 0 0 0 2px var(--bg, #0a0e14); }
-  .welcome-modal { max-width: 380px; text-align: center; }
-  .wc-coin { display: block; margin: 0 auto 0.5rem; }
-  .wc-title { font-family: var(--font-display); font-size: 1.4rem; margin: 0 0 0.35rem; }
-  .wc-sub { font-size: 0.92rem; color: var(--text-muted); margin: 0 0 1rem; }
-  .wc-list { list-style: none; padding: 0; margin: 0 0 1.2rem; display: flex; flex-direction: column; gap: 0.55rem; text-align: left; }
-  .wc-list li { display: flex; align-items: center; gap: 0.6rem; font-size: 0.9rem; color: var(--text);
-    background: var(--surface-2, rgba(255,255,255,0.04)); border: 1px solid var(--border); border-radius: 12px; padding: 0.6rem 0.8rem; }
-  .wc-list li span { font-size: 1.15rem; }
-  .wc-list b { color: #fde047; }
-  .wc-btn { width: 100%; padding: 0.85rem; border-radius: 13px; border: none; cursor: pointer; font-weight: 800; font-size: 1rem;
-    color: #3a2a00; background: linear-gradient(135deg, #fde047, #f59e0b); }
-  .giveup-modal { max-width: 360px; text-align: center; }
-  .gu-title { font-family: var(--font-display); font-size: 1.2rem; margin: 0 0 0.5rem; }
-  .gu-text { font-size: 0.88rem; color: var(--text-muted); margin: 0 0 1.2rem; line-height: 1.4; }
-  .gu-actions { display: flex; gap: 0.6rem; }
-  .gu-actions button { flex: 1; padding: 0.75rem 0.7rem; border-radius: 12px; cursor: pointer; font-weight: 800; font-size: 0.9rem; }
-  .gu-cancel { border: 1px solid var(--border-strong, var(--border)); background: var(--surface-2, rgba(255,255,255,0.05)); color: var(--text); }
-  .gu-confirm { border: none; background: rgba(248,113,113,0.18); border: 1px solid rgba(248,113,113,0.5); color: #fca5a5; }
-  .gu-confirm:hover { background: rgba(248,113,113,0.28); }
-  /* 💥 Double or Nothing — high-stakes gold/amber accent (distinct from the red Skip/Give-up) */
-  .don-modal .don-win { color: #fbbf24; }
-  .don-modal .don-loss { color: #fca5a5; }
-  .don-confirm { background: rgba(251,191,36,0.16) !important; border: 1px solid rgba(251,191,36,0.6) !important; color: #fcd34d !important; }
-  .don-confirm:hover { background: rgba(251,191,36,0.28) !important; }
-  .don-confirm:disabled { opacity: 0.55; cursor: default; }
-  /* CTA shown in the Cash Game when heat ≥ ×1.5 */
-  .don-cta {
-    display: flex; flex-direction: column; align-items: center; gap: 2px;
-    width: 100%; margin: 0 auto 0.5rem; padding: 0.6rem 0.9rem; border-radius: 14px; cursor: pointer;
-    background: linear-gradient(180deg, rgba(251,191,36,0.16), rgba(245,158,11,0.10));
-    border: 1px solid rgba(251,191,36,0.55); color: #fcd34d;
-    box-shadow: 0 0 18px rgba(251,191,36,0.18); animation: donPulse 1.8s ease-in-out infinite;
-  }
-  .don-cta:active { transform: scale(0.98); }
-  .don-cta-title { font-family: var(--font-display); font-weight: 900; font-size: 1rem; letter-spacing: 0.02em; }
-  .don-cta-sub { font-size: 0.74rem; color: var(--text-muted); }
-  .don-cta-sub b, .don-armed-sub b { color: #fbbf24; }
-  /* 🔥 Cash Game run line — momentum under the money hero */
-  .climb-run-line { margin: 0.35rem auto 0; text-align: center; font-size: 0.8rem; color: var(--text-muted); }
-  .climb-run-line .run-profit { color: #4ade80; }
-  .climb-run-line .run-profit.neg { color: #fca5a5; }
-  .climb-run-line.best { color: #fcd34d; }
-  @keyframes donPulse {
-    0%, 100% { box-shadow: 0 0 14px rgba(251,191,36,0.16); }
-    50% { box-shadow: 0 0 26px rgba(251,191,36,0.36); }
-  }
-  /* Armed (committed) indicator */
-  .don-armed {
-    display: flex; flex-direction: column; align-items: center; gap: 2px;
-    width: 100%; margin: 0 auto 0.5rem; padding: 0.55rem 0.9rem; border-radius: 14px;
-    background: rgba(251,191,36,0.12); border: 1px solid rgba(251,191,36,0.7);
-  }
-  .don-armed-title { font-family: var(--font-display); font-weight: 900; font-size: 0.95rem; color: #fcd34d; }
-  .don-armed-sub { font-size: 0.74rem; color: var(--text-muted); }
-  .chat-modal { max-width: 440px; }
-  .chat-h { font-family: var(--font-display); font-size: 1.15rem; margin: 0 0 0.8rem; }
-  .chat-msgs {
-    display: flex; flex-direction: column; gap: 6px; height: 300px; overflow-y: auto;
-    padding: 0.8rem; border-radius: 14px; border: 1px solid var(--border); background: var(--surface); text-align: left;
-  }
-  .chat-empty { color: var(--text-faint); font-size: 0.85rem; text-align: center; margin: auto; }
-  .cmsg {
-    max-width: 80%; align-self: flex-start; display: flex; flex-direction: column; gap: 1px;
-    padding: 0.45rem 0.7rem; border-radius: 12px; background: var(--surface-2, rgba(255,255,255,0.05)); border: 1px solid var(--border);
-  }
-  .cmsg.mine { align-self: flex-end; background: rgba(253, 224, 71,0.12); border-color: rgba(253, 224, 71,0.3); }
-  .cm-name { font-size: 0.66rem; font-weight: 700; color: var(--brand-2); }
-  .cmsg.mine .cm-name { align-self: flex-end; color: var(--text-faint); }
-  .cm-body { font-size: 0.88rem; color: var(--text); word-break: break-word; }
-  .chat-input-row { display: flex; gap: 0.5rem; margin-top: 0.7rem; }
-  .chat-input { flex: 1; min-width: 0; padding: 0.6rem 0.9rem; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; }
-  .chat-send { padding: 0.6rem 1.1rem; border: none; border-radius: 12px; cursor: pointer; font-weight: 700; color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .chat-send:disabled { opacity: 0.5; }
-  /* notification bell */
-  .bell-button { position: relative; }
-  .bell-badge {
-    position: absolute; top: -4px; right: -4px; min-width: 17px; height: 17px;
-    padding: 0 4px; border-radius: 999px; display: grid; place-items: center;
-    font-size: 0.62rem; font-weight: 800; color: #fff; line-height: 1;
-    background: #f43f5e; box-shadow: 0 0 0 2px var(--bg, #0a0e14);
-  }
-  /* notifications panel */
-  .notif-list { display: flex; flex-direction: column; gap: 0.5rem; max-height: 60vh; overflow-y: auto; }
-  .notif-item {
-    padding: 0.7rem 0.85rem; border-radius: 12px;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text);
-  }
-  .notif-item.fresh { border-color: rgba(253, 224, 71,0.45); background: linear-gradient(135deg, rgba(251, 191, 36,0.08), rgba(253, 224, 71,0.03)); }
-  .ni-main { text-align: left; display: flex; flex-direction: column; gap: 2px; width: 100%; background: none; border: none; color: inherit; cursor: pointer; padding: 0; }
-  .ni-title { font-family: var(--font-display); font-weight: 700; font-size: 0.92rem; }
-  .ni-body { font-size: 0.82rem; color: var(--text-muted); }
-  .ni-actions { display: flex; gap: 0.5rem; margin-top: 0.55rem; }
-  .ni-act { flex: 1; padding: 0.45rem 0.7rem; border-radius: 9px; font-weight: 800; font-size: 0.82rem; cursor: pointer; border: 1px solid var(--border); }
-  .ni-act.accept { color: #3a2a00; border: none; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .ni-act.decline { color: #f87171; background: transparent; border-color: rgba(248,113,113,0.4); }
-  .ni-done { display: inline-block; margin-top: 0.5rem; font-size: 0.8rem; font-weight: 800; }
-  .ni-done.accepted { color: var(--brand-2); }
-  .ni-done.declined { color: var(--text-faint); }
-  @media (hover: hover) and (pointer: fine) {
-    .menu-card:hover:not(.disabled) .mc-arrow { transform: translateX(3px); color: var(--brand-2); }
-  }
+	.resume-strip {
+		display: flex;
+		align-items: center;
+		gap: 9px;
+		width: 100%;
+		margin-bottom: 2px;
+		padding: 9px 14px;
+		border-radius: 12px;
+		cursor: pointer;
+		background: linear-gradient(180deg, rgba(16, 53, 43, 0.65), rgba(15, 42, 34, 0.65));
+		border: 1px solid rgba(16, 185, 129, 0.4);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.85rem;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+	}
+	.resume-strip:hover {
+		border-color: rgba(16, 185, 129, 0.65);
+	}
+	.resume-strip:active {
+		transform: scale(0.99);
+	}
+	.debt-banner {
+		display: flex;
+		align-items: center;
+		gap: 9px;
+		width: 100%;
+		margin-bottom: 2px;
+		padding: 9px 14px;
+		border-radius: 12px;
+		cursor: pointer;
+		background: linear-gradient(180deg, rgba(53, 16, 16, 0.7), rgba(42, 15, 15, 0.7));
+		border: 1px solid rgba(248, 113, 113, 0.5);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.82rem;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+	}
+	.debt-banner:hover {
+		border-color: rgba(248, 113, 113, 0.75);
+	}
+	.debt-banner:active {
+		transform: scale(0.99);
+	}
+	.db-text {
+		flex: 1;
+		text-align: left;
+		color: #fecaca;
+		font-weight: 600;
+	}
+	.db-text b {
+		color: #fb7185;
+	}
+	.db-go {
+		color: rgba(251, 113, 133, 0.85);
+	}
+	.rs-dot {
+		color: #34d399;
+		font-size: 0.8rem;
+	}
+	.rs-label {
+		flex: 1;
+		text-align: left;
+		color: #d1fae5;
+	}
+	.rs-go {
+		color: rgba(110, 231, 183, 0.7);
+	}
+	.rs-count {
+		min-width: 20px;
+		height: 20px;
+		padding: 0 6px;
+		border-radius: 999px;
+		display: grid;
+		place-items: center;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.72rem;
+		color: #0f2a22;
+		background: #6ee7b7;
+	}
+	.invite-count {
+		color: #1c1730;
+		background: #c4b5fd;
+	}
+	/* ▶ Resume menu modal */
+	.resume-menu {
+		text-align: left;
+	}
+	.rm-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin: 10px 0 4px;
+	}
+	.rm-row {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 12px 14px;
+		border-radius: 12px;
+		cursor: pointer;
+		background: rgba(16, 185, 129, 0.1);
+		border: 1px solid rgba(16, 185, 129, 0.4);
+		color: var(--text);
+	}
+	.rm-row:active {
+		transform: scale(0.98);
+	}
+	.rm-ic {
+		font-size: 1.2rem;
+	}
+	.rm-label {
+		flex: 1;
+		font-weight: 800;
+		font-size: 0.98rem;
+	}
+	.rm-arrow {
+		color: #6ee7b7;
+		font-size: 0.85rem;
+	}
+	.progress-modes {
+		border-left-color: rgba(251, 191, 36, 0.3);
+	}
+	.mc-arrow {
+		color: var(--text-faint);
+		font-size: 1.1rem;
+		transition:
+			transform 0.2s,
+			color 0.2s;
+	}
+	.mc-count {
+		min-width: 22px;
+		height: 22px;
+		padding: 0 6px;
+		border-radius: 999px;
+		display: inline-grid;
+		place-items: center;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.78rem;
+		color: #3a2a00;
+		line-height: 1;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		box-shadow: 0 0 12px rgba(251, 191, 36, 0.4);
+	}
+	/* Play accordion */
+	.menu-card.open .mc-arrow {
+		color: var(--brand-2);
+	}
+	.play-modes {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin: -0.35rem 0 0.3rem;
+		padding-left: 0.5rem;
+		border-left: 2px solid rgba(253, 224, 71, 0.25);
+	}
+	.play-mode {
+		display: flex;
+		align-items: center;
+		gap: 0.8rem;
+		width: 100%;
+		padding: 0.75rem 0.95rem;
+		border-radius: 12px;
+		cursor: pointer;
+		text-align: left;
+		background: rgba(255, 255, 255, 0.07);
+		border: 1px solid rgba(255, 255, 255, 0.14);
+		transition:
+			transform 0.12s,
+			border-color 0.15s,
+			background 0.15s;
+	}
+	.play-mode:hover:not(:disabled) {
+		transform: translateX(2px);
+		background: rgba(255, 255, 255, 0.11);
+	}
+	.play-mode:disabled {
+		cursor: not-allowed;
+	}
+	.play-mode.done {
+		opacity: 0.7;
+	}
+	/* per-mode accent so they pop on the dark background */
+	.play-mode.daily {
+		border-left: 3px solid #fbbf24;
+	}
+	.play-mode.cash {
+		border-left: 3px solid #fbbf24;
+	}
+	.play-mode.free {
+		border-left: 3px solid #60a5fa;
+	}
+	.play-mode.blitz {
+		border-left: 3px solid #f472b6;
+	}
+	.play-mode:hover.daily {
+		border-color: #fbbf24;
+	}
+	.play-mode:hover.cash {
+		border-color: #fbbf24;
+	}
+	.play-mode:hover.free {
+		border-color: #60a5fa;
+	}
+	.play-mode:hover.blitz {
+		border-color: #f472b6;
+	}
+	.pm-ic {
+		font-size: 1.3rem;
+		width: 1.6rem;
+		text-align: center;
+	}
+	.pm-t {
+		flex: 1;
+		font-family: var(--font-display);
+		font-weight: 600;
+		font-size: 0.98rem;
+		color: #fff;
+	}
+	.pm-tag {
+		font-size: 0.65rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: #f472b6;
+		border: 1px solid rgba(244, 114, 182, 0.4);
+		border-radius: 999px;
+		padding: 2px 7px;
+	}
+	.pm-soon-note {
+		text-align: center;
+		font-size: 0.78rem;
+		color: #f472b6;
+		margin: 2px 0 0;
+	}
+	/* utility footer (replaces the old floating icon cluster) */
+	.menu-footer {
+		display: flex;
+		justify-content: center;
+		gap: 1.2rem;
+		margin-top: 0.4rem;
+	}
+	.menu-footer button {
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text-faint);
+		font-size: 0.78rem;
+		font-weight: 600;
+		padding: 4px;
+	}
+	.menu-footer button:hover {
+		color: var(--text-muted);
+	}
+	/* back-to-menu button on game/sub screens */
+	/* ☰ hamburger main-menu (top-left) */
+	.menu-back-btn {
+		position: fixed;
+		top: 14px;
+		left: 14px;
+		z-index: 1000;
+		width: 38px;
+		height: 38px;
+		border-radius: 999px;
+		cursor: pointer;
+		display: grid;
+		place-items: center;
+		color: var(--text);
+		background: var(--surface-strong, rgba(20, 28, 40, 0.85));
+		border: 1px solid var(--border-strong, var(--border));
+		backdrop-filter: blur(10px);
+	}
+	.menu-back-btn:hover {
+		border-color: var(--brand-2);
+		color: var(--brand-2);
+	}
+	.hamburger,
+	.hamburger::before,
+	.hamburger::after {
+		content: '';
+		display: block;
+		width: 18px;
+		height: 2px;
+		border-radius: 2px;
+		background: currentColor;
+	}
+	.hamburger {
+		position: relative;
+	}
+	.hamburger::before {
+		position: absolute;
+		top: -6px;
+		left: 0;
+	}
+	.hamburger::after {
+		position: absolute;
+		top: 6px;
+		left: 0;
+	}
+	/* how-to-play (top-center) */
+	.help-btn {
+		position: fixed;
+		top: 14px;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 1000;
+		width: 38px;
+		height: 38px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 1.1rem;
+		line-height: 1;
+		display: grid;
+		place-items: center;
+		color: var(--text);
+		background: var(--surface-strong, rgba(20, 28, 40, 0.85));
+		border: 1px solid var(--border-strong, var(--border));
+		backdrop-filter: blur(10px);
+	}
+	.help-btn:hover {
+		border-color: var(--brand-2);
+		color: var(--brand-2);
+	}
+	/* 🔊 in-game audio button — sits just right of the help button */
+	.audio-btn {
+		position: fixed;
+		top: 14px;
+		left: calc(50% + 46px);
+		transform: translateX(-50%);
+		z-index: 1000;
+		width: 38px;
+		height: 38px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-size: 1.05rem;
+		line-height: 1;
+		display: grid;
+		place-items: center;
+		color: var(--text);
+		background: var(--surface-strong, rgba(20, 28, 40, 0.85));
+		border: 1px solid var(--border-strong, var(--border));
+		backdrop-filter: blur(10px);
+	}
+	.audio-btn:hover {
+		border-color: var(--brand-2);
+	}
+	.audio-btn:active {
+		transform: translateX(-50%) scale(0.92);
+	}
+	/* audio panel */
+	.audio-panel {
+		text-align: left;
+	}
+	.ap-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin: 10px 0;
+	}
+	.ap-toggle {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+		padding: 11px 14px;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 0.95rem;
+		color: var(--text);
+		background: var(--surface-2, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+	}
+	.ap-toggle:active {
+		transform: scale(0.98);
+	}
+	.ap-state {
+		font-size: 0.8rem;
+		font-weight: 800;
+		color: var(--text-faint);
+	}
+	.ap-state.on {
+		color: #4ade80;
+	}
+	.ma-tracks {
+		display: flex;
+		gap: 6px;
+		margin-top: 8px;
+	}
+	.ma-track {
+		flex: 1;
+		padding: 8px 4px;
+		border-radius: 10px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		background: var(--surface-2, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+	}
+	.ma-track.on {
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		border-color: transparent;
+	}
+	/* 🏳️ give up (top-right) — red exit arrow */
+	.giveup-btn {
+		position: fixed;
+		top: 14px;
+		right: 14px;
+		z-index: 1000;
+		width: 38px;
+		height: 38px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-size: 1.25rem;
+		line-height: 1;
+		font-weight: 800;
+		display: grid;
+		place-items: center;
+		color: #f87171;
+		background: var(--surface-strong, rgba(20, 28, 40, 0.85));
+		border: 1px solid rgba(248, 113, 113, 0.5);
+		backdrop-filter: blur(10px);
+	}
+	.giveup-btn:hover {
+		border-color: #f87171;
+		background: rgba(248, 113, 113, 0.16);
+	}
+	.giveup-btn:active {
+		transform: scale(0.93);
+	}
+	/* match chat — sits just below the help button so they never overlap */
+	.match-chat-btn {
+		position: fixed;
+		top: 60px;
+		right: 14px;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 9px 14px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-size: 1.02rem;
+		font-weight: 700;
+		color: var(--text);
+		background: var(--surface-strong, rgba(20, 28, 40, 0.9));
+		border: 1px solid rgba(251, 191, 36, 0.5);
+		backdrop-filter: blur(10px);
+		box-shadow:
+			0 2px 12px rgba(0, 0, 0, 0.4),
+			0 0 12px rgba(251, 191, 36, 0.15);
+	}
+	.match-chat-btn:hover {
+		border-color: var(--brand-2);
+	}
+	.match-chat-btn.unread {
+		border-color: #f43f5e;
+		animation: chatPulse 1.6s ease-in-out infinite;
+	}
+	@keyframes chatPulse {
+		0%,
+		100% {
+			box-shadow:
+				0 2px 12px rgba(0, 0, 0, 0.4),
+				0 0 0 0 rgba(244, 63, 94, 0.5);
+		}
+		50% {
+			box-shadow:
+				0 2px 12px rgba(0, 0, 0, 0.4),
+				0 0 0 6px rgba(244, 63, 94, 0);
+		}
+	}
+	.mcb-label {
+		font-family: var(--font-display);
+		font-size: 0.84rem;
+	}
+	.mc-dot {
+		position: absolute;
+		top: 3px;
+		right: 3px;
+		width: 10px;
+		height: 10px;
+		border-radius: 999px;
+		background: #f43f5e;
+		box-shadow: 0 0 0 2px var(--bg, #0a0e14);
+	}
+	.welcome-modal {
+		max-width: 380px;
+		text-align: center;
+	}
+	.wc-coin {
+		display: block;
+		margin: 0 auto 0.5rem;
+	}
+	.wc-title {
+		font-family: var(--font-display);
+		font-size: 1.4rem;
+		margin: 0 0 0.35rem;
+	}
+	.wc-sub {
+		font-size: 0.92rem;
+		color: var(--text-muted);
+		margin: 0 0 1rem;
+	}
+	.wc-list {
+		list-style: none;
+		padding: 0;
+		margin: 0 0 1.2rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.55rem;
+		text-align: left;
+	}
+	.wc-list li {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		font-size: 0.9rem;
+		color: var(--text);
+		background: var(--surface-2, rgba(255, 255, 255, 0.04));
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		padding: 0.6rem 0.8rem;
+	}
+	.wc-list li span {
+		font-size: 1.15rem;
+	}
+	.wc-list b {
+		color: #fde047;
+	}
+	.wc-btn {
+		width: 100%;
+		padding: 0.85rem;
+		border-radius: 13px;
+		border: none;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 1rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.giveup-modal {
+		max-width: 360px;
+		text-align: center;
+	}
+	.gu-title {
+		font-family: var(--font-display);
+		font-size: 1.2rem;
+		margin: 0 0 0.5rem;
+	}
+	.gu-text {
+		font-size: 0.88rem;
+		color: var(--text-muted);
+		margin: 0 0 1.2rem;
+		line-height: 1.4;
+	}
+	.gu-actions {
+		display: flex;
+		gap: 0.6rem;
+	}
+	.gu-actions button {
+		flex: 1;
+		padding: 0.75rem 0.7rem;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.9rem;
+	}
+	.gu-cancel {
+		border: 1px solid var(--border-strong, var(--border));
+		background: var(--surface-2, rgba(255, 255, 255, 0.05));
+		color: var(--text);
+	}
+	.gu-confirm {
+		border: none;
+		background: rgba(248, 113, 113, 0.18);
+		border: 1px solid rgba(248, 113, 113, 0.5);
+		color: #fca5a5;
+	}
+	.gu-confirm:hover {
+		background: rgba(248, 113, 113, 0.28);
+	}
+	/* 💥 Double or Nothing — high-stakes gold/amber accent (distinct from the red Skip/Give-up) */
+	.don-modal .don-win {
+		color: #fbbf24;
+	}
+	.don-modal .don-loss {
+		color: #fca5a5;
+	}
+	.don-confirm {
+		background: rgba(251, 191, 36, 0.16) !important;
+		border: 1px solid rgba(251, 191, 36, 0.6) !important;
+		color: #fcd34d !important;
+	}
+	.don-confirm:hover {
+		background: rgba(251, 191, 36, 0.28) !important;
+	}
+	.don-confirm:disabled {
+		opacity: 0.55;
+		cursor: default;
+	}
+	/* CTA shown in the Cash Game when heat ≥ ×1.5 */
+	.don-cta {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		width: 100%;
+		margin: 0 auto 0.5rem;
+		padding: 0.6rem 0.9rem;
+		border-radius: 14px;
+		cursor: pointer;
+		background: linear-gradient(180deg, rgba(251, 191, 36, 0.16), rgba(245, 158, 11, 0.1));
+		border: 1px solid rgba(251, 191, 36, 0.55);
+		color: #fcd34d;
+		box-shadow: 0 0 18px rgba(251, 191, 36, 0.18);
+		animation: donPulse 1.8s ease-in-out infinite;
+	}
+	.don-cta:active {
+		transform: scale(0.98);
+	}
+	.don-cta-title {
+		font-family: var(--font-display);
+		font-weight: 900;
+		font-size: 1rem;
+		letter-spacing: 0.02em;
+	}
+	.don-cta-sub {
+		font-size: 0.74rem;
+		color: var(--text-muted);
+	}
+	.don-cta-sub b,
+	.don-armed-sub b {
+		color: #fbbf24;
+	}
+	/* 🔥 Cash Game run line — momentum under the money hero */
+	.climb-run-line {
+		margin: 0.35rem auto 0;
+		text-align: center;
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+	.climb-run-line .run-profit {
+		color: #4ade80;
+	}
+	.climb-run-line .run-profit.neg {
+		color: #fca5a5;
+	}
+	.climb-run-line.best {
+		color: #fcd34d;
+	}
+	@keyframes donPulse {
+		0%,
+		100% {
+			box-shadow: 0 0 14px rgba(251, 191, 36, 0.16);
+		}
+		50% {
+			box-shadow: 0 0 26px rgba(251, 191, 36, 0.36);
+		}
+	}
+	/* Armed (committed) indicator */
+	.don-armed {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		width: 100%;
+		margin: 0 auto 0.5rem;
+		padding: 0.55rem 0.9rem;
+		border-radius: 14px;
+		background: rgba(251, 191, 36, 0.12);
+		border: 1px solid rgba(251, 191, 36, 0.7);
+	}
+	.don-armed-title {
+		font-family: var(--font-display);
+		font-weight: 900;
+		font-size: 0.95rem;
+		color: #fcd34d;
+	}
+	.don-armed-sub {
+		font-size: 0.74rem;
+		color: var(--text-muted);
+	}
+	.chat-modal {
+		max-width: 440px;
+	}
+	.chat-h {
+		font-family: var(--font-display);
+		font-size: 1.15rem;
+		margin: 0 0 0.8rem;
+	}
+	.chat-msgs {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+		height: 300px;
+		overflow-y: auto;
+		padding: 0.8rem;
+		border-radius: 14px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		text-align: left;
+	}
+	.chat-empty {
+		color: var(--text-faint);
+		font-size: 0.85rem;
+		text-align: center;
+		margin: auto;
+	}
+	.cmsg {
+		max-width: 80%;
+		align-self: flex-start;
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		padding: 0.45rem 0.7rem;
+		border-radius: 12px;
+		background: var(--surface-2, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border);
+	}
+	.cmsg.mine {
+		align-self: flex-end;
+		background: rgba(253, 224, 71, 0.12);
+		border-color: rgba(253, 224, 71, 0.3);
+	}
+	.cm-name {
+		font-size: 0.66rem;
+		font-weight: 700;
+		color: var(--brand-2);
+	}
+	.cmsg.mine .cm-name {
+		align-self: flex-end;
+		color: var(--text-faint);
+	}
+	.cm-body {
+		font-size: 0.88rem;
+		color: var(--text);
+		word-break: break-word;
+	}
+	.chat-input-row {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: 0.7rem;
+	}
+	.chat-input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.6rem 0.9rem;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.95rem;
+	}
+	.chat-send {
+		padding: 0.6rem 1.1rem;
+		border: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 700;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.chat-send:disabled {
+		opacity: 0.5;
+	}
+	/* notification bell */
+	.bell-button {
+		position: relative;
+	}
+	.bell-badge {
+		position: absolute;
+		top: -4px;
+		right: -4px;
+		min-width: 17px;
+		height: 17px;
+		padding: 0 4px;
+		border-radius: 999px;
+		display: grid;
+		place-items: center;
+		font-size: 0.62rem;
+		font-weight: 800;
+		color: #fff;
+		line-height: 1;
+		background: #f43f5e;
+		box-shadow: 0 0 0 2px var(--bg, #0a0e14);
+	}
+	/* notifications panel */
+	.notif-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+	.notif-item {
+		padding: 0.7rem 0.85rem;
+		border-radius: 12px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.notif-item.fresh {
+		border-color: rgba(253, 224, 71, 0.45);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.08), rgba(253, 224, 71, 0.03));
+	}
+	.ni-main {
+		text-align: left;
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		width: 100%;
+		background: none;
+		border: none;
+		color: inherit;
+		cursor: pointer;
+		padding: 0;
+	}
+	.ni-title {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.92rem;
+	}
+	.ni-body {
+		font-size: 0.82rem;
+		color: var(--text-muted);
+	}
+	.ni-actions {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: 0.55rem;
+	}
+	.ni-act {
+		flex: 1;
+		padding: 0.45rem 0.7rem;
+		border-radius: 9px;
+		font-weight: 800;
+		font-size: 0.82rem;
+		cursor: pointer;
+		border: 1px solid var(--border);
+	}
+	.ni-act.accept {
+		color: #3a2a00;
+		border: none;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.ni-act.decline {
+		color: #f87171;
+		background: transparent;
+		border-color: rgba(248, 113, 113, 0.4);
+	}
+	.ni-done {
+		display: inline-block;
+		margin-top: 0.5rem;
+		font-size: 0.8rem;
+		font-weight: 800;
+	}
+	.ni-done.accepted {
+		color: var(--brand-2);
+	}
+	.ni-done.declined {
+		color: var(--text-faint);
+	}
+	@media (hover: hover) and (pointer: fine) {
+		.menu-card:hover:not(.disabled) .mc-arrow {
+			transform: translateX(3px);
+			color: var(--brand-2);
+		}
+	}
 
-  /* Modal action button (reused brand button) */
-  .main-menu-btn {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 1rem;
-    padding: 13px 20px;
-    border-radius: var(--r-md);
-    border: none;
-    background: var(--brand-grad);
-    color: #3a2a00;
-    cursor: pointer;
-    box-shadow: var(--glow-brand);
-    transition: transform 0.15s var(--ease-spring), filter 0.2s;
-  }
-  .main-menu-btn:hover { transform: translateY(-2px); filter: brightness(1.05); }
-  .main-menu-btn.ghost-btn {
-    background: var(--surface-2, rgba(255, 255, 255, 0.06));
-    color: var(--text);
-    border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
-    box-shadow: none;
-  }
-  .main-menu-modal { text-align: center; }
-  .main-menu-modal .main-menu-btn { margin-top: 1rem; }
+	/* Modal action button (reused brand button) */
+	.main-menu-btn {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1rem;
+		padding: 13px 20px;
+		border-radius: var(--r-md);
+		border: none;
+		background: var(--brand-grad);
+		color: #3a2a00;
+		cursor: pointer;
+		box-shadow: var(--glow-brand);
+		transition:
+			transform 0.15s var(--ease-spring),
+			filter 0.2s;
+	}
+	.main-menu-btn:hover {
+		transform: translateY(-2px);
+		filter: brightness(1.05);
+	}
+	.main-menu-btn.ghost-btn {
+		background: var(--surface-2, rgba(255, 255, 255, 0.06));
+		color: var(--text);
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow: none;
+	}
+	.main-menu-modal {
+		text-align: center;
+	}
+	.main-menu-modal .main-menu-btn {
+		margin-top: 1rem;
+	}
 
-  .cat-sub { font-size: 0.85rem; color: var(--text-muted); margin: 0 0 16px; }
+	.cat-sub {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin: 0 0 16px;
+	}
 
-  /* Challenges modal */
-  .ch-modal { max-width: 440px; }
-  .ch-tabs { display: flex; gap: 8px; margin: 4px 0 14px; }
-  .ch-tab { flex: 1; padding: 9px 0; border-radius: 12px; border: 1px solid var(--border); background: var(--surface);
-    color: var(--text-muted); font-family: var(--font-display); font-weight: 700; font-size: 0.9rem; cursor: pointer; }
-  .ch-tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
-  .ch-empty { color: var(--text-muted); font-size: 0.92rem; padding: 2rem 1rem; }
-  .ch-empty b { color: var(--brand-2); }
-  .ch-new { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem; }
-  .ch-modes { display: flex; gap: 0.5rem; }
-  .ch-mode {
-    flex: 1; display: flex; flex-direction: column; gap: 0.15rem; align-items: flex-start;
-    padding: 0.55rem 0.7rem; border-radius: 10px; cursor: pointer; text-align: left;
-    border: 1px solid var(--border); background: var(--surface); color: var(--text);
-    font-weight: 700; font-size: 0.9rem; transition: border-color 0.15s, background 0.15s;
-  }
-  .ch-mode small { font-weight: 500; font-size: 0.68rem; color: var(--text-muted); }
-  .ch-mode.active { border-color: rgba(251,191,36,0.6); background: linear-gradient(135deg, rgba(251,191,36,0.14), rgba(251,191,36,0.04)); box-shadow: 0 0 12px rgba(251,191,36,0.15); }
-  .ch-search-wrap { position: relative; display: flex; flex-direction: column; }
-  .ch-search-wrap .ch-input { width: 100%; }
-  .ch-results {
-    display: flex; flex-direction: column; gap: 2px; margin-top: 4px;
-    border: 1px solid var(--border); border-radius: 10px; padding: 4px; background: var(--surface);
-  }
-  .ch-result-item {
-    text-align: left; padding: 0.45rem 0.6rem; border: none; border-radius: 8px; cursor: pointer;
-    background: none; color: var(--text); font-weight: 600; font-size: 0.9rem;
-  }
-  .ch-result-item:hover { background: rgba(255,255,255,0.06); }
-  .ch-friend-tag { font-size: 0.7rem; color: var(--brand-2); font-weight: 700; }
-  .ch-row { display: flex; gap: 0.5rem; }
-  .ch-input {
-    flex: 1; min-width: 0; padding: 0.6rem 0.8rem; border-radius: 10px; border: 1px solid var(--border);
-    background: var(--surface); color: var(--text); font-size: 0.9rem;
-  }
-  .ch-create { padding: 0.6rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .ch-create:disabled { opacity: 0.6; }
-  .ch-objective { font-size: 0.74rem; line-height: 1.4; color: var(--text-muted); margin: 0 0 10px; }
-  .ch-objective strong { color: var(--brand-2); }
-  .ch-toggle {
-    display: flex; align-items: center; gap: 8px; width: 100%; margin: 2px 0 10px; padding: 0;
-    background: none; border: none; cursor: pointer; color: var(--text-muted); font-size: 0.8rem; text-align: left; font-weight: 600;
-  }
-  .ch-toggle.on { color: var(--brand-2); }
-  .ch-tog-box {
-    width: 20px; height: 20px; flex-shrink: 0; border-radius: 6px; display: grid; place-items: center;
-    border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: #3a2a00; font-size: 0.75rem; font-weight: 800;
-  }
-  .ch-toggle.on .ch-tog-box { background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border-color: transparent; }
-  .ch-cats { display: flex; flex-wrap: wrap; gap: 4px; justify-content: center; }
-  .ch-cat { width: 34px; height: 34px; border-radius: 9px; cursor: pointer; font-size: 1rem; border: 1px solid var(--border); background: var(--surface); opacity: 0.5; transition: opacity 0.15s, border-color 0.15s; }
-  .ch-cat.on { opacity: 1; border-color: rgba(253, 224, 71,0.55); background: rgba(253, 224, 71,0.08); }
-  .ch-hint { font-size: 0.72rem; color: var(--text-faint); text-align: center; margin: 0; }
-  .ch-field { flex: 1; display: flex; flex-direction: column; gap: 3px; text-align: left; min-width: 0; }
-  .ch-field > span { font-size: 0.72rem; color: var(--text-faint); font-weight: 700; }
-  .ch-ante { margin-top: 0.2rem; }
-  .ante-chips { display: grid; grid-template-columns: repeat(4, 1fr); gap: 6px; margin: 4px 0 2px; }
-  .ante-chip { padding: 0.55rem 0.3rem; border-radius: 11px; border: 1px solid var(--border); background: var(--surface);
-    color: var(--text); font-family: var(--font-display); font-weight: 700; font-size: 0.82rem; cursor: pointer; white-space: nowrap; }
-  .ante-chip:hover { border-color: var(--brand-2); }
-  .ante-chip.on { border-color: var(--brand-2); background: linear-gradient(135deg, rgba(251,191,36,0.16), rgba(253,224,71,0.05)); color: var(--brand-2); }
-  .ch-ante .ch-hint { text-align: left; margin-top: 4px; line-height: 1.4; }
-  .ch-field > span { font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-faint); font-weight: 600; }
-  .ch-play.ghost { color: var(--brand-2); background: transparent; border: 1px solid rgba(253, 224, 71,0.4); }
-  .ch-list { display: flex; flex-direction: column; gap: 0.5rem; max-height: 280px; overflow-y: auto; }
-  .ch-item { display: flex; align-items: center; justify-content: space-between; gap: 0.6rem; padding: 0.7rem 0.8rem; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; }
-  .ch-info { display: flex; flex-direction: column; gap: 2px; text-align: left; min-width: 0; }
-  .ch-vs { font-weight: 600; font-size: 0.9rem; }
-  .ch-meta { font-size: 0.75rem; color: var(--text-faint); }
-  .ch-play { padding: 0.45rem 0.9rem; border: none; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.85rem; color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .ch-play:disabled { opacity: 0.6; }
-  .ch-waiting { font-size: 0.8rem; color: var(--text-faint); }
-  .ch-result { font-family: var(--font-display); font-weight: 700; font-size: 0.8rem; }
-  .ch-result.win { color: var(--brand-2); }
-  .ch-result.loss { color: #fb7185; }
-  .ch-result.tie { color: var(--text-muted); }
+	/* Challenges modal */
+	.ch-modal {
+		max-width: 440px;
+	}
+	.ch-tabs {
+		display: flex;
+		gap: 8px;
+		margin: 4px 0 14px;
+	}
+	.ch-tab {
+		flex: 1;
+		padding: 9px 0;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text-muted);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.9rem;
+		cursor: pointer;
+	}
+	.ch-tab.active {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		border-color: transparent;
+	}
+	.ch-empty {
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		padding: 2rem 1rem;
+	}
+	.ch-empty b {
+		color: var(--brand-2);
+	}
+	.ch-new {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+	.ch-modes {
+		display: flex;
+		gap: 0.5rem;
+	}
+	.ch-mode {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		align-items: flex-start;
+		padding: 0.55rem 0.7rem;
+		border-radius: 10px;
+		cursor: pointer;
+		text-align: left;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-weight: 700;
+		font-size: 0.9rem;
+		transition:
+			border-color 0.15s,
+			background 0.15s;
+	}
+	.ch-mode small {
+		font-weight: 500;
+		font-size: 0.68rem;
+		color: var(--text-muted);
+	}
+	.ch-mode.active {
+		border-color: rgba(251, 191, 36, 0.6);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.04));
+		box-shadow: 0 0 12px rgba(251, 191, 36, 0.15);
+	}
+	.ch-search-wrap {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+	}
+	.ch-search-wrap .ch-input {
+		width: 100%;
+	}
+	.ch-results {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		margin-top: 4px;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		padding: 4px;
+		background: var(--surface);
+	}
+	.ch-result-item {
+		text-align: left;
+		padding: 0.45rem 0.6rem;
+		border: none;
+		border-radius: 8px;
+		cursor: pointer;
+		background: none;
+		color: var(--text);
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.ch-result-item:hover {
+		background: rgba(255, 255, 255, 0.06);
+	}
+	.ch-friend-tag {
+		font-size: 0.7rem;
+		color: var(--brand-2);
+		font-weight: 700;
+	}
+	.ch-row {
+		display: flex;
+		gap: 0.5rem;
+	}
+	.ch-input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.6rem 0.8rem;
+		border-radius: 10px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.9rem;
+	}
+	.ch-create {
+		padding: 0.6rem 1rem;
+		border: none;
+		border-radius: 10px;
+		cursor: pointer;
+		font-weight: 700;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.ch-create:disabled {
+		opacity: 0.6;
+	}
+	.ch-objective {
+		font-size: 0.74rem;
+		line-height: 1.4;
+		color: var(--text-muted);
+		margin: 0 0 10px;
+	}
+	.ch-objective strong {
+		color: var(--brand-2);
+	}
+	.ch-toggle {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		width: 100%;
+		margin: 2px 0 10px;
+		padding: 0;
+		background: none;
+		border: none;
+		cursor: pointer;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		text-align: left;
+		font-weight: 600;
+	}
+	.ch-toggle.on {
+		color: var(--brand-2);
+	}
+	.ch-tog-box {
+		width: 20px;
+		height: 20px;
+		flex-shrink: 0;
+		border-radius: 6px;
+		display: grid;
+		place-items: center;
+		border: 1px solid var(--border);
+		background: var(--surface-2, rgba(255, 255, 255, 0.04));
+		color: #3a2a00;
+		font-size: 0.75rem;
+		font-weight: 800;
+	}
+	.ch-toggle.on .ch-tog-box {
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		border-color: transparent;
+	}
+	.ch-cats {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		justify-content: center;
+	}
+	.ch-cat {
+		width: 34px;
+		height: 34px;
+		border-radius: 9px;
+		cursor: pointer;
+		font-size: 1rem;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		opacity: 0.5;
+		transition:
+			opacity 0.15s,
+			border-color 0.15s;
+	}
+	.ch-cat.on {
+		opacity: 1;
+		border-color: rgba(253, 224, 71, 0.55);
+		background: rgba(253, 224, 71, 0.08);
+	}
+	.ch-hint {
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		text-align: center;
+		margin: 0;
+	}
+	.ch-field {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		text-align: left;
+		min-width: 0;
+	}
+	.ch-field > span {
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		font-weight: 700;
+	}
+	.ch-ante {
+		margin-top: 0.2rem;
+	}
+	.ante-chips {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 6px;
+		margin: 4px 0 2px;
+	}
+	.ante-chip {
+		padding: 0.55rem 0.3rem;
+		border-radius: 11px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.82rem;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.ante-chip:hover {
+		border-color: var(--brand-2);
+	}
+	.ante-chip.on {
+		border-color: var(--brand-2);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.16), rgba(253, 224, 71, 0.05));
+		color: var(--brand-2);
+	}
+	.ch-ante .ch-hint {
+		text-align: left;
+		margin-top: 4px;
+		line-height: 1.4;
+	}
+	.ch-field > span {
+		font-size: 0.62rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-faint);
+		font-weight: 600;
+	}
+	.ch-play.ghost {
+		color: var(--brand-2);
+		background: transparent;
+		border: 1px solid rgba(253, 224, 71, 0.4);
+	}
+	.ch-list {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-height: 280px;
+		overflow-y: auto;
+	}
+	.ch-item {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem;
+		padding: 0.7rem 0.8rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+	}
+	.ch-info {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		text-align: left;
+		min-width: 0;
+	}
+	.ch-vs {
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.ch-meta {
+		font-size: 0.75rem;
+		color: var(--text-faint);
+	}
+	.ch-play {
+		padding: 0.45rem 0.9rem;
+		border: none;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 0.85rem;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.ch-play:disabled {
+		opacity: 0.6;
+	}
+	.ch-waiting {
+		font-size: 0.8rem;
+		color: var(--text-faint);
+	}
+	.ch-result {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.8rem;
+	}
+	.ch-result.win {
+		color: var(--brand-2);
+	}
+	.ch-result.loss {
+		color: #fb7185;
+	}
+	.ch-result.tie {
+		color: var(--text-muted);
+	}
 
-  /* Streak + freeze chips (My Account) */
-  .account-stats {
-    display: flex;
-    gap: 10px;
-    justify-content: center;
-    margin: 14px 0 4px;
-  }
-  .stat-chip {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 5px;
-    padding: 8px 14px;
-    border-radius: var(--r-pill);
-    background: var(--surface);
-    border: 1px solid var(--border);
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 1.1rem;
-    color: var(--text);
-  }
-  .stat-emoji { font-size: 1rem; }
-  .stat-cap {
-    font-family: var(--font-ui);
-    font-weight: 600;
-    font-size: 0.62rem;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--text-faint);
-  }
+	/* Streak + freeze chips (My Account) */
+	.account-stats {
+		display: flex;
+		gap: 10px;
+		justify-content: center;
+		margin: 14px 0 4px;
+	}
+	.stat-chip {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 5px;
+		padding: 8px 14px;
+		border-radius: var(--r-pill);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.1rem;
+		color: var(--text);
+	}
+	.stat-emoji {
+		font-size: 1rem;
+	}
+	.stat-cap {
+		font-family: var(--font-ui);
+		font-weight: 600;
+		font-size: 0.62rem;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
 
-  .streak-message {
-    margin: 1rem 0 0 0;
-    font-size: 1.05rem;
-    color: var(--text-muted);
-  }
-  .cbt-medal { font-size: 2.6rem; line-height: 1; margin-bottom: 0.3rem; }
-  .cbt-result { font-size: 0.95rem; color: var(--text-muted); margin: 0.2rem 0 0; }
-  .cbt-stats {
-    display: flex;
-    justify-content: center;
-    gap: 0.6rem;
-    margin: 1.1rem 0 0.2rem;
-  }
-  .cbt-stat {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    min-width: 78px;
-    padding: 0.6rem 0.5rem;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid var(--border);
-    border-radius: 13px;
-  }
-  .cbt-val { font-family: var(--font-display); font-weight: 700; font-size: 1.15rem; color: var(--brand-2); }
-  .cbt-cap { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint); }
-  .account-email {
-    font-size: 0.95rem;
-    color: var(--text-muted);
-    margin: 0.5rem 0 0 0;
-  }
-  .ma-section-label {
-    text-align: left; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
-    color: var(--text-faint); margin: 1rem 0 0.1rem; padding-left: 0.2rem;
-  }
-  .ma-people-row { display: flex; gap: 8px; }
-  .ma-people-row .main-menu-btn { flex: 1; }
-  /* About: legal links + version + delete */
-  .ma-links { display: flex; align-items: center; justify-content: center; gap: 8px; margin: 2px 0 4px; }
-  .ma-link { color: var(--brand-2); font-size: 0.85rem; font-weight: 600; text-decoration: none; }
-  .ma-link:hover { text-decoration: underline; }
-  .ma-dot { color: var(--text-faint); }
-  .ma-version { text-align: center; font-size: 0.72rem; color: var(--text-faint); margin: 14px 0 2px; }
-  /* ── Sectioned settings layout ── */
-  .settings-modal { text-align: left; }
-  .settings-modal > h2 { text-align: center; }
-  .set-profile { display: flex; align-items: center; gap: 13px; margin: 6px 0 4px; }
-  .set-av { position: relative; background: none; border: none; cursor: pointer; padding: 0; flex: none; }
-  .set-av-edit { position: absolute; bottom: -4px; left: 50%; transform: translateX(-50%); font-size: 0.62rem; font-weight: 800;
-    color: #3a2a00; background: var(--brand-2, #fde047); padding: 1px 7px; border-radius: 999px; }
-  .set-id { display: flex; flex-direction: column; gap: 3px; min-width: 0; flex: 1; }
-  .set-uname { display: flex; align-items: center; gap: 8px; font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--text); }
-  .set-uname-edit { display: flex; gap: 6px; }
-  .set-email { font-size: 0.78rem; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .set-label { text-align: left; font-size: 0.7rem; font-weight: 800; letter-spacing: 0.09em; text-transform: uppercase;
-    color: var(--text-faint); margin: 16px 0 7px; padding-left: 0.3rem; }
-  .set-group { display: flex; flex-direction: column; border-radius: 14px; overflow: hidden; border: 1px solid var(--border); background: var(--surface); }
-  .set-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; width: 100%;
-    padding: 13px 15px; background: none; border: none; border-bottom: 1px solid var(--border); cursor: pointer;
-    color: var(--text); font-weight: 600; font-size: 0.95rem; text-align: left; text-decoration: none; }
-  .set-group > :last-child { border-bottom: none; }
-  .set-row:hover { background: rgba(255,255,255,0.04); }
-  .set-row.sub { cursor: default; padding: 11px 15px; }
-  .set-row.sub:hover { background: none; }
-  .set-row.sub.tracks { gap: 6px; }
-  .set-row.sub .mmc-slider { flex: 1; }
-  .set-row.danger { color: #f87171; }
-  .set-state { font-size: 0.82rem; font-weight: 800; color: var(--text-faint); }
-  .set-state.on { color: #4ade80; }
-  .chev { color: var(--text-faint); font-weight: 700; }
-  .main-menu-btn.ma-danger { background: rgba(248,113,113,0.12); color: #f87171; border: 1px solid rgba(248,113,113,0.5); }
-  .main-menu-btn.ma-danger:hover { background: rgba(248,113,113,0.2); }
-  .main-menu-btn.ma-danger:disabled { opacity: 0.5; cursor: not-allowed; }
-  .del-card { text-align: center; max-width: 360px; }
-  .del-body { font-size: 0.9rem; line-height: 1.5; color: var(--text-muted); margin: 6px 0 14px; }
-  .del-input { width: 100%; text-align: center; margin-bottom: 12px; }
-  .danger-overlay { z-index: 4000; }
-  .ma-toggle { display: flex; align-items: center; gap: 0.5rem; }
-  .ma-toggle-state {
-    margin-left: auto; font-size: 0.72rem; font-weight: 800; color: var(--brand-2);
-    background: rgba(253, 224, 71,0.12); border: 1px solid rgba(253, 224, 71,0.35);
-    padding: 2px 8px; border-radius: 999px;
-  }
-  .ma-music-ctl {
-    display: flex; align-items: center; gap: 0.6rem; margin: 0.4rem 0.2rem 0;
-    padding: 0.3rem 0.2rem;
-  }
-  .mmc-ic { font-size: 0.95rem; }
-  .mmc-slider { flex: 1; accent-color: #fbbf24; height: 4px; cursor: pointer; }
-  .mmc-pct { font-size: 0.72rem; font-weight: 800; color: var(--text-muted); min-width: 34px; text-align: right; }
-  .ma-track-select {
-    width: 100%; margin-top: 0.5rem; padding: 0.6rem 0.8rem; border-radius: 12px;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600;
-  }
-  .ma-username { display: flex; align-items: center; justify-content: center; gap: 0.5rem; margin: 0.7rem 0 0.2rem; }
-  .ma-uname { font-family: var(--font-display); font-weight: 800; font-size: 1.1rem; color: var(--brand-2); }
-  .ma-edit { background: none; border: none; color: var(--text-faint); font-size: 0.8rem; cursor: pointer; text-decoration: underline; }
-  .ma-input {
-    padding: 0.5rem 0.8rem; border-radius: 10px; border: 1px solid var(--border);
-    background: var(--surface); color: var(--text); font-size: 0.95rem; max-width: 180px;
-  }
-  .ma-save { padding: 0.5rem 1rem; border: none; border-radius: 10px; cursor: pointer; font-weight: 700; color: #3a2a00; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .ma-msg { text-align: center; font-size: 0.82rem; color: #f87171; margin: 0.2rem 0 0; }
+	.streak-message {
+		margin: 1rem 0 0 0;
+		font-size: 1.05rem;
+		color: var(--text-muted);
+	}
+	.cbt-medal {
+		font-size: 2.6rem;
+		line-height: 1;
+		margin-bottom: 0.3rem;
+	}
+	.cbt-result {
+		font-size: 0.95rem;
+		color: var(--text-muted);
+		margin: 0.2rem 0 0;
+	}
+	.cbt-stats {
+		display: flex;
+		justify-content: center;
+		gap: 0.6rem;
+		margin: 1.1rem 0 0.2rem;
+	}
+	.cbt-stat {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		min-width: 78px;
+		padding: 0.6rem 0.5rem;
+		background: rgba(255, 255, 255, 0.04);
+		border: 1px solid var(--border);
+		border-radius: 13px;
+	}
+	.cbt-val {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.15rem;
+		color: var(--brand-2);
+	}
+	.cbt-cap {
+		font-size: 0.68rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-faint);
+	}
+	.account-email {
+		font-size: 0.95rem;
+		color: var(--text-muted);
+		margin: 0.5rem 0 0 0;
+	}
+	.ma-section-label {
+		text-align: left;
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+		margin: 1rem 0 0.1rem;
+		padding-left: 0.2rem;
+	}
+	.ma-people-row {
+		display: flex;
+		gap: 8px;
+	}
+	.ma-people-row .main-menu-btn {
+		flex: 1;
+	}
+	/* About: legal links + version + delete */
+	.ma-links {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		margin: 2px 0 4px;
+	}
+	.ma-link {
+		color: var(--brand-2);
+		font-size: 0.85rem;
+		font-weight: 600;
+		text-decoration: none;
+	}
+	.ma-link:hover {
+		text-decoration: underline;
+	}
+	.ma-dot {
+		color: var(--text-faint);
+	}
+	.ma-version {
+		text-align: center;
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		margin: 14px 0 2px;
+	}
+	/* ── Sectioned settings layout ── */
+	.settings-modal {
+		text-align: left;
+	}
+	.settings-modal > h2 {
+		text-align: center;
+	}
+	.set-profile {
+		display: flex;
+		align-items: center;
+		gap: 13px;
+		margin: 6px 0 4px;
+	}
+	.set-av {
+		position: relative;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		flex: none;
+	}
+	.set-av-edit {
+		position: absolute;
+		bottom: -4px;
+		left: 50%;
+		transform: translateX(-50%);
+		font-size: 0.62rem;
+		font-weight: 800;
+		color: #3a2a00;
+		background: var(--brand-2, #fde047);
+		padding: 1px 7px;
+		border-radius: 999px;
+	}
+	.set-id {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		min-width: 0;
+		flex: 1;
+	}
+	.set-uname {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		color: var(--text);
+	}
+	.set-uname-edit {
+		display: flex;
+		gap: 6px;
+	}
+	.set-email {
+		font-size: 0.78rem;
+		color: var(--text-faint);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.set-label {
+		text-align: left;
+		font-size: 0.7rem;
+		font-weight: 800;
+		letter-spacing: 0.09em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+		margin: 16px 0 7px;
+		padding-left: 0.3rem;
+	}
+	.set-group {
+		display: flex;
+		flex-direction: column;
+		border-radius: 14px;
+		overflow: hidden;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.set-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+		width: 100%;
+		padding: 13px 15px;
+		background: none;
+		border: none;
+		border-bottom: 1px solid var(--border);
+		cursor: pointer;
+		color: var(--text);
+		font-weight: 600;
+		font-size: 0.95rem;
+		text-align: left;
+		text-decoration: none;
+	}
+	.set-group > :last-child {
+		border-bottom: none;
+	}
+	.set-row:hover {
+		background: rgba(255, 255, 255, 0.04);
+	}
+	.set-row.sub {
+		cursor: default;
+		padding: 11px 15px;
+	}
+	.set-row.sub:hover {
+		background: none;
+	}
+	.set-row.sub.tracks {
+		gap: 6px;
+	}
+	.set-row.sub .mmc-slider {
+		flex: 1;
+	}
+	.set-row.danger {
+		color: #f87171;
+	}
+	.set-state {
+		font-size: 0.82rem;
+		font-weight: 800;
+		color: var(--text-faint);
+	}
+	.set-state.on {
+		color: #4ade80;
+	}
+	.chev {
+		color: var(--text-faint);
+		font-weight: 700;
+	}
+	.main-menu-btn.ma-danger {
+		background: rgba(248, 113, 113, 0.12);
+		color: #f87171;
+		border: 1px solid rgba(248, 113, 113, 0.5);
+	}
+	.main-menu-btn.ma-danger:hover {
+		background: rgba(248, 113, 113, 0.2);
+	}
+	.main-menu-btn.ma-danger:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.del-card {
+		text-align: center;
+		max-width: 360px;
+	}
+	.del-body {
+		font-size: 0.9rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		margin: 6px 0 14px;
+	}
+	.del-input {
+		width: 100%;
+		text-align: center;
+		margin-bottom: 12px;
+	}
+	.danger-overlay {
+		z-index: 4000;
+	}
+	.ma-toggle {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+	.ma-toggle-state {
+		margin-left: auto;
+		font-size: 0.72rem;
+		font-weight: 800;
+		color: var(--brand-2);
+		background: rgba(253, 224, 71, 0.12);
+		border: 1px solid rgba(253, 224, 71, 0.35);
+		padding: 2px 8px;
+		border-radius: 999px;
+	}
+	.ma-music-ctl {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		margin: 0.4rem 0.2rem 0;
+		padding: 0.3rem 0.2rem;
+	}
+	.mmc-ic {
+		font-size: 0.95rem;
+	}
+	.mmc-slider {
+		flex: 1;
+		accent-color: #fbbf24;
+		height: 4px;
+		cursor: pointer;
+	}
+	.mmc-pct {
+		font-size: 0.72rem;
+		font-weight: 800;
+		color: var(--text-muted);
+		min-width: 34px;
+		text-align: right;
+	}
+	.ma-track-select {
+		width: 100%;
+		margin-top: 0.5rem;
+		padding: 0.6rem 0.8rem;
+		border-radius: 12px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		font-weight: 600;
+	}
+	.ma-username {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.5rem;
+		margin: 0.7rem 0 0.2rem;
+	}
+	.ma-uname {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.1rem;
+		color: var(--brand-2);
+	}
+	.ma-edit {
+		background: none;
+		border: none;
+		color: var(--text-faint);
+		font-size: 0.8rem;
+		cursor: pointer;
+		text-decoration: underline;
+	}
+	.ma-input {
+		padding: 0.5rem 0.8rem;
+		border-radius: 10px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.95rem;
+		max-width: 180px;
+	}
+	.ma-save {
+		padding: 0.5rem 1rem;
+		border: none;
+		border-radius: 10px;
+		cursor: pointer;
+		font-weight: 700;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.ma-msg {
+		text-align: center;
+		font-size: 0.82rem;
+		color: #f87171;
+		margin: 0.2rem 0 0;
+	}
 
-  /* First-run username gate */
-  .username-gate { z-index: 3000; }
-  .claim-card { text-align: center; max-width: 360px; }
-  .claim-coin { display: block; margin: 0 auto 0.4rem; filter: drop-shadow(0 6px 20px rgba(251,191,36,0.4)); }
-  .claim-sub { color: var(--text-muted); font-size: 0.88rem; line-height: 1.45; margin: 0.4rem 0 1.1rem; }
-  .claim-row {
-    display: flex; align-items: center; gap: 4px; padding: 0 0.9rem;
-    background: var(--surface); border: 1px solid rgba(251,191,36,0.4); border-radius: 12px;
-  }
-  .claim-row:focus-within { border-color: #fde047; }
-  .claim-at { font-family: var(--font-display); font-weight: 800; color: #fbbf24; font-size: 1.15rem; }
-  .claim-input {
-    flex: 1; min-width: 0; padding: 0.8rem 0.2rem; border: none; background: transparent;
-    color: var(--text); font-size: 1.1rem; font-family: var(--font-display); font-weight: 700;
-  }
-  .claim-input:focus { outline: none; }
-  .claim-msg { color: #f87171; font-size: 0.82rem; margin: 0.6rem 0 0; }
-  .claim-btn {
-    width: 100%; margin-top: 1rem; padding: 0.85rem; border: none; border-radius: 12px; cursor: pointer;
-    font-weight: 800; font-size: 1rem; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b);
-  }
-  .claim-btn:disabled { opacity: 0.5; cursor: default; }
-  .claim-hint { color: var(--text-faint); font-size: 0.74rem; margin: 0.7rem 0 0; }
+	/* First-run username gate */
+	.username-gate {
+		z-index: 3000;
+	}
+	.claim-card {
+		text-align: center;
+		max-width: 360px;
+	}
+	.claim-coin {
+		display: block;
+		margin: 0 auto 0.4rem;
+		filter: drop-shadow(0 6px 20px rgba(251, 191, 36, 0.4));
+	}
+	.claim-sub {
+		color: var(--text-muted);
+		font-size: 0.88rem;
+		line-height: 1.45;
+		margin: 0.4rem 0 1.1rem;
+	}
+	.claim-row {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 0 0.9rem;
+		background: var(--surface);
+		border: 1px solid rgba(251, 191, 36, 0.4);
+		border-radius: 12px;
+	}
+	.claim-row:focus-within {
+		border-color: #fde047;
+	}
+	.claim-at {
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: #fbbf24;
+		font-size: 1.15rem;
+	}
+	.claim-input {
+		flex: 1;
+		min-width: 0;
+		padding: 0.8rem 0.2rem;
+		border: none;
+		background: transparent;
+		color: var(--text);
+		font-size: 1.1rem;
+		font-family: var(--font-display);
+		font-weight: 700;
+	}
+	.claim-input:focus {
+		outline: none;
+	}
+	.claim-msg {
+		color: #f87171;
+		font-size: 0.82rem;
+		margin: 0.6rem 0 0;
+	}
+	.claim-btn {
+		width: 100%;
+		margin-top: 1rem;
+		padding: 0.85rem;
+		border: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 1rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.claim-btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.claim-hint {
+		color: var(--text-faint);
+		font-size: 0.74rem;
+		margin: 0.7rem 0 0;
+	}
 
-  .bankroll-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    margin: 0 auto;
-  }
+	.bankroll-container {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		width: 100%;
+		margin: 0 auto;
+	}
 
-  .bankroll-box {
-    position: relative;
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    padding: 12px 30px;
-    background: var(--surface-strong);
-    border: 1px solid var(--border);
-    border-radius: var(--r-lg);
-    box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    backdrop-filter: blur(14px);
-    -webkit-backdrop-filter: blur(14px);
-  }
-  .bankroll-box.pulse-up { animation: bankPulseUp 0.7s var(--ease-spring); }
-  .bankroll-box.pulse-down { animation: bankPulseDown 0.6s var(--ease-spring); }
-  @keyframes bankPulseUp {
-    0%, 100% { transform: scale(1); box-shadow: var(--shadow-md), inset 0 1px 0 rgba(255,255,255,0.06); }
-    40% { transform: scale(1.07); box-shadow: var(--shadow-md), 0 0 30px rgba(253, 224, 71,0.55); }
-  }
-  @keyframes bankPulseDown {
-    0%, 100% { transform: scale(1); }
-    35% { transform: scale(0.96); }
-  }
-  .bankroll-delta {
-    position: absolute;
-    top: 2px;
-    right: 12px;
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 0.95rem;
-    font-variant-numeric: tabular-nums;
-    pointer-events: none;
-    text-shadow: 0 0 12px currentColor;
-  }
-  .bankroll-delta.up { color: var(--brand-2); animation: deltaFloatUp 0.95s var(--ease-out) forwards; }
-  .bankroll-delta.down { color: #fb7185; animation: deltaFloatDown 0.95s var(--ease-out) forwards; }
-  @keyframes deltaFloatUp {
-    0% { opacity: 0; transform: translateY(8px); }
-    25% { opacity: 1; }
-    100% { opacity: 0; transform: translateY(-28px); }
-  }
-  @keyframes deltaFloatDown {
-    0% { opacity: 0; transform: translateY(-8px); }
-    25% { opacity: 1; }
-    100% { opacity: 0; transform: translateY(24px); }
-  }
-  .hot-hand-flash {
-    position: absolute;
-    top: -14px;
-    left: 50%;
-    transform: translateX(-50%);
-    white-space: nowrap;
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 0.9rem;
-    color: #fcd34d;
-    background: rgba(120, 53, 15, 0.85);
-    border: 1px solid rgba(251, 191, 36, 0.55);
-    border-radius: 999px;
-    padding: 4px 12px;
-    pointer-events: none;
-    text-shadow: 0 0 10px rgba(251, 191, 36, 0.6);
-    box-shadow: 0 0 18px rgba(251, 191, 36, 0.35);
-    animation: hotHandPop 1.3s var(--ease-out) forwards;
-    z-index: 5;
-  }
-  @keyframes hotHandPop {
-    0% { opacity: 0; transform: translateX(-50%) translateY(8px) scale(0.8); }
-    18% { opacity: 1; transform: translateX(-50%) translateY(0) scale(1.05); }
-    32% { transform: translateX(-50%) translateY(0) scale(1); }
-    80% { opacity: 1; }
-    100% { opacity: 0; transform: translateX(-50%) translateY(-22px) scale(1); }
-  }
+	.bankroll-box {
+		position: relative;
+		display: inline-flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		padding: 12px 30px;
+		background: var(--surface-strong);
+		border: 1px solid var(--border);
+		border-radius: var(--r-lg);
+		box-shadow:
+			var(--shadow-md),
+			inset 0 1px 0 rgba(255, 255, 255, 0.06);
+		backdrop-filter: blur(14px);
+		-webkit-backdrop-filter: blur(14px);
+	}
+	.bankroll-box.pulse-up {
+		animation: bankPulseUp 0.7s var(--ease-spring);
+	}
+	.bankroll-box.pulse-down {
+		animation: bankPulseDown 0.6s var(--ease-spring);
+	}
+	@keyframes bankPulseUp {
+		0%,
+		100% {
+			transform: scale(1);
+			box-shadow:
+				var(--shadow-md),
+				inset 0 1px 0 rgba(255, 255, 255, 0.06);
+		}
+		40% {
+			transform: scale(1.07);
+			box-shadow:
+				var(--shadow-md),
+				0 0 30px rgba(253, 224, 71, 0.55);
+		}
+	}
+	@keyframes bankPulseDown {
+		0%,
+		100% {
+			transform: scale(1);
+		}
+		35% {
+			transform: scale(0.96);
+		}
+	}
+	.bankroll-delta {
+		position: absolute;
+		top: 2px;
+		right: 12px;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+		font-variant-numeric: tabular-nums;
+		pointer-events: none;
+		text-shadow: 0 0 12px currentColor;
+	}
+	.bankroll-delta.up {
+		color: var(--brand-2);
+		animation: deltaFloatUp 0.95s var(--ease-out) forwards;
+	}
+	.bankroll-delta.down {
+		color: #fb7185;
+		animation: deltaFloatDown 0.95s var(--ease-out) forwards;
+	}
+	@keyframes deltaFloatUp {
+		0% {
+			opacity: 0;
+			transform: translateY(8px);
+		}
+		25% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+			transform: translateY(-28px);
+		}
+	}
+	@keyframes deltaFloatDown {
+		0% {
+			opacity: 0;
+			transform: translateY(-8px);
+		}
+		25% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+			transform: translateY(24px);
+		}
+	}
+	.hot-hand-flash {
+		position: absolute;
+		top: -14px;
+		left: 50%;
+		transform: translateX(-50%);
+		white-space: nowrap;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: #fcd34d;
+		background: rgba(120, 53, 15, 0.85);
+		border: 1px solid rgba(251, 191, 36, 0.55);
+		border-radius: 999px;
+		padding: 4px 12px;
+		pointer-events: none;
+		text-shadow: 0 0 10px rgba(251, 191, 36, 0.6);
+		box-shadow: 0 0 18px rgba(251, 191, 36, 0.35);
+		animation: hotHandPop 1.3s var(--ease-out) forwards;
+		z-index: 5;
+	}
+	@keyframes hotHandPop {
+		0% {
+			opacity: 0;
+			transform: translateX(-50%) translateY(8px) scale(0.8);
+		}
+		18% {
+			opacity: 1;
+			transform: translateX(-50%) translateY(0) scale(1.05);
+		}
+		32% {
+			transform: translateX(-50%) translateY(0) scale(1);
+		}
+		80% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+			transform: translateX(-50%) translateY(-22px) scale(1);
+		}
+	}
 
-  .bankroll-label {
-    font-family: var(--font-ui);
-    font-size: 0.62rem;
-    font-weight: 600;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--text-faint);
-  }
+	.bankroll-label {
+		font-family: var(--font-ui);
+		font-size: 0.62rem;
+		font-weight: 600;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
 
-  /* Live "spent · profit" line (all modes) */
-  .live-line { margin: 9px auto 0; text-align: center; font-size: 0.82rem; color: var(--text-muted); }
-  .live-line b { display: inline-block; font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--brand-2); }
-  .live-line b.lose { color: #fb7185; }
-  /* Cash Game bounty panel: one hero number (what you keep) that ticks down as you spend */
-  .bounty-panel { position: relative; display: flex; flex-direction: column; align-items: center; gap: 2px;
-    width: 100%; max-width: 340px; margin: 0 auto; padding: 14px 18px; border-radius: var(--r-lg, 18px);
-    border: 1px solid rgba(253, 224, 71, 0.4); background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.04));
-    box-shadow: 0 0 22px rgba(251, 191, 36, 0.16); }
-  .bounty-panel.loss { border-color: rgba(251,113,133,0.5); background: linear-gradient(135deg, rgba(251,113,133,0.13), rgba(251,113,133,0.03)); box-shadow: none; }
-  .bp-label { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--brand-2); }
-  .bounty-panel.loss .bp-label { color: #fb7185; }
-  .bp-amount { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.3rem; line-height: 1.05; color: #4ade80;
-    text-shadow: 0 0 18px rgba(52,211,153,0.5); font-variant-numeric: tabular-nums; transition: color 0.2s; }
-  .bp-amount-btn { background: none; border: none; padding: 0; cursor: pointer; }
-  .bounty-panel.loss .bp-amount { color: #fb7185; text-shadow: none; }
-  /* 🪙 Challenge ante: the bounty hero depletes as you spend; empties to a calm "out of ante" look */
-  .bounty-panel.ante-empty { border-color: rgba(148,163,184,0.4); background: linear-gradient(135deg, rgba(148,163,184,0.12), rgba(148,163,184,0.03)); box-shadow: none; }
-  .bounty-panel.ante-empty .bp-label, .bounty-panel.ante-empty .bp-amount { color: #cbd5e1; text-shadow: none; }
-  .ante-bar { width: 100%; max-width: 240px; height: 7px; margin: 6px auto 0; border-radius: 999px; background: rgba(255,255,255,0.10); overflow: hidden; }
-  .ante-fill { display: block; height: 100%; border-radius: 999px; background: linear-gradient(90deg, #fbbf24, #fde047); transition: width 0.35s ease; }
-  .match-ante-sub { margin: 4px auto 0; text-align: center; font-size: 0.72rem; color: var(--text-muted); }
-  /* lit gold bounty multiplier badge (left of the bounty) — ×1.0 today, boostable later */
-  .bp-mult-badge { position: absolute; left: 12px; top: 50%; transform: translateY(-50%);
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.05rem; line-height: 1;
-    padding: 5px 9px; border-radius: 9px; color: #3a2a00;
-    background: linear-gradient(135deg, #fff1a8, #f6cd4d 45%, #e0a312);
-    border: 1px solid rgba(180,130,15,0.95); cursor: pointer;
-    box-shadow: 0 0 14px rgba(251,191,36,0.65), inset 0 1px 0 rgba(255,255,255,0.6), inset 0 -2px 3px rgba(120,80,0,0.35); }
-  .bp-mult-badge:active { transform: translateY(-50%) scale(0.94); }
-  /* 🏆 win streak — mirror of the multiplier badge, on the right of the bounty (boosts mult) */
-  .bp-winstreak { position: absolute; right: 12px; top: 50%; transform: translateY(-50%); cursor: pointer;
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.95rem; line-height: 1;
-    padding: 5px 9px; border-radius: 9px; color: #3a2a00;
-    background: linear-gradient(135deg, #fff1a8, #f6cd4d 45%, #e0a312); border: 1px solid rgba(180,130,15,0.95);
-    box-shadow: 0 0 12px rgba(251,191,36,0.5), inset 0 1px 0 rgba(255,255,255,0.5); }
-  .bp-winstreak:active { transform: translateY(-50%) scale(0.94); }
-  /* ℹ️ Daily explainer modal (multiplier / Solve-to-Earn breakdown) */
-  .info-overlay { border: none; cursor: pointer; }
-  .info-card { position: relative; width: 100%; max-width: 330px; cursor: default; text-align: center;
-    background: var(--surface-strong, #141c28); border: 1px solid var(--border-strong, rgba(255,255,255,0.14));
-    border-radius: 18px; padding: 22px 20px; box-shadow: 0 20px 60px rgba(0,0,0,0.6); }
-  /* reusable red close ✕ (top-right) — returns to the game */
-  .modal-x { position: absolute; top: 10px; right: 10px; z-index: 2; width: 30px; height: 30px; border-radius: 50%;
-    display: grid; place-items: center; cursor: pointer; font-size: 0.8rem; font-weight: 900; color: #fff;
-    background: linear-gradient(135deg, #fb5a5a, #c81e1e); border: 1px solid rgba(0,0,0,0.25); box-shadow: 0 2px 6px rgba(200,30,30,0.4); }
-  .modal-x:hover { filter: brightness(1.08); }
-  .modal-x:active { transform: scale(0.92); }
-  /* 🎒 Bag button left of Solve (in-game) */
-  .bag-fab { position: fixed; z-index: 998; bottom: calc(env(safe-area-inset-bottom, 0px) + 188px);
-    right: calc(50% + 108px); width: 46px; height: 46px; border-radius: 12px; cursor: pointer; display: grid; place-items: center;
-    font-size: 1.5rem; color: var(--text); background: var(--surface-strong, rgba(20,28,40,0.9));
-    border: 1px solid rgba(253,224,71,0.5); backdrop-filter: blur(10px); box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
-  .bag-fab:active { transform: scale(0.93); }
-  .bag-fab-badge { position: absolute; top: -5px; right: -5px; min-width: 18px; height: 18px; padding: 0 4px; border-radius: 999px;
-    background: #ea580c; color: #fff; font-family: var(--font-display); font-weight: 800; font-size: 0.66rem; display: grid; place-items: center; }
-  .bag-chip { width: 54px; height: 54px; padding: 0; border-radius: 50%; display: grid; place-items: center; }
-  /* 🔐 Cash Game vault — sits to the left of Solve; absolute so Solve stays centered */
-  .solve-vault { position: absolute; right: 100%; margin-right: 12px; top: 50%; transform: translateY(-50%);
-    width: 50px; height: 50px; border-radius: 14px; display: grid; place-items: center; cursor: pointer;
-    background: var(--surface-strong, rgba(20,28,40,0.9)); border: 1px solid rgba(253,224,71,0.5);
-    backdrop-filter: blur(10px); box-shadow: 0 4px 12px rgba(0,0,0,0.4); transition: transform 0.16s var(--ease-spring); }
-  .solve-vault:active { transform: translateY(-50%) scale(0.93); }
-  .solve-vault img { width: 34px; height: 34px; object-fit: contain; }
-  .solve-vault-badge { position: absolute; top: -6px; right: -6px; min-width: 18px; height: 18px; padding: 0 4px; border-radius: 999px;
-    background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); color: #3a2a00;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.66rem; display: grid; place-items: center; }
-  .vault-ic { width: 34px; height: 34px; object-fit: contain; }
-  .vault-ic-sm { width: 46px; height: 46px; object-fit: contain; display: block; }
-  .vault-ic-xs { width: 22px; height: 22px; object-fit: contain; vertical-align: -5px; }
-  /* 🎒 Bag modal */
-  .bag-modal { max-width: 360px; max-height: 84vh; overflow-y: auto; }
-  .bag-use-h { font-family: var(--font-display); font-weight: 700; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.04em;
-    color: var(--brand-2); margin: 6px 0 8px; text-align: left; }
-  .bag-use-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-bottom: 16px; }
-  .bag-use { position: relative; display: flex; flex-direction: column; align-items: center; text-align: center; gap: 3px; cursor: pointer;
-    padding: 0.9rem 0.5rem; border-radius: 14px; color: var(--text);
-    background: linear-gradient(135deg, rgba(251,191,36,0.2), rgba(251,191,36,0.05)); border: 1px solid rgba(253,224,71,0.55); }
-  .bag-use:active { transform: scale(0.96); }
-  .bag-use:disabled { opacity: 0.5; cursor: default; }
-  .bag-use.locked { background: var(--surface); border: 1px solid var(--border); filter: grayscale(0.7); }
-  .bag-use.locked .bag-use-e { opacity: 0.55; }
-  .bag-use.locked .bag-use-d { color: var(--text-faint); }
-  .bag-msg { margin-top: 12px; padding: 10px 12px; border-radius: 11px; text-align: center; font-size: 0.82rem; line-height: 1.35;
-    color: var(--text); background: rgba(251,191,36,0.14); border: 1px solid rgba(253,224,71,0.45); }
-  .bag-use-e { font-size: 1.7rem; line-height: 1; }
-  .bag-use-n { position: absolute; top: 7px; right: 9px; font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.78rem; color: #fde047; }
-  .bag-use-name { font-family: var(--font-display); font-weight: 700; font-size: 0.86rem; }
-  .bag-use-d { font-size: 0.72rem; color: var(--text-muted); line-height: 1.3; }
-  .bag-inv { margin-bottom: 14px; }
-  .bag-store { width: 100%; padding: 11px; border-radius: 12px; border: none; cursor: pointer;
-    font-family: var(--font-display); font-weight: 800; color: #3a2a00; background: linear-gradient(135deg, #fde047, #f59e0b); }
-  /* in-game bank modal */
-  .bm-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-faint); margin: 0 0 2px; }
-  .bm-hist-h { font-family: var(--font-display); font-size: 0.78rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
-    color: var(--brand-2); text-align: left; margin: 16px 0 6px; }
-  .bm-ledger { display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden;
-    max-height: 40vh; overflow-y: auto; margin-bottom: 14px; }
-  .bm-row { display: flex; justify-content: space-between; gap: 10px; padding: 9px 11px; background: var(--surface); }
-  .bm-reason { color: var(--text-muted); font-size: 0.84rem; text-align: left; }
-  .bm-delta { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.84rem; font-variant-numeric: tabular-nums; }
-  .bm-delta.pos { color: #4ade80; } .bm-delta.neg { color: #fb7185; }
-  .info-big { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.6rem; line-height: 1; color: #fde047;
-    text-shadow: 0 0 22px rgba(251,191,36,0.5); }
-  .info-big.green { color: #4ade80; text-shadow: 0 0 22px rgba(74,222,128,0.45); }
-  .info-title { font-family: var(--font-display); font-size: 1.15rem; margin: 8px 0 2px; }
-  .info-sub { font-size: 0.84rem; color: var(--text-muted); margin: 0 0 14px; }
-  .info-rows { display: flex; flex-direction: column; gap: 7px; text-align: left; margin-bottom: 14px; }
-  .info-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; font-size: 0.88rem; color: var(--text); }
-  .info-row b { font-family: 'Orbitron', var(--font-display); font-variant-numeric: tabular-nums; }
-  .info-row .pos { color: #4ade80; } .info-row .neg { color: #fb7185; } .info-row .green { color: #4ade80; }
-  .info-row.total { border-top: 1px solid var(--border); padding-top: 8px; margin-top: 2px; font-weight: 700; }
-  .info-note { font-size: 0.76rem; color: var(--text-faint); line-height: 1.45; margin: 0 0 16px; }
-  .info-twist-do { font-family: var(--font-display); font-weight: 700; font-size: 1.02rem; color: #4ade80; margin: 0 0 14px; }
-  /* 🎁 Twist announcement during the opening reveal */
-  .twist-announce { display: flex; flex-direction: column; align-items: center; gap: 3px; text-align: center; margin: 2px auto 6px;
-    animation: twistAnnounceIn 0.5s cubic-bezier(0.34,1.56,0.64,1); }
-  .ta-label { font-size: 0.66rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--brand-2); }
-  .ta-name { font-family: var(--font-display); font-weight: 800; font-size: 1.35rem; color: #fde047; text-shadow: 0 0 16px rgba(251,191,36,0.5); }
-  .ta-blurb { font-size: 0.78rem; color: var(--text-muted); }
-  @keyframes twistAnnounceIn { 0% { opacity: 0; transform: translateY(-10px) scale(0.9); } 100% { opacity: 1; transform: none; } }
-  .info-note b { color: var(--brand-2); }
-  .info-inline { background: none; border: none; padding: 0; color: var(--brand-2); font: inherit; font-weight: 700; text-decoration: underline; cursor: pointer; }
-  .info-close { width: 100%; padding: 11px; border-radius: 12px; border: none; cursor: pointer;
-    font-family: var(--font-display); font-weight: 800; color: #3a2a00; background: linear-gradient(135deg, #fde047, #f59e0b); }
-  /* 🎰 Opening-reveal climax: bounty number pops + glows as it counts up */
-  .bounty-panel.count-pop { animation: bountyGlow 1.1s ease-out; }
-  .bounty-panel.count-pop .bp-amount { animation: bountyCount 1.1s cubic-bezier(0.34, 1.56, 0.64, 1); }
-  @keyframes bountyGlow {
-    0%   { box-shadow: 0 0 22px rgba(251,191,36,0.16); }
-    35%  { box-shadow: 0 0 16px 4px rgba(74,222,128,0.6), 0 0 40px rgba(74,222,128,0.4); border-color: rgba(74,222,128,0.7); }
-    100% { box-shadow: 0 0 22px rgba(251,191,36,0.16); }
-  }
-  @keyframes bountyCount {
-    0%   { transform: scale(0.7); opacity: 0.5; }
-    45%  { transform: scale(1.32); text-shadow: 0 0 30px rgba(74,222,128,0.95); }
-    100% { transform: scale(1); }
-  }
-  /* floating -$X spend feedback by the green number */
-  .spend-float { position: absolute; right: 16px; top: 8px; pointer-events: none;
-    font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.05rem; color: #fb7185;
-    text-shadow: 0 0 8px rgba(248,113,133,0.55); animation: spendFloat 1.1s ease-out forwards; }
-  @keyframes spendFloat {
-    0% { opacity: 0; transform: translateY(8px) scale(0.9); }
-    16% { opacity: 1; transform: translateY(0) scale(1.06); }
-    100% { opacity: 0; transform: translateY(-28px) scale(1); }
-  }
-  /* 💰 Top bankroll bar (very top, all modes) */
-  .top-bank { width: 100%; max-width: 340px; margin: 0 auto 12px; padding: 9px 16px; border-radius: 14px;
-    border: 1px solid rgba(253, 224, 71, 0.4); background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.03)); }
-  /* solo bankroll = a centered gold chip below WordBank (matches the menu) — tap → /bank */
-  .top-bank.solo { width: fit-content; max-width: none; margin: 0 auto 12px; padding: 7px 18px; text-align: center; cursor: pointer; }
-  .top-bank.solo:active { transform: scale(0.97); }
-  /* 💥 dramatic pop when the bankroll swings big (win payout / loss) */
-  .top-bank.solo.pop-up { animation: bankPopUp 1.1s cubic-bezier(0.34, 1.56, 0.64, 1); }
-  .top-bank.solo.pop-down { animation: bankPopDown 1.1s cubic-bezier(0.34, 1.56, 0.64, 1); }
-  @keyframes bankPopUp {
-    0% { transform: scale(1); border-color: rgba(253,224,71,0.4); }
-    22% { transform: scale(1.4); border-color: rgba(74,222,128,0.9); box-shadow: 0 0 30px rgba(74,222,128,0.7); }
-    55% { transform: scale(0.96); }
-    100% { transform: scale(1); }
-  }
-  @keyframes bankPopDown {
-    0% { transform: scale(1); }
-    18% { transform: scale(0.8) translateX(-3px); border-color: rgba(251,113,133,0.9); box-shadow: 0 0 22px rgba(251,113,133,0.6); }
-    36% { transform: scale(0.86) translateX(3px); }
-    100% { transform: scale(1); }
-  }
-  .top-bank.solo.pop-up .tb-solo { animation: bankColorUp 1.1s ease-out; }
-  .top-bank.solo.pop-down .tb-solo { animation: bankColorDown 1.1s ease-out; }
-  @keyframes bankColorUp { 0%,100% { color: #fcd34d; } 25% { color: #4ade80; text-shadow: 0 0 24px rgba(74,222,128,0.95); } }
-  @keyframes bankColorDown { 0%,100% { color: #fcd34d; } 25% { color: #fb7185; text-shadow: 0 0 20px rgba(251,113,133,0.9); } }
-  .tb-solo { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.55rem; color: #fcd34d; font-variant-numeric: tabular-nums; }
-  .tb-wallet-cap { display: block; font-size: 0.62rem; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-faint); }
-  /* 🏷️ Game-mode pill — centered under the wordmark, same for every mode */
-  .mode-pill {
-    display: inline-flex; align-items: center; gap: 6px; margin: -2px auto 10px;
-    padding: 4px 14px; border-radius: 999px; white-space: nowrap; cursor: pointer;
-    font-family: var(--font-display); font-weight: 800; font-size: 0.72rem;
-    text-transform: uppercase; letter-spacing: 0.1em; color: var(--brand-2);
-    background: rgba(253, 224, 71, 0.08); border: 1px solid rgba(253, 224, 71, 0.3);
-    transition: transform 0.16s var(--ease-spring), background 0.2s, border-color 0.2s;
-  }
-  .mode-pill:hover { background: rgba(253, 224, 71, 0.14); border-color: rgba(253, 224, 71, 0.5); }
-  .mode-pill:active { transform: scale(0.95); }
-  .mp-emoji { font-size: 0.9rem; letter-spacing: 0; }
-  .mp-info { font-size: 0.72rem; opacity: 0.6; letter-spacing: 0; }
+	/* Live "spent · profit" line (all modes) */
+	.live-line {
+		margin: 9px auto 0;
+		text-align: center;
+		font-size: 0.82rem;
+		color: var(--text-muted);
+	}
+	.live-line b {
+		display: inline-block;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		color: var(--brand-2);
+	}
+	.live-line b.lose {
+		color: #fb7185;
+	}
+	/* Cash Game bounty panel: one hero number (what you keep) that ticks down as you spend */
+	.bounty-panel {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		width: 100%;
+		max-width: 340px;
+		margin: 0 auto;
+		padding: 14px 18px;
+		border-radius: var(--r-lg, 18px);
+		border: 1px solid rgba(253, 224, 71, 0.4);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.14), rgba(251, 191, 36, 0.04));
+		box-shadow: 0 0 22px rgba(251, 191, 36, 0.16);
+	}
+	.bounty-panel.loss {
+		border-color: rgba(251, 113, 133, 0.5);
+		background: linear-gradient(135deg, rgba(251, 113, 133, 0.13), rgba(251, 113, 133, 0.03));
+		box-shadow: none;
+	}
+	.bp-label {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--brand-2);
+	}
+	.bounty-panel.loss .bp-label {
+		color: #fb7185;
+	}
+	.bp-amount {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2.3rem;
+		line-height: 1.05;
+		color: #4ade80;
+		text-shadow: 0 0 18px rgba(52, 211, 153, 0.5);
+		font-variant-numeric: tabular-nums;
+		transition: color 0.2s;
+	}
+	.bp-amount-btn {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+	}
+	.bounty-panel.loss .bp-amount {
+		color: #fb7185;
+		text-shadow: none;
+	}
+	/* 🪙 Challenge ante: the bounty hero depletes as you spend; empties to a calm "out of ante" look */
+	.bounty-panel.ante-empty {
+		border-color: rgba(148, 163, 184, 0.4);
+		background: linear-gradient(135deg, rgba(148, 163, 184, 0.12), rgba(148, 163, 184, 0.03));
+		box-shadow: none;
+	}
+	.bounty-panel.ante-empty .bp-label,
+	.bounty-panel.ante-empty .bp-amount {
+		color: #cbd5e1;
+		text-shadow: none;
+	}
+	.ante-bar {
+		width: 100%;
+		max-width: 240px;
+		height: 7px;
+		margin: 6px auto 0;
+		border-radius: 999px;
+		background: rgba(255, 255, 255, 0.1);
+		overflow: hidden;
+	}
+	.ante-fill {
+		display: block;
+		height: 100%;
+		border-radius: 999px;
+		background: linear-gradient(90deg, #fbbf24, #fde047);
+		transition: width 0.35s ease;
+	}
+	.match-ante-sub {
+		margin: 4px auto 0;
+		text-align: center;
+		font-size: 0.72rem;
+		color: var(--text-muted);
+	}
+	/* lit gold bounty multiplier badge (left of the bounty) — ×1.0 today, boostable later */
+	.bp-mult-badge {
+		position: absolute;
+		left: 12px;
+		top: 50%;
+		transform: translateY(-50%);
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		line-height: 1;
+		padding: 5px 9px;
+		border-radius: 9px;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fff1a8, #f6cd4d 45%, #e0a312);
+		border: 1px solid rgba(180, 130, 15, 0.95);
+		cursor: pointer;
+		box-shadow:
+			0 0 14px rgba(251, 191, 36, 0.65),
+			inset 0 1px 0 rgba(255, 255, 255, 0.6),
+			inset 0 -2px 3px rgba(120, 80, 0, 0.35);
+	}
+	.bp-mult-badge:active {
+		transform: translateY(-50%) scale(0.94);
+	}
+	/* 🏆 win streak — mirror of the multiplier badge, on the right of the bounty (boosts mult) */
+	.bp-winstreak {
+		position: absolute;
+		right: 12px;
+		top: 50%;
+		transform: translateY(-50%);
+		cursor: pointer;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 0.95rem;
+		line-height: 1;
+		padding: 5px 9px;
+		border-radius: 9px;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fff1a8, #f6cd4d 45%, #e0a312);
+		border: 1px solid rgba(180, 130, 15, 0.95);
+		box-shadow:
+			0 0 12px rgba(251, 191, 36, 0.5),
+			inset 0 1px 0 rgba(255, 255, 255, 0.5);
+	}
+	.bp-winstreak:active {
+		transform: translateY(-50%) scale(0.94);
+	}
+	/* ℹ️ Daily explainer modal (multiplier / Solve-to-Earn breakdown) */
+	.info-overlay {
+		border: none;
+		cursor: pointer;
+	}
+	.info-card {
+		position: relative;
+		width: 100%;
+		max-width: 330px;
+		cursor: default;
+		text-align: center;
+		background: var(--surface-strong, #141c28);
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.14));
+		border-radius: 18px;
+		padding: 22px 20px;
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+	}
+	/* reusable red close ✕ (top-right) — returns to the game */
+	.modal-x {
+		position: absolute;
+		top: 10px;
+		right: 10px;
+		z-index: 2;
+		width: 30px;
+		height: 30px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		font-size: 0.8rem;
+		font-weight: 900;
+		color: #fff;
+		background: linear-gradient(135deg, #fb5a5a, #c81e1e);
+		border: 1px solid rgba(0, 0, 0, 0.25);
+		box-shadow: 0 2px 6px rgba(200, 30, 30, 0.4);
+	}
+	.modal-x:hover {
+		filter: brightness(1.08);
+	}
+	.modal-x:active {
+		transform: scale(0.92);
+	}
+	/* 🎒 Bag button left of Solve (in-game) */
+	.bag-fab {
+		position: fixed;
+		z-index: 998;
+		bottom: calc(env(safe-area-inset-bottom, 0px) + 188px);
+		right: calc(50% + 108px);
+		width: 46px;
+		height: 46px;
+		border-radius: 12px;
+		cursor: pointer;
+		display: grid;
+		place-items: center;
+		font-size: 1.5rem;
+		color: var(--text);
+		background: var(--surface-strong, rgba(20, 28, 40, 0.9));
+		border: 1px solid rgba(253, 224, 71, 0.5);
+		backdrop-filter: blur(10px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	}
+	.bag-fab:active {
+		transform: scale(0.93);
+	}
+	.bag-fab-badge {
+		position: absolute;
+		top: -5px;
+		right: -5px;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 4px;
+		border-radius: 999px;
+		background: #ea580c;
+		color: #fff;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.66rem;
+		display: grid;
+		place-items: center;
+	}
+	.bag-chip {
+		width: 54px;
+		height: 54px;
+		padding: 0;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+	}
+	/* 🔐 Cash Game vault — sits to the left of Solve; absolute so Solve stays centered */
+	.solve-vault {
+		position: absolute;
+		right: 100%;
+		margin-right: 12px;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 50px;
+		height: 50px;
+		border-radius: 14px;
+		display: grid;
+		place-items: center;
+		cursor: pointer;
+		background: var(--surface-strong, rgba(20, 28, 40, 0.9));
+		border: 1px solid rgba(253, 224, 71, 0.5);
+		backdrop-filter: blur(10px);
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+		transition: transform 0.16s var(--ease-spring);
+	}
+	.solve-vault:active {
+		transform: translateY(-50%) scale(0.93);
+	}
+	.solve-vault img {
+		width: 34px;
+		height: 34px;
+		object-fit: contain;
+	}
+	.solve-vault-badge {
+		position: absolute;
+		top: -6px;
+		right: -6px;
+		min-width: 18px;
+		height: 18px;
+		padding: 0 4px;
+		border-radius: 999px;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		color: #3a2a00;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.66rem;
+		display: grid;
+		place-items: center;
+	}
+	.vault-ic {
+		width: 34px;
+		height: 34px;
+		object-fit: contain;
+	}
+	.vault-ic-sm {
+		width: 46px;
+		height: 46px;
+		object-fit: contain;
+		display: block;
+	}
+	.vault-ic-xs {
+		width: 22px;
+		height: 22px;
+		object-fit: contain;
+		vertical-align: -5px;
+	}
+	/* 🎒 Bag modal */
+	.bag-modal {
+		max-width: 360px;
+		max-height: 84vh;
+		overflow-y: auto;
+	}
+	.bag-use-h {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.78rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--brand-2);
+		margin: 6px 0 8px;
+		text-align: left;
+	}
+	.bag-use-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 8px;
+		margin-bottom: 16px;
+	}
+	.bag-use {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: 3px;
+		cursor: pointer;
+		padding: 0.9rem 0.5rem;
+		border-radius: 14px;
+		color: var(--text);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.2), rgba(251, 191, 36, 0.05));
+		border: 1px solid rgba(253, 224, 71, 0.55);
+	}
+	.bag-use:active {
+		transform: scale(0.96);
+	}
+	.bag-use:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.bag-use.locked {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		filter: grayscale(0.7);
+	}
+	.bag-use.locked .bag-use-e {
+		opacity: 0.55;
+	}
+	.bag-use.locked .bag-use-d {
+		color: var(--text-faint);
+	}
+	.bag-msg {
+		margin-top: 12px;
+		padding: 10px 12px;
+		border-radius: 11px;
+		text-align: center;
+		font-size: 0.82rem;
+		line-height: 1.35;
+		color: var(--text);
+		background: rgba(251, 191, 36, 0.14);
+		border: 1px solid rgba(253, 224, 71, 0.45);
+	}
+	.bag-use-e {
+		font-size: 1.7rem;
+		line-height: 1;
+	}
+	.bag-use-n {
+		position: absolute;
+		top: 7px;
+		right: 9px;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 0.78rem;
+		color: #fde047;
+	}
+	.bag-use-name {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.86rem;
+	}
+	.bag-use-d {
+		font-size: 0.72rem;
+		color: var(--text-muted);
+		line-height: 1.3;
+	}
+	.bag-inv {
+		margin-bottom: 14px;
+	}
+	.bag-store {
+		width: 100%;
+		padding: 11px;
+		border-radius: 12px;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	/* in-game bank modal */
+	.bm-label {
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--text-faint);
+		margin: 0 0 2px;
+	}
+	.bm-hist-h {
+		font-family: var(--font-display);
+		font-size: 0.78rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--brand-2);
+		text-align: left;
+		margin: 16px 0 6px;
+	}
+	.bm-ledger {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		background: var(--border);
+		border-radius: 12px;
+		overflow: hidden;
+		max-height: 40vh;
+		overflow-y: auto;
+		margin-bottom: 14px;
+	}
+	.bm-row {
+		display: flex;
+		justify-content: space-between;
+		gap: 10px;
+		padding: 9px 11px;
+		background: var(--surface);
+	}
+	.bm-reason {
+		color: var(--text-muted);
+		font-size: 0.84rem;
+		text-align: left;
+	}
+	.bm-delta {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 0.84rem;
+		font-variant-numeric: tabular-nums;
+	}
+	.bm-delta.pos {
+		color: #4ade80;
+	}
+	.bm-delta.neg {
+		color: #fb7185;
+	}
+	.info-big {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2.6rem;
+		line-height: 1;
+		color: #fde047;
+		text-shadow: 0 0 22px rgba(251, 191, 36, 0.5);
+	}
+	.info-big.green {
+		color: #4ade80;
+		text-shadow: 0 0 22px rgba(74, 222, 128, 0.45);
+	}
+	.info-title {
+		font-family: var(--font-display);
+		font-size: 1.15rem;
+		margin: 8px 0 2px;
+	}
+	.info-sub {
+		font-size: 0.84rem;
+		color: var(--text-muted);
+		margin: 0 0 14px;
+	}
+	.info-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+		text-align: left;
+		margin-bottom: 14px;
+	}
+	.info-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+		font-size: 0.88rem;
+		color: var(--text);
+	}
+	.info-row b {
+		font-family: 'Orbitron', var(--font-display);
+		font-variant-numeric: tabular-nums;
+	}
+	.info-row .pos {
+		color: #4ade80;
+	}
+	.info-row .neg {
+		color: #fb7185;
+	}
+	.info-row .green {
+		color: #4ade80;
+	}
+	.info-row.total {
+		border-top: 1px solid var(--border);
+		padding-top: 8px;
+		margin-top: 2px;
+		font-weight: 700;
+	}
+	.info-note {
+		font-size: 0.76rem;
+		color: var(--text-faint);
+		line-height: 1.45;
+		margin: 0 0 16px;
+	}
+	.info-twist-do {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.02rem;
+		color: #4ade80;
+		margin: 0 0 14px;
+	}
+	/* 🎁 Twist announcement during the opening reveal */
+	.twist-announce {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 3px;
+		text-align: center;
+		margin: 2px auto 6px;
+		animation: twistAnnounceIn 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	.ta-label {
+		font-size: 0.66rem;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--brand-2);
+	}
+	.ta-name {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.35rem;
+		color: #fde047;
+		text-shadow: 0 0 16px rgba(251, 191, 36, 0.5);
+	}
+	.ta-blurb {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+	}
+	@keyframes twistAnnounceIn {
+		0% {
+			opacity: 0;
+			transform: translateY(-10px) scale(0.9);
+		}
+		100% {
+			opacity: 1;
+			transform: none;
+		}
+	}
+	.info-note b {
+		color: var(--brand-2);
+	}
+	.info-inline {
+		background: none;
+		border: none;
+		padding: 0;
+		color: var(--brand-2);
+		font: inherit;
+		font-weight: 700;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+	.info-close {
+		width: 100%;
+		padding: 11px;
+		border-radius: 12px;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	/* 🎰 Opening-reveal climax: bounty number pops + glows as it counts up */
+	.bounty-panel.count-pop {
+		animation: bountyGlow 1.1s ease-out;
+	}
+	.bounty-panel.count-pop .bp-amount {
+		animation: bountyCount 1.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes bountyGlow {
+		0% {
+			box-shadow: 0 0 22px rgba(251, 191, 36, 0.16);
+		}
+		35% {
+			box-shadow:
+				0 0 16px 4px rgba(74, 222, 128, 0.6),
+				0 0 40px rgba(74, 222, 128, 0.4);
+			border-color: rgba(74, 222, 128, 0.7);
+		}
+		100% {
+			box-shadow: 0 0 22px rgba(251, 191, 36, 0.16);
+		}
+	}
+	@keyframes bountyCount {
+		0% {
+			transform: scale(0.7);
+			opacity: 0.5;
+		}
+		45% {
+			transform: scale(1.32);
+			text-shadow: 0 0 30px rgba(74, 222, 128, 0.95);
+		}
+		100% {
+			transform: scale(1);
+		}
+	}
+	/* floating -$X spend feedback by the green number */
+	.spend-float {
+		position: absolute;
+		right: 16px;
+		top: 8px;
+		pointer-events: none;
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		color: #fb7185;
+		text-shadow: 0 0 8px rgba(248, 113, 133, 0.55);
+		animation: spendFloat 1.1s ease-out forwards;
+	}
+	@keyframes spendFloat {
+		0% {
+			opacity: 0;
+			transform: translateY(8px) scale(0.9);
+		}
+		16% {
+			opacity: 1;
+			transform: translateY(0) scale(1.06);
+		}
+		100% {
+			opacity: 0;
+			transform: translateY(-28px) scale(1);
+		}
+	}
+	/* 💰 Top bankroll bar (very top, all modes) */
+	.top-bank {
+		width: 100%;
+		max-width: 340px;
+		margin: 0 auto 12px;
+		padding: 9px 16px;
+		border-radius: 14px;
+		border: 1px solid rgba(253, 224, 71, 0.4);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.03));
+	}
+	/* solo bankroll = a centered gold chip below WordBank (matches the menu) — tap → /bank */
+	.top-bank.solo {
+		width: fit-content;
+		max-width: none;
+		margin: 0 auto 12px;
+		padding: 7px 18px;
+		text-align: center;
+		cursor: pointer;
+	}
+	.top-bank.solo:active {
+		transform: scale(0.97);
+	}
+	/* 💥 dramatic pop when the bankroll swings big (win payout / loss) */
+	.top-bank.solo.pop-up {
+		animation: bankPopUp 1.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	.top-bank.solo.pop-down {
+		animation: bankPopDown 1.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes bankPopUp {
+		0% {
+			transform: scale(1);
+			border-color: rgba(253, 224, 71, 0.4);
+		}
+		22% {
+			transform: scale(1.4);
+			border-color: rgba(74, 222, 128, 0.9);
+			box-shadow: 0 0 30px rgba(74, 222, 128, 0.7);
+		}
+		55% {
+			transform: scale(0.96);
+		}
+		100% {
+			transform: scale(1);
+		}
+	}
+	@keyframes bankPopDown {
+		0% {
+			transform: scale(1);
+		}
+		18% {
+			transform: scale(0.8) translateX(-3px);
+			border-color: rgba(251, 113, 133, 0.9);
+			box-shadow: 0 0 22px rgba(251, 113, 133, 0.6);
+		}
+		36% {
+			transform: scale(0.86) translateX(3px);
+		}
+		100% {
+			transform: scale(1);
+		}
+	}
+	.top-bank.solo.pop-up .tb-solo {
+		animation: bankColorUp 1.1s ease-out;
+	}
+	.top-bank.solo.pop-down .tb-solo {
+		animation: bankColorDown 1.1s ease-out;
+	}
+	@keyframes bankColorUp {
+		0%,
+		100% {
+			color: #fcd34d;
+		}
+		25% {
+			color: #4ade80;
+			text-shadow: 0 0 24px rgba(74, 222, 128, 0.95);
+		}
+	}
+	@keyframes bankColorDown {
+		0%,
+		100% {
+			color: #fcd34d;
+		}
+		25% {
+			color: #fb7185;
+			text-shadow: 0 0 20px rgba(251, 113, 133, 0.9);
+		}
+	}
+	.tb-solo {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.55rem;
+		color: #fcd34d;
+		font-variant-numeric: tabular-nums;
+	}
+	.tb-wallet-cap {
+		display: block;
+		font-size: 0.62rem;
+		font-weight: 700;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
+	/* 🏷️ Game-mode pill — centered under the wordmark, same for every mode */
+	.mode-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin: -2px auto 10px;
+		padding: 4px 14px;
+		border-radius: 999px;
+		white-space: nowrap;
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--brand-2);
+		background: rgba(253, 224, 71, 0.08);
+		border: 1px solid rgba(253, 224, 71, 0.3);
+		transition:
+			transform 0.16s var(--ease-spring),
+			background 0.2s,
+			border-color 0.2s;
+	}
+	.mode-pill:hover {
+		background: rgba(253, 224, 71, 0.14);
+		border-color: rgba(253, 224, 71, 0.5);
+	}
+	.mode-pill:active {
+		transform: scale(0.95);
+	}
+	.mp-emoji {
+		font-size: 0.9rem;
+		letter-spacing: 0;
+	}
+	.mp-info {
+		font-size: 0.72rem;
+		opacity: 0.6;
+		letter-spacing: 0;
+	}
 
+	.bankroll-amount {
+		display: inline-flex;
+		align-items: center;
+	}
 
-  .bankroll-amount {
-    display: inline-flex;
-    align-items: center;
-  }
+	.currency {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.55rem;
+		margin-right: 3px;
+		color: #fcd34d;
+		text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
+	}
 
-  .currency {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 1.55rem;
-    margin-right: 3px;
-    color: #fcd34d;
-    text-shadow: 0 0 14px rgba(251, 191, 36, 0.45);
-  }
+	.game-logo {
+		display: block;
+		width: min(52vw, 180px);
+		height: auto;
+		margin: 2px auto 10px;
+		filter: drop-shadow(0 2px 12px rgba(0, 0, 0, 0.5));
+	}
 
-  .game-logo {
-    display: block;
-    width: min(52vw, 180px);
-    height: auto;
-    margin: 2px auto 10px;
-    filter: drop-shadow(0 2px 12px rgba(0, 0, 0, 0.5));
-  }
+	.logo-container {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin-top: -20px;
+		margin-bottom: 0;
+	}
 
-  .logo-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-top: -20px;
-    margin-bottom: 0;
-  }
+	:global(html, body) {
+		overflow-x: hidden;
+		touch-action: manipulation;
+	}
 
-  :global(html, body) {
-    overflow-x: hidden;
-    touch-action: manipulation;
-  }
+	@keyframes winPulse {
+		0%,
+		100% {
+			transform: scale(1) rotate(0deg);
+			text-shadow: 0px 0px 10px green;
+		}
+		25% {
+			transform: scale(1.2) rotate(3deg);
+			text-shadow: 0px 0px 20px limegreen;
+		}
+		50% {
+			transform: scale(1.5) rotate(-3deg);
+			text-shadow: 0px 0px 30px limegreen;
+		}
+		75% {
+			transform: scale(1.2) rotate(3deg);
+			text-shadow: 0px 0px 20px green;
+		}
+	}
 
-  @keyframes winPulse {
-    0%, 100% { transform: scale(1) rotate(0deg); text-shadow: 0px 0px 10px green; }
-    25% { transform: scale(1.2) rotate(3deg); text-shadow: 0px 0px 20px limegreen; }
-    50% { transform: scale(1.5) rotate(-3deg); text-shadow: 0px 0px 30px limegreen; }
-    75% { transform: scale(1.2) rotate(3deg); text-shadow: 0px 0px 20px green; }
-  }
+	@keyframes winFlash {
+		0% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.2;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 
-  @keyframes winFlash {
-    0% { opacity: 1; }
-    50% { opacity: 0.2; }
-    100% { opacity: 1; }
-  }
+	.banner.win {
+		font-family: var(--font-display);
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		color: #3a2a00;
+		text-transform: uppercase;
+		background: var(--brand-grad);
+		text-align: center;
+		padding: 14px 28px;
+		border-radius: var(--r-pill);
+		box-shadow: var(--glow-brand);
+		animation: bannerPop 0.5s var(--ease-spring) both;
+	}
+	@keyframes bannerPop {
+		from {
+			transform: scale(0.8);
+			opacity: 0;
+		}
+		to {
+			transform: scale(1);
+			opacity: 1;
+		}
+	}
 
+	@keyframes gameOverPulse {
+		0%,
+		100% {
+			transform: scale(1) rotate(0deg);
+			text-shadow: 0px 0px 10px red;
+		}
+		25% {
+			transform: scale(1.2) rotate(3deg);
+			text-shadow: 0px 0px 20px red;
+		}
+		50% {
+			transform: scale(1.5) rotate(-3deg);
+			text-shadow: 0px 0px 30px red;
+		}
+		75% {
+			transform: scale(1.2) rotate(3deg);
+			text-shadow: 0px 0px 20px red;
+		}
+	}
 
-  .banner.win {
-    font-family: var(--font-display);
-    font-size: 1.6rem;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    color: #3a2a00;
-    text-transform: uppercase;
-    background: var(--brand-grad);
-    text-align: center;
-    padding: 14px 28px;
-    border-radius: var(--r-pill);
-    box-shadow: var(--glow-brand);
-    animation: bannerPop 0.5s var(--ease-spring) both;
-  }
-  @keyframes bannerPop {
-    from { transform: scale(0.8); opacity: 0; }
-    to { transform: scale(1); opacity: 1; }
-  }
+	@keyframes gameOverFlash {
+		0% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.2;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
 
-  @keyframes gameOverPulse {
-    0%, 100% { transform: scale(1) rotate(0deg); text-shadow: 0px 0px 10px red; }
-    25% { transform: scale(1.2) rotate(3deg); text-shadow: 0px 0px 20px red; }
-    50% { transform: scale(1.5) rotate(-3deg); text-shadow: 0px 0px 30px red; }
-    75% { transform: scale(1.2) rotate(3deg); text-shadow: 0px 0px 20px red; }
-  }
+	.banner.lose {
+		font-family: var(--font-display);
+		font-size: 1.6rem;
+		font-weight: 700;
+		letter-spacing: 0.02em;
+		color: #fff;
+		text-transform: uppercase;
+		background: linear-gradient(135deg, #fb5a5a, #c81e1e);
+		text-align: center;
+		padding: 14px 28px;
+		border-radius: var(--r-pill);
+		box-shadow: 0 8px 28px rgba(200, 30, 30, 0.4);
+		animation: bannerPop 0.5s var(--ease-spring) both;
+	}
 
-  @keyframes gameOverFlash {
-    0% { opacity: 1; }
-    50% { opacity: 0.2; }
-    100% { opacity: 1; }
-  }
+	button:focus,
+	button:active {
+		outline: none !important;
+		box-shadow: none !important;
+		background: inherit !important;
+	}
 
-  .banner.lose {
-    font-family: var(--font-display);
-    font-size: 1.6rem;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    color: #fff;
-    text-transform: uppercase;
-    background: linear-gradient(135deg, #fb5a5a, #c81e1e);
-    text-align: center;
-    padding: 14px 28px;
-    border-radius: var(--r-pill);
-    box-shadow: 0 8px 28px rgba(200, 30, 30, 0.4);
-    animation: bannerPop 0.5s var(--ease-spring) both;
-  }
+	button:focus-visible {
+		outline: none !important;
+	}
 
-  button:focus,
-  button:active {
-    outline: none !important;
-    box-shadow: none !important;
-    background: inherit !important;
-  }
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(4, 7, 12, 0.66);
+		backdrop-filter: blur(8px);
+		-webkit-backdrop-filter: blur(8px);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		z-index: 9999;
+		animation: fadeIn 0.25s ease-out;
+	}
+	.modal-backdrop {
+		position: absolute;
+		inset: 0;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+	}
 
-  button:focus-visible {
-    outline: none !important;
-  }
-
-  .modal-overlay {
-    position: fixed;
-    inset: 0;
-    background: rgba(4, 7, 12, 0.66);
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 9999;
-    animation: fadeIn 0.25s ease-out;
-  }
-  .modal-backdrop {
-    position: absolute;
-    inset: 0;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-  }
-
-  .modal-content {
-    background: var(--surface-strong);
-    padding: 28px 24px;
-    border-radius: var(--r-xl);
-    width: 90%;
-    max-width: 400px;
-    /* Never taller than the screen — scroll internally so the close button and
+	.modal-content {
+		background: var(--surface-strong);
+		padding: 28px 24px;
+		border-radius: var(--r-xl);
+		width: 90%;
+		max-width: 400px;
+		/* Never taller than the screen — scroll internally so the close button and
        all controls stay reachable (was trapping users on tall forms). */
-    max-height: calc(100dvh - 24px);
-    overflow-y: auto;
-    -webkit-overflow-scrolling: touch;
-    overscroll-behavior: contain;
-    text-align: center;
-    box-shadow: var(--shadow-lg);
-    animation: slideIn 0.35s var(--ease-out);
-    border: 1px solid var(--border-strong);
-    color: var(--text);
-    backdrop-filter: blur(20px) saturate(140%);
-    -webkit-backdrop-filter: blur(20px) saturate(140%);
-    position: relative;
-    z-index: 1;
-  }
-  .modal-content :global(h2) { font-family: var(--font-display); }
+		max-height: calc(100dvh - 24px);
+		overflow-y: auto;
+		-webkit-overflow-scrolling: touch;
+		overscroll-behavior: contain;
+		text-align: center;
+		box-shadow: var(--shadow-lg);
+		animation: slideIn 0.35s var(--ease-out);
+		border: 1px solid var(--border-strong);
+		color: var(--text);
+		backdrop-filter: blur(20px) saturate(140%);
+		-webkit-backdrop-filter: blur(20px) saturate(140%);
+		position: relative;
+		z-index: 1;
+	}
+	.modal-content :global(h2) {
+		font-family: var(--font-display);
+	}
 
-  .close-btn {
-    position: absolute;
-    top: 12px;
-    right: 12px;
-    width: 32px;
-    height: 32px;
-    display: grid;
-    place-items: center;
-    font-size: 13px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--r-pill);
-    cursor: pointer;
-    transition: background 0.2s, border-color 0.2s;
-  }
-  .close-btn:hover { background: rgba(251, 90, 90, 0.16); border-color: rgba(251, 90, 90, 0.4); }
+	.close-btn {
+		position: absolute;
+		top: 12px;
+		right: 12px;
+		width: 32px;
+		height: 32px;
+		display: grid;
+		place-items: center;
+		font-size: 13px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--r-pill);
+		cursor: pointer;
+		transition:
+			background 0.2s,
+			border-color 0.2s;
+	}
+	.close-btn:hover {
+		background: rgba(251, 90, 90, 0.16);
+		border-color: rgba(251, 90, 90, 0.4);
+	}
 
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
+	@keyframes fadeIn {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
 
-  @keyframes slideIn {
-    from { transform: translateY(-20px); }
-    to { transform: translateY(0); }
-  }
+	@keyframes slideIn {
+		from {
+			transform: translateY(-20px);
+		}
+		to {
+			transform: translateY(0);
+		}
+	}
 
-  .next-puzzle-button {
-    margin-top: 12px;
-    background: var(--brand-grad);
-    color: #3a2a00;
-    font-family: var(--font-display);
-    font-weight: 700;
-    border: none;
-    padding: 13px 28px;
-    border-radius: var(--r-md);
-    font-size: 1rem;
-    cursor: pointer;
-    box-shadow: var(--glow-brand);
-    transition: transform 0.16s var(--ease-spring), filter 0.2s;
-  }
-  .next-puzzle-button:hover { transform: translateY(-2px); filter: brightness(1.05); }
-  .next-puzzle-button:active { transform: scale(0.97); }
+	.next-puzzle-button {
+		margin-top: 12px;
+		background: var(--brand-grad);
+		color: #3a2a00;
+		font-family: var(--font-display);
+		font-weight: 700;
+		border: none;
+		padding: 13px 28px;
+		border-radius: var(--r-md);
+		font-size: 1rem;
+		cursor: pointer;
+		box-shadow: var(--glow-brand);
+		transition:
+			transform 0.16s var(--ease-spring),
+			filter 0.2s;
+	}
+	.next-puzzle-button:hover {
+		transform: translateY(-2px);
+		filter: brightness(1.05);
+	}
+	.next-puzzle-button:active {
+		transform: scale(0.97);
+	}
 
-  /* Result modal */
-  .result-modal h2 { font-size: 1.7rem; margin: 4px 0 2px; }
-  .result-medal {
-    font-size: 3.4rem;
-    line-height: 1;
-    margin-bottom: 6px;
-    animation: wb-pop-in 0.6s var(--ease-spring) both;
-    filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.5));
-  }
-  .result-medal.gold { filter: drop-shadow(0 0 22px rgba(251, 191, 36, 0.6)); }
-  .result-medal.silver { filter: drop-shadow(0 0 18px rgba(203, 213, 225, 0.5)); }
-  .result-medal.bronze { filter: drop-shadow(0 0 18px rgba(217, 119, 60, 0.5)); }
-  .result-sub {
-    color: var(--text-muted);
-    font-family: var(--font-display);
-    font-weight: 600;
-    font-size: 0.92rem;
-    margin: 0 0 16px;
-  }
-  .result-bankroll {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    padding: 14px;
-    margin: 0 0 18px;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--r-lg);
-  }
-  .rb-label {
-    font-size: 0.6rem;
-    letter-spacing: 0.2em;
-    text-transform: uppercase;
-    color: var(--text-faint);
-    font-weight: 600;
-  }
-  .rb-amount {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 2rem;
-    color: #fcd34d;
-    text-shadow: 0 0 18px rgba(251, 191, 36, 0.4);
-  }
-  /* 🏆 Win banner */
-  .win-h { font-family: var(--font-display); font-weight: 800; font-size: 1.7rem; margin: 0 0 2px;
-    animation: winPunch 0.5s cubic-bezier(0.34,1.56,0.64,1); }
-  @keyframes winPunch { 0% { opacity: 0; transform: scale(0.6); } 60% { transform: scale(1.12); } 100% { opacity: 1; transform: scale(1); } }
-  .win-math { display: flex; flex-direction: column; gap: 7px; text-align: left; margin: 14px auto 12px; max-width: 300px;
-    padding: 14px 16px; border-radius: 16px; border: 1px solid rgba(253,224,71,0.4);
-    background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.04)); }
-  .wm-row { display: flex; justify-content: space-between; align-items: baseline; gap: 10px; font-size: 0.92rem; color: var(--text); }
-  .wm-row small { color: var(--text-faint); font-size: 0.72rem; }
-  .wm-row b { font-family: 'Orbitron', var(--font-display); font-variant-numeric: tabular-nums; }
-  .wm-row .neg { color: #fb7185; }
-  .wm-row.total { border-top: 1px solid rgba(253,224,71,0.3); padding-top: 9px; margin-top: 2px; font-weight: 700; font-size: 1rem; }
-  .wm-row .profit { font-size: 1.8rem; color: #4ade80; text-shadow: 0 0 18px rgba(74,222,128,0.5); }
-  .win-twist { font-size: 0.82rem; color: var(--text-muted); margin: 0 0 12px; }
-  .win-twist b { color: var(--brand-2); }
-  .win-bank { display: flex; flex-direction: column; align-items: center; gap: 2px; margin: 0 0 10px; }
-  .wb-label { font-size: 0.66rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-faint); }
-  .wb-amount { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.9rem; color: #fde047;
-    text-shadow: 0 0 18px rgba(251,191,36,0.45); font-variant-numeric: tabular-nums; }
-  .win-rank { font-size: 0.86rem; color: var(--text-muted); margin: 0 0 14px; }
-  .win-rank b { color: #fde047; font-family: var(--font-display); }
-  .win-menu { margin-top: 10px; background: none; border: none; color: var(--text-faint); font-size: 0.84rem; text-decoration: underline; cursor: pointer; }
-  .result-actions {
-    display: flex;
-    gap: 10px;
-  }
-  .result-actions > * { flex: 1; margin-top: 0; }
-  .share-btn {
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: 1rem;
-    padding: 13px 18px;
-    border-radius: var(--r-md);
-    background: var(--surface-2);
-    color: var(--text);
-    border: 1px solid var(--border-strong);
-    cursor: pointer;
-    transition: transform 0.15s var(--ease-spring), background 0.2s, border-color 0.2s;
-  }
-  .share-btn:hover { transform: translateY(-2px); background: rgba(56, 189, 248, 0.14); border-color: rgba(56, 189, 248, 0.4); }
-  .share-btn:active { transform: scale(0.97); }
+	/* Result modal */
+	.result-modal h2 {
+		font-size: 1.7rem;
+		margin: 4px 0 2px;
+	}
+	.result-medal {
+		font-size: 3.4rem;
+		line-height: 1;
+		margin-bottom: 6px;
+		animation: wb-pop-in 0.6s var(--ease-spring) both;
+		filter: drop-shadow(0 6px 18px rgba(0, 0, 0, 0.5));
+	}
+	.result-medal.gold {
+		filter: drop-shadow(0 0 22px rgba(251, 191, 36, 0.6));
+	}
+	.result-medal.silver {
+		filter: drop-shadow(0 0 18px rgba(203, 213, 225, 0.5));
+	}
+	.result-medal.bronze {
+		filter: drop-shadow(0 0 18px rgba(217, 119, 60, 0.5));
+	}
+	.result-sub {
+		color: var(--text-muted);
+		font-family: var(--font-display);
+		font-weight: 600;
+		font-size: 0.92rem;
+		margin: 0 0 16px;
+	}
+	.result-bankroll {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		padding: 14px;
+		margin: 0 0 18px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--r-lg);
+	}
+	.rb-label {
+		font-size: 0.6rem;
+		letter-spacing: 0.2em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+		font-weight: 600;
+	}
+	.rb-amount {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 2rem;
+		color: #fcd34d;
+		text-shadow: 0 0 18px rgba(251, 191, 36, 0.4);
+	}
+	/* 🏆 Win banner */
+	.win-h {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.7rem;
+		margin: 0 0 2px;
+		animation: winPunch 0.5s cubic-bezier(0.34, 1.56, 0.64, 1);
+	}
+	@keyframes winPunch {
+		0% {
+			opacity: 0;
+			transform: scale(0.6);
+		}
+		60% {
+			transform: scale(1.12);
+		}
+		100% {
+			opacity: 1;
+			transform: scale(1);
+		}
+	}
+	.win-math {
+		display: flex;
+		flex-direction: column;
+		gap: 7px;
+		text-align: left;
+		margin: 14px auto 12px;
+		max-width: 300px;
+		padding: 14px 16px;
+		border-radius: 16px;
+		border: 1px solid rgba(253, 224, 71, 0.4);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.04));
+	}
+	.wm-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 10px;
+		font-size: 0.92rem;
+		color: var(--text);
+	}
+	.wm-row small {
+		color: var(--text-faint);
+		font-size: 0.72rem;
+	}
+	.wm-row b {
+		font-family: 'Orbitron', var(--font-display);
+		font-variant-numeric: tabular-nums;
+	}
+	.wm-row .neg {
+		color: #fb7185;
+	}
+	.wm-row.total {
+		border-top: 1px solid rgba(253, 224, 71, 0.3);
+		padding-top: 9px;
+		margin-top: 2px;
+		font-weight: 700;
+		font-size: 1rem;
+	}
+	.wm-row .profit {
+		font-size: 1.8rem;
+		color: #4ade80;
+		text-shadow: 0 0 18px rgba(74, 222, 128, 0.5);
+	}
+	.win-twist {
+		font-size: 0.82rem;
+		color: var(--text-muted);
+		margin: 0 0 12px;
+	}
+	.win-twist b {
+		color: var(--brand-2);
+	}
+	.win-bank {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		margin: 0 0 10px;
+	}
+	.wb-label {
+		font-size: 0.66rem;
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
+	.wb-amount {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.9rem;
+		color: #fde047;
+		text-shadow: 0 0 18px rgba(251, 191, 36, 0.45);
+		font-variant-numeric: tabular-nums;
+	}
+	.win-rank {
+		font-size: 0.86rem;
+		color: var(--text-muted);
+		margin: 0 0 14px;
+	}
+	.win-rank b {
+		color: #fde047;
+		font-family: var(--font-display);
+	}
+	.win-menu {
+		margin-top: 10px;
+		background: none;
+		border: none;
+		color: var(--text-faint);
+		font-size: 0.84rem;
+		text-decoration: underline;
+		cursor: pointer;
+	}
+	.result-actions {
+		display: flex;
+		gap: 10px;
+	}
+	.result-actions > * {
+		flex: 1;
+		margin-top: 0;
+	}
+	.share-btn {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1rem;
+		padding: 13px 18px;
+		border-radius: var(--r-md);
+		background: var(--surface-2);
+		color: var(--text);
+		border: 1px solid var(--border-strong);
+		cursor: pointer;
+		transition:
+			transform 0.15s var(--ease-spring),
+			background 0.2s,
+			border-color 0.2s;
+	}
+	.share-btn:hover {
+		transform: translateY(-2px);
+		background: rgba(56, 189, 248, 0.14);
+		border-color: rgba(56, 189, 248, 0.4);
+	}
+	.share-btn:active {
+		transform: scale(0.97);
+	}
 
-  .subcategory-hint {
-  font-size: 1rem;
-  font-style: italic;
-  color: #999;
-  margin-bottom: 12px;
-}
-
-
-
-
+	.subcategory-hint {
+		font-size: 1rem;
+		font-style: italic;
+		color: #999;
+		margin-bottom: 12px;
+	}
 </style>

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -1,24 +1,43 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import ActivityPanel from '$lib/components/ActivityPanel.svelte';
-  import { track } from '$lib/analytics.js';
-  onMount(() => track('activity_view'));
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import ActivityPanel from '$lib/components/ActivityPanel.svelte';
+	import { track } from '$lib/analytics.js';
+	onMount(() => track('activity_view'));
 </script>
 
 <svelte:head><title>WordBank — Activity</title></svelte:head>
 
 <main class="a-page">
-  <PageNav />
-  <h1>📣 Activity</h1>
-  <p class="sub">You, your friends, and your groups.</p>
-  <ActivityPanel />
+	<PageNav />
+	<h1>📣 Activity</h1>
+	<p class="sub">You, your friends, and your groups.</p>
+	<ActivityPanel />
 </main>
 
 <style>
-  .a-page { max-width: 560px; margin: 0 auto; padding: 16px 14px 60px; }
-  .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
-  h1 { font-family: var(--font-display); font-size: 1.5rem; margin: 4px 0 2px; }
-  .sub { color: var(--text-faint); font-size: 0.84rem; margin: 0 0 16px; }
+	.a-page {
+		max-width: 560px;
+		margin: 0 auto;
+		padding: 16px 14px 60px;
+	}
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		cursor: pointer;
+		padding: 6px 0;
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.5rem;
+		margin: 4px 0 2px;
+	}
+	.sub {
+		color: var(--text-faint);
+		font-size: 0.84rem;
+		margin: 0 0 16px;
+	}
 </style>

--- a/src/routes/auth/callback/+server.js
+++ b/src/routes/auth/callback/+server.js
@@ -3,54 +3,54 @@ import { createServerClient } from '@supabase/ssr';
 
 // OAuth (Google) + magic-link PKCE callback: exchange the ?code for a session.
 export const GET = async ({ url, cookies }) => {
-  const code = url.searchParams.get('code');
-  const next = url.searchParams.get('next') ?? '/';
+	const code = url.searchParams.get('code');
+	const next = url.searchParams.get('next') ?? '/';
 
-  // Provider can also bounce back with an error (cancelled, access_denied, etc.).
-  const providerError = url.searchParams.get('error_description') || url.searchParams.get('error');
-  if (providerError) {
-    console.error('OAuth provider error:', providerError);
-    return redirect(303, '/?auth_error=' + encodeURIComponent(providerError));
-  }
+	// Provider can also bounce back with an error (cancelled, access_denied, etc.).
+	const providerError = url.searchParams.get('error_description') || url.searchParams.get('error');
+	if (providerError) {
+		console.error('OAuth provider error:', providerError);
+		return redirect(303, '/?auth_error=' + encodeURIComponent(providerError));
+	}
 
-  if (code) {
-    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-    if (!supabaseUrl || !supabaseAnonKey) {
-      console.error('Missing Supabase env vars on Vercel');
-      return redirect(303, '/?auth_error=config');
-    }
-    const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-      // getAll/setAll is the chunk-safe API in @supabase/ssr >=0.5 — reads the
-      // (possibly chunked) PKCE code-verifier + writes the session cookies.
-      cookies: {
-        getAll() {
-          return cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookies.set(name, value, {
-              ...options,
-              path: '/',
-              // MUST be JS-readable: the app reads the session with the BROWSER
-              // Supabase client (document.cookie). httpOnly here = the session is
-              // set but invisible to the app → "No session" after Google sign-in.
-              httpOnly: false,
-              sameSite: 'lax',
-              secure: import.meta.env.PROD
-            });
-          });
-        }
-      }
-    });
+	if (code) {
+		const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+		const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+		if (!supabaseUrl || !supabaseAnonKey) {
+			console.error('Missing Supabase env vars on Vercel');
+			return redirect(303, '/?auth_error=config');
+		}
+		const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+			// getAll/setAll is the chunk-safe API in @supabase/ssr >=0.5 — reads the
+			// (possibly chunked) PKCE code-verifier + writes the session cookies.
+			cookies: {
+				getAll() {
+					return cookies.getAll();
+				},
+				setAll(cookiesToSet) {
+					cookiesToSet.forEach(({ name, value, options }) => {
+						cookies.set(name, value, {
+							...options,
+							path: '/',
+							// MUST be JS-readable: the app reads the session with the BROWSER
+							// Supabase client (document.cookie). httpOnly here = the session is
+							// set but invisible to the app → "No session" after Google sign-in.
+							httpOnly: false,
+							sameSite: 'lax',
+							secure: import.meta.env.PROD
+						});
+					});
+				}
+			}
+		});
 
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (!error) {
-      return redirect(303, next);
-    }
-    console.error('Auth callback exchange error:', error.message);
-    return redirect(303, '/?auth_error=exchange&auth_detail=' + encodeURIComponent(error.message));
-  }
+		const { error } = await supabase.auth.exchangeCodeForSession(code);
+		if (!error) {
+			return redirect(303, next);
+		}
+		console.error('Auth callback exchange error:', error.message);
+		return redirect(303, '/?auth_error=exchange&auth_detail=' + encodeURIComponent(error.message));
+	}
 
-  return redirect(303, '/?auth_error=nocode');
+	return redirect(303, '/?auth_error=nocode');
 };

--- a/src/routes/auth/confirm/+server.js
+++ b/src/routes/auth/confirm/+server.js
@@ -6,53 +6,53 @@ import { createServerClient } from '@supabase/ssr';
 // needs NO local code verifier, so the link works on ANY device — request the
 // reset on a laptop, open the email on your phone, and it still completes.
 export const GET = async ({ url, cookies }) => {
-  const token_hash = url.searchParams.get('token_hash');
-  const type = url.searchParams.get('type');
-  const next = url.searchParams.get('next') ?? '/';
+	const token_hash = url.searchParams.get('token_hash');
+	const type = url.searchParams.get('type');
+	const next = url.searchParams.get('next') ?? '/';
 
-  if (token_hash && type) {
-    const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-    const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-    if (supabaseUrl && supabaseAnonKey) {
-      const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
-        cookies: {
-          get(name) {
-            return cookies.get(name);
-          },
-          set(name, value, options) {
-            cookies.set(name, value, {
-              ...options,
-              path: '/',
-              httpOnly: false, // browser Supabase client must read the session via document.cookie
-              sameSite: 'lax',
-              secure: import.meta.env.PROD
-            });
-          },
-          remove(name, options) {
-            cookies.delete(name, {
-              ...options,
-              path: '/',
-              httpOnly: true,
-              sameSite: 'lax',
-              secure: import.meta.env.PROD
-            });
-          }
-        }
-      });
+	if (token_hash && type) {
+		const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+		const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+		if (supabaseUrl && supabaseAnonKey) {
+			const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+				cookies: {
+					get(name) {
+						return cookies.get(name);
+					},
+					set(name, value, options) {
+						cookies.set(name, value, {
+							...options,
+							path: '/',
+							httpOnly: false, // browser Supabase client must read the session via document.cookie
+							sameSite: 'lax',
+							secure: import.meta.env.PROD
+						});
+					},
+					remove(name, options) {
+						cookies.delete(name, {
+							...options,
+							path: '/',
+							httpOnly: true,
+							sameSite: 'lax',
+							secure: import.meta.env.PROD
+						});
+					}
+				}
+			});
 
-      const { error } = await supabase.auth.verifyOtp({
-        type: /** @type {any} */ (type),
-        token_hash
-      });
-      if (!error) {
-        return redirect(303, next);
-      }
-      console.error('Auth confirm error:', error.message);
-    } else {
-      console.error('Missing Supabase env vars on Vercel');
-    }
-  }
+			const { error } = await supabase.auth.verifyOtp({
+				type: /** @type {any} */ (type),
+				token_hash
+			});
+			if (!error) {
+				return redirect(303, next);
+			}
+			console.error('Auth confirm error:', error.message);
+		} else {
+			console.error('Missing Supabase env vars on Vercel');
+		}
+	}
 
-  // Verification failed → land on the reset page with a clear message.
-  return redirect(303, '/reset-password?error_description=Email+link+is+invalid+or+has+expired');
+	// Verification failed → land on the reset page with a clear message.
+	return redirect(303, '/reset-password?error_description=Email+link+is+invalid+or+has+expired');
 };

--- a/src/routes/avatar/+page.svelte
+++ b/src/routes/avatar/+page.svelte
@@ -1,197 +1,446 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import Avatar from '$lib/components/Avatar.svelte';
-  import { CATEGORIES, DEFAULT_AVATAR } from '$lib/avatar.js';
-  import { getMyAvatar, setAvatar, buyCosmetic, getBank } from '$lib/stores/statsStore.js';
-  import { fx } from '$lib/sound.js';
-  import { track } from '$lib/analytics.js';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import Avatar from '$lib/components/Avatar.svelte';
+	import { CATEGORIES, DEFAULT_AVATAR } from '$lib/avatar.js';
+	import { getMyAvatar, setAvatar, buyCosmetic, getBank } from '$lib/stores/statsStore.js';
+	import { fx } from '$lib/sound.js';
+	import { track } from '$lib/analytics.js';
 
-  /** @type {any} */ let config = { ...DEFAULT_AVATAR };
-  /** @type {string[]} */ let owned = [];
-  let bank = 0;
-  let loading = true;
-  let saving = false;
-  let activeCat = CATEGORIES[0].key;
-  let dirty = false;
-  let toast = '';
-  /** @type {any} */ let buying = null; // option pending purchase-confirm
+	/** @type {any} */ let config = { ...DEFAULT_AVATAR };
+	/** @type {string[]} */ let owned = [];
+	let bank = 0;
+	let loading = true;
+	let saving = false;
+	let activeCat = CATEGORIES[0].key;
+	let dirty = false;
+	let toast = '';
+	/** @type {any} */ let buying = null; // option pending purchase-confirm
 
-  onMount(async () => {
-    track('avatar_open');
-    const [a, b] = await Promise.all([getMyAvatar(), getBank()]);
-    if (a.config) config = { ...DEFAULT_AVATAR, ...a.config };
-    owned = a.owned ?? [];
-    bank = b?.bank ?? 0;
-    loading = false;
-  });
+	onMount(async () => {
+		track('avatar_open');
+		const [a, b] = await Promise.all([getMyAvatar(), getBank()]);
+		if (a.config) config = { ...DEFAULT_AVATAR, ...a.config };
+		owned = a.owned ?? [];
+		bank = b?.bank ?? 0;
+		loading = false;
+	});
 
-  $: cat = CATEGORIES.find((c) => c.key === activeCat) ?? CATEGORIES[0];
-  const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
-  /** @param {any} o */
-  const locked = (o) => !!o.price && !owned.includes(o.cosmeticId);
-  /** preview config with one category overridden @param {string} key @param {string} value */
-  // a shirt design only shows on the Graphic Tee, so equipping a design auto-wears it
-  const withDeps = (/** @type {string} */ key, /** @type {string} */ value) =>
-    key === 'clothingGraphic' ? { clothingGraphic: value, clothing: 'graphicShirt' } : { [key]: value };
-  const preview = (/** @type {string} */ key, /** @type {string} */ value) => ({ ...config, ...withDeps(key, value) });
+	$: cat = CATEGORIES.find((c) => c.key === activeCat) ?? CATEGORIES[0];
+	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+	/** @param {any} o */
+	const locked = (o) => !!o.price && !owned.includes(o.cosmeticId);
+	/** preview config with one category overridden @param {string} key @param {string} value */
+	// a shirt design only shows on the Graphic Tee, so equipping a design auto-wears it
+	const withDeps = (/** @type {string} */ key, /** @type {string} */ value) =>
+		key === 'clothingGraphic'
+			? { clothingGraphic: value, clothing: 'graphicShirt' }
+			: { [key]: value };
+	const preview = (/** @type {string} */ key, /** @type {string} */ value) => ({
+		...config,
+		...withDeps(key, value)
+	});
 
-  function flash(/** @type {string} */ m) { toast = m; setTimeout(() => { if (toast === m) toast = ''; }, 1800); }
+	function flash(/** @type {string} */ m) {
+		toast = m;
+		setTimeout(() => {
+			if (toast === m) toast = '';
+		}, 1800);
+	}
 
-  // 🎲 Surprise look — only from free / already-owned options (never auto-buys).
-  function randomize() {
-    fx('select');
-    const next = { ...config };
-    for (const cat of CATEGORIES) {
-      const avail = cat.options.filter((/** @type {any} */ o) => !locked(o));
-      if (avail.length) Object.assign(next, withDeps(cat.key, avail[Math.floor(Math.random() * avail.length)].value));
-    }
-    config = next;
-    dirty = true;
-  }
+	// 🎲 Surprise look — only from free / already-owned options (never auto-buys).
+	function randomize() {
+		fx('select');
+		const next = { ...config };
+		for (const cat of CATEGORIES) {
+			const avail = cat.options.filter((/** @type {any} */ o) => !locked(o));
+			if (avail.length)
+				Object.assign(
+					next,
+					withDeps(cat.key, avail[Math.floor(Math.random() * avail.length)].value)
+				);
+		}
+		config = next;
+		dirty = true;
+	}
 
-  /** @param {string} key @param {any} o */
-  function choose(key, o) {
-    if (locked(o)) { buying = { key, o }; return; }
-    fx('tap');
-    config = { ...config, ...withDeps(key, o.value) };
-    dirty = true;
-  }
+	/** @param {string} key @param {any} o */
+	function choose(key, o) {
+		if (locked(o)) {
+			buying = { key, o };
+			return;
+		}
+		fx('tap');
+		config = { ...config, ...withDeps(key, o.value) };
+		dirty = true;
+	}
 
-  async function confirmBuy() {
-    if (!buying) return;
-    const { key, o } = buying;
-    if (bank < o.price) { flash("Not enough Cash"); buying = null; return; }
-    saving = true;
-    const res = await buyCosmetic(o.cosmeticId);
-    saving = false;
-    if (!res.ok) { flash(res.reason === 'insufficient' ? 'Not enough Cash' : 'Could not buy'); buying = null; return; }
-    fx('win');
-    owned = [...owned, o.cosmeticId];
-    bank -= o.price;
-    config = { ...config, ...withDeps(key, o.value) };
-    dirty = true;
-    buying = null;
-    flash('Unlocked!');
-  }
+	async function confirmBuy() {
+		if (!buying) return;
+		const { key, o } = buying;
+		if (bank < o.price) {
+			flash('Not enough Cash');
+			buying = null;
+			return;
+		}
+		saving = true;
+		const res = await buyCosmetic(o.cosmeticId);
+		saving = false;
+		if (!res.ok) {
+			flash(res.reason === 'insufficient' ? 'Not enough Cash' : 'Could not buy');
+			buying = null;
+			return;
+		}
+		fx('win');
+		owned = [...owned, o.cosmeticId];
+		bank -= o.price;
+		config = { ...config, ...withDeps(key, o.value) };
+		dirty = true;
+		buying = null;
+		flash('Unlocked!');
+	}
 
-  async function save() {
-    saving = true;
-    const res = await setAvatar(config);
-    saving = false;
-    if (res.ok) { fx('select'); dirty = false; flash('Saved'); }
-    else flash('Could not save');
-  }
+	async function save() {
+		saving = true;
+		const res = await setAvatar(config);
+		saving = false;
+		if (res.ok) {
+			fx('select');
+			dirty = false;
+			flash('Saved');
+		} else flash('Could not save');
+	}
 </script>
 
 <svelte:head><title>WordBank — Avatar</title></svelte:head>
 
 <main class="av-page">
-  <header class="av-head">
-    <div class="av-nav">
-      <button class="back-btn" on:click={() => (history.length > 1 ? history.back() : goto('/'))}>← Back</button>
-      <button class="back-btn home" on:click={() => goto('/')} title="Main menu" aria-label="Main menu">🏠</button>
-    </div>
-    <div class="av-head-right">
-      <button class="av-rand" on:click={randomize} title="Surprise me">🎲</button>
-      <span class="av-cash">💰 {fmt(bank)}</span>
-    </div>
-  </header>
+	<header class="av-head">
+		<div class="av-nav">
+			<button class="back-btn" on:click={() => (history.length > 1 ? history.back() : goto('/'))}
+				>← Back</button
+			>
+			<button
+				class="back-btn home"
+				on:click={() => goto('/')}
+				title="Main menu"
+				aria-label="Main menu">🏠</button
+			>
+		</div>
+		<div class="av-head-right">
+			<button class="av-rand" on:click={randomize} title="Surprise me">🎲</button>
+			<span class="av-cash">💰 {fmt(bank)}</span>
+		</div>
+	</header>
 
-  {#if loading}
-    <p class="loading">Loading…</p>
-  {:else}
-    <div class="av-hero"><Avatar {config} fx size={150} /></div>
+	{#if loading}
+		<p class="loading">Loading…</p>
+	{:else}
+		<div class="av-hero"><Avatar {config} fx size={150} /></div>
 
-    <div class="cat-row">
-      {#each CATEGORIES as c}
-        <button class="cat-chip" class:on={c.key === activeCat} on:click={() => { activeCat = c.key; fx('tap'); }}>{c.label}</button>
-      {/each}
-    </div>
+		<div class="cat-row">
+			{#each CATEGORIES as c}
+				<button
+					class="cat-chip"
+					class:on={c.key === activeCat}
+					on:click={() => {
+						activeCat = c.key;
+						fx('tap');
+					}}>{c.label}</button
+				>
+			{/each}
+		</div>
 
-    <div class="opt-grid" class:colors={cat.type === 'color'}>
-      {#each cat.options as o (o.value)}
-        <button class="opt" class:sel={config[cat.key] === o.value} class:locked={locked(o)} on:click={() => choose(cat.key, o)}
-          title={o.label}>
-          {#if cat.type === 'color'}
-            <span class="sw" style="background:#{o.value}"></span>
-          {:else}
-            <Avatar config={preview(cat.key, o.value)} fx={cat.type === 'fx'} size={62} />
-          {/if}
-          <span class="opt-label">{o.label}</span>
-          {#if locked(o)}<span class="opt-price">🔒 {fmt(o.price)}</span>{/if}
-        </button>
-      {/each}
-    </div>
-  {/if}
+		<div class="opt-grid" class:colors={cat.type === 'color'}>
+			{#each cat.options as o (o.value)}
+				<button
+					class="opt"
+					class:sel={config[cat.key] === o.value}
+					class:locked={locked(o)}
+					on:click={() => choose(cat.key, o)}
+					title={o.label}
+				>
+					{#if cat.type === 'color'}
+						<span class="sw" style="background:#{o.value}"></span>
+					{:else}
+						<Avatar config={preview(cat.key, o.value)} fx={cat.type === 'fx'} size={62} />
+					{/if}
+					<span class="opt-label">{o.label}</span>
+					{#if locked(o)}<span class="opt-price">🔒 {fmt(o.price)}</span>{/if}
+				</button>
+			{/each}
+		</div>
+	{/if}
 
-  {#if toast}<div class="av-toast">{toast}</div>{/if}
+	{#if toast}<div class="av-toast">{toast}</div>{/if}
 
-  <button class="av-save" class:dirty disabled={saving || !dirty} on:click={save}>{saving ? 'Saving…' : dirty ? 'Save' : 'Saved'}</button>
+	<button class="av-save" class:dirty disabled={saving || !dirty} on:click={save}
+		>{saving ? 'Saving…' : dirty ? 'Save' : 'Saved'}</button
+	>
 </main>
 
 {#if buying}
-  <div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Unlock item">
-    <button type="button" class="modal-backdrop" aria-label="Cancel" on:click={() => buying = null}></button>
-    <div class="buy-card">
-      <Avatar config={preview(buying.key, buying.o.value)} fx size={120} />
-      <h3>{buying.o.label}</h3>
-      <p class="buy-price">{fmt(buying.o.price)}</p>
-      <button class="buy-go" disabled={saving || bank < buying.o.price} on:click={confirmBuy}>
-        {bank < buying.o.price ? 'Not enough Cash' : (saving ? 'Unlocking…' : `Unlock for ${fmt(buying.o.price)}`)}
-      </button>
-      <button class="buy-cancel" on:click={() => buying = null}>Cancel</button>
-    </div>
-  </div>
+	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Unlock item">
+		<button
+			type="button"
+			class="modal-backdrop"
+			aria-label="Cancel"
+			on:click={() => (buying = null)}
+		></button>
+		<div class="buy-card">
+			<Avatar config={preview(buying.key, buying.o.value)} fx size={120} />
+			<h3>{buying.o.label}</h3>
+			<p class="buy-price">{fmt(buying.o.price)}</p>
+			<button class="buy-go" disabled={saving || bank < buying.o.price} on:click={confirmBuy}>
+				{bank < buying.o.price
+					? 'Not enough Cash'
+					: saving
+						? 'Unlocking…'
+						: `Unlock for ${fmt(buying.o.price)}`}
+			</button>
+			<button class="buy-cancel" on:click={() => (buying = null)}>Cancel</button>
+		</div>
+	</div>
 {/if}
 
 <style>
-  .av-page { max-width: 480px; margin: 0 auto; padding: 1rem 1rem 6rem; min-height: 100vh; }
-  .av-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.5rem; }
-  .av-nav { display: flex; gap: 8px; }
-  .back-btn { padding: 0.5rem 1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
-  .back-btn.home { padding: 0.5rem 0.7rem; font-size: 1.05rem; }
-  .av-head-right { display: flex; align-items: center; gap: 10px; }
-  .av-rand { width: 38px; height: 38px; border-radius: 50%; cursor: pointer; font-size: 1.1rem; line-height: 1;
-    background: var(--surface); border: 1px solid var(--border); }
-  .av-rand:active { transform: scale(0.92) rotate(20deg); }
-  .av-cash { font-family: var(--font-display); font-weight: 800; color: var(--brand-2); }
-  .loading { text-align: center; color: var(--text-muted); padding: 3rem; }
-  .av-hero { display: grid; place-items: center; margin: 0.5rem 0 1rem; }
-  .av-hero :global(.wb-avatar) { box-shadow: 0 8px 30px rgba(0,0,0,0.5); }
+	.av-page {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 1rem 1rem 6rem;
+		min-height: 100vh;
+	}
+	.av-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 0.5rem;
+	}
+	.av-nav {
+		display: flex;
+		gap: 8px;
+	}
+	.back-btn {
+		padding: 0.5rem 1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.back-btn.home {
+		padding: 0.5rem 0.7rem;
+		font-size: 1.05rem;
+	}
+	.av-head-right {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+	}
+	.av-rand {
+		width: 38px;
+		height: 38px;
+		border-radius: 50%;
+		cursor: pointer;
+		font-size: 1.1rem;
+		line-height: 1;
+		background: var(--surface);
+		border: 1px solid var(--border);
+	}
+	.av-rand:active {
+		transform: scale(0.92) rotate(20deg);
+	}
+	.av-cash {
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: var(--brand-2);
+	}
+	.loading {
+		text-align: center;
+		color: var(--text-muted);
+		padding: 3rem;
+	}
+	.av-hero {
+		display: grid;
+		place-items: center;
+		margin: 0.5rem 0 1rem;
+	}
+	.av-hero :global(.wb-avatar) {
+		box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+	}
 
-  .cat-row { display: flex; gap: 7px; overflow-x: auto; padding: 4px 0 10px; -webkit-overflow-scrolling: touch; scrollbar-width: none; }
-  .cat-row::-webkit-scrollbar { display: none; }
-  .cat-chip { flex: none; padding: 7px 13px; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.82rem; white-space: nowrap;
-    color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); }
-  .cat-chip.on { color: #3a2a00; background: linear-gradient(135deg, #fde047, #f59e0b); border-color: transparent; }
+	.cat-row {
+		display: flex;
+		gap: 7px;
+		overflow-x: auto;
+		padding: 4px 0 10px;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+	}
+	.cat-row::-webkit-scrollbar {
+		display: none;
+	}
+	.cat-chip {
+		flex: none;
+		padding: 7px 13px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 0.82rem;
+		white-space: nowrap;
+		color: var(--text-muted);
+		background: var(--surface);
+		border: 1px solid var(--border);
+	}
+	.cat-chip.on {
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		border-color: transparent;
+	}
 
-  .opt-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 9px; }
-  .opt-grid.colors { grid-template-columns: repeat(5, 1fr); }
-  .opt { position: relative; display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 8px 4px; border-radius: 14px; cursor: pointer;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); }
-  .opt.sel { border-color: var(--brand-2); box-shadow: 0 0 0 1px var(--brand-2); }
-  .opt.locked { opacity: 0.96; }
-  .opt.locked :global(.wb-avatar) { filter: grayscale(0.5) brightness(0.8); }
-  .opt-label { font-size: 0.68rem; color: var(--text-muted); text-align: center; line-height: 1.1; }
-  .opt-price { font-size: 0.68rem; font-weight: 800; color: var(--brand-2); }
-  .sw { width: 42px; height: 42px; border-radius: 50%; border: 2px solid rgba(255,255,255,0.25); }
-  .colors .opt-label { display: none; }
+	.opt-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 9px;
+	}
+	.opt-grid.colors {
+		grid-template-columns: repeat(5, 1fr);
+	}
+	.opt {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 4px;
+		padding: 8px 4px;
+		border-radius: 14px;
+		cursor: pointer;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.opt.sel {
+		border-color: var(--brand-2);
+		box-shadow: 0 0 0 1px var(--brand-2);
+	}
+	.opt.locked {
+		opacity: 0.96;
+	}
+	.opt.locked :global(.wb-avatar) {
+		filter: grayscale(0.5) brightness(0.8);
+	}
+	.opt-label {
+		font-size: 0.68rem;
+		color: var(--text-muted);
+		text-align: center;
+		line-height: 1.1;
+	}
+	.opt-price {
+		font-size: 0.68rem;
+		font-weight: 800;
+		color: var(--brand-2);
+	}
+	.sw {
+		width: 42px;
+		height: 42px;
+		border-radius: 50%;
+		border: 2px solid rgba(255, 255, 255, 0.25);
+	}
+	.colors .opt-label {
+		display: none;
+	}
 
-  .av-toast { position: fixed; left: 50%; bottom: 84px; transform: translateX(-50%); z-index: 1200; padding: 9px 18px; border-radius: 999px;
-    background: rgba(20,28,40,0.95); color: var(--text); border: 1px solid var(--border-strong, var(--border)); font-weight: 700; font-size: 0.9rem; }
-  .av-save { position: fixed; left: 50%; bottom: 18px; transform: translateX(-50%); z-index: 1100; width: calc(100% - 2rem); max-width: 448px;
-    height: 52px; border-radius: 16px; cursor: pointer; font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; border: none;
-    background: var(--surface-2, rgba(255,255,255,0.08)); color: var(--text-faint); }
-  .av-save.dirty { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; box-shadow: 0 8px 24px rgba(245,158,11,0.4); }
-  .av-save:disabled { cursor: default; }
+	.av-toast {
+		position: fixed;
+		left: 50%;
+		bottom: 84px;
+		transform: translateX(-50%);
+		z-index: 1200;
+		padding: 9px 18px;
+		border-radius: 999px;
+		background: rgba(20, 28, 40, 0.95);
+		color: var(--text);
+		border: 1px solid var(--border-strong, var(--border));
+		font-weight: 700;
+		font-size: 0.9rem;
+	}
+	.av-save {
+		position: fixed;
+		left: 50%;
+		bottom: 18px;
+		transform: translateX(-50%);
+		z-index: 1100;
+		width: calc(100% - 2rem);
+		max-width: 448px;
+		height: 52px;
+		border-radius: 16px;
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		border: none;
+		background: var(--surface-2, rgba(255, 255, 255, 0.08));
+		color: var(--text-faint);
+	}
+	.av-save.dirty {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		box-shadow: 0 8px 24px rgba(245, 158, 11, 0.4);
+	}
+	.av-save:disabled {
+		cursor: default;
+	}
 
-  .buy-card { position: relative; z-index: 1; width: calc(100% - 3rem); max-width: 320px; margin: auto; padding: 22px; border-radius: 20px; text-align: center;
-    background: var(--surface-strong, rgba(20,26,38,0.95)); border: 1px solid var(--border-strong, var(--border)); display: flex; flex-direction: column; align-items: center; gap: 8px; }
-  .buy-card h3 { margin: 6px 0 0; font-family: var(--font-display); }
-  .buy-price { margin: 0; font-family: var(--font-display); font-weight: 800; font-size: 1.3rem; color: var(--brand-2); }
-  .buy-go { width: 100%; height: 48px; border-radius: 14px; border: none; cursor: pointer; font-weight: 800; font-size: 1rem; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b); }
-  .buy-go:disabled { opacity: 0.5; cursor: not-allowed; }
-  .buy-cancel { background: none; border: none; color: var(--text-muted); cursor: pointer; font-weight: 600; padding: 4px; }
+	.buy-card {
+		position: relative;
+		z-index: 1;
+		width: calc(100% - 3rem);
+		max-width: 320px;
+		margin: auto;
+		padding: 22px;
+		border-radius: 20px;
+		text-align: center;
+		background: var(--surface-strong, rgba(20, 26, 38, 0.95));
+		border: 1px solid var(--border-strong, var(--border));
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 8px;
+	}
+	.buy-card h3 {
+		margin: 6px 0 0;
+		font-family: var(--font-display);
+	}
+	.buy-price {
+		margin: 0;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.3rem;
+		color: var(--brand-2);
+	}
+	.buy-go {
+		width: 100%;
+		height: 48px;
+		border-radius: 14px;
+		border: none;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 1rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.buy-go:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.buy-cancel {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-weight: 600;
+		padding: 4px;
+	}
 </style>

--- a/src/routes/avatar/fx/+page.svelte
+++ b/src/routes/avatar/fx/+page.svelte
@@ -1,70 +1,204 @@
 <script>
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import { renderAvatarSvg, renderHoloAvatar } from '$lib/avatar.js';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { renderAvatarSvg, renderHoloAvatar } from '$lib/avatar.js';
 
-  const base = { skinColor: 'edb98a', top: 'shortFlat', hairColor: '4a312c', eyes: 'happy',
-    eyebrows: 'default', mouth: 'smile', clothing: 'blazerAndShirt', clothesColor: '5199e4',
-    accessories: 'sunglasses', facialHair: 'none' };
+	const base = {
+		skinColor: 'edb98a',
+		top: 'shortFlat',
+		hairColor: '4a312c',
+		eyes: 'happy',
+		eyebrows: 'default',
+		mouth: 'smile',
+		clothing: 'blazerAndShirt',
+		clothesColor: '5199e4',
+		accessories: 'sunglasses',
+		facialHair: 'none'
+	};
 
-  let holo = true, frame = true, crown = true, aura = true;
-  $: svg = holo ? renderHoloAvatar(base) : renderAvatarSvg(base);
+	let holo = true,
+		frame = true,
+		crown = true,
+		aura = true;
+	$: svg = holo ? renderHoloAvatar(base) : renderAvatarSvg(base);
 </script>
 
 <svelte:head><title>WordBank — Premium FX</title></svelte:head>
 
 <main class="fxp">
-  <header class="fxp-head">
-    <PageNav />
-    <span class="fxp-tag">Premium FX demo</span>
-  </header>
+	<header class="fxp-head">
+		<PageNav />
+		<span class="fxp-tag">Premium FX demo</span>
+	</header>
 
-  <p class="fxp-note">These effects layer on the avatar you already have — no new character art. This is the top tier of the cosmetic store.</p>
+	<p class="fxp-note">
+		These effects layer on the avatar you already have — no new character art. This is the top tier
+		of the cosmetic store.
+	</p>
 
-  <div class="fxp-stage-wrap">
-    <div class="fxp-stage" style="--sz:230px">
-      {#if aura}<div class="fx-aura"></div>{/if}
-      {#if frame}<div class="fx-ring"></div>{/if}
-      <div class="fx-inner" class:framed={frame}>{@html svg}</div>
-      {#if crown}<img class="fx-crown" src="/avatar/fx/crown.svg" alt="" />{/if}
-    </div>
-  </div>
+	<div class="fxp-stage-wrap">
+		<div class="fxp-stage" style="--sz:230px">
+			{#if aura}<div class="fx-aura"></div>{/if}
+			{#if frame}<div class="fx-ring"></div>{/if}
+			<div class="fx-inner" class:framed={frame}>{@html svg}</div>
+			{#if crown}<img class="fx-crown" src="/avatar/fx/crown.svg" alt="" />{/if}
+		</div>
+	</div>
 
-  <div class="fxp-toggles">
-    <button class="fxp-t" class:on={holo} on:click={() => holo = !holo}>✨ Holographic Shirt</button>
-    <button class="fxp-t" class:on={frame} on:click={() => frame = !frame}>🌀 Neon Frame</button>
-    <button class="fxp-t" class:on={crown} on:click={() => crown = !crown}>👑 Crown</button>
-    <button class="fxp-t" class:on={aura} on:click={() => aura = !aura}>🔆 Glow Aura</button>
-  </div>
+	<div class="fxp-toggles">
+		<button class="fxp-t" class:on={holo} on:click={() => (holo = !holo)}
+			>✨ Holographic Shirt</button
+		>
+		<button class="fxp-t" class:on={frame} on:click={() => (frame = !frame)}>🌀 Neon Frame</button>
+		<button class="fxp-t" class:on={crown} on:click={() => (crown = !crown)}>👑 Crown</button>
+		<button class="fxp-t" class:on={aura} on:click={() => (aura = !aura)}>🔆 Glow Aura</button>
+	</div>
 </main>
 
 <style>
-  .fxp { max-width: 480px; margin: 0 auto; padding: 1rem 1rem 4rem; }
-  .fxp-head { display: flex; align-items: center; justify-content: space-between; }
-  .back-btn { padding: 0.5rem 1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
-  .fxp-tag { font-size: 0.75rem; font-weight: 700; color: var(--text-faint); }
-  .fxp-note { font-size: 0.82rem; line-height: 1.5; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 0.7rem 0.9rem; }
-  .fxp-stage-wrap { display: grid; place-items: center; min-height: 320px; margin: 1rem 0; }
+	.fxp {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 1rem 1rem 4rem;
+	}
+	.fxp-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.back-btn {
+		padding: 0.5rem 1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.fxp-tag {
+		font-size: 0.75rem;
+		font-weight: 700;
+		color: var(--text-faint);
+	}
+	.fxp-note {
+		font-size: 0.82rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		padding: 0.7rem 0.9rem;
+	}
+	.fxp-stage-wrap {
+		display: grid;
+		place-items: center;
+		min-height: 320px;
+		margin: 1rem 0;
+	}
 
-  .fxp-stage { position: relative; width: var(--sz); height: var(--sz); }
-  .fx-aura { position: absolute; inset: -22%; border-radius: 50%; z-index: 0; filter: blur(14px);
-    background: radial-gradient(circle, rgba(124,255,107,0.5), rgba(92,208,255,0.35) 45%, transparent 70%);
-    animation: fxpulse 2.6s ease-in-out infinite; }
-  .fx-ring { position: absolute; inset: -8px; border-radius: 50%; z-index: 1;
-    background: conic-gradient(from 0deg, #ff5cf0, #5cd0ff, #7cff6b, #ffe45c, #ff5cf0);
-    box-shadow: 0 0 26px rgba(124,255,107,0.55), 0 0 14px rgba(255,92,240,0.5); animation: fxspin 4s linear infinite; }
-  .fx-inner { position: absolute; inset: 0; z-index: 2; border-radius: 50%; overflow: hidden; background: #0b0f1a; }
-  .fx-inner.framed { box-shadow: inset 0 0 0 2px rgba(0,0,0,0.4); }
-  .fx-inner :global(svg) { width: 100%; height: 100%; display: block; }
-  .fx-crown { position: absolute; z-index: 3; top: -7%; left: 50%; transform: translateX(-50%); width: 52%;
-    filter: drop-shadow(0 3px 5px rgba(0,0,0,0.5)); animation: fxfloat 2.4s ease-in-out infinite; }
+	.fxp-stage {
+		position: relative;
+		width: var(--sz);
+		height: var(--sz);
+	}
+	.fx-aura {
+		position: absolute;
+		inset: -22%;
+		border-radius: 50%;
+		z-index: 0;
+		filter: blur(14px);
+		background: radial-gradient(
+			circle,
+			rgba(124, 255, 107, 0.5),
+			rgba(92, 208, 255, 0.35) 45%,
+			transparent 70%
+		);
+		animation: fxpulse 2.6s ease-in-out infinite;
+	}
+	.fx-ring {
+		position: absolute;
+		inset: -8px;
+		border-radius: 50%;
+		z-index: 1;
+		background: conic-gradient(from 0deg, #ff5cf0, #5cd0ff, #7cff6b, #ffe45c, #ff5cf0);
+		box-shadow:
+			0 0 26px rgba(124, 255, 107, 0.55),
+			0 0 14px rgba(255, 92, 240, 0.5);
+		animation: fxspin 4s linear infinite;
+	}
+	.fx-inner {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		border-radius: 50%;
+		overflow: hidden;
+		background: #0b0f1a;
+	}
+	.fx-inner.framed {
+		box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.4);
+	}
+	.fx-inner :global(svg) {
+		width: 100%;
+		height: 100%;
+		display: block;
+	}
+	.fx-crown {
+		position: absolute;
+		z-index: 3;
+		top: -7%;
+		left: 50%;
+		transform: translateX(-50%);
+		width: 52%;
+		filter: drop-shadow(0 3px 5px rgba(0, 0, 0, 0.5));
+		animation: fxfloat 2.4s ease-in-out infinite;
+	}
 
-  @keyframes fxspin { to { transform: rotate(360deg); } }
-  @keyframes fxpulse { 0%,100% { opacity: 0.65; transform: scale(0.96); } 50% { opacity: 1; transform: scale(1.04); } }
-  @keyframes fxfloat { 0%,100% { transform: translateX(-50%) translateY(0); } 50% { transform: translateX(-50%) translateY(-4px); } }
+	@keyframes fxspin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+	@keyframes fxpulse {
+		0%,
+		100% {
+			opacity: 0.65;
+			transform: scale(0.96);
+		}
+		50% {
+			opacity: 1;
+			transform: scale(1.04);
+		}
+	}
+	@keyframes fxfloat {
+		0%,
+		100% {
+			transform: translateX(-50%) translateY(0);
+		}
+		50% {
+			transform: translateX(-50%) translateY(-4px);
+		}
+	}
 
-  .fxp-toggles { display: flex; flex-wrap: wrap; gap: 9px; justify-content: center; }
-  .fxp-t { padding: 10px 16px; border-radius: 999px; cursor: pointer; font-weight: 800; font-size: 0.9rem;
-    color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); }
-  .fxp-t.on { color: #3a2a00; background: linear-gradient(135deg, #fde047, #f59e0b); border-color: transparent; }
+	.fxp-toggles {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 9px;
+		justify-content: center;
+	}
+	.fxp-t {
+		padding: 10px 16px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.9rem;
+		color: var(--text-muted);
+		background: var(--surface);
+		border: 1px solid var(--border);
+	}
+	.fxp-t.on {
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		border-color: transparent;
+	}
 </style>

--- a/src/routes/avatar/kit/+page.svelte
+++ b/src/routes/avatar/kit/+page.svelte
@@ -1,60 +1,136 @@
 <script>
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import KitAvatar from '$lib/components/KitAvatar.svelte';
-  import { SLOTS, PARTS, DEFAULT_KIT, KIT_READY } from '$lib/avatarKit.js';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import KitAvatar from '$lib/components/KitAvatar.svelte';
+	import { SLOTS, PARTS, DEFAULT_KIT, KIT_READY } from '$lib/avatarKit.js';
 
-  /** @type {any} */ let config = { ...DEFAULT_KIT };
-  /** @param {string} slot @param {string} id */
-  function pick(slot, id) { config = { ...config, [slot]: id }; }
-  const fmt = (/** @type {number} */ n) => '$' + n.toLocaleString();
+	/** @type {any} */ let config = { ...DEFAULT_KIT };
+	/** @param {string} slot @param {string} id */
+	function pick(slot, id) {
+		config = { ...config, [slot]: id };
+	}
+	const fmt = (/** @type {number} */ n) => '$' + n.toLocaleString();
 </script>
 
 <svelte:head><title>WordBank — Avatar Kit (preview)</title></svelte:head>
 
 <main class="kp">
-  <header class="kp-head">
-    <PageNav />
-    <span class="kp-tag">{KIT_READY ? 'Kit: LIVE' : 'Kit: scaffold preview'}</span>
-  </header>
+	<header class="kp-head">
+		<PageNav />
+		<span class="kp-tag">{KIT_READY ? 'Kit: LIVE' : 'Kit: scaffold preview'}</span>
+	</header>
 
-  <p class="kp-note">
-    Full-body kit — real <b>Humaaans</b> art. Mix & match below. When you're happy with the
-    look + wardrobe, set <code>KIT_READY = true</code> in <code>avatarKit.js</code> and I'll
-    switch the builder/store/profile over to this from the current head-and-shoulders avatar.
-  </p>
+	<p class="kp-note">
+		Full-body kit — real <b>Humaaans</b> art. Mix & match below. When you're happy with the look +
+		wardrobe, set <code>KIT_READY = true</code> in <code>avatarKit.js</code> and I'll switch the builder/store/profile
+		over to this from the current head-and-shoulders avatar.
+	</p>
 
-  <div class="kp-stage"><KitAvatar {config} size={220} /></div>
+	<div class="kp-stage"><KitAvatar {config} size={220} /></div>
 
-  {#each SLOTS as s (s.key)}
-    <div class="kp-slot">
-      <div class="kp-slot-label">{s.label}</div>
-      <div class="kp-opts">
-        {#each PARTS[s.key] as o (o.id)}
-          <button class="kp-opt" class:on={config[s.key] === o.id} on:click={() => pick(s.key, o.id)}>
-            {o.label}{#if o.price}<span class="kp-price">🔒 {fmt(o.price)}</span>{/if}
-          </button>
-        {/each}
-      </div>
-    </div>
-  {/each}
+	{#each SLOTS as s (s.key)}
+		<div class="kp-slot">
+			<div class="kp-slot-label">{s.label}</div>
+			<div class="kp-opts">
+				{#each PARTS[s.key] as o (o.id)}
+					<button
+						class="kp-opt"
+						class:on={config[s.key] === o.id}
+						on:click={() => pick(s.key, o.id)}
+					>
+						{o.label}{#if o.price}<span class="kp-price">🔒 {fmt(o.price)}</span>{/if}
+					</button>
+				{/each}
+			</div>
+		</div>
+	{/each}
 </main>
 
 <style>
-  .kp { max-width: 480px; margin: 0 auto; padding: 1rem 1rem 4rem; }
-  .kp-head { display: flex; align-items: center; justify-content: space-between; }
-  .back-btn { padding: 0.5rem 1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
-  .kp-tag { font-size: 0.75rem; font-weight: 700; color: var(--text-faint); }
-  .kp-note { font-size: 0.82rem; line-height: 1.5; color: var(--text-muted); background: var(--surface); border: 1px solid var(--border); border-radius: 12px; padding: 0.7rem 0.9rem; }
-  .kp-note code { color: var(--brand-2); }
-  .kp-stage { display: grid; place-items: center; margin: 1rem 0 1.4rem; }
-  .kp-stage :global(.kit) { background: radial-gradient(circle at 50% 38%, rgba(255,255,255,0.06), transparent 60%); }
-  .kp-slot { margin-bottom: 12px; }
-  .kp-slot-label { font-family: var(--font-display); font-weight: 700; font-size: 0.85rem; color: var(--text-muted); margin-bottom: 6px; }
-  .kp-opts { display: flex; flex-wrap: wrap; gap: 7px; }
-  .kp-opt { display: flex; align-items: center; gap: 6px; padding: 8px 12px; border-radius: 999px; cursor: pointer; font-weight: 700; font-size: 0.82rem;
-    color: var(--text); background: var(--surface); border: 1px solid var(--border); }
-  .kp-opt.on { color: #3a2a00; background: linear-gradient(135deg, #fde047, #f59e0b); border-color: transparent; }
-  .kp-price { font-size: 0.72rem; font-weight: 800; color: var(--brand-2); }
-  .kp-opt.on .kp-price { color: #3a2a00; }
+	.kp {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 1rem 1rem 4rem;
+	}
+	.kp-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.back-btn {
+		padding: 0.5rem 1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.kp-tag {
+		font-size: 0.75rem;
+		font-weight: 700;
+		color: var(--text-faint);
+	}
+	.kp-note {
+		font-size: 0.82rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		padding: 0.7rem 0.9rem;
+	}
+	.kp-note code {
+		color: var(--brand-2);
+	}
+	.kp-stage {
+		display: grid;
+		place-items: center;
+		margin: 1rem 0 1.4rem;
+	}
+	.kp-stage :global(.kit) {
+		background: radial-gradient(circle at 50% 38%, rgba(255, 255, 255, 0.06), transparent 60%);
+	}
+	.kp-slot {
+		margin-bottom: 12px;
+	}
+	.kp-slot-label {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin-bottom: 6px;
+	}
+	.kp-opts {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 7px;
+	}
+	.kp-opt {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		padding: 8px 12px;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 0.82rem;
+		color: var(--text);
+		background: var(--surface);
+		border: 1px solid var(--border);
+	}
+	.kp-opt.on {
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		border-color: transparent;
+	}
+	.kp-price {
+		font-size: 0.72rem;
+		font-weight: 800;
+		color: var(--brand-2);
+	}
+	.kp-opt.on .kp-price {
+		color: #3a2a00;
+	}
 </style>

--- a/src/routes/badges/+page.svelte
+++ b/src/routes/badges/+page.svelte
@@ -1,19 +1,36 @@
 <script>
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import BadgesPanel from '$lib/components/BadgesPanel.svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import BadgesPanel from '$lib/components/BadgesPanel.svelte';
 </script>
 
 <svelte:head><title>WordBank — Badges</title></svelte:head>
 
 <main class="badges-page">
-  <PageNav />
-  <h1>🏅 Badges</h1>
-  <BadgesPanel />
+	<PageNav />
+	<h1>🏅 Badges</h1>
+	<BadgesPanel />
 </main>
 
 <style>
-  .badges-page { max-width: 480px; margin: 0 auto; padding: 28px 16px 60px; font-family: var(--font-ui); }
-  .badges-page h1 { font-family: var(--font-display); font-size: 1.8rem; margin: 6px 0 4px; text-align: center; }
-  .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
+	.badges-page {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 28px 16px 60px;
+		font-family: var(--font-ui);
+	}
+	.badges-page h1 {
+		font-family: var(--font-display);
+		font-size: 1.8rem;
+		margin: 6px 0 4px;
+		text-align: center;
+	}
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		cursor: pointer;
+		padding: 6px 0;
+	}
 </style>

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,287 +1,744 @@
 <script>
-  import { onMount } from 'svelte';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import { getBank, takeLoan, repayLoan } from '$lib/stores/statsStore.js';
-  import InventoryList from '$lib/components/InventoryList.svelte';
-  import { requirePin } from '$lib/pinConfirm.js';
-  import { track } from '$lib/analytics.js';
-  import { fx } from '$lib/sound.js';
+	import { onMount } from 'svelte';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { getBank, takeLoan, repayLoan } from '$lib/stores/statsStore.js';
+	import InventoryList from '$lib/components/InventoryList.svelte';
+	import { requirePin } from '$lib/pinConfirm.js';
+	import { track } from '$lib/analytics.js';
+	import { fx } from '$lib/sound.js';
 
-  /** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
-  let b = null;
-  let loading = true;
-  /** @type {{title:string, desc:string}|null} */
-  let info = null;
+	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
+	let b = null;
+	let loading = true;
+	/** @type {{title:string, desc:string}|null} */
+	let info = null;
 
-  // 💸 Loan Shark
-  let borrowAmt = 100;      // $ to borrow (dial)
-  let repayAmt = 0;         // $ to repay (dial)
-  let loanBusy = '';
-  let loanMsg = '';
-  $: loanCap = b?.loan_cap ?? 0;
-  $: owed = b?.loan ?? 0;
-  $: feeOnBorrow = Math.round(borrowAmt * 0.25);
-  $: if (borrowAmt > loanCap) borrowAmt = loanCap;
-  $: if (borrowAmt < 10 && loanCap >= 10) borrowAmt = 10;
-  $: maxRepay = Math.max(0, Math.min(owed, b?.bank ?? 0));
-  $: if (repayAmt > maxRepay) repayAmt = maxRepay;
+	// 💸 Loan Shark
+	let borrowAmt = 100; // $ to borrow (dial)
+	let repayAmt = 0; // $ to repay (dial)
+	let loanBusy = '';
+	let loanMsg = '';
+	$: loanCap = b?.loan_cap ?? 0;
+	$: owed = b?.loan ?? 0;
+	$: feeOnBorrow = Math.round(borrowAmt * 0.25);
+	$: if (borrowAmt > loanCap) borrowAmt = loanCap;
+	$: if (borrowAmt < 10 && loanCap >= 10) borrowAmt = 10;
+	$: maxRepay = Math.max(0, Math.min(owed, b?.bank ?? 0));
+	$: if (repayAmt > maxRepay) repayAmt = maxRepay;
 
-  async function load() {
-    b = await getBank(500);
-    repayAmt = Math.max(0, Math.min(b?.loan ?? 0, b?.bank ?? 0));
-  }
-  onMount(async () => {
-    track('bank_view');
-    try { await load(); } finally { loading = false; }
-  });
+	async function load() {
+		b = await getBank(500);
+		repayAmt = Math.max(0, Math.min(b?.loan ?? 0, b?.bank ?? 0));
+	}
+	onMount(async () => {
+		track('bank_view');
+		try {
+			await load();
+		} finally {
+			loading = false;
+		}
+	});
 
-  async function borrow() {
-    if (loanBusy || borrowAmt < 10) return;
-    const total = borrowAmt + Math.round(borrowAmt * 0.25);
-    try { await requirePin(`Borrow $${borrowAmt.toLocaleString()} — you'll owe $${total.toLocaleString()}`, [
-      { label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
-      { label: 'Fee (25%)', value: '$' + Math.round(borrowAmt * 0.25).toLocaleString() },
-      { label: 'You owe', value: '$' + total.toLocaleString() }
-    ]); } catch { return; }
-    loanBusy = 'borrow'; loanMsg = '';
-    const res = await takeLoan(borrowAmt);
-    loanBusy = '';
-    if (res?.ok) { fx('win'); track('take_loan', { amount: borrowAmt, owed: res.owed }); await load(); }
-    else { loanMsg = res?.reason === 'active_loan' ? 'Pay off your current loan first.' : res?.reason === 'over_cap' ? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.` : 'Could not borrow right now.'; }
-  }
-  async function repay(/** @type {number|null} */ amt) {
-    if (loanBusy) return;
-    const pay = amt ?? maxRepay;
-    if (pay <= 0) return;
-    loanBusy = 'repay'; loanMsg = '';
-    const res = await repayLoan(amt);
-    loanBusy = '';
-    if (res?.ok) { fx('tap'); track('repay_loan', { amount: res.paid, cleared: res.cleared }); await load(); }
-    else { loanMsg = res?.reason === 'insufficient' ? 'Not enough Cash to repay.' : 'Could not repay right now.'; }
-  }
+	async function borrow() {
+		if (loanBusy || borrowAmt < 10) return;
+		const total = borrowAmt + Math.round(borrowAmt * 0.25);
+		try {
+			await requirePin(
+				`Borrow $${borrowAmt.toLocaleString()} — you'll owe $${total.toLocaleString()}`,
+				[
+					{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
+					{ label: 'Fee (25%)', value: '$' + Math.round(borrowAmt * 0.25).toLocaleString() },
+					{ label: 'You owe', value: '$' + total.toLocaleString() }
+				]
+			);
+		} catch {
+			return;
+		}
+		loanBusy = 'borrow';
+		loanMsg = '';
+		const res = await takeLoan(borrowAmt);
+		loanBusy = '';
+		if (res?.ok) {
+			fx('win');
+			track('take_loan', { amount: borrowAmt, owed: res.owed });
+			await load();
+		} else {
+			loanMsg =
+				res?.reason === 'active_loan'
+					? 'Pay off your current loan first.'
+					: res?.reason === 'over_cap'
+						? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.`
+						: 'Could not borrow right now.';
+		}
+	}
+	async function repay(/** @type {number|null} */ amt) {
+		if (loanBusy) return;
+		const pay = amt ?? maxRepay;
+		if (pay <= 0) return;
+		loanBusy = 'repay';
+		loanMsg = '';
+		const res = await repayLoan(amt);
+		loanBusy = '';
+		if (res?.ok) {
+			fx('tap');
+			track('repay_loan', { amount: res.paid, cleared: res.cleared });
+			await load();
+		} else {
+			loanMsg =
+				res?.reason === 'insufficient' ? 'Not enough Cash to repay.' : 'Could not repay right now.';
+		}
+	}
 
-  const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
-  const dateOnly = (/** @type {string} */ at) => at ? new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '';
+	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+	const dateOnly = (/** @type {string} */ at) =>
+		at ? new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '';
 
-  // Ledger filters: by type, and sort by date/amount. Custom dropdowns so the menu
-  // opens downward over the ledger.
-  let typeFilter = 'all';
-  let sortBy = 'newest';
-  /** @type {null|'type'|'sort'} */
-  let openMenu = null;
-  const SORTS = [{ k: 'newest', label: 'Newest' }, { k: 'oldest', label: 'Oldest' }, { k: 'largest', label: 'Largest' }, { k: 'smallest', label: 'Smallest' }];
-  $: sortLabel = SORTS.find((s) => s.k === sortBy)?.label ?? 'Newest';
-  $: ledgerTypes = b ? [...new Set(b.ledger.map((/** @type {any} */ e) => e.reason))] : [];
-  $: shownLedger = (b ? [...b.ledger] : [])
-    .filter((/** @type {any} */ e) => typeFilter === 'all' || e.reason === typeFilter)
-    .sort((/** @type {any} */ x, /** @type {any} */ y) => {
-      if (sortBy === 'oldest') return new Date(x.at).getTime() - new Date(y.at).getTime();
-      if (sortBy === 'largest') return Math.abs(y.delta) - Math.abs(x.delta);
-      if (sortBy === 'smallest') return Math.abs(x.delta) - Math.abs(y.delta);
-      return new Date(y.at).getTime() - new Date(x.at).getTime();
-    });
+	// Ledger filters: by type, and sort by date/amount. Custom dropdowns so the menu
+	// opens downward over the ledger.
+	let typeFilter = 'all';
+	let sortBy = 'newest';
+	/** @type {null|'type'|'sort'} */
+	let openMenu = null;
+	const SORTS = [
+		{ k: 'newest', label: 'Newest' },
+		{ k: 'oldest', label: 'Oldest' },
+		{ k: 'largest', label: 'Largest' },
+		{ k: 'smallest', label: 'Smallest' }
+	];
+	$: sortLabel = SORTS.find((s) => s.k === sortBy)?.label ?? 'Newest';
+	$: ledgerTypes = b ? [...new Set(b.ledger.map((/** @type {any} */ e) => e.reason))] : [];
+	$: shownLedger = (b ? [...b.ledger] : [])
+		.filter((/** @type {any} */ e) => typeFilter === 'all' || e.reason === typeFilter)
+		.sort((/** @type {any} */ x, /** @type {any} */ y) => {
+			if (sortBy === 'oldest') return new Date(x.at).getTime() - new Date(y.at).getTime();
+			if (sortBy === 'largest') return Math.abs(y.delta) - Math.abs(x.delta);
+			if (sortBy === 'smallest') return Math.abs(x.delta) - Math.abs(y.delta);
+			return new Date(y.at).getTime() - new Date(x.at).getTime();
+		});
 
-  /** @param {string} reason */
-  function reasonLabel(reason) {
-    return ({
-      daily_win: 'Daily reward', daily_reward: 'Daily reward',
-      attendance: 'Attendance reward', arcade_cashout: 'Cash Game cash-out', climb_bounty: 'Cash Game bounty',
-      freeplay_reward: 'Free Play reward', freeplay_cashout: 'Exchanged credits → Cash',
-      cosmetic_buy: 'Store purchase', powerup_buy: 'Power-up purchase',
-      loan_take: 'Loan received', loan_repay: 'Loan repayment', loan_skim: 'Loan auto-payment',
-      wager_win: 'Won a wager', wager_stake: 'Wager staked', wager_refund: 'Wager refunded',
-      makeup_reward: 'Make-up Daily', challenge_payout: 'Challenge payout'
-    })[reason] || reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-  }
+	/** @param {string} reason */
+	function reasonLabel(reason) {
+		return (
+			{
+				daily_win: 'Daily reward',
+				daily_reward: 'Daily reward',
+				attendance: 'Attendance reward',
+				arcade_cashout: 'Cash Game cash-out',
+				climb_bounty: 'Cash Game bounty',
+				freeplay_reward: 'Free Play reward',
+				freeplay_cashout: 'Exchanged credits → Cash',
+				cosmetic_buy: 'Store purchase',
+				powerup_buy: 'Power-up purchase',
+				loan_take: 'Loan received',
+				loan_repay: 'Loan repayment',
+				loan_skim: 'Loan auto-payment',
+				wager_win: 'Won a wager',
+				wager_stake: 'Wager staked',
+				wager_refund: 'Wager refunded',
+				makeup_reward: 'Make-up Daily',
+				challenge_payout: 'Challenge payout'
+			}[reason] || reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+		);
+	}
 </script>
 
 <svelte:head><title>WordBank — Bank</title></svelte:head>
 
 <main class="bank-page">
-  <PageNav back="/" />
-  <h1 class="bank-title">🏦 Bank</h1>
+	<PageNav back="/" />
+	<h1 class="bank-title">🏦 Bank</h1>
 
-  {#if loading}
-    <p class="loading">Loading…</p>
-  {:else if b}
-    <!-- Balances -->
-    <div class="balances">
-      <button class="bal cash" onclick={() => info = { title: '💰 Cash', desc: 'Your main currency — and your score. Earn it by solving puzzles in the Daily, Cash Game, and challenges. Spend it on letters mid-game and on power-ups & cosmetics in the Store. It can’t be bought with real money.' }}>
-        <span class="bal-label">💰 Cash <span class="bal-i">ⓘ</span></span>
-        <span class="bal-value">{fmt(b.bank)}</span>
-      </button>
-    </div>
+	{#if loading}
+		<p class="loading">Loading…</p>
+	{:else if b}
+		<!-- Balances -->
+		<div class="balances">
+			<button
+				class="bal cash"
+				onclick={() =>
+					(info = {
+						title: '💰 Cash',
+						desc: 'Your main currency — and your score. Earn it by solving puzzles in the Daily, Cash Game, and challenges. Spend it on letters mid-game and on power-ups & cosmetics in the Store. It can’t be bought with real money.'
+					})}
+			>
+				<span class="bal-label">💰 Cash <span class="bal-i">ⓘ</span></span>
+				<span class="bal-value">{fmt(b.bank)}</span>
+			</button>
+		</div>
 
-    <!-- 💸 Loan Shark -->
-    {#if b.in_the_red}
-      <!-- In debt: repay panel + the teeth -->
-      <div class="loan-card debt">
-        <div class="loan-head">
-          <span class="loan-title">🦈 You owe the Shark</span>
-          <span class="loan-owed">{fmt(owed)}</span>
-        </div>
-        <p class="loan-note">Store is locked and half of every payout auto-pays your debt until it's clear. Your net worth is <b class="neg">{fmt(b.net_worth)}</b>.</p>
-        {#if maxRepay > 0}
-          <div class="loan-dial">
-            <button class="loan-step" onclick={() => repayAmt = Math.max(0, repayAmt - 50)} aria-label="Less" disabled={repayAmt <= 0}>−</button>
-            <div class="loan-amt"><span class="loan-usd">{fmt(repayAmt)}</span><span class="loan-sub">of {fmt(owed)} owed</span></div>
-            <button class="loan-step" onclick={() => repayAmt = Math.min(maxRepay, repayAmt + 50)} aria-label="More" disabled={repayAmt >= maxRepay}>+</button>
-          </div>
-          <input class="loan-slider" type="range" min="0" max={maxRepay} step="10" bind:value={repayAmt} />
-          <div class="loan-actions">
-            <button class="loan-btn ghost" disabled={!!loanBusy || repayAmt <= 0} onclick={() => repay(repayAmt)}>Repay {fmt(repayAmt)}</button>
-            <button class="loan-btn pay" disabled={!!loanBusy} onclick={() => repay(null)}>Pay max ({fmt(maxRepay)})</button>
-          </div>
-        {:else}
-          <p class="loan-note">Earn some Cash (play the Daily) then come back to repay.</p>
-        {/if}
-        {#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
-      </div>
-    {:else if loanCap > 0}
-      <!-- No debt: borrow panel -->
-      <details class="loan-card">
-        <summary class="loan-summary">🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary>
-        <p class="loan-note">A 25% fee, one loan at a time. While you owe, the Store locks and half of every payout auto-pays it down.</p>
-        <div class="loan-dial">
-          <button class="loan-step" onclick={() => borrowAmt = Math.max(10, borrowAmt - 50)} aria-label="Less" disabled={borrowAmt <= 10}>−</button>
-          <div class="loan-amt"><span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub">you'll owe {fmt(borrowAmt + feeOnBorrow)}</span></div>
-          <button class="loan-step" onclick={() => borrowAmt = Math.min(loanCap, borrowAmt + 50)} aria-label="More" disabled={borrowAmt >= loanCap}>+</button>
-        </div>
-        <input class="loan-slider" type="range" min="10" max={loanCap} step="10" bind:value={borrowAmt} />
-        <button class="loan-btn borrow" disabled={!!loanBusy || borrowAmt < 10} onclick={borrow}>🦈 Borrow {fmt(borrowAmt)} (fee {fmt(feeOnBorrow)})</button>
-        {#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
-      </details>
-    {/if}
+		<!-- 💸 Loan Shark -->
+		{#if b.in_the_red}
+			<!-- In debt: repay panel + the teeth -->
+			<div class="loan-card debt">
+				<div class="loan-head">
+					<span class="loan-title">🦈 You owe the Shark</span>
+					<span class="loan-owed">{fmt(owed)}</span>
+				</div>
+				<p class="loan-note">
+					Store is locked and half of every payout auto-pays your debt until it's clear. Your net
+					worth is <b class="neg">{fmt(b.net_worth)}</b>.
+				</p>
+				{#if maxRepay > 0}
+					<div class="loan-dial">
+						<button
+							class="loan-step"
+							onclick={() => (repayAmt = Math.max(0, repayAmt - 50))}
+							aria-label="Less"
+							disabled={repayAmt <= 0}>−</button
+						>
+						<div class="loan-amt">
+							<span class="loan-usd">{fmt(repayAmt)}</span><span class="loan-sub"
+								>of {fmt(owed)} owed</span
+							>
+						</div>
+						<button
+							class="loan-step"
+							onclick={() => (repayAmt = Math.min(maxRepay, repayAmt + 50))}
+							aria-label="More"
+							disabled={repayAmt >= maxRepay}>+</button
+						>
+					</div>
+					<input
+						class="loan-slider"
+						type="range"
+						min="0"
+						max={maxRepay}
+						step="10"
+						bind:value={repayAmt}
+					/>
+					<div class="loan-actions">
+						<button
+							class="loan-btn ghost"
+							disabled={!!loanBusy || repayAmt <= 0}
+							onclick={() => repay(repayAmt)}>Repay {fmt(repayAmt)}</button
+						>
+						<button class="loan-btn pay" disabled={!!loanBusy} onclick={() => repay(null)}
+							>Pay max ({fmt(maxRepay)})</button
+						>
+					</div>
+				{:else}
+					<p class="loan-note">Earn some Cash (play the Daily) then come back to repay.</p>
+				{/if}
+				{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
+			</div>
+		{:else if loanCap > 0}
+			<!-- No debt: borrow panel -->
+			<details class="loan-card">
+				<summary class="loan-summary"
+					>🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary
+				>
+				<p class="loan-note">
+					A 25% fee, one loan at a time. While you owe, the Store locks and half of every payout
+					auto-pays it down.
+				</p>
+				<div class="loan-dial">
+					<button
+						class="loan-step"
+						onclick={() => (borrowAmt = Math.max(10, borrowAmt - 50))}
+						aria-label="Less"
+						disabled={borrowAmt <= 10}>−</button
+					>
+					<div class="loan-amt">
+						<span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub"
+							>you'll owe {fmt(borrowAmt + feeOnBorrow)}</span
+						>
+					</div>
+					<button
+						class="loan-step"
+						onclick={() => (borrowAmt = Math.min(loanCap, borrowAmt + 50))}
+						aria-label="More"
+						disabled={borrowAmt >= loanCap}>+</button
+					>
+				</div>
+				<input
+					class="loan-slider"
+					type="range"
+					min="10"
+					max={loanCap}
+					step="10"
+					bind:value={borrowAmt}
+				/>
+				<button class="loan-btn borrow" disabled={!!loanBusy || borrowAmt < 10} onclick={borrow}
+					>🦈 Borrow {fmt(borrowAmt)} (fee {fmt(feeOnBorrow)})</button
+				>
+				{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
+			</details>
+		{/if}
 
-    <!-- Items (your vault) -->
-    <h2 class="hist-title">🎒 Your Items</h2>
-    <InventoryList addHref="/shop?from=bank" />
+		<!-- Items (your vault) -->
+		<h2 class="hist-title">🎒 Your Items</h2>
+		<InventoryList addHref="/shop?from=bank" />
 
-    <!-- Ledger -->
-    <div class="led-head">
-      <h2 class="hist-title">📒 Ledger</h2>
-      {#if b.ledger.length}
-        <div class="led-filters">
-          <div class="led-dd">
-            <button class="led-sel" onclick={() => openMenu = openMenu === 'type' ? null : 'type'}>{typeFilter === 'all' ? 'All types' : reasonLabel(typeFilter)} <span class="dd-cv">▾</span></button>
-            {#if openMenu === 'type'}
-              <div class="led-menu">
-                <button class:on={typeFilter === 'all'} onclick={() => { typeFilter = 'all'; openMenu = null; }}>All types</button>
-                {#each ledgerTypes as t}<button class:on={typeFilter === t} onclick={() => { typeFilter = t; openMenu = null; }}>{reasonLabel(t)}</button>{/each}
-              </div>
-            {/if}
-          </div>
-          <div class="led-dd">
-            <button class="led-sel" onclick={() => openMenu = openMenu === 'sort' ? null : 'sort'}>{sortLabel} <span class="dd-cv">▾</span></button>
-            {#if openMenu === 'sort'}
-              <div class="led-menu">
-                {#each SORTS as s}<button class:on={sortBy === s.k} onclick={() => { sortBy = s.k; openMenu = null; }}>{s.label}</button>{/each}
-              </div>
-            {/if}
-          </div>
-        </div>
-      {/if}
-    </div>
-    {#if openMenu}<button class="led-backdrop" onclick={() => openMenu = null} aria-label="Close" tabindex="-1"></button>{/if}
-    {#if b.ledger.length === 0}
-      <p class="empty">No transactions yet. Win the Daily, show up for attendance, or climb the Cash Game to grow your Cash.</p>
-    {:else}
-      <div class="ledger scroll">
-        {#each shownLedger as e}
-          <div class="led-row">
-            <span class="led-date">{dateOnly(e.at)}</span>
-            <span class="led-reason">{reasonLabel(e.reason)}</span>
-            <span class="led-delta" class:pos={e.delta > 0} class:neg={e.delta < 0}>{e.delta > 0 ? '+' : '−'}{fmt(Math.abs(e.delta))}</span>
-          </div>
-        {/each}
-      </div>
-    {/if}
-  {/if}
+		<!-- Ledger -->
+		<div class="led-head">
+			<h2 class="hist-title">📒 Ledger</h2>
+			{#if b.ledger.length}
+				<div class="led-filters">
+					<div class="led-dd">
+						<button class="led-sel" onclick={() => (openMenu = openMenu === 'type' ? null : 'type')}
+							>{typeFilter === 'all' ? 'All types' : reasonLabel(typeFilter)}
+							<span class="dd-cv">▾</span></button
+						>
+						{#if openMenu === 'type'}
+							<div class="led-menu">
+								<button
+									class:on={typeFilter === 'all'}
+									onclick={() => {
+										typeFilter = 'all';
+										openMenu = null;
+									}}>All types</button
+								>
+								{#each ledgerTypes as t}<button
+										class:on={typeFilter === t}
+										onclick={() => {
+											typeFilter = t;
+											openMenu = null;
+										}}>{reasonLabel(t)}</button
+									>{/each}
+							</div>
+						{/if}
+					</div>
+					<div class="led-dd">
+						<button class="led-sel" onclick={() => (openMenu = openMenu === 'sort' ? null : 'sort')}
+							>{sortLabel} <span class="dd-cv">▾</span></button
+						>
+						{#if openMenu === 'sort'}
+							<div class="led-menu">
+								{#each SORTS as s}<button
+										class:on={sortBy === s.k}
+										onclick={() => {
+											sortBy = s.k;
+											openMenu = null;
+										}}>{s.label}</button
+									>{/each}
+							</div>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+		{#if openMenu}<button
+				class="led-backdrop"
+				onclick={() => (openMenu = null)}
+				aria-label="Close"
+				tabindex="-1"
+			></button>{/if}
+		{#if b.ledger.length === 0}
+			<p class="empty">
+				No transactions yet. Win the Daily, show up for attendance, or climb the Cash Game to grow
+				your Cash.
+			</p>
+		{:else}
+			<div class="ledger scroll">
+				{#each shownLedger as e}
+					<div class="led-row">
+						<span class="led-date">{dateOnly(e.at)}</span>
+						<span class="led-reason">{reasonLabel(e.reason)}</span>
+						<span class="led-delta" class:pos={e.delta > 0} class:neg={e.delta < 0}
+							>{e.delta > 0 ? '+' : '−'}{fmt(Math.abs(e.delta))}</span
+						>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	{/if}
 
-  {#if info}
-    <div class="si-overlay" role="button" tabindex="0" onclick={() => info = null}
-      onkeydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') info = null; }}>
-      <div class="si-card" role="document" onclick={(e) => e.stopPropagation()}>
-        <h3 class="si-title">{info.title}</h3>
-        <p class="si-desc">{info.desc}</p>
-        <button class="si-close" onclick={() => info = null}>Got it</button>
-      </div>
-    </div>
-  {/if}
+	{#if info}
+		<div
+			class="si-overlay"
+			role="button"
+			tabindex="0"
+			onclick={() => (info = null)}
+			onkeydown={(e) => {
+				if (e.key === 'Escape' || e.key === 'Enter') info = null;
+			}}
+		>
+			<div class="si-card" role="document" onclick={(e) => e.stopPropagation()}>
+				<h3 class="si-title">{info.title}</h3>
+				<p class="si-desc">{info.desc}</p>
+				<button class="si-close" onclick={() => (info = null)}>Got it</button>
+			</div>
+		</div>
+	{/if}
 </main>
 
 <style>
-  .bank-page { max-width: 480px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
-  .bank-title { font-family: var(--font-display); font-size: 1.5rem; margin: 4px 0 16px; text-align: center; }
-  .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
+	.bank-page {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem 3rem;
+	}
+	.bank-title {
+		font-family: var(--font-display);
+		font-size: 1.5rem;
+		margin: 4px 0 16px;
+		text-align: center;
+	}
+	.loading {
+		color: var(--text-muted);
+		padding: 2rem;
+		text-align: center;
+	}
 
-  .balances { display: grid; grid-template-columns: 1fr; gap: 10px; margin-bottom: 14px; }
-  .bal { display: flex; flex-direction: column; gap: 2px; padding: 14px; border-radius: 16px; background: var(--surface); border: 1px solid var(--border);
-    text-align: left; cursor: pointer; font: inherit; color: inherit; }
-  .bal:hover { border-color: var(--brand-2); }
-  .bal:active { transform: scale(0.98); }
-  .bal-label { font-size: 0.78rem; color: var(--text-muted); font-weight: 700; }
-  .bal-i { color: var(--text-faint); font-size: 0.72rem; }
+	.balances {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 10px;
+		margin-bottom: 14px;
+	}
+	.bal {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: 14px;
+		border-radius: 16px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		text-align: left;
+		cursor: pointer;
+		font: inherit;
+		color: inherit;
+	}
+	.bal:hover {
+		border-color: var(--brand-2);
+	}
+	.bal:active {
+		transform: scale(0.98);
+	}
+	.bal-label {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		font-weight: 700;
+	}
+	.bal-i {
+		color: var(--text-faint);
+		font-size: 0.72rem;
+	}
 
-  /* balance explanation popup */
-  .si-overlay { position: fixed; inset: 0; z-index: 4000; display: grid; place-items: center; padding: 24px;
-    background: rgba(4,8,14,0.72); backdrop-filter: blur(6px); border: none; }
-  .si-card { width: 100%; max-width: 320px; padding: 22px; border-radius: 18px; text-align: center;
-    background: var(--surface-strong, rgba(20,26,38,0.96)); border: 1px solid var(--border-strong, rgba(255,255,255,0.16));
-    box-shadow: 0 20px 50px rgba(0,0,0,0.5); display: flex; flex-direction: column; gap: 10px; }
-  .si-title { font-family: var(--font-display); font-size: 1.15rem; margin: 0; }
-  .si-desc { font-size: 0.92rem; line-height: 1.5; color: var(--text-muted); margin: 0; }
-  .si-close { margin-top: 4px; height: 44px; border-radius: 12px; border: none; cursor: pointer; font-weight: 800; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b); }
-  .bal-value { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.7rem; color: var(--brand-2); }
+	/* balance explanation popup */
+	.si-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 4000;
+		display: grid;
+		place-items: center;
+		padding: 24px;
+		background: rgba(4, 8, 14, 0.72);
+		backdrop-filter: blur(6px);
+		border: none;
+	}
+	.si-card {
+		width: 100%;
+		max-width: 320px;
+		padding: 22px;
+		border-radius: 18px;
+		text-align: center;
+		background: var(--surface-strong, rgba(20, 26, 38, 0.96));
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+	.si-title {
+		font-family: var(--font-display);
+		font-size: 1.15rem;
+		margin: 0;
+	}
+	.si-desc {
+		font-size: 0.92rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		margin: 0;
+	}
+	.si-close {
+		margin-top: 4px;
+		height: 44px;
+		border-radius: 12px;
+		border: none;
+		cursor: pointer;
+		font-weight: 800;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.bal-value {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.7rem;
+		color: var(--brand-2);
+	}
 
-  /* 💸 Loan Shark */
-  .loan-card { border-radius: 16px; padding: 14px 16px; margin: 0 0 14px; border: 1px solid var(--border); background: var(--surface); }
-  .loan-card.debt { border-color: rgba(248,113,113,0.5); background: linear-gradient(135deg, rgba(248,113,113,0.12), rgba(248,113,113,0.03)); }
-  .loan-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; }
-  .loan-title { font-family: var(--font-display); font-weight: 800; font-size: 1rem; }
-  .loan-owed { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 1.5rem; color: #fb7185; }
-  .loan-summary { cursor: pointer; font-family: var(--font-display); font-weight: 700; font-size: 0.95rem; list-style: none; display: flex; align-items: center; justify-content: space-between; }
-  .loan-summary::-webkit-details-marker { display: none; }
-  .loan-cv { color: var(--text-faint); font-size: 0.8rem; }
-  .loan-note { font-size: 0.78rem; color: var(--text-muted); margin: 8px 0; line-height: 1.4; }
-  .loan-note .neg { color: #fb7185; }
-  .loan-dial { display: flex; align-items: center; justify-content: center; gap: 12px; width: 100%; max-width: 320px; margin: 4px auto 0; }
-  .loan-step { width: 44px; height: 44px; flex: none; border-radius: 12px; cursor: pointer; font-size: 1.5rem; font-weight: 800; background: var(--surface); border: 1px solid var(--border); color: var(--text); display: grid; place-items: center; }
-  .loan-step:disabled { opacity: 0.3; cursor: default; }
-  .loan-amt { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 1px; }
-  .loan-usd { font-family: 'Orbitron', var(--font-display); font-weight: 800; color: var(--brand-2); font-size: 1.6rem; line-height: 1; }
-  .loan-sub { font-size: 0.68rem; color: var(--text-faint); }
-  .loan-slider { width: 100%; max-width: 320px; display: block; margin: 12px auto; accent-color: #fb7185; }
-  .loan-actions { display: flex; gap: 8px; }
-  .loan-btn { flex: 1; padding: 0.8rem; border: none; border-radius: 12px; cursor: pointer; font-weight: 800; font-size: 0.92rem; }
-  .loan-btn.borrow { width: 100%; color: #2a1005; background: linear-gradient(135deg, #fbbf24, #f59e0b); }
-  .loan-btn.pay { color: #06281d; background: linear-gradient(135deg, #6ee7b7, #34d399); }
-  .loan-btn.ghost { background: var(--surface); border: 1px solid var(--border); color: var(--text); }
-  .loan-btn:disabled { opacity: 0.45; cursor: default; }
+	/* 💸 Loan Shark */
+	.loan-card {
+		border-radius: 16px;
+		padding: 14px 16px;
+		margin: 0 0 14px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.loan-card.debt {
+		border-color: rgba(248, 113, 113, 0.5);
+		background: linear-gradient(135deg, rgba(248, 113, 113, 0.12), rgba(248, 113, 113, 0.03));
+	}
+	.loan-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 10px;
+	}
+	.loan-title {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1rem;
+	}
+	.loan-owed {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.5rem;
+		color: #fb7185;
+	}
+	.loan-summary {
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+		list-style: none;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.loan-summary::-webkit-details-marker {
+		display: none;
+	}
+	.loan-cv {
+		color: var(--text-faint);
+		font-size: 0.8rem;
+	}
+	.loan-note {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		margin: 8px 0;
+		line-height: 1.4;
+	}
+	.loan-note .neg {
+		color: #fb7185;
+	}
+	.loan-dial {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 12px;
+		width: 100%;
+		max-width: 320px;
+		margin: 4px auto 0;
+	}
+	.loan-step {
+		width: 44px;
+		height: 44px;
+		flex: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-size: 1.5rem;
+		font-weight: 800;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		display: grid;
+		place-items: center;
+	}
+	.loan-step:disabled {
+		opacity: 0.3;
+		cursor: default;
+	}
+	.loan-amt {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1px;
+	}
+	.loan-usd {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		color: var(--brand-2);
+		font-size: 1.6rem;
+		line-height: 1;
+	}
+	.loan-sub {
+		font-size: 0.68rem;
+		color: var(--text-faint);
+	}
+	.loan-slider {
+		width: 100%;
+		max-width: 320px;
+		display: block;
+		margin: 12px auto;
+		accent-color: #fb7185;
+	}
+	.loan-actions {
+		display: flex;
+		gap: 8px;
+	}
+	.loan-btn {
+		flex: 1;
+		padding: 0.8rem;
+		border: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.92rem;
+	}
+	.loan-btn.borrow {
+		width: 100%;
+		color: #2a1005;
+		background: linear-gradient(135deg, #fbbf24, #f59e0b);
+	}
+	.loan-btn.pay {
+		color: #06281d;
+		background: linear-gradient(135deg, #6ee7b7, #34d399);
+	}
+	.loan-btn.ghost {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.loan-btn:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
 
-  .led-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 1.4rem 0 0.6rem; flex-wrap: wrap; }
-  .hist-title { font-family: var(--font-display); font-size: 1rem; margin: 0; }
-  .led-filters { display: flex; gap: 6px; }
-  .led-dd { position: relative; }
-  .led-sel { display: flex; align-items: center; gap: 5px; padding: 6px 10px; border-radius: 9px; border: 1px solid var(--border);
-    background: var(--surface); color: var(--text); font-size: 0.74rem; font-weight: 600; cursor: pointer; white-space: nowrap; }
-  .led-sel:hover { border-color: var(--brand-2); }
-  .dd-cv { color: var(--text-faint); font-size: 0.7rem; }
-  .led-backdrop { position: fixed; inset: 0; z-index: 25; background: transparent; border: none; cursor: default; }
-  .led-menu { position: absolute; top: calc(100% + 4px); right: 0; z-index: 30; min-width: 150px; max-height: 260px; overflow-y: auto;
-    display: flex; flex-direction: column; padding: 5px; border-radius: 12px;
-    background: var(--surface-strong, rgba(20,26,38,0.98)); border: 1px solid var(--border-strong, rgba(255,255,255,0.16)); box-shadow: 0 16px 40px rgba(0,0,0,0.55); }
-  .led-menu button { text-align: left; padding: 8px 10px; border-radius: 8px; border: none; background: none; color: var(--text); cursor: pointer; font-size: 0.82rem; white-space: nowrap; }
-  .led-menu button:hover { background: rgba(255,255,255,0.06); }
-  .led-menu button.on { color: var(--brand-2); font-weight: 700; }
-  .empty { color: var(--text-muted); font-size: 0.9rem; text-align: center; padding: 1rem 0; }
-  .ledger { display: flex; flex-direction: column; gap: 1px; background: var(--border); border-radius: 12px; overflow: hidden; }
-  .ledger.scroll { max-height: 300px; overflow-y: auto; }
-  .led-row { display: grid; grid-template-columns: auto 1fr auto; align-items: center; gap: 10px; padding: 0.5rem 0.8rem; background: var(--surface); }
-  .led-date { font-size: 0.72rem; color: var(--text-faint); font-variant-numeric: tabular-nums; white-space: nowrap; }
-  .led-reason { color: var(--text); font-size: 0.86rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .led-delta { font-family: var(--font-display); font-weight: 700; font-size: 0.88rem; white-space: nowrap; }
-  .led-delta.pos { color: var(--brand-2); }
-  .led-delta.neg { color: #fb7185; }
+	.led-head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+		margin: 1.4rem 0 0.6rem;
+		flex-wrap: wrap;
+	}
+	.hist-title {
+		font-family: var(--font-display);
+		font-size: 1rem;
+		margin: 0;
+	}
+	.led-filters {
+		display: flex;
+		gap: 6px;
+	}
+	.led-dd {
+		position: relative;
+	}
+	.led-sel {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		padding: 6px 10px;
+		border-radius: 9px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.74rem;
+		font-weight: 600;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.led-sel:hover {
+		border-color: var(--brand-2);
+	}
+	.dd-cv {
+		color: var(--text-faint);
+		font-size: 0.7rem;
+	}
+	.led-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 25;
+		background: transparent;
+		border: none;
+		cursor: default;
+	}
+	.led-menu {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		z-index: 30;
+		min-width: 150px;
+		max-height: 260px;
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		padding: 5px;
+		border-radius: 12px;
+		background: var(--surface-strong, rgba(20, 26, 38, 0.98));
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow: 0 16px 40px rgba(0, 0, 0, 0.55);
+	}
+	.led-menu button {
+		text-align: left;
+		padding: 8px 10px;
+		border-radius: 8px;
+		border: none;
+		background: none;
+		color: var(--text);
+		cursor: pointer;
+		font-size: 0.82rem;
+		white-space: nowrap;
+	}
+	.led-menu button:hover {
+		background: rgba(255, 255, 255, 0.06);
+	}
+	.led-menu button.on {
+		color: var(--brand-2);
+		font-weight: 700;
+	}
+	.empty {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		text-align: center;
+		padding: 1rem 0;
+	}
+	.ledger {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		background: var(--border);
+		border-radius: 12px;
+		overflow: hidden;
+	}
+	.ledger.scroll {
+		max-height: 300px;
+		overflow-y: auto;
+	}
+	.led-row {
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: center;
+		gap: 10px;
+		padding: 0.5rem 0.8rem;
+		background: var(--surface);
+	}
+	.led-date {
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+	}
+	.led-reason {
+		color: var(--text);
+		font-size: 0.86rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.led-delta {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.88rem;
+		white-space: nowrap;
+	}
+	.led-delta.pos {
+		color: var(--brand-2);
+	}
+	.led-delta.neg {
+		color: #fb7185;
+	}
 </style>

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -1,22 +1,43 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import FriendsPanel from '$lib/components/FriendsPanel.svelte';
-  import { track } from '$lib/analytics.js';
-  onMount(() => track('friends_view'));
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import FriendsPanel from '$lib/components/FriendsPanel.svelte';
+	import { track } from '$lib/analytics.js';
+	onMount(() => track('friends_view'));
 </script>
 
 <svelte:head><title>WordBank — Friends</title></svelte:head>
 
 <main class="friends-page">
-  <PageNav />
-  <h1>👥 Friends</h1>
-  <FriendsPanel onChallenge={(/** @type {string} */ u) => goto('/?challenge=' + encodeURIComponent(u))} />
+	<PageNav />
+	<h1>👥 Friends</h1>
+	<FriendsPanel
+		onChallenge={(/** @type {string} */ u) => goto('/?challenge=' + encodeURIComponent(u))}
+	/>
 </main>
 
 <style>
-  .friends-page { max-width: 480px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
-  .back-btn { display: inline-block; margin-bottom: 1.2rem; padding: 0.55rem 1.1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
-  h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0 0 1rem; }
+	.friends-page {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem 3rem;
+	}
+	.back-btn {
+		display: inline-block;
+		margin-bottom: 1.2rem;
+		padding: 0.55rem 1.1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.7rem;
+		margin: 0 0 1rem;
+	}
 </style>

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -1,19 +1,23 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import GroupsPanel from '$lib/components/GroupsPanel.svelte';
-  import PageNav from '$lib/components/PageNav.svelte';
-  import { track } from '$lib/analytics.js';
-  onMount(() => track('groups_view'));
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import GroupsPanel from '$lib/components/GroupsPanel.svelte';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { track } from '$lib/analytics.js';
+	onMount(() => track('groups_view'));
 </script>
 
 <svelte:head><title>WordBank — Groups</title></svelte:head>
 
 <main class="groups-page">
-  <PageNav />
-  <GroupsPanel title="👥 Groups" onExit={() => goto('/')} />
+	<PageNav />
+	<GroupsPanel title="👥 Groups" onExit={() => goto('/')} />
 </main>
 
 <style>
-  .groups-page { max-width: 560px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+	.groups-page {
+		max-width: 560px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem 3rem;
+	}
 </style>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,19 +1,34 @@
 <script>
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import HistoryList from '$lib/components/HistoryList.svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import HistoryList from '$lib/components/HistoryList.svelte';
 </script>
 
 <svelte:head><title>WordBank — History</title></svelte:head>
 
 <main class="h-page">
-  <PageNav />
-  <h1>📜 History</h1>
-  <HistoryList />
+	<PageNav />
+	<h1>📜 History</h1>
+	<HistoryList />
 </main>
 
 <style>
-  .h-page { max-width: 560px; margin: 0 auto; padding: 16px 14px 60px; }
-  .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
-  h1 { font-family: var(--font-display); font-size: 1.5rem; margin: 4px 0 14px; }
+	.h-page {
+		max-width: 560px;
+		margin: 0 auto;
+		padding: 16px 14px 60px;
+	}
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		cursor: pointer;
+		padding: 6px 0;
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.5rem;
+		margin: 4px 0 14px;
+	}
 </style>

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -1,22 +1,42 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
-  import { track } from '$lib/analytics.js';
-  onMount(() => track('leaderboard_view'));
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
+	import { track } from '$lib/analytics.js';
+	onMount(() => track('leaderboard_view'));
 </script>
 
 <svelte:head><title>WordBank — Leaderboard</title></svelte:head>
 
 <main class="lb-page">
-  <PageNav />
-  <h1>🏆 Leaderboard</h1>
-  <LeaderboardPanel />
+	<PageNav />
+	<h1>🏆 Leaderboard</h1>
+	<LeaderboardPanel />
 </main>
 
 <style>
-  .lb-page { max-width: 640px; margin: 0 auto; padding: 2rem 1rem 3rem; text-align: center; }
-  .back-btn { display: inline-block; margin-bottom: 1rem; padding: 0.55rem 1.1rem; background: var(--surface); color: var(--text); border: 1px solid var(--border); border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem; }
-  h1 { font-family: var(--font-display); font-size: 1.9rem; margin: 0 0 1rem; }
+	.lb-page {
+		max-width: 640px;
+		margin: 0 auto;
+		padding: 2rem 1rem 3rem;
+		text-align: center;
+	}
+	.back-btn {
+		display: inline-block;
+		margin-bottom: 1rem;
+		padding: 0.55rem 1.1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.9rem;
+		margin: 0 0 1rem;
+	}
 </style>

--- a/src/routes/my-friends/+page.svelte
+++ b/src/routes/my-friends/+page.svelte
@@ -1,87 +1,200 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import PageNav from '$lib/components/PageNav.svelte';
-  import { listFriends, removeFriend } from '$lib/stores/statsStore.js';
-  import { requireConfirm } from '$lib/confirm.js';
-  import { fx } from '$lib/sound.js';
-  import { track } from '$lib/analytics.js';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { listFriends, removeFriend } from '$lib/stores/statsStore.js';
+	import { requireConfirm } from '$lib/confirm.js';
+	import { fx } from '$lib/sound.js';
+	import { track } from '$lib/analytics.js';
 
-  /** @type {any[]} */ let friends = $state([]);
-  let loading = $state(true);
-  let q = $state('');
-  let busy = $state('');
+	/** @type {any[]} */ let friends = $state([]);
+	let loading = $state(true);
+	let q = $state('');
+	let busy = $state('');
 
-  onMount(async () => { track('my_friends_view'); try { friends = await listFriends(); } finally { loading = false; } });
+	onMount(async () => {
+		track('my_friends_view');
+		try {
+			friends = await listFriends();
+		} finally {
+			loading = false;
+		}
+	});
 
-  let shown = $derived(
-    friends
-      .filter((f) => (f.name || f.username || '').toLowerCase().includes(q.trim().toLowerCase()))
-      .sort((a, b) => (a.username || a.name || '').localeCompare(b.username || b.name || '', undefined, { sensitivity: 'base' }))
-  );
+	let shown = $derived(
+		friends
+			.filter((f) => (f.name || f.username || '').toLowerCase().includes(q.trim().toLowerCase()))
+			.sort((a, b) =>
+				(a.username || a.name || '').localeCompare(b.username || b.name || '', undefined, {
+					sensitivity: 'base'
+				})
+			)
+	);
 
-  /** @param {any} f */
-  async function remove(f) {
-    if (busy) return;
-    if (!(await requireConfirm({ title: 'Remove friend?', message: `Remove @${f.username || f.name} from your friends?`, confirmText: 'Remove', danger: true }))) return;
-    busy = f.id;
-    await removeFriend(f.id);
-    friends = friends.filter((x) => x.id !== f.id);
-    busy = '';
-    fx('tap');
-  }
-  /** @param {any} f */
-  const initial = (f) => (f.name || f.username || '?').slice(0, 1).toUpperCase();
+	/** @param {any} f */
+	async function remove(f) {
+		if (busy) return;
+		if (
+			!(await requireConfirm({
+				title: 'Remove friend?',
+				message: `Remove @${f.username || f.name} from your friends?`,
+				confirmText: 'Remove',
+				danger: true
+			}))
+		)
+			return;
+		busy = f.id;
+		await removeFriend(f.id);
+		friends = friends.filter((x) => x.id !== f.id);
+		busy = '';
+		fx('tap');
+	}
+	/** @param {any} f */
+	const initial = (f) => (f.name || f.username || '?').slice(0, 1).toUpperCase();
 </script>
 
 <svelte:head><title>WordBank — My Friends</title></svelte:head>
 
 <main class="ml-page">
-  <PageNav />
-  <h1 class="ml-title">My Friends{#if friends.length} · {friends.length}{/if}</h1>
+	<PageNav />
+	<h1 class="ml-title">
+		My Friends{#if friends.length}
+			· {friends.length}{/if}
+	</h1>
 
-  {#if loading}
-    <p class="ml-muted">Loading…</p>
-  {:else if friends.length === 0}
-    <p class="ml-muted">No friends yet. Add some from <button class="ml-link" onclick={() => goto('/?people=1')}>Friends & Groups</button>.</p>
-  {:else}
-    <input class="ml-search" type="search" placeholder="Search your friends" bind:value={q} />
-    {#if shown.length === 0}
-      <p class="ml-muted">No match for “{q}”.</p>
-    {:else}
-      <div class="ml-list">
-        {#each shown as f (f.id)}
-          <div class="ml-row">
-            <button class="ml-main" onclick={() => goto('/u/' + encodeURIComponent(f.username || ''))}>
-              <span class="ml-coin" style={f.color ? `--c:${f.color}` : ''}>{initial(f)}</span>
-              <span class="ml-name">@{f.username || f.name}</span>
-              <span class="ml-go">›</span>
-            </button>
-            <button class="ml-rm" disabled={busy === f.id} onclick={() => remove(f)} title="Remove friend" aria-label="Remove friend">✕</button>
-          </div>
-        {/each}
-      </div>
-    {/if}
-  {/if}
+	{#if loading}
+		<p class="ml-muted">Loading…</p>
+	{:else if friends.length === 0}
+		<p class="ml-muted">
+			No friends yet. Add some from <button class="ml-link" onclick={() => goto('/?people=1')}
+				>Friends & Groups</button
+			>.
+		</p>
+	{:else}
+		<input class="ml-search" type="search" placeholder="Search your friends" bind:value={q} />
+		{#if shown.length === 0}
+			<p class="ml-muted">No match for “{q}”.</p>
+		{:else}
+			<div class="ml-list">
+				{#each shown as f (f.id)}
+					<div class="ml-row">
+						<button
+							class="ml-main"
+							onclick={() => goto('/u/' + encodeURIComponent(f.username || ''))}
+						>
+							<span class="ml-coin" style={f.color ? `--c:${f.color}` : ''}>{initial(f)}</span>
+							<span class="ml-name">@{f.username || f.name}</span>
+							<span class="ml-go">›</span>
+						</button>
+						<button
+							class="ml-rm"
+							disabled={busy === f.id}
+							onclick={() => remove(f)}
+							title="Remove friend"
+							aria-label="Remove friend">✕</button
+						>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	{/if}
 </main>
 
 <style>
-  .ml-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
-  .ml-title { font-family: var(--font-display); font-size: 1.4rem; margin: 4px 0 14px; }
-  .ml-muted { color: var(--text-muted); padding: 1.5rem 0; text-align: center; }
-  .ml-link { background: none; border: none; color: var(--brand-2); font: inherit; cursor: pointer; text-decoration: underline; }
-  .ml-search { width: 100%; padding: 0.7rem 1rem; border-radius: 12px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; margin-bottom: 14px; }
-  .ml-list { display: flex; flex-direction: column; gap: 8px; }
-  .ml-row { display: flex; align-items: center; gap: 8px; }
-  .ml-main { flex: 1; display: flex; align-items: center; gap: 12px; padding: 11px 14px; border-radius: 14px; cursor: pointer;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); text-align: left; }
-  .ml-main:hover { border-color: var(--brand-2); }
-  .ml-coin { width: 36px; height: 36px; flex: none; border-radius: 50%; display: grid; place-items: center; font-family: var(--font-display); font-weight: 800; color: #3a2a00;
-    background: linear-gradient(135deg, var(--c, #fde047), #f59e0b); }
-  .ml-name { flex: 1; font-weight: 700; font-size: 0.98rem; }
-  .ml-go { color: var(--text-faint); }
-  .ml-rm { width: 40px; height: 40px; flex: none; border-radius: 12px; cursor: pointer; font-size: 0.9rem;
-    background: rgba(248,113,113,0.1); color: #f87171; border: 1px solid rgba(248,113,113,0.4); }
-  .ml-rm:hover { background: rgba(248,113,113,0.2); }
-  .ml-rm:disabled { opacity: 0.5; }
+	.ml-page {
+		max-width: 520px;
+		margin: 0 auto;
+		padding: 16px 14px 60px;
+	}
+	.ml-title {
+		font-family: var(--font-display);
+		font-size: 1.4rem;
+		margin: 4px 0 14px;
+	}
+	.ml-muted {
+		color: var(--text-muted);
+		padding: 1.5rem 0;
+		text-align: center;
+	}
+	.ml-link {
+		background: none;
+		border: none;
+		color: var(--brand-2);
+		font: inherit;
+		cursor: pointer;
+		text-decoration: underline;
+	}
+	.ml-search {
+		width: 100%;
+		padding: 0.7rem 1rem;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text);
+		font-size: 0.95rem;
+		margin-bottom: 14px;
+	}
+	.ml-list {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+	}
+	.ml-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.ml-main {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: 12px;
+		padding: 11px 14px;
+		border-radius: 14px;
+		cursor: pointer;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		text-align: left;
+	}
+	.ml-main:hover {
+		border-color: var(--brand-2);
+	}
+	.ml-coin {
+		width: 36px;
+		height: 36px;
+		flex: none;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: #3a2a00;
+		background: linear-gradient(135deg, var(--c, #fde047), #f59e0b);
+	}
+	.ml-name {
+		flex: 1;
+		font-weight: 700;
+		font-size: 0.98rem;
+	}
+	.ml-go {
+		color: var(--text-faint);
+	}
+	.ml-rm {
+		width: 40px;
+		height: 40px;
+		flex: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-size: 0.9rem;
+		background: rgba(248, 113, 113, 0.1);
+		color: #f87171;
+		border: 1px solid rgba(248, 113, 113, 0.4);
+	}
+	.ml-rm:hover {
+		background: rgba(248, 113, 113, 0.2);
+	}
+	.ml-rm:disabled {
+		opacity: 0.5;
+	}
 </style>

--- a/src/routes/my-groups/+page.svelte
+++ b/src/routes/my-groups/+page.svelte
@@ -1,19 +1,23 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import GroupsPanel from '$lib/components/GroupsPanel.svelte';
-  import PageNav from '$lib/components/PageNav.svelte';
-  import { track } from '$lib/analytics.js';
-  onMount(() => track('my_groups_view'));
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import GroupsPanel from '$lib/components/GroupsPanel.svelte';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { track } from '$lib/analytics.js';
+	onMount(() => track('my_groups_view'));
 </script>
 
 <svelte:head><title>WordBank — Groups</title></svelte:head>
 
 <main class="groups-page">
-  <PageNav />
-  <GroupsPanel title="👥 Groups" onExit={() => goto('/')} />
+	<PageNav />
+	<GroupsPanel title="👥 Groups" onExit={() => goto('/')} />
 </main>
 
 <style>
-  .groups-page { max-width: 560px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
+	.groups-page {
+		max-width: 560px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem 3rem;
+	}
 </style>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,117 +1,131 @@
 <script>
-  // Public, no-auth privacy policy page. URL: /privacy
-  // Used for TestFlight external testing + App Store submission.
-  const CONTACT = 'charlieforeman77@gmail.com'; // ← change to your support email if you prefer
-  const UPDATED = 'June 21, 2026';
+	// Public, no-auth privacy policy page. URL: /privacy
+	// Used for TestFlight external testing + App Store submission.
+	const CONTACT = 'charlieforeman77@gmail.com'; // ← change to your support email if you prefer
+	const UPDATED = 'June 21, 2026';
 </script>
 
 <svelte:head>
-  <title>WordBank — Privacy Policy</title>
-  <meta name="robots" content="index" />
+	<title>WordBank — Privacy Policy</title>
+	<meta name="robots" content="index" />
 </svelte:head>
 
 <main class="legal">
-  <h1>WordBank Privacy Policy</h1>
-  <p class="updated">Last updated: {UPDATED}</p>
+	<h1>WordBank Privacy Policy</h1>
+	<p class="updated">Last updated: {UPDATED}</p>
 
-  <p>
-    WordBank ("we," "us," or "the app") is a word-puzzle game. This policy explains
-    what we collect, how we use it, and the choices you have. We keep it short
-    because we collect very little.
-  </p>
+	<p>
+		WordBank ("we," "us," or "the app") is a word-puzzle game. This policy explains what we collect,
+		how we use it, and the choices you have. We keep it short because we collect very little.
+	</p>
 
-  <h2>Information we collect</h2>
-  <ul>
-    <li><strong>Account info:</strong> the email address you sign up with. Passwords
-      are handled by our authentication provider and stored only as a secure hash —
-      we never see your password.</li>
-    <li><strong>Gameplay data:</strong> your progress and results — puzzles played,
-      scores, bankrolls, win/loss, streaks, badges, and leaderboard standings.</li>
-    <li><strong>Basic technical data:</strong> standard information needed to run the
-      app reliably (e.g., that comes with normal network requests).</li>
-    <li><strong>Usage analytics:</strong> anonymous, first‑party events about how the
-      app is used (e.g., opening the app, starting/finishing a puzzle) so we can
-      understand engagement and improve the game. This stays in our own systems;
-      we don't use third‑party ad trackers.</li>
-  </ul>
+	<h2>Information we collect</h2>
+	<ul>
+		<li>
+			<strong>Account info:</strong> the email address you sign up with. Passwords are handled by our
+			authentication provider and stored only as a secure hash — we never see your password.
+		</li>
+		<li>
+			<strong>Gameplay data:</strong> your progress and results — puzzles played, scores, bankrolls,
+			win/loss, streaks, badges, and leaderboard standings.
+		</li>
+		<li>
+			<strong>Basic technical data:</strong> standard information needed to run the app reliably (e.g.,
+			that comes with normal network requests).
+		</li>
+		<li>
+			<strong>Usage analytics:</strong> anonymous, first‑party events about how the app is used (e.g.,
+			opening the app, starting/finishing a puzzle) so we can understand engagement and improve the game.
+			This stays in our own systems; we don't use third‑party ad trackers.
+		</li>
+	</ul>
 
-  <h2>What we do NOT collect</h2>
-  <ul>
-    <li>No payment or financial information (the app has no purchases).</li>
-    <li>No precise location, contacts, photos, microphone, or camera access.</li>
-    <li>No advertising identifiers — we don't run ads.</li>
-  </ul>
+	<h2>What we do NOT collect</h2>
+	<ul>
+		<li>No payment or financial information (the app has no purchases).</li>
+		<li>No precise location, contacts, photos, microphone, or camera access.</li>
+		<li>No advertising identifiers — we don't run ads.</li>
+	</ul>
 
-  <h2>How we use your information</h2>
-  <ul>
-    <li>To create your account and let you sign in.</li>
-    <li>To save your progress and show your scores, streaks, badges, and leaderboard rank.</li>
-    <li>To operate, maintain, and improve the game.</li>
-  </ul>
+	<h2>How we use your information</h2>
+	<ul>
+		<li>To create your account and let you sign in.</li>
+		<li>To save your progress and show your scores, streaks, badges, and leaderboard rank.</li>
+		<li>To operate, maintain, and improve the game.</li>
+	</ul>
 
-  <h2>How your data is stored and shared</h2>
-  <p>
-    We use trusted infrastructure providers to run WordBank: <strong>Supabase</strong>
-    (database and authentication) and <strong>Vercel</strong> (app hosting). Your data
-    is stored on their secure infrastructure on our behalf. We do
-    <strong>not sell your data</strong>, and we do not share it for advertising. We may
-    disclose information if required by law.
-  </p>
+	<h2>How your data is stored and shared</h2>
+	<p>
+		We use trusted infrastructure providers to run WordBank: <strong>Supabase</strong>
+		(database and authentication) and <strong>Vercel</strong> (app hosting). Your data is stored on
+		their secure infrastructure on our behalf. We do
+		<strong>not sell your data</strong>, and we do not share it for advertising. We may disclose
+		information if required by law.
+	</p>
 
-  <h2>Data security</h2>
-  <p>
-    Connections use HTTPS encryption, and your answers/scores are validated on the
-    server. No system is perfectly secure, but we take reasonable measures to protect
-    your information.
-  </p>
+	<h2>Data security</h2>
+	<p>
+		Connections use HTTPS encryption, and your answers/scores are validated on the server. No system
+		is perfectly secure, but we take reasonable measures to protect your information.
+	</p>
 
-  <h2>Your choices &amp; deleting your account</h2>
-  <p>
-    You can permanently delete your account and all associated data at any time from
-    inside the app: <strong>My Account → Delete Account</strong>. This erases your
-    account immediately and can't be undone. You can also email
-    <a href={`mailto:${CONTACT}`}>{CONTACT}</a> and we'll delete it for you.
-  </p>
+	<h2>Your choices &amp; deleting your account</h2>
+	<p>
+		You can permanently delete your account and all associated data at any time from inside the app: <strong
+			>My Account → Delete Account</strong
+		>. This erases your account immediately and can't be undone. You can also email
+		<a href={`mailto:${CONTACT}`}>{CONTACT}</a> and we'll delete it for you.
+	</p>
 
-  <h2>Children</h2>
-  <p>
-    WordBank is not directed to children under 13, and we do not knowingly collect
-    personal information from children under 13.
-  </p>
+	<h2>Children</h2>
+	<p>
+		WordBank is not directed to children under 13, and we do not knowingly collect personal
+		information from children under 13.
+	</p>
 
-  <h2>Changes to this policy</h2>
-  <p>
-    We may update this policy from time to time. We'll revise the "Last updated" date
-    above when we do.
-  </p>
+	<h2>Changes to this policy</h2>
+	<p>
+		We may update this policy from time to time. We'll revise the "Last updated" date above when we
+		do.
+	</p>
 
-  <h2>Contact</h2>
-  <p>
-    Questions about privacy? Email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
-  </p>
+	<h2>Contact</h2>
+	<p>
+		Questions about privacy? Email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+	</p>
 </main>
 
 <style>
-  .legal {
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 2.5rem 1.25rem 4rem;
-    color: var(--text, #e6edf3);
-    line-height: 1.6;
-    font-size: 1rem;
-  }
-  h1 {
-    font-family: var(--font-display, system-ui, sans-serif);
-    font-size: 1.8rem;
-    margin: 0 0 0.25rem;
-  }
-  .updated { color: var(--text-faint, #8b98a9); font-size: 0.9rem; margin: 0 0 1.5rem; }
-  h2 {
-    font-family: var(--font-display, system-ui, sans-serif);
-    font-size: 1.15rem;
-    margin: 1.8rem 0 0.5rem;
-  }
-  ul { padding-left: 1.2rem; }
-  li { margin: 0.3rem 0; }
-  a { color: var(--brand-2, #fde047); }
+	.legal {
+		max-width: 720px;
+		margin: 0 auto;
+		padding: 2.5rem 1.25rem 4rem;
+		color: var(--text, #e6edf3);
+		line-height: 1.6;
+		font-size: 1rem;
+	}
+	h1 {
+		font-family: var(--font-display, system-ui, sans-serif);
+		font-size: 1.8rem;
+		margin: 0 0 0.25rem;
+	}
+	.updated {
+		color: var(--text-faint, #8b98a9);
+		font-size: 0.9rem;
+		margin: 0 0 1.5rem;
+	}
+	h2 {
+		font-family: var(--font-display, system-ui, sans-serif);
+		font-size: 1.15rem;
+		margin: 1.8rem 0 0.5rem;
+	}
+	ul {
+		padding-left: 1.2rem;
+	}
+	li {
+		margin: 0.3rem 0;
+	}
+	a {
+		color: var(--brand-2, #fde047);
+	}
 </style>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -1,310 +1,857 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
-  import { getProfileDetail, getMyAvatar, getUserBadges } from '$lib/stores/statsStore.js';
-  import { badgeInfo } from '$lib/badges.js';
-  import Avatar from '$lib/components/Avatar.svelte';
-  import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
-  import { unreadCount, requestInbox } from '$lib/stores/notificationStore.js';
-  import { track } from '$lib/analytics.js';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import { getProfileDetail, getMyAvatar, getUserBadges } from '$lib/stores/statsStore.js';
+	import { badgeInfo } from '$lib/badges.js';
+	import Avatar from '$lib/components/Avatar.svelte';
+	import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
+	import { unreadCount, requestInbox } from '$lib/stores/notificationStore.js';
+	import { track } from '$lib/analytics.js';
 
-  /** @type {'overview'|'stats'|'alerts'} */
-  let tab = $state('overview');
-  /** @type {any|null} */
-  let d = $state(null);
-  let loading = $state(true);
-  let avatar = $state(null);
-  /** @type {string[]} */
-  let earned = $state([]);
-  let earnedBadges = $derived(earned.map((id) => badgeInfo(id)).filter(Boolean));
-  /** @type {{title:string, desc:string, link?:string, linkLabel?:string}|null} */
-  let statInfo = $state(null);
+	/** @type {'overview'|'stats'|'alerts'} */
+	let tab = $state('overview');
+	/** @type {any|null} */
+	let d = $state(null);
+	let loading = $state(true);
+	let avatar = $state(null);
+	/** @type {string[]} */
+	let earned = $state([]);
+	let earnedBadges = $derived(earned.map((id) => badgeInfo(id)).filter(Boolean));
+	/** @type {{title:string, desc:string, link?:string, linkLabel?:string}|null} */
+	let statInfo = $state(null);
 
-  // True when we deep-linked straight into a sub-view (e.g. the menu bell → ?tab=alerts).
-  // Back then returns to the menu instead of the Overview the user never saw.
-  let deepLinked = $state(false);
+	// True when we deep-linked straight into a sub-view (e.g. the menu bell → ?tab=alerts).
+	// Back then returns to the menu instead of the Overview the user never saw.
+	let deepLinked = $state(false);
 
-  onMount(async () => {
-    track('profile_view');
-    const t = $page.url.searchParams.get('tab');
-    if (t === 'stats' || t === 'alerts') { tab = /** @type {any} */ (t); deepLinked = true; }
-    getMyAvatar().then((a) => { avatar = a.config; });
-    getUserBadges().then((b) => { earned = b; });
-    try { d = await getProfileDetail(); } finally { loading = false; }
-  });
+	onMount(async () => {
+		track('profile_view');
+		const t = $page.url.searchParams.get('tab');
+		if (t === 'stats' || t === 'alerts') {
+			tab = /** @type {any} */ (t);
+			deepLinked = true;
+		}
+		getMyAvatar().then((a) => {
+			avatar = a.config;
+		});
+		getUserBadges().then((b) => {
+			earned = b;
+		});
+		try {
+			d = await getProfileDetail();
+		} finally {
+			loading = false;
+		}
+	});
 
-  // Note: the unread count only drops when a notification is acted on or dismissed —
-  // NOT just from viewing the list. (No mark-all-read on open.)
-  /** @param {any} n */
-  function notifNav(n) {
-    // Challenge invites/results → open the Challenges hub on the menu.
-    if (n?.type === 'challenge_incoming' || n?.data?.match_id || n?.data?.challenge_id) { requestInbox('challenges'); goto('/'); }
-  }
+	// Note: the unread count only drops when a notification is acted on or dismissed —
+	// NOT just from viewing the list. (No mark-all-read on open.)
+	/** @param {any} n */
+	function notifNav(n) {
+		// Challenge invites/results → open the Challenges hub on the menu.
+		if (n?.type === 'challenge_incoming' || n?.data?.match_id || n?.data?.challenge_id) {
+			requestInbox('challenges');
+			goto('/');
+		}
+	}
 
-  // Back: deep-linked sub-view → menu; sub-view reached from Overview → Overview; Overview → menu.
-  function back() {
-    if (tab !== 'overview' && !deepLinked) tab = 'overview';
-    else goto('/');
-  }
+	// Back: deep-linked sub-view → menu; sub-view reached from Overview → Overview; Overview → menu.
+	function back() {
+		if (tab !== 'overview' && !deepLinked) tab = 'overview';
+		else goto('/');
+	}
 
-  const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
-  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '—';
-  const time = (/** @type {any} */ ms) => !ms ? '—' : Number(ms) < 60000 ? Math.round(Number(ms) / 1000) + 's' : (Number(ms) / 60000).toFixed(1) + 'm';
-  const pct = (/** @type {number} */ w, /** @type {number} */ n) => n > 0 ? Math.round((w / n) * 100) + '%' : '—';
+	const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
+	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '—');
+	const time = (/** @type {any} */ ms) =>
+		!ms
+			? '—'
+			: Number(ms) < 60000
+				? Math.round(Number(ms) / 1000) + 's'
+				: (Number(ms) / 60000).toFixed(1) + 'm';
+	const pct = (/** @type {number} */ w, /** @type {number} */ n) =>
+		n > 0 ? Math.round((w / n) * 100) + '%' : '—';
 </script>
 
 <svelte:head><title>WordBank — Profile</title></svelte:head>
 
-{#snippet chip(value, label)}
-  <div class="stat"><span class="sv">{value}</span><span class="sc">{label}</span></div>
+{#snippet chip(/** @type {string|number} */ value, /** @type {string} */ label)}
+	<div class="stat"><span class="sv">{value}</span><span class="sc">{label}</span></div>
 {/snippet}
-{#snippet chipLink(/** @type {any} */ value, /** @type {string} */ label, /** @type {string} */ href)}
-  <button class="stat stat-link" onclick={() => goto(href)}><span class="sv">{value}</span><span class="sc">{label} ›</span></button>
+{#snippet chipLink(
+	/** @type {any} */ value,
+	/** @type {string} */ label,
+	/** @type {string} */ href
+)}
+	<button class="stat stat-link" onclick={() => goto(href)}
+		><span class="sv">{value}</span><span class="sc">{label} ›</span></button
+	>
 {/snippet}
-{#snippet chipAct(/** @type {any} */ value, /** @type {string} */ label, /** @type {() => void} */ action)}
-  <button class="stat stat-link" onclick={action}><span class="sv">{value}</span><span class="sc">{label} ⓘ</span></button>
+{#snippet chipAct(
+	/** @type {any} */ value,
+	/** @type {string} */ label,
+	/** @type {() => void} */ action
+)}
+	<button class="stat stat-link" onclick={action}
+		><span class="sv">{value}</span><span class="sc">{label} ⓘ</span></button
+	>
 {/snippet}
 
 <main class="you-page">
-  <div class="topbar">
-    <button class="back-btn" onclick={back}>← Back</button>
-    <h1 class="page-title">{tab === 'overview' ? 'Profile' : tab === 'stats' ? 'Full Stats' : 'Notifications'}</h1>
-    <button class="gear" onclick={() => goto('/?account=1')} title="Settings" aria-label="Settings">⚙️</button>
-  </div>
+	<div class="topbar">
+		<button class="back-btn" onclick={back}>← Back</button>
+		<h1 class="page-title">
+			{tab === 'overview' ? 'Profile' : tab === 'stats' ? 'Full Stats' : 'Notifications'}
+		</h1>
+		<button class="gear" onclick={() => goto('/?account=1')} title="Settings" aria-label="Settings"
+			>⚙️</button
+		>
+	</div>
 
-  {#if loading}
-    <p class="muted">Loading…</p>
-  {:else if d}
-    {#if tab === 'overview'}
-      <div class="ov-hero">
-        <button class="prof-avatar" onclick={() => goto('/avatar')}>
-          <Avatar config={avatar} fx size={120} />
-          <span class="prof-avatar-edit">🎨 Edit Avatar</span>
-        </button>
-        <div class="ov-id">
-          <div class="uname-row">
-            <span class="uname">{d.username ? '@' + d.username : 'You'}</span>
-            <button class="bell-btn" onclick={() => tab = 'alerts'} aria-label="Notifications" title="Notifications">
-              🔔{#if $unreadCount > 0}<span class="bell-count">{$unreadCount > 99 ? '99+' : $unreadCount}</span>{/if}
-            </button>
-          </div>
-          <button class="nw nw-btn" onclick={() => goto('/bank')}>{fmt(d.net_worth)}<span class="nw-go"> ›</span></button>
-          <div class="ov-social">
-            <button class="ov-social-btn" onclick={() => goto('/my-friends')}>👋 My Friends ›</button>
-            <button class="ov-social-btn" onclick={() => goto('/my-groups')}>👥 My Groups ›</button>
-          </div>
-        </div>
-      </div>
+	{#if loading}
+		<p class="muted">Loading…</p>
+	{:else if d}
+		{#if tab === 'overview'}
+			<div class="ov-hero">
+				<button class="prof-avatar" onclick={() => goto('/avatar')}>
+					<Avatar config={avatar} fx size={120} />
+					<span class="prof-avatar-edit">🎨 Edit Avatar</span>
+				</button>
+				<div class="ov-id">
+					<div class="uname-row">
+						<span class="uname">{d.username ? '@' + d.username : 'You'}</span>
+						<button
+							class="bell-btn"
+							onclick={() => (tab = 'alerts')}
+							aria-label="Notifications"
+							title="Notifications"
+						>
+							🔔{#if $unreadCount > 0}<span class="bell-count"
+									>{$unreadCount > 99 ? '99+' : $unreadCount}</span
+								>{/if}
+						</button>
+					</div>
+					<button class="nw nw-btn" onclick={() => goto('/bank')}
+						>{fmt(d.net_worth)}<span class="nw-go"> ›</span></button
+					>
+					<div class="ov-social">
+						<button class="ov-social-btn" onclick={() => goto('/my-friends')}
+							>👋 My Friends ›</button
+						>
+						<button class="ov-social-btn" onclick={() => goto('/my-groups')}>👥 My Groups ›</button>
+					</div>
+				</div>
+			</div>
 
-      <div class="grid ov-summary">
-        {@render chipAct((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Total Solves', () => statInfo = { title: 'Total solves', desc: 'Every puzzle you’ve solved across all modes — Daily, Cash Game, and challenges.' })}
-        {@render chipAct(d.overall.games_played ?? 0, 'Games Played', () => statInfo = { title: 'Games played', desc: 'How many games you’ve started across every mode — whether you solved them or not.' })}
-        {@render chipAct('🔥 ' + (d.daily.current_streak ?? 0), 'Play Streak', () => statInfo = { title: '🔥 Play streak', desc: 'Days in a row you’ve shown up for the Daily. Miss a day and it resets (a freeze can save it).', link: '/streak', linkLabel: 'View Daily Calendar' })}
-        {@render chipAct('🏆 ' + (d.daily.win_streak ?? 0), 'Win Streak', () => statInfo = { title: '🏆 Win streak', desc: 'Daily puzzles you’ve solved in a row. Powers your bounty multiplier — the longer it runs, the more you earn.', link: '/streak', linkLabel: 'View Daily Calendar' })}
-        {@render chipAct(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Daily Win %', () => statInfo = { title: 'Daily win rate', desc: 'The share of Dailies you’ve played that you actually solved.' })}
-        {@render chipAct(d.overall.clean_solves ?? 0, 'Clean Solves', () => statInfo = { title: 'Clean solves', desc: 'Puzzles you solved with zero wrong letters — pure deduction, no misses.' })}
-      </div>
+			<div class="grid ov-summary">
+				{@render chipAct(
+					(d.overall.puzzles_solved ?? 0).toLocaleString(),
+					'Total Solves',
+					() =>
+						(statInfo = {
+							title: 'Total solves',
+							desc: 'Every puzzle you’ve solved across all modes — Daily, Cash Game, and challenges.'
+						})
+				)}
+				{@render chipAct(
+					d.overall.games_played ?? 0,
+					'Games Played',
+					() =>
+						(statInfo = {
+							title: 'Games played',
+							desc: 'How many games you’ve started across every mode — whether you solved them or not.'
+						})
+				)}
+				{@render chipAct(
+					'🔥 ' + (d.daily.current_streak ?? 0),
+					'Play Streak',
+					() =>
+						(statInfo = {
+							title: '🔥 Play streak',
+							desc: 'Days in a row you’ve shown up for the Daily. Miss a day and it resets (a freeze can save it).',
+							link: '/streak',
+							linkLabel: 'View Daily Calendar'
+						})
+				)}
+				{@render chipAct(
+					'🏆 ' + (d.daily.win_streak ?? 0),
+					'Win Streak',
+					() =>
+						(statInfo = {
+							title: '🏆 Win streak',
+							desc: 'Daily puzzles you’ve solved in a row. Powers your bounty multiplier — the longer it runs, the more you earn.',
+							link: '/streak',
+							linkLabel: 'View Daily Calendar'
+						})
+				)}
+				{@render chipAct(
+					pct(d.daily.won ?? 0, d.daily.played ?? 0),
+					'Daily Win %',
+					() =>
+						(statInfo = {
+							title: 'Daily win rate',
+							desc: 'The share of Dailies you’ve played that you actually solved.'
+						})
+				)}
+				{@render chipAct(
+					d.overall.clean_solves ?? 0,
+					'Clean Solves',
+					() =>
+						(statInfo = {
+							title: 'Clean solves',
+							desc: 'Puzzles you solved with zero wrong letters — pure deduction, no misses.'
+						})
+				)}
+			</div>
 
-      <button class="ov-badges-card" onclick={() => goto('/badges')}>
-        <span class="ov-badges-h">🏅 Badges <span class="arrow">›</span></span>
-        <span class="ov-badges">
-          {#if earnedBadges.length}
-            {#each earnedBadges.slice(0, 14) as bdg}<span class="ov-badge" title={bdg.name}>{bdg.emoji}</span>{/each}
-          {:else}<span class="ov-badges-empty">None yet — play to earn them</span>{/if}
-        </span>
-      </button>
+			<button class="ov-badges-card" onclick={() => goto('/badges')}>
+				<span class="ov-badges-h">🏅 Badges <span class="arrow">›</span></span>
+				<span class="ov-badges">
+					{#if earnedBadges.length}
+						{#each earnedBadges.slice(0, 14) as bdg}<span class="ov-badge" title={bdg.name}
+								>{bdg.emoji}</span
+							>{/each}
+					{:else}<span class="ov-badges-empty">None yet — play to earn them</span>{/if}
+				</span>
+			</button>
 
-      <div class="ov-nav">
-        <button class="ov-link" onclick={() => tab = 'stats'}>📊 Full stats <span class="arrow">›</span></button>
-        <button class="ov-link" onclick={() => goto('/history')}>📜 Play history <span class="arrow">›</span></button>
-        <button class="ov-link" onclick={() => goto('/streak')}>📅 Daily Calendar <span class="arrow">›</span></button>
-      </div>
-    {:else if tab === 'stats'}
-      <div class="sec-title">📊 Overall</div>
-      <div class="grid">
-        {@render chip((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles solved')}
-        {@render chip(d.overall.games_played ?? 0, 'Games played')}
-        {@render chip(d.overall.clean_solves ?? 0, 'Clean solves')}
-        {@render chip(fmt(d.overall.earned), 'Lifetime earned')}
-        {@render chip(fmt(d.overall.spent), 'Lifetime spent')}
-      </div>
+			<div class="ov-nav">
+				<button class="ov-link" onclick={() => (tab = 'stats')}
+					>📊 Full stats <span class="arrow">›</span></button
+				>
+				<button class="ov-link" onclick={() => goto('/history')}
+					>📜 Play history <span class="arrow">›</span></button
+				>
+				<button class="ov-link" onclick={() => goto('/streak')}
+					>📅 Daily Calendar <span class="arrow">›</span></button
+				>
+			</div>
+		{:else if tab === 'stats'}
+			<div class="sec-title">📊 Overall</div>
+			<div class="grid">
+				{@render chip((d.overall.puzzles_solved ?? 0).toLocaleString(), 'Puzzles solved')}
+				{@render chip(d.overall.games_played ?? 0, 'Games played')}
+				{@render chip(d.overall.clean_solves ?? 0, 'Clean solves')}
+				{@render chip(fmt(d.overall.earned), 'Lifetime earned')}
+				{@render chip(fmt(d.overall.spent), 'Lifetime spent')}
+			</div>
 
-      <div class="sec-title">📅 Daily</div>
-      <div class="grid">
-        {@render chipLink('🔥 ' + (d.daily.current_streak ?? 0), 'Play streak', '/streak')}
-        {@render chip(d.daily.best_streak ?? 0, 'Best play')}
-        {@render chipLink('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak', '/streak')}
-        {@render chip(d.daily.best_win_streak ?? 0, 'Best win')}
-        {@render chip(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Win rate')}
-        {@render chip(d.daily.won ?? 0, 'Dailies won')}
-        {@render chip(fmt(d.daily.best_bounty), 'Best bounty')}
-      </div>
+			<div class="sec-title">📅 Daily</div>
+			<div class="grid">
+				{@render chipLink('🔥 ' + (d.daily.current_streak ?? 0), 'Play streak', '/streak')}
+				{@render chip(d.daily.best_streak ?? 0, 'Best play')}
+				{@render chipLink('🏆 ' + (d.daily.win_streak ?? 0), 'Win streak', '/streak')}
+				{@render chip(d.daily.best_win_streak ?? 0, 'Best win')}
+				{@render chip(pct(d.daily.won ?? 0, d.daily.played ?? 0), 'Win rate')}
+				{@render chip(d.daily.won ?? 0, 'Dailies won')}
+				{@render chip(fmt(d.daily.best_bounty), 'Best bounty')}
+			</div>
 
-      <div class="sec-title">🎰 Cash Game</div>
-      <div class="grid">
-        {@render chip('#' + (d.cash_game.position ?? 0), 'Furthest')}
-        {@render chip(d.cash_game.solved ?? 0, 'Solved')}
-        {@render chip(fmt(d.cash_game.earned), 'Earned')}
-        {@render chip(mult(d.cash_game.best_multiple), 'Best ×')}
-        {@render chip(time(d.cash_game.fastest_ms), 'Fastest')}
-      </div>
+			<div class="sec-title">🎰 Cash Game</div>
+			<div class="grid">
+				{@render chip('#' + (d.cash_game.position ?? 0), 'Furthest')}
+				{@render chip(d.cash_game.solved ?? 0, 'Solved')}
+				{@render chip(fmt(d.cash_game.earned), 'Earned')}
+				{@render chip(mult(d.cash_game.best_multiple), 'Best ×')}
+				{@render chip(time(d.cash_game.fastest_ms), 'Fastest')}
+			</div>
 
-      <div class="sec-title">⚔️ 1-on-1</div>
-      <div class="grid">
-        {@render chip(`${d.challenges_1v1.wins ?? 0}-${d.challenges_1v1.losses ?? 0}-${d.challenges_1v1.ties ?? 0}`, 'W-L-T')}
-        {@render chip(pct(d.challenges_1v1.wins ?? 0, d.challenges_1v1.played ?? 0), 'Win rate')}
-        {@render chip(fmt(d.challenges_1v1.biggest_pot), 'Biggest pot')}
-      </div>
+			<div class="sec-title">⚔️ 1-on-1</div>
+			<div class="grid">
+				{@render chip(
+					`${d.challenges_1v1.wins ?? 0}-${d.challenges_1v1.losses ?? 0}-${d.challenges_1v1.ties ?? 0}`,
+					'W-L-T'
+				)}
+				{@render chip(pct(d.challenges_1v1.wins ?? 0, d.challenges_1v1.played ?? 0), 'Win rate')}
+				{@render chip(fmt(d.challenges_1v1.biggest_pot), 'Biggest pot')}
+			</div>
 
-      <div class="sec-title">👥 Group challenges</div>
-      <div class="grid">
-        {@render chip(d.challenges_group.played ?? 0, 'Played')}
-        {@render chip(d.challenges_group.wins ?? 0, 'Wins (1st)')}
-        {@render chip(d.challenges_group.podiums ?? 0, 'Podiums')}
-      </div>
+			<div class="sec-title">👥 Group challenges</div>
+			<div class="grid">
+				{@render chip(d.challenges_group.played ?? 0, 'Played')}
+				{@render chip(d.challenges_group.wins ?? 0, 'Wins (1st)')}
+				{@render chip(d.challenges_group.podiums ?? 0, 'Podiums')}
+			</div>
 
-      {#if (d.rivals ?? []).length}
-        <div class="sec-title">🤺 Rivals <span class="sec-hint">(tap for the full head-to-head)</span></div>
-        <div class="cats">
-          {#each d.rivals as r}
-            <button class="cat-row rival" onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))}>
-              <span class="cat-name">@{r.name}</span>
-              <span class="rival-rec">
-                <b class="w">{r.wins}W</b> <b class="l">{r.losses}L</b>{#if r.ties}<b class="t">{r.ties}T</b>{/if}
-                <span class="arrow">›</span>
-              </span>
-            </button>
-          {/each}
-        </div>
-      {/if}
+			{#if (d.rivals ?? []).length}
+				<div class="sec-title">
+					🤺 Rivals <span class="sec-hint">(tap for the full head-to-head)</span>
+				</div>
+				<div class="cats">
+					{#each d.rivals as r}
+						<button
+							class="cat-row rival"
+							onclick={() => goto('/u/' + encodeURIComponent(r.name || ''))}
+						>
+							<span class="cat-name">@{r.name}</span>
+							<span class="rival-rec">
+								<b class="w">{r.wins}W</b> <b class="l">{r.losses}L</b>{#if r.ties}<b class="t"
+										>{r.ties}T</b
+									>{/if}
+								<span class="arrow">›</span>
+							</span>
+						</button>
+					{/each}
+				</div>
+			{/if}
 
-      {#if (d.categories ?? []).length}
-        <div class="sec-title">🗂️ Categories</div>
-        <div class="cats">
-          {#each d.categories as c}
-            <div class="cat-row">
-              <span class="cat-name">{c.category}</span>
-              <span class="cat-meta">{c.solves} solved{#if c.best_multiple} · best {mult(c.best_multiple)}{/if}</span>
-            </div>
-          {/each}
-        </div>
-      {/if}
-    {:else}
-      <NotificationsPanel onNavigate={notifNav} />
-    {/if}
-  {/if}
+			{#if (d.categories ?? []).length}
+				<div class="sec-title">🗂️ Categories</div>
+				<div class="cats">
+					{#each d.categories as c}
+						<div class="cat-row">
+							<span class="cat-name">{c.category}</span>
+							<span class="cat-meta"
+								>{c.solves} solved{#if c.best_multiple}
+									· best {mult(c.best_multiple)}{/if}</span
+							>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		{:else}
+			<NotificationsPanel onNavigate={notifNav} />
+		{/if}
+	{/if}
 
-  {#if statInfo}
-    <div class="si-overlay" role="button" tabindex="0" onclick={() => statInfo = null}
-      onkeydown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') statInfo = null; }}>
-      <div class="si-card" role="document" onclick={(e) => e.stopPropagation()}>
-        <h3 class="si-title">{statInfo.title}</h3>
-        <p class="si-desc">{statInfo.desc}</p>
-        {#if statInfo.link}<button class="si-link" onclick={() => goto(/** @type {string} */ (statInfo?.link))}>{statInfo.linkLabel} →</button>{/if}
-        <button class="si-close" onclick={() => statInfo = null}>Got it</button>
-      </div>
-    </div>
-  {/if}
+	{#if statInfo}
+		<div
+			class="si-overlay"
+			role="button"
+			tabindex="0"
+			onclick={() => (statInfo = null)}
+			onkeydown={(e) => {
+				if (e.key === 'Escape' || e.key === 'Enter') statInfo = null;
+			}}
+		>
+			<div class="si-card" role="document" onclick={(e) => e.stopPropagation()}>
+				<h3 class="si-title">{statInfo.title}</h3>
+				<p class="si-desc">{statInfo.desc}</p>
+				{#if statInfo.link}<button
+						class="si-link"
+						onclick={() => goto(/** @type {string} */ (statInfo?.link))}
+						>{statInfo.linkLabel} →</button
+					>{/if}
+				<button class="si-close" onclick={() => (statInfo = null)}>Got it</button>
+			</div>
+		</div>
+	{/if}
 </main>
 
 <style>
-  .you-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
-  /* stat explanation popup */
-  .si-overlay { position: fixed; inset: 0; z-index: 4000; display: grid; place-items: center; padding: 24px;
-    background: rgba(4,8,14,0.72); backdrop-filter: blur(6px); border: none; }
-  .si-card { width: 100%; max-width: 320px; padding: 22px; border-radius: 18px; text-align: center;
-    background: var(--surface-strong, rgba(20,26,38,0.96)); border: 1px solid var(--border-strong, rgba(255,255,255,0.16));
-    box-shadow: 0 20px 50px rgba(0,0,0,0.5); display: flex; flex-direction: column; gap: 10px; }
-  .si-title { font-family: var(--font-display); font-size: 1.15rem; margin: 0; }
-  .si-desc { font-size: 0.92rem; line-height: 1.5; color: var(--text-muted); margin: 0; }
-  .si-link { background: none; border: none; color: var(--brand-2); font-weight: 700; cursor: pointer; padding: 4px; font-size: 0.92rem; }
-  .si-close { margin-top: 4px; height: 44px; border-radius: 12px; border: none; cursor: pointer; font-weight: 800; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b); }
-  .topbar { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-  .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
-  .tb-right { display: flex; gap: 6px; }
-  .page-title { font-family: var(--font-display); font-size: 1.2rem; margin: 0; }
-  .gear { background: none; border: none; font-size: 1.1rem; cursor: pointer; padding: 6px; opacity: 0.85; }
-  .gear:hover { opacity: 1; }
-  .muted { color: var(--text-muted); text-align: center; padding: 2rem 0; }
+	.you-page {
+		max-width: 520px;
+		margin: 0 auto;
+		padding: 16px 14px 60px;
+	}
+	/* stat explanation popup */
+	.si-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 4000;
+		display: grid;
+		place-items: center;
+		padding: 24px;
+		background: rgba(4, 8, 14, 0.72);
+		backdrop-filter: blur(6px);
+		border: none;
+	}
+	.si-card {
+		width: 100%;
+		max-width: 320px;
+		padding: 22px;
+		border-radius: 18px;
+		text-align: center;
+		background: var(--surface-strong, rgba(20, 26, 38, 0.96));
+		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
+		box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+	.si-title {
+		font-family: var(--font-display);
+		font-size: 1.15rem;
+		margin: 0;
+	}
+	.si-desc {
+		font-size: 0.92rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		margin: 0;
+	}
+	.si-link {
+		background: none;
+		border: none;
+		color: var(--brand-2);
+		font-weight: 700;
+		cursor: pointer;
+		padding: 4px;
+		font-size: 0.92rem;
+	}
+	.si-close {
+		margin-top: 4px;
+		height: 44px;
+		border-radius: 12px;
+		border: none;
+		cursor: pointer;
+		font-weight: 800;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.topbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 8px;
+	}
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		cursor: pointer;
+		padding: 6px 0;
+	}
+	.tb-right {
+		display: flex;
+		gap: 6px;
+	}
+	.page-title {
+		font-family: var(--font-display);
+		font-size: 1.2rem;
+		margin: 0;
+	}
+	.gear {
+		background: none;
+		border: none;
+		font-size: 1.1rem;
+		cursor: pointer;
+		padding: 6px;
+		opacity: 0.85;
+	}
+	.gear:hover {
+		opacity: 1;
+	}
+	.muted {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 2rem 0;
+	}
 
-  .head { text-align: center; margin: 8px 0 18px; }
-  .coin { width: 64px; height: 64px; margin: 0 auto 8px; border-radius: 50%; display: grid; place-items: center;
-    font-family: var(--font-display); font-weight: 800; font-size: 1.6rem; color: #3a2a00;
-    background: linear-gradient(135deg, var(--c, #fde047), #f59e0b); box-shadow: 0 0 24px rgba(251,191,36,0.4); }
-  .uname { font-family: var(--font-display); font-weight: 700; font-size: 1.3rem; }
-  .nw { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2.1rem; color: #fde047;
-    margin-top: 10px; text-shadow: 0 0 18px rgba(251,191,36,0.5); }
-  .nw-sub { font-size: 0.72rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.1em; }
+	.head {
+		text-align: center;
+		margin: 8px 0 18px;
+	}
+	.coin {
+		width: 64px;
+		height: 64px;
+		margin: 0 auto 8px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.6rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, var(--c, #fde047), #f59e0b);
+		box-shadow: 0 0 24px rgba(251, 191, 36, 0.4);
+	}
+	.uname {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.3rem;
+	}
+	.nw {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2.1rem;
+		color: #fde047;
+		margin-top: 10px;
+		text-shadow: 0 0 18px rgba(251, 191, 36, 0.5);
+	}
+	.nw-sub {
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
 
-  .tabs { display: flex; gap: 8px; margin: 0 0 16px; }
-  .tab { flex: 1; padding: 9px 0; border-radius: 12px; border: 1px solid var(--border); background: var(--surface);
-    color: var(--text-muted); font-weight: 700; font-size: 0.88rem; cursor: pointer; }
-  .tab.active { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
-  .tab-count { display: inline-grid; place-items: center; min-width: 16px; height: 16px; padding: 0 4px; margin-left: 3px;
-    border-radius: 999px; background: #f43f5e; color: #fff; font-size: 0.62rem; font-weight: 800; vertical-align: middle; }
+	.tabs {
+		display: flex;
+		gap: 8px;
+		margin: 0 0 16px;
+	}
+	.tab {
+		flex: 1;
+		padding: 9px 0;
+		border-radius: 12px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+		color: var(--text-muted);
+		font-weight: 700;
+		font-size: 0.88rem;
+		cursor: pointer;
+	}
+	.tab.active {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		border-color: transparent;
+	}
+	.tab-count {
+		display: inline-grid;
+		place-items: center;
+		min-width: 16px;
+		height: 16px;
+		padding: 0 4px;
+		margin-left: 3px;
+		border-radius: 999px;
+		background: #f43f5e;
+		color: #fff;
+		font-size: 0.62rem;
+		font-weight: 800;
+		vertical-align: middle;
+	}
 
-  .sec-title { font-family: var(--font-display); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em;
-    text-transform: uppercase; color: var(--gold); text-align: left; margin: 18px 2px 8px; }
-  .grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
-  .prof-avatar { display: flex; flex-direction: column; align-items: center; gap: 6px; margin: 0 auto 14px; background: none; border: none; cursor: pointer; }
-  .prof-avatar-edit { font-size: 0.82rem; font-weight: 700; color: var(--brand-2); }
-  /* Overview tab */
-  .ov-hero { display: flex; align-items: center; gap: 16px; margin: 6px 0 16px; }
-  .ov-hero .prof-avatar { margin: 0; }
-  .ov-id { display: flex; flex-direction: column; align-items: flex-start; gap: 2px; min-width: 0; }
-  .uname-row { display: flex; align-items: center; gap: 8px; }
-  .bell-btn { position: relative; background: none; border: none; cursor: pointer; font-size: 1.3rem; line-height: 1; padding: 2px; }
-  .bell-count { position: absolute; top: -4px; right: -7px; min-width: 17px; height: 17px; display: grid; place-items: center; padding: 0 4px;
-    border-radius: 999px; background: #dc2626; color: #fff; font-size: 0.62rem; font-weight: 800; }
-  .ov-id .uname { font-size: 1.15rem; }
-  .ov-social { display: flex; flex-direction: column; gap: 5px; margin-top: 8px; align-items: flex-start; }
-  .ov-social-btn { background: var(--surface); border: 1px solid var(--border); color: var(--text); cursor: pointer;
-    padding: 6px 12px; border-radius: 999px; font-weight: 700; font-size: 0.82rem; }
-  .ov-social-btn:hover { border-color: var(--brand-2); }
-  .ov-id .nw { font-size: 1.7rem; }
-  .ov-id .nw-sub { font-size: 0.8rem; color: var(--text-faint); -webkit-text-fill-color: var(--text-faint); }
-  .ov-people { display: inline-flex; align-items: center; gap: 6px; margin-top: 6px; padding: 7px 14px 7px 30px; position: relative;
-    border-radius: 999px; cursor: pointer; font-weight: 800; font-size: 0.85rem; color: #3a2a00;
-    background: linear-gradient(135deg, #fde047, #f59e0b); border: none; }
-  .ov-people .vs-ppl { position: absolute; left: 11px; font-size: 0.95rem; }
-  .ov-people .vs-ppl-plus { position: absolute; left: 22px; top: 6px; font-size: 0.7rem; font-weight: 900; }
-  .ov-people:active { transform: scale(0.97); }
-  .ov-summary { margin-bottom: 4px; }
-  .sec-link { float: right; background: none; border: none; color: var(--brand-2); font-weight: 700; font-size: 0.72rem; cursor: pointer; text-transform: none; letter-spacing: 0; }
-  .nw-btn { background: none; border: none; padding: 0; cursor: pointer; display: inline-flex; align-items: baseline; }
-  .nw-go { font-size: 1rem; color: var(--text-faint); font-family: var(--font-display); }
-  .ov-badges-card { display: block; width: 100%; text-align: left; cursor: pointer; margin-top: 16px; padding: 12px 14px; border-radius: 14px;
-    background: var(--surface); border: 1px solid var(--border); }
-  .ov-badges-card:hover { border-color: var(--brand-2); }
-  .ov-badges-h { display: flex; justify-content: space-between; font-family: var(--font-display); font-size: 0.82rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; color: var(--gold); margin-bottom: 8px; }
-  .ov-badges-h .arrow { color: var(--text-faint); }
-  .ov-badges { display: flex; flex-wrap: wrap; gap: 8px; padding: 4px 0; }
-  .ov-badge { font-size: 1.5rem; line-height: 1; }
-  .ov-badges-empty { font-size: 0.85rem; color: var(--text-muted); }
-  .ov-nav { display: flex; flex-direction: column; gap: 8px; margin-top: 16px; }
-  .ov-count { margin-left: auto; margin-right: 8px; min-width: 20px; height: 20px; display: inline-grid; place-items: center; padding: 0 5px; border-radius: 999px; background: #dc2626; color: #fff; font-size: 0.72rem; font-weight: 800; }
-  .ov-link { display: flex; justify-content: space-between; align-items: center; padding: 13px 15px; border-radius: 14px; cursor: pointer;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 700; font-size: 0.95rem; text-align: left; }
-  .ov-link:hover { border-color: var(--brand-2); }
-  .ov-link .arrow { color: var(--text-faint); }
-  .stat { display: flex; flex-direction: column; gap: 3px; padding: 0.85rem 0.4rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px; text-align: center; }
-  .stat-link { cursor: pointer; color: var(--text); font: inherit; }
-  .stat-link:hover { border-color: var(--brand-2); }
-  .stat-link:active { transform: scale(0.97); }
-  .stat-link .sc { color: var(--brand-2); }
-  .sv { font-family: var(--font-display); font-weight: 800; font-size: 1.02rem; color: var(--text); }
-  .sc { font-size: 0.58rem; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-faint); }
+	.sec-title {
+		font-family: var(--font-display);
+		font-size: 0.78rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+		color: var(--gold);
+		text-align: left;
+		margin: 18px 2px 8px;
+	}
+	.grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr 1fr;
+		gap: 8px;
+	}
+	.prof-avatar {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 6px;
+		margin: 0 auto 14px;
+		background: none;
+		border: none;
+		cursor: pointer;
+	}
+	.prof-avatar-edit {
+		font-size: 0.82rem;
+		font-weight: 700;
+		color: var(--brand-2);
+	}
+	/* Overview tab */
+	.ov-hero {
+		display: flex;
+		align-items: center;
+		gap: 16px;
+		margin: 6px 0 16px;
+	}
+	.ov-hero .prof-avatar {
+		margin: 0;
+	}
+	.ov-id {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 2px;
+		min-width: 0;
+	}
+	.uname-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+	.bell-btn {
+		position: relative;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-size: 1.3rem;
+		line-height: 1;
+		padding: 2px;
+	}
+	.bell-count {
+		position: absolute;
+		top: -4px;
+		right: -7px;
+		min-width: 17px;
+		height: 17px;
+		display: grid;
+		place-items: center;
+		padding: 0 4px;
+		border-radius: 999px;
+		background: #dc2626;
+		color: #fff;
+		font-size: 0.62rem;
+		font-weight: 800;
+	}
+	.ov-id .uname {
+		font-size: 1.15rem;
+	}
+	.ov-social {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+		margin-top: 8px;
+		align-items: flex-start;
+	}
+	.ov-social-btn {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		cursor: pointer;
+		padding: 6px 12px;
+		border-radius: 999px;
+		font-weight: 700;
+		font-size: 0.82rem;
+	}
+	.ov-social-btn:hover {
+		border-color: var(--brand-2);
+	}
+	.ov-id .nw {
+		font-size: 1.7rem;
+	}
+	.ov-id .nw-sub {
+		font-size: 0.8rem;
+		color: var(--text-faint);
+		-webkit-text-fill-color: var(--text-faint);
+	}
+	.ov-people {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		margin-top: 6px;
+		padding: 7px 14px 7px 30px;
+		position: relative;
+		border-radius: 999px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.85rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		border: none;
+	}
+	.ov-people .vs-ppl {
+		position: absolute;
+		left: 11px;
+		font-size: 0.95rem;
+	}
+	.ov-people .vs-ppl-plus {
+		position: absolute;
+		left: 22px;
+		top: 6px;
+		font-size: 0.7rem;
+		font-weight: 900;
+	}
+	.ov-people:active {
+		transform: scale(0.97);
+	}
+	.ov-summary {
+		margin-bottom: 4px;
+	}
+	.sec-link {
+		float: right;
+		background: none;
+		border: none;
+		color: var(--brand-2);
+		font-weight: 700;
+		font-size: 0.72rem;
+		cursor: pointer;
+		text-transform: none;
+		letter-spacing: 0;
+	}
+	.nw-btn {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		display: inline-flex;
+		align-items: baseline;
+	}
+	.nw-go {
+		font-size: 1rem;
+		color: var(--text-faint);
+		font-family: var(--font-display);
+	}
+	.ov-badges-card {
+		display: block;
+		width: 100%;
+		text-align: left;
+		cursor: pointer;
+		margin-top: 16px;
+		padding: 12px 14px;
+		border-radius: 14px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+	}
+	.ov-badges-card:hover {
+		border-color: var(--brand-2);
+	}
+	.ov-badges-h {
+		display: flex;
+		justify-content: space-between;
+		font-family: var(--font-display);
+		font-size: 0.82rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		text-transform: uppercase;
+		color: var(--gold);
+		margin-bottom: 8px;
+	}
+	.ov-badges-h .arrow {
+		color: var(--text-faint);
+	}
+	.ov-badges {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		padding: 4px 0;
+	}
+	.ov-badge {
+		font-size: 1.5rem;
+		line-height: 1;
+	}
+	.ov-badges-empty {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+	.ov-nav {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-top: 16px;
+	}
+	.ov-count {
+		margin-left: auto;
+		margin-right: 8px;
+		min-width: 20px;
+		height: 20px;
+		display: inline-grid;
+		place-items: center;
+		padding: 0 5px;
+		border-radius: 999px;
+		background: #dc2626;
+		color: #fff;
+		font-size: 0.72rem;
+		font-weight: 800;
+	}
+	.ov-link {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 13px 15px;
+		border-radius: 14px;
+		cursor: pointer;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		font-weight: 700;
+		font-size: 0.95rem;
+		text-align: left;
+	}
+	.ov-link:hover {
+		border-color: var(--brand-2);
+	}
+	.ov-link .arrow {
+		color: var(--text-faint);
+	}
+	.stat {
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+		padding: 0.85rem 0.4rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 14px;
+		text-align: center;
+	}
+	.stat-link {
+		cursor: pointer;
+		color: var(--text);
+		font: inherit;
+	}
+	.stat-link:hover {
+		border-color: var(--brand-2);
+	}
+	.stat-link:active {
+		transform: scale(0.97);
+	}
+	.stat-link .sc {
+		color: var(--brand-2);
+	}
+	.sv {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.02rem;
+		color: var(--text);
+	}
+	.sc {
+		font-size: 0.58rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-faint);
+	}
 
-  .cats { display: flex; flex-direction: column; gap: 6px; }
-  .cat-row { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 9px 11px;
-    background: var(--surface); border: 1px solid var(--border); border-radius: 10px; }
-  .cat-name { font-weight: 600; color: var(--text); font-size: 0.86rem; }
-  .cat-meta { color: var(--text-faint); font-size: 0.74rem; }
-  .sec-hint { font-family: var(--font-ui); font-weight: 500; font-size: 0.62rem; color: var(--text-faint); text-transform: none; letter-spacing: 0; }
-  .rival { width: 100%; cursor: pointer; }
-  .rival-rec { display: flex; align-items: center; gap: 7px; font-size: 0.8rem; font-variant-numeric: tabular-nums; }
-  .rival-rec .w { color: #7ee0a8; } .rival-rec .l { color: #fb7185; } .rival-rec .t { color: var(--text-muted); }
-  .rival-rec .arrow { color: var(--text-faint); font-size: 1rem; margin-left: 2px; }
+	.cats {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.cat-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 10px;
+		padding: 9px 11px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 10px;
+	}
+	.cat-name {
+		font-weight: 600;
+		color: var(--text);
+		font-size: 0.86rem;
+	}
+	.cat-meta {
+		color: var(--text-faint);
+		font-size: 0.74rem;
+	}
+	.sec-hint {
+		font-family: var(--font-ui);
+		font-weight: 500;
+		font-size: 0.62rem;
+		color: var(--text-faint);
+		text-transform: none;
+		letter-spacing: 0;
+	}
+	.rival {
+		width: 100%;
+		cursor: pointer;
+	}
+	.rival-rec {
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		font-size: 0.8rem;
+		font-variant-numeric: tabular-nums;
+	}
+	.rival-rec .w {
+		color: #7ee0a8;
+	}
+	.rival-rec .l {
+		color: #fb7185;
+	}
+	.rival-rec .t {
+		color: var(--text-muted);
+	}
+	.rival-rec .arrow {
+		color: var(--text-faint);
+		font-size: 1rem;
+		margin-left: 2px;
+	}
 </style>

--- a/src/routes/reset-password/+page.svelte
+++ b/src/routes/reset-password/+page.svelte
@@ -1,140 +1,166 @@
 <script>
-  import { supabase } from '$lib/supabaseClient';
-  import { goto } from '$app/navigation';
-  import { onMount } from 'svelte';
+	import { supabase } from '$lib/supabaseClient';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
 
-  let password = '';
-  let confirmPassword = '';
-  let message = '';
-  let isTokenReady = false;
-  let success = false;
-  // A one-time recovery token (token_hash) from the email link. We DON'T verify
-  // it on load — email scanners/prefetchers GET links and would burn the
-  // one-time token. We hold it and verify only when the user submits the form.
-  let tokenHash = '';
-  let otpType = '';
+	let password = '';
+	let confirmPassword = '';
+	let message = '';
+	let isTokenReady = false;
+	let success = false;
+	// A one-time recovery token (token_hash) from the email link. We DON'T verify
+	// it on load — email scanners/prefetchers GET links and would burn the
+	// one-time token. We hold it and verify only when the user submits the form.
+	let tokenHash = '';
+	let otpType = '';
 
-  onMount(() => {
-    const url = new URL(window.location.href);
+	onMount(() => {
+		const url = new URL(window.location.href);
 
-    // Supabase passes errors (expired/used link) back as query params.
-    const errDesc = url.searchParams.get('error_description');
-    if (errDesc) {
-      message = `⛔ ${decodeURIComponent(errDesc.replace(/\+/g, ' '))}`;
-      return;
-    }
+		// Supabase passes errors (expired/used link) back as query params.
+		const errDesc = url.searchParams.get('error_description');
+		if (errDesc) {
+			message = `⛔ ${decodeURIComponent(errDesc.replace(/\+/g, ' '))}`;
+			return;
+		}
 
-    // Recovery link landed here directly with a token_hash → show the form now,
-    // verify on submit (prefetch-safe, no local code verifier, works cross-device).
-    tokenHash = url.searchParams.get('token_hash') ?? '';
-    otpType = url.searchParams.get('type') ?? '';
-    if (tokenHash && otpType) {
-      isTokenReady = true;
-      return;
-    }
+		// Recovery link landed here directly with a token_hash → show the form now,
+		// verify on submit (prefetch-safe, no local code verifier, works cross-device).
+		tokenHash = url.searchParams.get('token_hash') ?? '';
+		otpType = url.searchParams.get('type') ?? '';
+		if (tokenHash && otpType) {
+			isTokenReady = true;
+			return;
+		}
 
-    // Otherwise a session was already established (e.g. via /auth/confirm, or the
-    // user is signed in) — surface the form once we see it.
-    let settled = false;
-    const ready = () => { settled = true; isTokenReady = true; message = ''; };
-    supabase.auth.getSession().then(({ data }) => { if (data.session) ready(); });
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session) ready();
-    });
-    const timer = setTimeout(() => {
-      if (!settled) message = '⛔ This reset link is invalid or has expired. Please request a new one.';
-    }, 3000);
+		// Otherwise a session was already established (e.g. via /auth/confirm, or the
+		// user is signed in) — surface the form once we see it.
+		let settled = false;
+		const ready = () => {
+			settled = true;
+			isTokenReady = true;
+			message = '';
+		};
+		supabase.auth.getSession().then(({ data }) => {
+			if (data.session) ready();
+		});
+		const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+			if (session) ready();
+		});
+		const timer = setTimeout(() => {
+			if (!settled)
+				message = '⛔ This reset link is invalid or has expired. Please request a new one.';
+		}, 3000);
 
-    return () => { clearTimeout(timer); sub.subscription.unsubscribe(); };
-  });
+		return () => {
+			clearTimeout(timer);
+			sub.subscription.unsubscribe();
+		};
+	});
 
-  async function updatePassword() {
-    if (!password || !confirmPassword) {
-      message = '⚠️ Please fill in both fields.';
-      success = false;
-      return;
-    }
+	async function updatePassword() {
+		if (!password || !confirmPassword) {
+			message = '⚠️ Please fill in both fields.';
+			success = false;
+			return;
+		}
 
-    if (password !== confirmPassword) {
-      message = '❌ Passwords do not match.';
-      success = false;
-      return;
-    }
+		if (password !== confirmPassword) {
+			message = '❌ Passwords do not match.';
+			success = false;
+			return;
+		}
 
-    // Verify the one-time token now (deferred from page load). This establishes
-    // the recovery session; if the link is expired/used, the user finds out here.
-    if (tokenHash && otpType) {
-      const { error: verifyErr } = await supabase.auth.verifyOtp({
-        token_hash: tokenHash, type: /** @type {any} */ (otpType)
-      });
-      if (verifyErr) {
-        message = `⛔ ${verifyErr.message}`;
-        success = false;
-        return;
-      }
-      tokenHash = ''; // consumed
-    }
+		// Verify the one-time token now (deferred from page load). This establishes
+		// the recovery session; if the link is expired/used, the user finds out here.
+		if (tokenHash && otpType) {
+			const { error: verifyErr } = await supabase.auth.verifyOtp({
+				token_hash: tokenHash,
+				type: /** @type {any} */ (otpType)
+			});
+			if (verifyErr) {
+				message = `⛔ ${verifyErr.message}`;
+				success = false;
+				return;
+			}
+			tokenHash = ''; // consumed
+		}
 
-    console.log("🔐 Attempting password update...");
-    const { error } = await supabase.auth.updateUser({ password });
+		console.log('🔐 Attempting password update...');
+		const { error } = await supabase.auth.updateUser({ password });
 
-    if (error) {
-      message = `❌ ${error.message}`;
-      success = false;
-      console.error("❌ Password update error:", error.message);
-    } else {
-      message = '✅ Password updated! Redirecting...';
-      success = true;
-      console.log("✅ Password update successful.");
-      setTimeout(() => goto('/'), 2000);
-    }
-  }
+		if (error) {
+			message = `❌ ${error.message}`;
+			success = false;
+			console.error('❌ Password update error:', error.message);
+		} else {
+			message = '✅ Password updated! Redirecting...';
+			success = true;
+			console.log('✅ Password update successful.');
+			setTimeout(() => goto('/'), 2000);
+		}
+	}
 </script>
 
 <main class="reset-wrapper">
-  <div class="reset-card glass fade-up">
-    <h2>Reset your password</h2>
+	<div class="reset-card glass fade-up">
+		<h2>Reset your password</h2>
 
-    {#if message}
-      <p class="message {success ? 'success' : 'error'}">{message}</p>
-    {/if}
+		{#if message}
+			<p class="message {success ? 'success' : 'error'}">{message}</p>
+		{/if}
 
-    {#if isTokenReady}
-      <input class="field" type="password" placeholder="New password" bind:value={password} />
-      <input class="field" type="password" placeholder="Confirm password" bind:value={confirmPassword} />
-      <button class="btn-brand full" on:click={updatePassword}>Update password</button>
-    {/if}
-  </div>
+		{#if isTokenReady}
+			<input class="field" type="password" placeholder="New password" bind:value={password} />
+			<input
+				class="field"
+				type="password"
+				placeholder="Confirm password"
+				bind:value={confirmPassword}
+			/>
+			<button class="btn-brand full" on:click={updatePassword}>Update password</button>
+		{/if}
+	</div>
 </main>
 
 <style>
-  .reset-wrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 100vh;
-    padding: 20px;
-  }
-  .reset-card {
-    width: 100%;
-    max-width: 400px;
-    padding: 30px 26px;
-    text-align: center;
-    box-shadow: var(--shadow-lg);
-  }
-  h2 {
-    font-family: var(--font-display);
-    font-size: 1.4rem;
-    margin: 0 0 1.2rem;
-  }
-  .field { margin: 10px 0; text-align: left; }
-  .full { width: 100%; margin-top: 8px; }
+	.reset-wrapper {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		min-height: 100vh;
+		padding: 20px;
+	}
+	.reset-card {
+		width: 100%;
+		max-width: 400px;
+		padding: 30px 26px;
+		text-align: center;
+		box-shadow: var(--shadow-lg);
+	}
+	h2 {
+		font-family: var(--font-display);
+		font-size: 1.4rem;
+		margin: 0 0 1.2rem;
+	}
+	.field {
+		margin: 10px 0;
+		text-align: left;
+	}
+	.full {
+		width: 100%;
+		margin-top: 8px;
+	}
 
-  .message {
-    margin: 0 0 1rem;
-    font-weight: 600;
-    font-size: 0.9rem;
-  }
-  .message.success { color: var(--brand-2); }
-  .message.error { color: var(--danger); }
+	.message {
+		margin: 0 0 1rem;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.message.success {
+		color: var(--brand-2);
+	}
+	.message.error {
+		color: var(--danger);
+	}
 </style>

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -1,256 +1,449 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import { page } from '$app/stores';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import { getShop, buyCosmetic, equipCosmetic, unequipCosmetic, getPowerups, buyPowerup } from '$lib/stores/statsStore.js';
-  import { track } from '$lib/analytics.js';
-  import { fx } from '$lib/sound.js';
-  import InventoryList from '$lib/components/InventoryList.svelte';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import {
+		getShop,
+		buyCosmetic,
+		equipCosmetic,
+		unequipCosmetic,
+		getPowerups,
+		buyPowerup
+	} from '$lib/stores/statsStore.js';
+	import { track } from '$lib/analytics.js';
+	import { fx } from '$lib/sound.js';
+	import InventoryList from '$lib/components/InventoryList.svelte';
 
-  // Back goes to the Bank when you came from its empty-slot "+", else the menu.
-  let backTo = $derived($page.url.searchParams.get('from') === 'bank' ? '/bank' : '/');
+	// Back goes to the Bank when you came from its empty-slot "+", else the menu.
+	let backTo = $derived($page.url.searchParams.get('from') === 'bank' ? '/bank' : '/');
 
-  let bank = $state(0);
-  /** @type {any[]} */
-  let items = $state([]);
-  /** @type {any[]} */
-  let pups = $state([]);
-  let loading = $state(true);
-  let busy = $state('');
-  let msg = $state('');
+	let bank = $state(0);
+	/** @type {any[]} */
+	let items = $state([]);
+	/** @type {any[]} */
+	let pups = $state([]);
+	let loading = $state(true);
+	let busy = $state('');
+	let msg = $state('');
 
-  const PUP_META = /** @type {Record<string,{icon:string,desc:string}>} */ ({
-    free_reveal:  { icon: '🔍', desc: 'Reveal the most useful letter' },
-    free_vowel:   { icon: '🅰️', desc: 'Reveal one vowel free' },
-    half_off:     { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
-    vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
-    reveal_word:  { icon: '📖', desc: 'Reveal a whole word' },
-    extra_hint:   { icon: '💡', desc: 'Reveal the first letter of each word' },
-    last_letters: { icon: '🔚', desc: 'Reveal the last letter of each word' },
-    sabotage_tax: { icon: '💸', desc: "An opponent's letters cost +50%" },
-    sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" },
-    sabotage_toll:        { icon: '🚧', desc: "An opponent's next letter costs 3×" },
-    sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
-    sabotage_lock:        { icon: '🔒', desc: 'Wipe a letter an opponent revealed' },
-    bounty_boost:  { icon: '💥', desc: 'Adds ×0.5 to your Daily bounty' },
-    jackpot_boost: { icon: '💎', desc: 'Adds ×1.0 to your Daily bounty' }
-  });
+	const PUP_META = /** @type {Record<string,{icon:string,desc:string}>} */ ({
+		free_reveal: { icon: '🔍', desc: 'Reveal the most useful letter' },
+		free_vowel: { icon: '🅰️', desc: 'Reveal one vowel free' },
+		half_off: { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
+		vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
+		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
+		extra_hint: { icon: '💡', desc: 'Reveal the first letter of each word' },
+		last_letters: { icon: '🔚', desc: 'Reveal the last letter of each word' },
+		sabotage_tax: { icon: '💸', desc: "An opponent's letters cost +50%" },
+		sabotage_fog: { icon: '🌫️', desc: "Hide an opponent's clue" },
+		sabotage_toll: { icon: '🚧', desc: "An opponent's next letter costs 3×" },
+		sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
+		sabotage_lock: { icon: '🔒', desc: 'Wipe a letter an opponent revealed' },
+		bounty_boost: { icon: '💥', desc: 'Adds ×0.5 to your Daily bounty' },
+		jackpot_boost: { icon: '💎', desc: 'Adds ×1.0 to your Daily bounty' }
+	});
 
-  /** @type {any[]} */
-  let sabs = $state([]);
-  /** @type {any[]} */
-  let dboost = $state([]);
+	/** @type {any[]} */
+	let sabs = $state([]);
+	/** @type {any[]} */
+	let dboost = $state([]);
 
-  let inventoryKey = $state(0); // bump to re-mount the bag after a purchase
+	let inventoryKey = $state(0); // bump to re-mount the bag after a purchase
 
-  async function load() {
-    const [shop, pu] = await Promise.all([getShop(), getPowerups()]);
-    bank = shop.bank;
-    items = shop.items;
-    pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
-    sabs = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'sabotage');
-    dboost = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'daily');
-    inventoryKey++;
-  }
+	async function load() {
+		const [shop, pu] = await Promise.all([getShop(), getPowerups()]);
+		bank = shop.bank;
+		items = shop.items;
+		pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
+		sabs = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'sabotage');
+		dboost = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'daily');
+		inventoryKey++;
+	}
 
-  /** @param {any} item */
-  async function buyPup(item) {
-    if (busy) return;
-    busy = item.id; msg = '';
-    const res = await buyPowerup(item.id);
-    busy = '';
-    if (res?.ok) { fx('win'); track('powerup_buy', { id: item.id }); await load(); }
-    else { msg = res?.reason === 'insufficient' ? 'Not enough Cash.' : res?.reason === 'owned' ? 'You already own one — use it first.' : 'Could not buy that.'; }
-  }
-  onMount(async () => {
-    track('shop_view');
-    try { await load(); } finally { loading = false; }
-  });
+	/** @param {any} item */
+	async function buyPup(item) {
+		if (busy) return;
+		busy = item.id;
+		msg = '';
+		const res = await buyPowerup(item.id);
+		busy = '';
+		if (res?.ok) {
+			fx('win');
+			track('powerup_buy', { id: item.id });
+			await load();
+		} else {
+			msg =
+				res?.reason === 'insufficient'
+					? 'Not enough Cash.'
+					: res?.reason === 'owned'
+						? 'You already own one — use it first.'
+						: 'Could not buy that.';
+		}
+	}
+	onMount(async () => {
+		track('shop_view');
+		try {
+			await load();
+		} finally {
+			loading = false;
+		}
+	});
 
-  let titles = $derived(items.filter((i) => i.kind === 'title'));
-  let colors = $derived(items.filter((i) => i.kind === 'color'));
+	let titles = $derived(items.filter((i) => i.kind === 'title'));
+	let colors = $derived(items.filter((i) => i.kind === 'color'));
 
-  /** @param {any} item */
-  async function buy(item) {
-    if (busy) return;
-    busy = item.id; msg = '';
-    const res = await buyCosmetic(item.id);
-    busy = '';
-    if (res.ok) { fx('win'); track('cosmetic_buy', { id: item.id }); await load(); }
-    else { msg = res.reason === 'insufficient' ? "Not enough Cash." : 'Could not buy that.'; }
-  }
-  /** @param {any} item */
-  async function equip(item) {
-    if (busy) return;
-    busy = item.id;
-    const res = item.equipped ? await unequipCosmetic(item.kind) : await equipCosmetic(item.id);
-    busy = '';
-    if (res.ok) { await load(); }
-  }
+	/** @param {any} item */
+	async function buy(item) {
+		if (busy) return;
+		busy = item.id;
+		msg = '';
+		const res = await buyCosmetic(item.id);
+		busy = '';
+		if (res.ok) {
+			fx('win');
+			track('cosmetic_buy', { id: item.id });
+			await load();
+		} else {
+			msg = res.reason === 'insufficient' ? 'Not enough Cash.' : 'Could not buy that.';
+		}
+	}
+	/** @param {any} item */
+	async function equip(item) {
+		if (busy) return;
+		busy = item.id;
+		const res = item.equipped ? await unequipCosmetic(item.kind) : await equipCosmetic(item.id);
+		busy = '';
+		if (res.ok) {
+			await load();
+		}
+	}
 </script>
 
 <svelte:head><title>WordBank — Store</title></svelte:head>
 
 <main class="shop-page">
-  <PageNav back={backTo} showHome={false} />
+	<PageNav back={backTo} showHome={false} />
 
-  <div class="head">
-    <h1>🛍️ Store</h1>
-    <span class="bank-chip">💰 ${bank.toLocaleString()}</span>
-  </div>
-  <p class="sub">Power-ups for the Cash Game &amp; challenges, plus cosmetics.</p>
+	<div class="head">
+		<h1>🛍️ Store</h1>
+		<span class="bank-chip">💰 ${bank.toLocaleString()}</span>
+	</div>
+	<p class="sub">Power-ups for the Cash Game &amp; challenges, plus cosmetics.</p>
 
-  {#if loading}
-    <p class="loading">Loading…</p>
-  {:else}
-    {#if msg}<p class="msg">{msg}</p>{/if}
+	{#if loading}
+		<p class="loading">Loading…</p>
+	{:else}
+		{#if msg}<p class="msg">{msg}</p>{/if}
 
-    {#key inventoryKey}
-      <details class="inv-details">
-        <summary class="inv-summary">🎒 What you own</summary>
-        <InventoryList />
-      </details>
-    {/key}
+		{#key inventoryKey}
+			<details class="inv-details">
+				<summary class="inv-summary">🎒 What you own</summary>
+				<InventoryList />
+			</details>
+		{/key}
 
-    {#if dboost.length}
-      <h2 class="section">💥 Bounty Boosts</h2>
-      <p class="section-note">Stock up, then tap them in the Daily to multiply your bounty — they stack on your win-streak multiplier (carry up to 5 of each).</p>
-      <div class="grid">
-        {#each dboost as item}
-          <div class="card pup" class:owned={item.owned > 0}>
-            <span class="pup-ic">{PUP_META[item.id]?.icon ?? '💥'}</span>
-            <span class="c-label">{item.name}{#if item.owned > 0} <span class="owned-x">×{item.owned}</span>{/if}</span>
-            <span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
-            {#if item.owned >= 5}
-              <button class="c-btn equip on" disabled>✓ Maxed (5)</button>
-            {:else}
-              <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buyPup(item)}>
-                💰 ${item.price.toLocaleString()}
-              </button>
-            {/if}
-          </div>
-        {/each}
-      </div>
-    {/if}
+		{#if dboost.length}
+			<h2 class="section">💥 Bounty Boosts</h2>
+			<p class="section-note">
+				Stock up, then tap them in the Daily to multiply your bounty — they stack on your win-streak
+				multiplier (carry up to 5 of each).
+			</p>
+			<div class="grid">
+				{#each dboost as item}
+					<div class="card pup" class:owned={item.owned > 0}>
+						<span class="pup-ic">{PUP_META[item.id]?.icon ?? '💥'}</span>
+						<span class="c-label"
+							>{item.name}{#if item.owned > 0}
+								<span class="owned-x">×{item.owned}</span>{/if}</span
+						>
+						<span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
+						{#if item.owned >= 5}
+							<button class="c-btn equip on" disabled>✓ Maxed (5)</button>
+						{:else}
+							<button
+								class="c-btn buy"
+								disabled={busy === item.id || bank < item.price}
+								onclick={() => buyPup(item)}
+							>
+								💰 ${item.price.toLocaleString()}
+							</button>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
 
-    <h2 class="section">⚡ Power-ups</h2>
-    <p class="section-note">Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like — the Daily stays power-up-free.</p>
-    <div class="grid">
-      {#each pups as item}
-        <div class="card pup" class:owned={item.owned > 0}>
-          <span class="pup-ic">{PUP_META[item.id]?.icon ?? '✨'}</span>
-          <span class="c-label">{item.name}</span>
-          <span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
-          {#if item.owned > 0}
-            <button class="c-btn equip on" disabled>✓ In your bag</button>
-          {:else}
-            <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buyPup(item)}>
-              💰 ${item.price.toLocaleString()}
-            </button>
-          {/if}
-        </div>
-      {/each}
-    </div>
+		<h2 class="section">⚡ Power-ups</h2>
+		<p class="section-note">
+			Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like —
+			the Daily stays power-up-free.
+		</p>
+		<div class="grid">
+			{#each pups as item}
+				<div class="card pup" class:owned={item.owned > 0}>
+					<span class="pup-ic">{PUP_META[item.id]?.icon ?? '✨'}</span>
+					<span class="c-label">{item.name}</span>
+					<span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
+					{#if item.owned > 0}
+						<button class="c-btn equip on" disabled>✓ In your bag</button>
+					{:else}
+						<button
+							class="c-btn buy"
+							disabled={busy === item.id || bank < item.price}
+							onclick={() => buyPup(item)}
+						>
+							💰 ${item.price.toLocaleString()}
+						</button>
+					{/if}
+				</div>
+			{/each}
+		</div>
 
-    {#if sabs.length}
-      <h2 class="section">😈 Sabotage</h2>
-      <p class="section-note">Bring these to a challenge with power-ups on, then hit an opponent — they get notified.</p>
-      <div class="grid">
-        {#each sabs as item}
-          <div class="card pup" class:owned={item.owned > 0}>
-            <span class="pup-ic">{PUP_META[item.id]?.icon ?? '😈'}</span>
-            <span class="c-label">{item.name}</span>
-            <span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
-            {#if item.owned > 0}
-              <button class="c-btn equip on" disabled>✓ In your bag</button>
-            {:else}
-              <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buyPup(item)}>
-                💰 ${item.price.toLocaleString()}
-              </button>
-            {/if}
-          </div>
-        {/each}
-      </div>
-    {/if}
+		{#if sabs.length}
+			<h2 class="section">😈 Sabotage</h2>
+			<p class="section-note">
+				Bring these to a challenge with power-ups on, then hit an opponent — they get notified.
+			</p>
+			<div class="grid">
+				{#each sabs as item}
+					<div class="card pup" class:owned={item.owned > 0}>
+						<span class="pup-ic">{PUP_META[item.id]?.icon ?? '😈'}</span>
+						<span class="c-label">{item.name}</span>
+						<span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
+						{#if item.owned > 0}
+							<button class="c-btn equip on" disabled>✓ In your bag</button>
+						{:else}
+							<button
+								class="c-btn buy"
+								disabled={busy === item.id || bank < item.price}
+								onclick={() => buyPup(item)}
+							>
+								💰 ${item.price.toLocaleString()}
+							</button>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
 
-    <h2 class="section">Titles</h2>
-    <div class="grid">
-      {#each titles as item}
-        <div class="card" class:owned={item.owned}>
-          <span class="c-label">{item.label}</span>
-          {#if item.owned}
-            <button class="c-btn equip" class:on={item.equipped} disabled={busy === item.id} onclick={() => equip(item)}>
-              {item.equipped ? '✓ Equipped' : 'Equip'}
-            </button>
-          {:else}
-            <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buy(item)}>
-              💰 ${item.price.toLocaleString()}
-            </button>
-          {/if}
-        </div>
-      {/each}
-    </div>
+		<h2 class="section">Titles</h2>
+		<div class="grid">
+			{#each titles as item}
+				<div class="card" class:owned={item.owned}>
+					<span class="c-label">{item.label}</span>
+					{#if item.owned}
+						<button
+							class="c-btn equip"
+							class:on={item.equipped}
+							disabled={busy === item.id}
+							onclick={() => equip(item)}
+						>
+							{item.equipped ? '✓ Equipped' : 'Equip'}
+						</button>
+					{:else}
+						<button
+							class="c-btn buy"
+							disabled={busy === item.id || bank < item.price}
+							onclick={() => buy(item)}
+						>
+							💰 ${item.price.toLocaleString()}
+						</button>
+					{/if}
+				</div>
+			{/each}
+		</div>
 
-    <h2 class="section">Name Colors</h2>
-    <div class="grid">
-      {#each colors as item}
-        <div class="card" class:owned={item.owned}>
-          <span class="c-label" style="color:{item.value}">{item.label}</span>
-          {#if item.owned}
-            <button class="c-btn equip" class:on={item.equipped} disabled={busy === item.id} onclick={() => equip(item)}>
-              {item.equipped ? '✓ Equipped' : 'Equip'}
-            </button>
-          {:else}
-            <button class="c-btn buy" disabled={busy === item.id || bank < item.price} onclick={() => buy(item)}>
-              💰 ${item.price.toLocaleString()}
-            </button>
-          {/if}
-        </div>
-      {/each}
-    </div>
-  {/if}
+		<h2 class="section">Name Colors</h2>
+		<div class="grid">
+			{#each colors as item}
+				<div class="card" class:owned={item.owned}>
+					<span class="c-label" style="color:{item.value}">{item.label}</span>
+					{#if item.owned}
+						<button
+							class="c-btn equip"
+							class:on={item.equipped}
+							disabled={busy === item.id}
+							onclick={() => equip(item)}
+						>
+							{item.equipped ? '✓ Equipped' : 'Equip'}
+						</button>
+					{:else}
+						<button
+							class="c-btn buy"
+							disabled={busy === item.id || bank < item.price}
+							onclick={() => buy(item)}
+						>
+							💰 ${item.price.toLocaleString()}
+						</button>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	{/if}
 </main>
 
 <style>
-  .shop-page { max-width: 480px; margin: 0 auto; padding: 1.5rem 1rem 3rem; }
-  .back-btn {
-    display: inline-block; margin-bottom: 1.2rem; padding: 0.55rem 1.1rem;
-    background: var(--surface); color: var(--text); border: 1px solid var(--border);
-    border-radius: 12px; cursor: pointer; font-weight: 600; font-size: 0.9rem;
-  }
-  .head { display: flex; align-items: baseline; justify-content: space-between; }
-  h1 { font-family: var(--font-display); font-size: 1.7rem; margin: 0; }
-  .bank-chip { font-family: var(--font-display); font-weight: 800; color: #fbbf24; font-size: 1.05rem; }
-  .sub { color: var(--text-muted); font-size: 0.9rem; margin: 0.2rem 0 1.4rem; }
-  .loading { color: var(--text-muted); padding: 2rem; text-align: center; }
-  .msg { text-align: center; color: #f87171; font-size: 0.88rem; margin: 0 0 1rem; }
-  .owned-x { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 0.78rem; color: #fde047; }
-  .inv-details { margin: 0 0 0.4rem; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); padding: 0 0.9rem; }
-  .inv-summary { cursor: pointer; padding: 0.85rem 0; font-family: var(--font-display); font-weight: 700; font-size: 0.98rem; list-style: none; }
-  .inv-summary::-webkit-details-marker { display: none; }
-  .inv-summary::after { content: ' ▾'; color: var(--text-faint); }
-  .inv-details[open] .inv-summary::after { content: ' ▴'; }
-  .inv-details[open] { padding-bottom: 0.9rem; }
-  .section { font-family: var(--font-display); font-size: 1.05rem; margin: 1.4rem 0 0.4rem; }
-  .section-note { font-size: 0.76rem; color: var(--text-faint); margin: 0 0 0.8rem; }
-  .card.pup { align-items: center; text-align: center; gap: 0.3rem; }
-  .pup-ic { font-size: 1.7rem; line-height: 1; }
-  .pup-desc { font-size: 0.72rem; color: var(--text-muted); line-height: 1.3; min-height: 2.1em; }
-  .card.pup .c-btn { margin-top: 0.3rem; }
-  .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.6rem; }
-  .card {
-    display: flex; flex-direction: column; gap: 0.6rem; align-items: flex-start;
-    padding: 0.9rem; border-radius: 14px; border: 1px solid var(--border); background: var(--surface);
-  }
-  .card.owned { border-color: rgba(253, 224, 71,0.35); }
-  .c-label { font-family: var(--font-display); font-weight: 700; font-size: 1rem; }
-  .c-btn {
-    width: 100%; padding: 0.5rem 0.7rem; border-radius: 10px; cursor: pointer; font-weight: 700; font-size: 0.85rem;
-    border: 1px solid var(--border); background: var(--surface-2, rgba(255,255,255,0.04)); color: var(--text);
-  }
-  .c-btn.buy { color: #3a2a00; border: none; background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); }
-  .c-btn.buy:disabled { opacity: 0.45; cursor: default; }
-  .c-btn.equip.on { color: var(--brand-2); border-color: rgba(253, 224, 71,0.5); background: rgba(253, 224, 71,0.1); }
-  .c-btn:disabled { opacity: 0.6; }
+	.shop-page {
+		max-width: 480px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem 3rem;
+	}
+	.back-btn {
+		display: inline-block;
+		margin-bottom: 1.2rem;
+		padding: 0.55rem 1.1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.7rem;
+		margin: 0;
+	}
+	.bank-chip {
+		font-family: var(--font-display);
+		font-weight: 800;
+		color: #fbbf24;
+		font-size: 1.05rem;
+	}
+	.sub {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin: 0.2rem 0 1.4rem;
+	}
+	.loading {
+		color: var(--text-muted);
+		padding: 2rem;
+		text-align: center;
+	}
+	.msg {
+		text-align: center;
+		color: #f87171;
+		font-size: 0.88rem;
+		margin: 0 0 1rem;
+	}
+	.owned-x {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 0.78rem;
+		color: #fde047;
+	}
+	.inv-details {
+		margin: 0 0 0.4rem;
+		border: 1px solid var(--border);
+		border-radius: 14px;
+		background: var(--surface);
+		padding: 0 0.9rem;
+	}
+	.inv-summary {
+		cursor: pointer;
+		padding: 0.85rem 0;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.98rem;
+		list-style: none;
+	}
+	.inv-summary::-webkit-details-marker {
+		display: none;
+	}
+	.inv-summary::after {
+		content: ' ▾';
+		color: var(--text-faint);
+	}
+	.inv-details[open] .inv-summary::after {
+		content: ' ▴';
+	}
+	.inv-details[open] {
+		padding-bottom: 0.9rem;
+	}
+	.section {
+		font-family: var(--font-display);
+		font-size: 1.05rem;
+		margin: 1.4rem 0 0.4rem;
+	}
+	.section-note {
+		font-size: 0.76rem;
+		color: var(--text-faint);
+		margin: 0 0 0.8rem;
+	}
+	.card.pup {
+		align-items: center;
+		text-align: center;
+		gap: 0.3rem;
+	}
+	.pup-ic {
+		font-size: 1.7rem;
+		line-height: 1;
+	}
+	.pup-desc {
+		font-size: 0.72rem;
+		color: var(--text-muted);
+		line-height: 1.3;
+		min-height: 2.1em;
+	}
+	.card.pup .c-btn {
+		margin-top: 0.3rem;
+	}
+	.grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0.6rem;
+	}
+	.card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		align-items: flex-start;
+		padding: 0.9rem;
+		border-radius: 14px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.card.owned {
+		border-color: rgba(253, 224, 71, 0.35);
+	}
+	.c-label {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1rem;
+	}
+	.c-btn {
+		width: 100%;
+		padding: 0.5rem 0.7rem;
+		border-radius: 10px;
+		cursor: pointer;
+		font-weight: 700;
+		font-size: 0.85rem;
+		border: 1px solid var(--border);
+		background: var(--surface-2, rgba(255, 255, 255, 0.04));
+		color: var(--text);
+	}
+	.c-btn.buy {
+		color: #3a2a00;
+		border: none;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.c-btn.buy:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.c-btn.equip.on {
+		color: var(--brand-2);
+		border-color: rgba(253, 224, 71, 0.5);
+		background: rgba(253, 224, 71, 0.1);
+	}
+	.c-btn:disabled {
+		opacity: 0.6;
+	}
 </style>

--- a/src/routes/streak/+page.svelte
+++ b/src/routes/streak/+page.svelte
@@ -1,204 +1,422 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import { getStreakOverview } from '$lib/stores/statsStore.js';
-  import { enterMakeup } from '$lib/stores/GameStore.js';
-  import { track } from '$lib/analytics.js';
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { getStreakOverview } from '$lib/stores/statsStore.js';
+	import { enterMakeup } from '$lib/stores/GameStore.js';
+	import { track } from '$lib/analytics.js';
 
-  /** @type {{ current_streak:number, highest_streak:number, freezes:number, days:{d:string,won:boolean}[] }|null} */
-  let ov = null;
-  let loading = true;
-  let showFreezeInfo = false;
+	/** @type {{ current_streak:number, highest_streak:number, freezes:number, days:{d:string,won:boolean}[] }|null} */
+	let ov = null;
+	let loading = true;
+	let showFreezeInfo = false;
 
-  onMount(async () => {
-    track('streak_view');
-    try { ov = await getStreakOverview(); }
-    finally { loading = false; }
-  });
+	onMount(async () => {
+		track('streak_view');
+		try {
+			ov = await getStreakOverview();
+		} finally {
+			loading = false;
+		}
+	});
 
-  // Motivational line (Duolingo-style).
-  $: nudge = (() => {
-    if (!ov) return '';
-    const c = ov.current_streak, h = ov.highest_streak;
-    if (c === 0) return 'Win today’s Daily to start a streak!';
-    if (c >= h) return 'You’re on your longest streak ever — keep it alive!';
-    const away = (h + 1) - c;
-    return `You’re ${away} day${away === 1 ? '' : 's'} from a new personal best (${h}).`;
-  })();
+	// Motivational line (Duolingo-style).
+	$: nudge = (() => {
+		if (!ov) return '';
+		const c = ov.current_streak,
+			h = ov.highest_streak;
+		if (c === 0) return 'Win today’s Daily to start a streak!';
+		if (c >= h) return 'You’re on your longest streak ever — keep it alive!';
+		const away = h + 1 - c;
+		return `You’re ${away} day${away === 1 ? '' : 's'} from a new personal best (${h}).`;
+	})();
 
-  // ---- Current-month calendar heatmap ----
-  const WD = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
-  const MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
-  const now = new Date();
-  const year = now.getFullYear(), month = now.getMonth(), todayDate = now.getDate();
-  const pad = (/** @type {number} */ n) => String(n).padStart(2, '0');
+	// ---- Current-month calendar heatmap ----
+	const WD = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+	const MONTHS = [
+		'January',
+		'February',
+		'March',
+		'April',
+		'May',
+		'June',
+		'July',
+		'August',
+		'September',
+		'October',
+		'November',
+		'December'
+	];
+	const now = new Date();
+	const year = now.getFullYear(),
+		month = now.getMonth(),
+		todayDate = now.getDate();
+	const pad = (/** @type {number} */ n) => String(n).padStart(2, '0');
 
-  /** @type {Map<string, boolean>} date 'YYYY-MM-DD' -> won */
-  $: dayMap = (() => {
-    const m = new Map();
-    for (const e of ov?.days ?? []) m.set(String(e.d).slice(0, 10), !!e.won);
-    return m;
-  })();
+	/** @type {Map<string, boolean>} date 'YYYY-MM-DD' -> won */
+	$: dayMap = (() => {
+		const m = new Map();
+		for (const e of ov?.days ?? []) m.set(String(e.d).slice(0, 10), !!e.won);
+		return m;
+	})();
 
-  // grid cells: leading blanks for the first weekday, then each day with a status
-  $: cells = (() => {
-    const firstWeekday = new Date(year, month, 1).getDay();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    /** @type {{blank?:boolean, day?:number, key?:string, status?:string, isToday?:boolean, playable?:boolean}[]} */
-    const out = [];
-    for (let i = 0; i < firstWeekday; i++) out.push({ blank: true });
-    for (let d = 1; d <= daysInMonth; d++) {
-      const key = `${year}-${pad(month + 1)}-${pad(d)}`;
-      let status = 'none';
-      if (d > todayDate) status = 'future';
-      else if (dayMap.has(key)) status = dayMap.get(key) ? 'won' : 'lost';
-      // A past day this month that was never played → make it up.
-      const playable = status === 'none' && d < todayDate;
-      out.push({ day: d, key, status, isToday: d === todayDate, playable });
-    }
-    return out;
-  })();
+	// grid cells: leading blanks for the first weekday, then each day with a status
+	$: cells = (() => {
+		const firstWeekday = new Date(year, month, 1).getDay();
+		const daysInMonth = new Date(year, month + 1, 0).getDate();
+		/** @type {{blank?:boolean, day?:number, key?:string, status?:string, isToday?:boolean, playable?:boolean}[]} */
+		const out = [];
+		for (let i = 0; i < firstWeekday; i++) out.push({ blank: true });
+		for (let d = 1; d <= daysInMonth; d++) {
+			const key = `${year}-${pad(month + 1)}-${pad(d)}`;
+			let status = 'none';
+			if (d > todayDate) status = 'future';
+			else if (dayMap.has(key)) status = dayMap.get(key) ? 'won' : 'lost';
+			// A past day this month that was never played → make it up.
+			const playable = status === 'none' && d < todayDate;
+			out.push({ day: d, key, status, isToday: d === todayDate, playable });
+		}
+		return out;
+	})();
 
-  let starting = false;
-  /** @param {any} c */
-  async function onCellClick(c) {
-    if (starting) return;
-    if (c.playable && c.key) {
-      starting = true;
-      track('makeup_calendar_click', { date: c.key });
-      const ok = await enterMakeup(c.key);
-      starting = false;
-      if (ok) goto('/');
-    } else if (c.isToday && c.status === 'none') {
-      goto('/'); // today's daily is played from the menu
-    }
-  }
+	let starting = false;
+	/** @param {any} c */
+	async function onCellClick(c) {
+		if (starting) return;
+		if (c.playable && c.key) {
+			starting = true;
+			track('makeup_calendar_click', { date: c.key });
+			const ok = await enterMakeup(c.key);
+			starting = false;
+			if (ok) goto('/');
+		} else if (c.isToday && c.status === 'none') {
+			goto('/'); // today's daily is played from the menu
+		}
+	}
 </script>
 
 <svelte:head><title>WordBank — Daily Calendar</title></svelte:head>
 
 <main class="streak-page">
-  <PageNav />
+	<PageNav />
 
-  {#if loading}
-    <p class="loading">Loading…</p>
-  {:else}
-    <div class="hero">
-      <div class="flame" class:lit={ov && ov.current_streak > 0}>🔥</div>
-      <div class="count">{ov?.current_streak ?? 0}</div>
-      <div class="count-label">play streak</div>
-    </div>
+	{#if loading}
+		<p class="loading">Loading…</p>
+	{:else}
+		<div class="hero">
+			<div class="flame" class:lit={ov && ov.current_streak > 0}>🔥</div>
+			<div class="count">{ov?.current_streak ?? 0}</div>
+			<div class="count-label">play streak</div>
+		</div>
 
-    {#if nudge}<p class="nudge">{nudge}</p>{/if}
+		{#if nudge}<p class="nudge">{nudge}</p>{/if}
 
-    <div class="stat-row">
-      <div class="stat"><span class="sv">{ov?.highest_streak ?? 0}</span><span class="sc">Longest</span></div>
-      <button class="stat stat-tap" on:click={() => showFreezeInfo = !showFreezeInfo}><span class="sv">❄️ {ov?.freezes ?? 0}</span><span class="sc">Freezes ›</span></button>
-      <div class="stat"><span class="sv">{dayMap.size}</span><span class="sc">Days played</span></div>
-    </div>
-    {#if showFreezeInfo}
-      <div class="freeze-info">
-        <b>❄️ Streak freezes</b> protect your play streak. Miss a single day and a freeze is spent automatically — your streak keeps going. You earn one every 7 days you show up (max 3). Miss two days in a row and the streak resets.
-      </div>
-    {/if}
+		<div class="stat-row">
+			<div class="stat">
+				<span class="sv">{ov?.highest_streak ?? 0}</span><span class="sc">Longest</span>
+			</div>
+			<button class="stat stat-tap" on:click={() => (showFreezeInfo = !showFreezeInfo)}
+				><span class="sv">❄️ {ov?.freezes ?? 0}</span><span class="sc">Freezes ›</span></button
+			>
+			<div class="stat">
+				<span class="sv">{dayMap.size}</span><span class="sc">Days played</span>
+			</div>
+		</div>
+		{#if showFreezeInfo}
+			<div class="freeze-info">
+				<b>❄️ Streak freezes</b> protect your play streak. Miss a single day and a freeze is spent automatically
+				— your streak keeps going. You earn one every 7 days you show up (max 3). Miss two days in a
+				row and the streak resets.
+			</div>
+		{/if}
 
-    <div class="cal">
-      <h2 class="cal-title">{MONTHS[month]} {year}</h2>
-      <div class="cal-grid">
-        {#each WD as w}<div class="wd">{w}</div>{/each}
-        {#each cells as c}
-          {#if c.blank}
-            <div class="cell blank"></div>
-          {:else if c.playable}
-            <button class="cell none playable" class:today={c.isToday} disabled={starting}
-              title={`Play ${MONTHS[month]} ${c.day}`} on:click={() => onCellClick(c)}>
-              <span class="cell-day">{c.day}</span><span class="cell-play">▶</span>
-            </button>
-          {:else}
-            <div class="cell {c.status}" class:today={c.isToday} title={`${MONTHS[month]} ${c.day}`}>
-              {#if c.status === 'won'}🔥{:else}{c.day}{/if}
-            </div>
-          {/if}
-        {/each}
-      </div>
-      <p class="makeup-hint">Tap a ▶ day to play that puzzle and fill your calendar — earns 🗓️ Perfect Week / 📅 Perfect Month badges. (Doesn’t change your streak.)</p>
-      <div class="legend">
-        <span><i class="dot won"></i> Won</span>
-        <span><i class="dot lost"></i> Missed</span>
-        <span><i class="dot play"></i> Make up</span>
-      </div>
-    </div>
-  {/if}
+		<div class="cal">
+			<h2 class="cal-title">{MONTHS[month]} {year}</h2>
+			<div class="cal-grid">
+				{#each WD as w}<div class="wd">{w}</div>{/each}
+				{#each cells as c}
+					{#if c.blank}
+						<div class="cell blank"></div>
+					{:else if c.playable}
+						<button
+							class="cell none playable"
+							class:today={c.isToday}
+							disabled={starting}
+							title={`Play ${MONTHS[month]} ${c.day}`}
+							on:click={() => onCellClick(c)}
+						>
+							<span class="cell-day">{c.day}</span><span class="cell-play">▶</span>
+						</button>
+					{:else}
+						<div
+							class="cell {c.status}"
+							class:today={c.isToday}
+							title={`${MONTHS[month]} ${c.day}`}
+						>
+							{#if c.status === 'won'}🔥{:else}{c.day}{/if}
+						</div>
+					{/if}
+				{/each}
+			</div>
+			<p class="makeup-hint">
+				Tap a ▶ day to play that puzzle and fill your calendar — earns 🗓️ Perfect Week / 📅 Perfect
+				Month badges. (Doesn’t change your streak.)
+			</p>
+			<div class="legend">
+				<span><i class="dot won"></i> Won</span>
+				<span><i class="dot lost"></i> Missed</span>
+				<span><i class="dot play"></i> Make up</span>
+			</div>
+		</div>
+	{/if}
 </main>
 
 <style>
-  .streak-page { max-width: 460px; margin: 0 auto; padding: 1.5rem 1rem 3rem; text-align: center; }
-  .back-btn {
-    display: inline-block; margin-bottom: 1.2rem; padding: 0.55rem 1.1rem;
-    background: var(--surface); color: var(--text); border: 1px solid var(--border);
-    border-radius: var(--r-md, 12px); cursor: pointer; font-weight: 600; font-size: 0.9rem;
-  }
-  .loading { color: var(--text-muted); padding: 2rem; }
+	.streak-page {
+		max-width: 460px;
+		margin: 0 auto;
+		padding: 1.5rem 1rem 3rem;
+		text-align: center;
+	}
+	.back-btn {
+		display: inline-block;
+		margin-bottom: 1.2rem;
+		padding: 0.55rem 1.1rem;
+		background: var(--surface);
+		color: var(--text);
+		border: 1px solid var(--border);
+		border-radius: var(--r-md, 12px);
+		cursor: pointer;
+		font-weight: 600;
+		font-size: 0.9rem;
+	}
+	.loading {
+		color: var(--text-muted);
+		padding: 2rem;
+	}
 
-  .hero { display: flex; flex-direction: column; align-items: center; gap: 2px; margin-top: 0.5rem; }
-  .flame { font-size: 4.2rem; line-height: 1; filter: grayscale(1) opacity(0.4); }
-  .flame.lit { filter: none; animation: flamePulse 2.2s ease-in-out infinite; }
-  @keyframes flamePulse { 0%,100% { transform: scale(1); } 50% { transform: scale(1.08); } }
-  .count { font-family: var(--font-display); font-weight: 800; font-size: 3.4rem; line-height: 1; color: var(--brand-2); }
-  .count-label { color: var(--text-muted); font-size: 0.95rem; text-transform: uppercase; letter-spacing: 0.06em; }
+	.hero {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 2px;
+		margin-top: 0.5rem;
+	}
+	.flame {
+		font-size: 4.2rem;
+		line-height: 1;
+		filter: grayscale(1) opacity(0.4);
+	}
+	.flame.lit {
+		filter: none;
+		animation: flamePulse 2.2s ease-in-out infinite;
+	}
+	@keyframes flamePulse {
+		0%,
+		100% {
+			transform: scale(1);
+		}
+		50% {
+			transform: scale(1.08);
+		}
+	}
+	.count {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 3.4rem;
+		line-height: 1;
+		color: var(--brand-2);
+	}
+	.count-label {
+		color: var(--text-muted);
+		font-size: 0.95rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
 
-  .nudge {
-    margin: 1.1rem auto 0; max-width: 340px; padding: 0.8rem 1rem;
-    background: rgba(251, 191, 36, 0.1); border: 1px solid rgba(251, 191, 36, 0.35);
-    border-radius: 14px; color: #fcd34d; font-weight: 600; font-size: 0.95rem;
-  }
+	.nudge {
+		margin: 1.1rem auto 0;
+		max-width: 340px;
+		padding: 0.8rem 1rem;
+		background: rgba(251, 191, 36, 0.1);
+		border: 1px solid rgba(251, 191, 36, 0.35);
+		border-radius: 14px;
+		color: #fcd34d;
+		font-weight: 600;
+		font-size: 0.95rem;
+	}
 
-  .stat-row { display: flex; justify-content: center; gap: 0.6rem; margin: 1.4rem 0 0.5rem; }
-  .stat {
-    flex: 1; max-width: 120px; display: flex; flex-direction: column; align-items: center; gap: 3px;
-    padding: 0.7rem 0.4rem; background: var(--surface); border: 1px solid var(--border); border-radius: 14px;
-  }
-  .stat-tap { cursor: pointer; color: var(--text); font: inherit; }
-  .stat-tap:hover { border-color: var(--brand-2); }
-  .stat-tap .sc { color: var(--brand-2); }
-  .freeze-info { margin: 0.4rem auto 0; max-width: 340px; padding: 0.7rem 0.9rem; border-radius: 12px; font-size: 0.82rem; line-height: 1.5;
-    color: var(--text-muted); background: rgba(96,165,250,0.1); border: 1px solid rgba(96,165,250,0.3); }
-  .freeze-info b { color: #93c5fd; }
-  .sv { font-family: var(--font-display); font-weight: 700; font-size: 1.2rem; color: var(--text); }
-  .sc { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-faint); }
+	.stat-row {
+		display: flex;
+		justify-content: center;
+		gap: 0.6rem;
+		margin: 1.4rem 0 0.5rem;
+	}
+	.stat {
+		flex: 1;
+		max-width: 120px;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 3px;
+		padding: 0.7rem 0.4rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 14px;
+	}
+	.stat-tap {
+		cursor: pointer;
+		color: var(--text);
+		font: inherit;
+	}
+	.stat-tap:hover {
+		border-color: var(--brand-2);
+	}
+	.stat-tap .sc {
+		color: var(--brand-2);
+	}
+	.freeze-info {
+		margin: 0.4rem auto 0;
+		max-width: 340px;
+		padding: 0.7rem 0.9rem;
+		border-radius: 12px;
+		font-size: 0.82rem;
+		line-height: 1.5;
+		color: var(--text-muted);
+		background: rgba(96, 165, 250, 0.1);
+		border: 1px solid rgba(96, 165, 250, 0.3);
+	}
+	.freeze-info b {
+		color: #93c5fd;
+	}
+	.sv {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 1.2rem;
+		color: var(--text);
+	}
+	.sc {
+		font-size: 0.7rem;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-faint);
+	}
 
-  .cal { margin-top: 1.8rem; }
-  .cal-title { font-family: var(--font-display); font-size: 1.05rem; margin: 0 0 0.8rem; }
-  .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 6px; }
-  .wd { font-size: 0.7rem; color: var(--text-faint); padding-bottom: 2px; }
-  .cell {
-    aspect-ratio: 1; display: grid; place-items: center; border-radius: 9px;
-    font-size: 0.8rem; font-weight: 600; color: var(--text-muted);
-    background: rgba(255,255,255,0.03); border: 1px solid var(--border);
-  }
-  .cell.blank { background: none; border: none; }
-  .cell.won { background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border-color: transparent; color: #3a2a00; }
-  .cell.lost { background: rgba(251, 113, 133, 0.12); border-color: rgba(251,113,133,0.3); color: #fb7185; }
-  .cell.none { color: var(--text-faint); }
-  .cell.future { opacity: 0.3; }
-  .cell.today { box-shadow: 0 0 0 2px var(--brand-2); }
-  /* make-up (playable) cells */
-  .cell.playable {
-    position: relative; cursor: pointer; color: var(--text);
-    border-color: rgba(56,189,248,0.45); background: rgba(56,189,248,0.08);
-    transition: transform 0.12s, background 0.15s;
-  }
-  .cell.playable:hover { background: rgba(56,189,248,0.16); transform: translateY(-1px); }
-  .cell.playable:disabled { opacity: 0.5; cursor: default; }
-  .cell.playable .cell-day { font-size: 0.8rem; }
-  .cell.playable .cell-play { position: absolute; bottom: 2px; right: 4px; font-size: 0.5rem; color: #38bdf8; }
+	.cal {
+		margin-top: 1.8rem;
+	}
+	.cal-title {
+		font-family: var(--font-display);
+		font-size: 1.05rem;
+		margin: 0 0 0.8rem;
+	}
+	.cal-grid {
+		display: grid;
+		grid-template-columns: repeat(7, 1fr);
+		gap: 6px;
+	}
+	.wd {
+		font-size: 0.7rem;
+		color: var(--text-faint);
+		padding-bottom: 2px;
+	}
+	.cell {
+		aspect-ratio: 1;
+		display: grid;
+		place-items: center;
+		border-radius: 9px;
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: var(--text-muted);
+		background: rgba(255, 255, 255, 0.03);
+		border: 1px solid var(--border);
+	}
+	.cell.blank {
+		background: none;
+		border: none;
+	}
+	.cell.won {
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		border-color: transparent;
+		color: #3a2a00;
+	}
+	.cell.lost {
+		background: rgba(251, 113, 133, 0.12);
+		border-color: rgba(251, 113, 133, 0.3);
+		color: #fb7185;
+	}
+	.cell.none {
+		color: var(--text-faint);
+	}
+	.cell.future {
+		opacity: 0.3;
+	}
+	.cell.today {
+		box-shadow: 0 0 0 2px var(--brand-2);
+	}
+	/* make-up (playable) cells */
+	.cell.playable {
+		position: relative;
+		cursor: pointer;
+		color: var(--text);
+		border-color: rgba(56, 189, 248, 0.45);
+		background: rgba(56, 189, 248, 0.08);
+		transition:
+			transform 0.12s,
+			background 0.15s;
+	}
+	.cell.playable:hover {
+		background: rgba(56, 189, 248, 0.16);
+		transform: translateY(-1px);
+	}
+	.cell.playable:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.cell.playable .cell-day {
+		font-size: 0.8rem;
+	}
+	.cell.playable .cell-play {
+		position: absolute;
+		bottom: 2px;
+		right: 4px;
+		font-size: 0.5rem;
+		color: #38bdf8;
+	}
 
-  .makeup-hint { font-size: 0.74rem; color: var(--text-muted); margin: 0.9rem 0 0; line-height: 1.4; }
-  .legend { display: flex; justify-content: center; gap: 1rem; margin-top: 1rem; font-size: 0.75rem; color: var(--text-faint); }
-  .legend span { display: inline-flex; align-items: center; gap: 5px; }
-  .dot { width: 11px; height: 11px; border-radius: 4px; display: inline-block; }
-  .dot.won { background: linear-gradient(135deg,#fbbf24,#fde047); }
-  .dot.lost { background: rgba(251,113,133,0.4); }
-  .dot.play { background: rgba(56,189,248,0.3); border: 1px solid rgba(56,189,248,0.5); }
+	.makeup-hint {
+		font-size: 0.74rem;
+		color: var(--text-muted);
+		margin: 0.9rem 0 0;
+		line-height: 1.4;
+	}
+	.legend {
+		display: flex;
+		justify-content: center;
+		gap: 1rem;
+		margin-top: 1rem;
+		font-size: 0.75rem;
+		color: var(--text-faint);
+	}
+	.legend span {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+	}
+	.dot {
+		width: 11px;
+		height: 11px;
+		border-radius: 4px;
+		display: inline-block;
+	}
+	.dot.won {
+		background: linear-gradient(135deg, #fbbf24, #fde047);
+	}
+	.dot.lost {
+		background: rgba(251, 113, 133, 0.4);
+	}
+	.dot.play {
+		background: rgba(56, 189, 248, 0.3);
+		border: 1px solid rgba(56, 189, 248, 0.5);
+	}
 </style>

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,119 +1,144 @@
 <script>
-  // Public, no-auth Terms of Service page. URL: /terms
-  // Used for TestFlight external testing + App Store submission.
-  const CONTACT = 'charlieforeman77@gmail.com';
-  const UPDATED = 'June 26, 2026';
+	// Public, no-auth Terms of Service page. URL: /terms
+	// Used for TestFlight external testing + App Store submission.
+	const CONTACT = 'charlieforeman77@gmail.com';
+	const UPDATED = 'June 26, 2026';
 </script>
 
 <svelte:head>
-  <title>WordBank — Terms of Service</title>
-  <meta name="robots" content="index" />
+	<title>WordBank — Terms of Service</title>
+	<meta name="robots" content="index" />
 </svelte:head>
 
 <main class="legal">
-  <h1>WordBank Terms of Service</h1>
-  <p class="updated">Last updated: {UPDATED}</p>
+	<h1>WordBank Terms of Service</h1>
+	<p class="updated">Last updated: {UPDATED}</p>
 
-  <p>
-    Welcome to WordBank ("we," "us," or "the app"), a word-puzzle game. By creating an
-    account or using the app, you agree to these Terms. If you don't agree, please don't
-    use WordBank.
-  </p>
+	<p>
+		Welcome to WordBank ("we," "us," or "the app"), a word-puzzle game. By creating an account or
+		using the app, you agree to these Terms. If you don't agree, please don't use WordBank.
+	</p>
 
-  <h2>The service</h2>
-  <p>
-    WordBank is a game where you solve hidden phrases, play a shared Daily, climb for
-    in-game Cash, and challenge other players. We provide the app "as is" and may add,
-    change, or remove features over time.
-  </p>
+	<h2>The service</h2>
+	<p>
+		WordBank is a game where you solve hidden phrases, play a shared Daily, climb for in-game Cash,
+		and challenge other players. We provide the app "as is" and may add, change, or remove features
+		over time.
+	</p>
 
-  <h2>Virtual currency ("Cash")</h2>
-  <ul>
-    <li>The "Cash," "$", and balances in WordBank are <strong>virtual, in-game points
-      only</strong>. They have <strong>no real-world monetary value</strong>.</li>
-    <li>Virtual Cash <strong>cannot be purchased, sold, withdrawn, or exchanged</strong>
-      for real money or anything of value.</li>
-    <li>Challenges and wagers between players are played entirely with this virtual
-      Cash. They are <strong>not gambling</strong> and involve no real money.</li>
-    <li>We may adjust, reset, or remove virtual balances as part of running and balancing
-      the game.</li>
-  </ul>
+	<h2>Virtual currency ("Cash")</h2>
+	<ul>
+		<li>
+			The "Cash," "$", and balances in WordBank are <strong>virtual, in-game points only</strong>.
+			They have <strong>no real-world monetary value</strong>.
+		</li>
+		<li>
+			Virtual Cash <strong>cannot be purchased, sold, withdrawn, or exchanged</strong>
+			for real money or anything of value.
+		</li>
+		<li>
+			Challenges and wagers between players are played entirely with this virtual Cash. They are <strong
+				>not gambling</strong
+			> and involve no real money.
+		</li>
+		<li>
+			We may adjust, reset, or remove virtual balances as part of running and balancing the game.
+		</li>
+	</ul>
 
-  <h2>Your account</h2>
-  <ul>
-    <li>You're responsible for activity on your account and for keeping your login secure.</li>
-    <li>Provide accurate information and use the app only if you're old enough to do so
-      in your country (and at least 13).</li>
-    <li>Pick a username that isn't offensive or impersonating someone else; we may
-      reclaim or change usernames that violate this.</li>
-  </ul>
+	<h2>Your account</h2>
+	<ul>
+		<li>You're responsible for activity on your account and for keeping your login secure.</li>
+		<li>
+			Provide accurate information and use the app only if you're old enough to do so in your
+			country (and at least 13).
+		</li>
+		<li>
+			Pick a username that isn't offensive or impersonating someone else; we may reclaim or change
+			usernames that violate this.
+		</li>
+	</ul>
 
-  <h2>Fair play &amp; acceptable use</h2>
-  <p>You agree not to:</p>
-  <ul>
-    <li>Cheat, exploit bugs, automate play, or use tools/bots to gain an unfair advantage.</li>
-    <li>Harass other players or post abusive, illegal, or infringing content (e.g., in
-      challenge or group chat).</li>
-    <li>Attempt to access, disrupt, or reverse-engineer the app, its servers, or other
-      players' accounts.</li>
-  </ul>
-  <p>We may suspend or terminate accounts that break these rules.</p>
+	<h2>Fair play &amp; acceptable use</h2>
+	<p>You agree not to:</p>
+	<ul>
+		<li>Cheat, exploit bugs, automate play, or use tools/bots to gain an unfair advantage.</li>
+		<li>
+			Harass other players or post abusive, illegal, or infringing content (e.g., in challenge or
+			group chat).
+		</li>
+		<li>
+			Attempt to access, disrupt, or reverse-engineer the app, its servers, or other players'
+			accounts.
+		</li>
+	</ul>
+	<p>We may suspend or terminate accounts that break these rules.</p>
 
-  <h2>Deleting your account</h2>
-  <p>
-    You can permanently delete your account and all associated data at any time from
-    <strong>My Account → Delete Account</strong>. This is immediate and can't be undone.
-    We may also terminate accounts that violate these Terms.
-  </p>
+	<h2>Deleting your account</h2>
+	<p>
+		You can permanently delete your account and all associated data at any time from
+		<strong>My Account → Delete Account</strong>. This is immediate and can't be undone. We may also
+		terminate accounts that violate these Terms.
+	</p>
 
-  <h2>No warranty</h2>
-  <p>
-    WordBank is provided "as is" and "as available," without warranties of any kind. We
-    don't guarantee the app will always be available, error-free, or that scores,
-    streaks, or balances will never be affected by maintenance or fixes.
-  </p>
+	<h2>No warranty</h2>
+	<p>
+		WordBank is provided "as is" and "as available," without warranties of any kind. We don't
+		guarantee the app will always be available, error-free, or that scores, streaks, or balances
+		will never be affected by maintenance or fixes.
+	</p>
 
-  <h2>Limitation of liability</h2>
-  <p>
-    To the fullest extent permitted by law, we are not liable for any indirect,
-    incidental, or consequential damages, or for loss of virtual Cash, progress, or
-    data, arising from your use of the app.
-  </p>
+	<h2>Limitation of liability</h2>
+	<p>
+		To the fullest extent permitted by law, we are not liable for any indirect, incidental, or
+		consequential damages, or for loss of virtual Cash, progress, or data, arising from your use of
+		the app.
+	</p>
 
-  <h2>Changes to these Terms</h2>
-  <p>
-    We may update these Terms from time to time. We'll revise the "Last updated" date
-    above when we do; continuing to use the app means you accept the updated Terms.
-  </p>
+	<h2>Changes to these Terms</h2>
+	<p>
+		We may update these Terms from time to time. We'll revise the "Last updated" date above when we
+		do; continuing to use the app means you accept the updated Terms.
+	</p>
 
-  <h2>Contact</h2>
-  <p>
-    Questions about these Terms? Email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>. See
-    also our <a href="/privacy">Privacy Policy</a>.
-  </p>
+	<h2>Contact</h2>
+	<p>
+		Questions about these Terms? Email <a href={`mailto:${CONTACT}`}>{CONTACT}</a>. See also our
+		<a href="/privacy">Privacy Policy</a>.
+	</p>
 </main>
 
 <style>
-  .legal {
-    max-width: 720px;
-    margin: 0 auto;
-    padding: 2.5rem 1.25rem 4rem;
-    color: var(--text, #e6edf3);
-    line-height: 1.6;
-    font-size: 1rem;
-  }
-  h1 {
-    font-family: var(--font-display, system-ui, sans-serif);
-    font-size: 1.8rem;
-    margin: 0 0 0.25rem;
-  }
-  .updated { color: var(--text-faint, #8b98a9); font-size: 0.9rem; margin: 0 0 1.5rem; }
-  h2 {
-    font-family: var(--font-display, system-ui, sans-serif);
-    font-size: 1.15rem;
-    margin: 1.8rem 0 0.5rem;
-  }
-  ul { padding-left: 1.2rem; }
-  li { margin: 0.3rem 0; }
-  a { color: var(--brand-2, #fde047); }
+	.legal {
+		max-width: 720px;
+		margin: 0 auto;
+		padding: 2.5rem 1.25rem 4rem;
+		color: var(--text, #e6edf3);
+		line-height: 1.6;
+		font-size: 1rem;
+	}
+	h1 {
+		font-family: var(--font-display, system-ui, sans-serif);
+		font-size: 1.8rem;
+		margin: 0 0 0.25rem;
+	}
+	.updated {
+		color: var(--text-faint, #8b98a9);
+		font-size: 0.9rem;
+		margin: 0 0 1.5rem;
+	}
+	h2 {
+		font-family: var(--font-display, system-ui, sans-serif);
+		font-size: 1.15rem;
+		margin: 1.8rem 0 0.5rem;
+	}
+	ul {
+		padding-left: 1.2rem;
+	}
+	li {
+		margin: 0.3rem 0;
+	}
+	a {
+		color: var(--brand-2, #fde047);
+	}
 </style>

--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -1,232 +1,515 @@
 <script>
-  import { onMount } from 'svelte';
-  import { goto } from '$app/navigation';
-  import PageNav from "$lib/components/PageNav.svelte";
-  import { page } from '$app/stores';
-  import { getPublicProfile, addFriend, requestJoinGroup } from '$lib/stores/statsStore.js';
-  import Avatar from '$lib/components/Avatar.svelte';
-  import { track } from '$lib/analytics.js';
-  /** @type {Record<string,string>} */ let busyFriend = $state({});
-  /** @type {Record<string,string>} */ let groupState = $state({});
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import { page } from '$app/stores';
+	import { getPublicProfile, addFriend, requestJoinGroup } from '$lib/stores/statsStore.js';
+	import Avatar from '$lib/components/Avatar.svelte';
+	import { track } from '$lib/analytics.js';
+	/** @type {Record<string,string>} */ let busyFriend = $state({});
+	/** @type {Record<string,string>} */ let groupState = $state({});
 
-  /** @type {any} */
-  let p = $state(null);
-  let loading = $state(true);
-  let notFound = $state(false);
-  let addBusy = $state(false);
-  let addMsg = $state('');
+	/** @type {any} */
+	let p = $state(null);
+	let loading = $state(true);
+	let notFound = $state(false);
+	let addBusy = $state(false);
+	let addMsg = $state('');
 
-  const username = $derived($page.params.username);
+	const username = $derived($page.params.username);
 
-  const money = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
-  const mult = (/** @type {any} */ x) => x ? (Number(x) / 100).toFixed(1) + '×' : '—';
-  const winPct = (/** @type {any} */ a) =>
-    a?.games_played ? Math.round((a.games_won / a.games_played) * 100) + '%' : '—';
+	const money = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
+	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '—');
+	const winPct = (/** @type {any} */ a) =>
+		a?.games_played ? Math.round((a.games_won / a.games_played) * 100) + '%' : '—';
 
-  async function load() {
-    loading = true; notFound = false;
-    const d = await getPublicProfile($page.params.username);
-    p = d; notFound = !d; loading = false;
-  }
+	async function load() {
+		loading = true;
+		notFound = false;
+		const d = await getPublicProfile($page.params.username);
+		p = d;
+		notFound = !d;
+		loading = false;
+	}
 
-  async function add() {
-    if (addBusy || !p) return;
-    addBusy = true;
-    const res = await addFriend(p.username);
-    if (res?.ok) { addMsg = 'Request sent ✓'; p = { ...p, request_outgoing: true }; }
-    else addMsg = res?.reason || 'Could not send request';
-    addBusy = false;
-  }
+	async function add() {
+		if (addBusy || !p) return;
+		addBusy = true;
+		const res = await addFriend(p.username);
+		if (res?.ok) {
+			addMsg = 'Request sent ✓';
+			p = { ...p, request_outgoing: true };
+		} else addMsg = res?.reason || 'Could not send request';
+		addBusy = false;
+	}
 
-  /** @param {string} uname */
-  async function addOne(uname) {
-    if (busyFriend[uname]) return;
-    busyFriend = { ...busyFriend, [uname]: 'busy' };
-    const res = await addFriend(uname);
-    busyFriend = { ...busyFriend, [uname]: res?.ok ? 'sent' : 'err' };
-  }
-  /** @param {any} g */
-  async function join(g) {
-    if (groupState[g.id]) return;
-    groupState = { ...groupState, [g.id]: 'busy' };
-    const res = await requestJoinGroup(g.id);
-    groupState = { ...groupState, [g.id]: res?.ok ? 'requested' : 'err' };
-  }
+	/** @param {string} uname */
+	async function addOne(uname) {
+		if (busyFriend[uname]) return;
+		busyFriend = { ...busyFriend, [uname]: 'busy' };
+		const res = await addFriend(uname);
+		busyFriend = { ...busyFriend, [uname]: res?.ok ? 'sent' : 'err' };
+	}
+	/** @param {any} g */
+	async function join(g) {
+		if (groupState[g.id]) return;
+		groupState = { ...groupState, [g.id]: 'busy' };
+		const res = await requestJoinGroup(g.id);
+		groupState = { ...groupState, [g.id]: res?.ok ? 'requested' : 'err' };
+	}
 
-  onMount(() => { track('public_profile_view'); load(); });
-  $effect(() => { $page.params.username; load(); });
+	onMount(() => {
+		track('public_profile_view');
+		load();
+	});
+	$effect(() => {
+		$page.params.username;
+		load();
+	});
 </script>
 
 <svelte:head><title>WordBank — @{username}</title></svelte:head>
 
 <main class="u-page">
-  <PageNav />
+	<PageNav />
 
-  {#if loading}
-    <p class="msg">Loading…</p>
-  {:else if notFound}
-    <p class="msg">No player named <b>@{username}</b>.</p>
-  {:else}
-    <header class="u-head">
-      {#if p.avatar}
-        <Avatar config={p.avatar} fx size={110} />
-      {:else}
-        <div class="u-coin" style={p.color ? `--c:${p.color}` : ''}>{(p.name || p.username || '?').slice(0, 1).toUpperCase()}</div>
-      {/if}
-      <h1>@{p.username}</h1>
-      {#if p.title}<span class="u-title">{p.title}</span>{/if}
-      <div class="u-net" class:neg={Number(p.net_worth) < 0}>{money(p.net_worth)}</div>
-      <span class="u-net-lbl">Net Worth</span>
-    </header>
+	{#if loading}
+		<p class="msg">Loading…</p>
+	{:else if notFound}
+		<p class="msg">No player named <b>@{username}</b>.</p>
+	{:else}
+		<header class="u-head">
+			{#if p.avatar}
+				<Avatar config={p.avatar} fx size={110} />
+			{:else}
+				<div class="u-coin" style={p.color ? `--c:${p.color}` : ''}>
+					{(p.name || p.username || '?').slice(0, 1).toUpperCase()}
+				</div>
+			{/if}
+			<h1>@{p.username}</h1>
+			{#if p.title}<span class="u-title">{p.title}</span>{/if}
+			<div class="u-net" class:neg={Number(p.net_worth) < 0}>{money(p.net_worth)}</div>
+			<span class="u-net-lbl">Net Worth</span>
+		</header>
 
-    {#if !p.is_self}
-      <!-- Head-to-head -->
-      {@const h = p.head_to_head || {}}
-      <section class="h2h">
-        <div class="h2h-h">Your record vs @{p.username}</div>
-        <div class="h2h-tally">
-          <div class="t win"><b>{h.wins ?? 0}</b><span>W</span></div>
-          <div class="t loss"><b>{h.losses ?? 0}</b><span>L</span></div>
-          <div class="t tie"><b>{h.ties ?? 0}</b><span>T</span></div>
-        </div>
-        {#if (h.last5 ?? []).length}
-          <div class="h2h-last">
-            {#each h.last5 as g}
-              <span class="pip {g.outcome}">{g.outcome === 'won' ? 'W' : g.outcome === 'lost' ? 'L' : 'T'}</span>
-            {/each}
-          </div>
-        {:else}
-          <div class="h2h-empty">No challenges yet — send one!</div>
-        {/if}
-      </section>
+		{#if !p.is_self}
+			<!-- Head-to-head -->
+			{@const h = p.head_to_head || {}}
+			<section class="h2h">
+				<div class="h2h-h">Your record vs @{p.username}</div>
+				<div class="h2h-tally">
+					<div class="t win"><b>{h.wins ?? 0}</b><span>W</span></div>
+					<div class="t loss"><b>{h.losses ?? 0}</b><span>L</span></div>
+					<div class="t tie"><b>{h.ties ?? 0}</b><span>T</span></div>
+				</div>
+				{#if (h.last5 ?? []).length}
+					<div class="h2h-last">
+						{#each h.last5 as g}
+							<span class="pip {g.outcome}"
+								>{g.outcome === 'won' ? 'W' : g.outcome === 'lost' ? 'L' : 'T'}</span
+							>
+						{/each}
+					</div>
+				{:else}
+					<div class="h2h-empty">No challenges yet — send one!</div>
+				{/if}
+			</section>
 
-      <div class="u-actions">
-        {#if p.is_friend}
-          <span class="pill friend">✓ Friends</span>
-        {:else if p.request_outgoing}
-          <span class="pill muted">Request sent</span>
-        {:else if p.request_incoming}
-          <button class="pill" onclick={() => goto('/friends')}>Respond to request →</button>
-        {:else}
-          <button class="pill" disabled={addBusy} onclick={add}>+ Add friend</button>
-        {/if}
-        <button class="pill gold" onclick={() => goto('/?challenge=' + p.username)}>⚔️ Challenge</button>
-      </div>
-      {#if addMsg}<p class="add-msg">{addMsg}</p>{/if}
-    {:else}
-      <div class="u-actions"><button class="pill" onclick={() => goto('/profile')}>This is you → your stats</button></div>
-    {/if}
+			<div class="u-actions">
+				{#if p.is_friend}
+					<span class="pill friend">✓ Friends</span>
+				{:else if p.request_outgoing}
+					<span class="pill muted">Request sent</span>
+				{:else if p.request_incoming}
+					<button class="pill" onclick={() => goto('/friends')}>Respond to request →</button>
+				{:else}
+					<button class="pill" disabled={addBusy} onclick={add}>+ Add friend</button>
+				{/if}
+				<button class="pill gold" onclick={() => goto('/?challenge=' + p.username)}
+					>⚔️ Challenge</button
+				>
+			</div>
+			{#if addMsg}<p class="add-msg">{addMsg}</p>{/if}
+		{:else}
+			<div class="u-actions">
+				<button class="pill" onclick={() => goto('/profile')}>This is you → your stats</button>
+			</div>
+		{/if}
 
-    <section class="grid">
-      <div class="stat"><span class="s-n">🔥 {p.current_streak}</span><span class="s-l">Streak</span></div>
-      <div class="stat"><span class="s-n">{p.longest_streak}</span><span class="s-l">Best streak</span></div>
-      <div class="stat"><span class="s-n">{winPct(p)}</span><span class="s-l">Daily win %</span></div>
-      <div class="stat"><span class="s-n">{p.puzzles_solved}</span><span class="s-l">Puzzles solved</span></div>
-      <div class="stat"><span class="s-n">{p.challenge_wins}</span><span class="s-l">Challenge wins</span></div>
-      <div class="stat"><span class="s-n">#{p.climb_position}</span><span class="s-l">Furthest</span></div>
-      <div class="stat"><span class="s-n">{mult(p.avg_multiple_x100)}</span><span class="s-l">Avg multiple</span></div>
-      <div class="stat"><span class="s-n">{mult(p.best_multiple_x100)}</span><span class="s-l">Best multiple</span></div>
-    </section>
+		<section class="grid">
+			<div class="stat">
+				<span class="s-n">🔥 {p.current_streak}</span><span class="s-l">Streak</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">{p.longest_streak}</span><span class="s-l">Best streak</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">{winPct(p)}</span><span class="s-l">Daily win %</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">{p.puzzles_solved}</span><span class="s-l">Puzzles solved</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">{p.challenge_wins}</span><span class="s-l">Challenge wins</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">#{p.climb_position}</span><span class="s-l">Furthest</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">{mult(p.avg_multiple_x100)}</span><span class="s-l">Avg multiple</span>
+			</div>
+			<div class="stat">
+				<span class="s-n">{mult(p.best_multiple_x100)}</span><span class="s-l">Best multiple</span>
+			</div>
+		</section>
 
-    {#if (p.badges ?? []).length}
-      <section class="badges">
-        <div class="b-h">Badges · {p.badges.length}</div>
-        <div class="b-wrap">{#each p.badges as b}<span class="badge">🏅 {(b || '').replace(/_/g, ' ').replace(/\b\w/g, (/** @type {string} */ c) => c.toUpperCase())}</span>{/each}</div>
-      </section>
-    {/if}
+		{#if (p.badges ?? []).length}
+			<section class="badges">
+				<div class="b-h">Badges · {p.badges.length}</div>
+				<div class="b-wrap">
+					{#each p.badges as b}<span class="badge"
+							>🏅 {(b || '')
+								.replace(/_/g, ' ')
+								.replace(/\b\w/g, (/** @type {string} */ c) => c.toUpperCase())}</span
+						>{/each}
+				</div>
+			</section>
+		{/if}
 
-    {#if !p.is_self && (p.friends ?? []).length}
-      <section class="social">
-        <div class="b-h">Friends · {p.friends.length}</div>
-        {#each p.friends as f}
-          <div class="soc-row">
-            <button class="soc-main" onclick={() => goto('/u/' + encodeURIComponent(f.username))}>@{f.username}<span class="soc-go">›</span></button>
-            <button class="soc-act" disabled={!!busyFriend[f.username]} onclick={() => addOne(f.username)}>
-              {busyFriend[f.username] === 'sent' ? '✓ Sent' : busyFriend[f.username] === 'err' ? 'Failed' : '+ Add'}
-            </button>
-          </div>
-        {/each}
-      </section>
-    {/if}
+		{#if !p.is_self && (p.friends ?? []).length}
+			<section class="social">
+				<div class="b-h">Friends · {p.friends.length}</div>
+				{#each p.friends as f}
+					<div class="soc-row">
+						<button class="soc-main" onclick={() => goto('/u/' + encodeURIComponent(f.username))}
+							>@{f.username}<span class="soc-go">›</span></button
+						>
+						<button
+							class="soc-act"
+							disabled={!!busyFriend[f.username]}
+							onclick={() => addOne(f.username)}
+						>
+							{busyFriend[f.username] === 'sent'
+								? '✓ Sent'
+								: busyFriend[f.username] === 'err'
+									? 'Failed'
+									: '+ Add'}
+						</button>
+					</div>
+				{/each}
+			</section>
+		{/if}
 
-    {#if !p.is_self && (p.groups ?? []).length}
-      <section class="social">
-        <div class="b-h">Groups · {p.groups.length}</div>
-        {#each p.groups as g}
-          <div class="soc-row">
-            <span class="soc-main static">👥 {g.name}</span>
-            {#if g.my_status === 'member'}
-              <span class="soc-tag">✓ Member</span>
-            {:else if groupState[g.id] === 'requested' || g.my_status === 'requested'}
-              <span class="soc-tag">Requested</span>
-            {:else}
-              <button class="soc-act" disabled={groupState[g.id] === 'busy'} onclick={() => join(g)}>{groupState[g.id] === 'err' ? 'Failed' : 'Ask to join'}</button>
-            {/if}
-          </div>
-        {/each}
-      </section>
-    {/if}
-  {/if}
+		{#if !p.is_self && (p.groups ?? []).length}
+			<section class="social">
+				<div class="b-h">Groups · {p.groups.length}</div>
+				{#each p.groups as g}
+					<div class="soc-row">
+						<span class="soc-main static">👥 {g.name}</span>
+						{#if g.my_status === 'member'}
+							<span class="soc-tag">✓ Member</span>
+						{:else if groupState[g.id] === 'requested' || g.my_status === 'requested'}
+							<span class="soc-tag">Requested</span>
+						{:else}
+							<button class="soc-act" disabled={groupState[g.id] === 'busy'} onclick={() => join(g)}
+								>{groupState[g.id] === 'err' ? 'Failed' : 'Ask to join'}</button
+							>
+						{/if}
+					</div>
+				{/each}
+			</section>
+		{/if}
+	{/if}
 </main>
 
 <style>
-  .u-page { max-width: 520px; margin: 0 auto; padding: 16px 14px 60px; }
-  .back-btn { background: none; border: none; color: var(--text-muted); font-size: 0.92rem; cursor: pointer; padding: 6px 0; }
-  .msg { color: var(--text-muted); text-align: center; padding: 40px 0; }
+	.u-page {
+		max-width: 520px;
+		margin: 0 auto;
+		padding: 16px 14px 60px;
+	}
+	.back-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		cursor: pointer;
+		padding: 6px 0;
+	}
+	.msg {
+		color: var(--text-muted);
+		text-align: center;
+		padding: 40px 0;
+	}
 
-  .u-head { text-align: center; margin: 10px 0 20px; }
-  .u-coin { width: 72px; height: 72px; margin: 0 auto 10px; border-radius: 50%; display: grid; place-items: center;
-    font-family: var(--font-display); font-weight: 800; font-size: 1.8rem; color: #3a2a00;
-    background: linear-gradient(135deg, var(--c, #fde047), #f59e0b); box-shadow: 0 0 26px rgba(251,191,36,0.4); }
-  h1 { font-family: var(--font-display); font-size: 1.4rem; margin: 0; }
-  .u-title { display: inline-block; margin-top: 4px; font-size: 0.78rem; color: var(--gold); }
-  .u-net { font-family: 'Orbitron', var(--font-display); font-weight: 800; font-size: 2rem; color: #fde047;
-    margin-top: 12px; text-shadow: 0 0 18px rgba(251,191,36,0.5); }
-  .u-net.neg { color: #fb7185; text-shadow: none; }
-  .u-net-lbl { font-size: 0.72rem; color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.1em; }
+	.u-head {
+		text-align: center;
+		margin: 10px 0 20px;
+	}
+	.u-coin {
+		width: 72px;
+		height: 72px;
+		margin: 0 auto 10px;
+		border-radius: 50%;
+		display: grid;
+		place-items: center;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.8rem;
+		color: #3a2a00;
+		background: linear-gradient(135deg, var(--c, #fde047), #f59e0b);
+		box-shadow: 0 0 26px rgba(251, 191, 36, 0.4);
+	}
+	h1 {
+		font-family: var(--font-display);
+		font-size: 1.4rem;
+		margin: 0;
+	}
+	.u-title {
+		display: inline-block;
+		margin-top: 4px;
+		font-size: 0.78rem;
+		color: var(--gold);
+	}
+	.u-net {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 2rem;
+		color: #fde047;
+		margin-top: 12px;
+		text-shadow: 0 0 18px rgba(251, 191, 36, 0.5);
+	}
+	.u-net.neg {
+		color: #fb7185;
+		text-shadow: none;
+	}
+	.u-net-lbl {
+		font-size: 0.72rem;
+		color: var(--text-faint);
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+	}
 
-  .h2h { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-md); padding: 14px; margin-bottom: 14px; }
-  .h2h-h { color: var(--text-muted); font-size: 0.82rem; font-weight: 600; margin-bottom: 12px; text-align: center; }
-  .h2h-tally { display: flex; justify-content: center; gap: 22px; }
-  .t { display: flex; flex-direction: column; align-items: center; }
-  .t b { font-family: var(--font-display); font-size: 1.6rem; }
-  .t span { font-size: 0.7rem; color: var(--text-faint); }
-  .t.win b { color: #7ee0a8; } .t.loss b { color: #fb7185; } .t.tie b { color: var(--text-muted); }
-  .h2h-last { display: flex; justify-content: center; gap: 6px; margin-top: 12px; }
-  .pip { width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; font-size: 0.72rem; font-weight: 800; }
-  .pip.won { background: rgba(126,224,168,0.2); color: #7ee0a8; }
-  .pip.lost { background: rgba(251,113,133,0.2); color: #fb7185; }
-  .pip.tie { background: var(--surface-2); color: var(--text-muted); }
-  .h2h-empty { text-align: center; color: var(--text-faint); font-size: 0.8rem; margin-top: 10px; }
+	.h2h {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--r-md);
+		padding: 14px;
+		margin-bottom: 14px;
+	}
+	.h2h-h {
+		color: var(--text-muted);
+		font-size: 0.82rem;
+		font-weight: 600;
+		margin-bottom: 12px;
+		text-align: center;
+	}
+	.h2h-tally {
+		display: flex;
+		justify-content: center;
+		gap: 22px;
+	}
+	.t {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+	.t b {
+		font-family: var(--font-display);
+		font-size: 1.6rem;
+	}
+	.t span {
+		font-size: 0.7rem;
+		color: var(--text-faint);
+	}
+	.t.win b {
+		color: #7ee0a8;
+	}
+	.t.loss b {
+		color: #fb7185;
+	}
+	.t.tie b {
+		color: var(--text-muted);
+	}
+	.h2h-last {
+		display: flex;
+		justify-content: center;
+		gap: 6px;
+		margin-top: 12px;
+	}
+	.pip {
+		width: 22px;
+		height: 22px;
+		border-radius: 6px;
+		display: grid;
+		place-items: center;
+		font-size: 0.72rem;
+		font-weight: 800;
+	}
+	.pip.won {
+		background: rgba(126, 224, 168, 0.2);
+		color: #7ee0a8;
+	}
+	.pip.lost {
+		background: rgba(251, 113, 133, 0.2);
+		color: #fb7185;
+	}
+	.pip.tie {
+		background: var(--surface-2);
+		color: var(--text-muted);
+	}
+	.h2h-empty {
+		text-align: center;
+		color: var(--text-faint);
+		font-size: 0.8rem;
+		margin-top: 10px;
+	}
 
-  .u-actions { display: flex; gap: 10px; justify-content: center; margin-bottom: 6px; flex-wrap: wrap; }
-  .pill { padding: 9px 18px; border-radius: var(--r-pill); border: 1px solid var(--border-strong); background: var(--surface);
-    color: var(--text); font-weight: 700; font-size: 0.86rem; cursor: pointer; }
-  .pill.gold { background: linear-gradient(135deg, #fde047, #f59e0b); color: #3a2a00; border-color: transparent; }
-  .pill.friend { color: #7ee0a8; }
-  .pill.muted { color: var(--text-faint); cursor: default; }
-  .add-msg { text-align: center; color: var(--text-muted); font-size: 0.82rem; margin: 8px 0 0; }
+	.u-actions {
+		display: flex;
+		gap: 10px;
+		justify-content: center;
+		margin-bottom: 6px;
+		flex-wrap: wrap;
+	}
+	.pill {
+		padding: 9px 18px;
+		border-radius: var(--r-pill);
+		border: 1px solid var(--border-strong);
+		background: var(--surface);
+		color: var(--text);
+		font-weight: 700;
+		font-size: 0.86rem;
+		cursor: pointer;
+	}
+	.pill.gold {
+		background: linear-gradient(135deg, #fde047, #f59e0b);
+		color: #3a2a00;
+		border-color: transparent;
+	}
+	.pill.friend {
+		color: #7ee0a8;
+	}
+	.pill.muted {
+		color: var(--text-faint);
+		cursor: default;
+	}
+	.add-msg {
+		text-align: center;
+		color: var(--text-muted);
+		font-size: 0.82rem;
+		margin: 8px 0 0;
+	}
 
-  .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; margin: 18px 0; }
-  .stat { background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-sm); padding: 12px 6px; text-align: center; }
-  .s-n { display: block; font-family: var(--font-display); font-weight: 800; font-size: 1.05rem; color: var(--text); }
-  .s-l { display: block; font-size: 0.64rem; color: var(--text-faint); margin-top: 3px; }
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(4, 1fr);
+		gap: 8px;
+		margin: 18px 0;
+	}
+	.stat {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--r-sm);
+		padding: 12px 6px;
+		text-align: center;
+	}
+	.s-n {
+		display: block;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.05rem;
+		color: var(--text);
+	}
+	.s-l {
+		display: block;
+		font-size: 0.64rem;
+		color: var(--text-faint);
+		margin-top: 3px;
+	}
 
-  .badges { margin-top: 6px; }
-  .b-h { color: var(--text-faint); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
-  .b-wrap { display: flex; flex-wrap: wrap; gap: 7px; }
-  .social { margin-top: 18px; }
-  .soc-row { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
-  .soc-main { flex: 1; display: flex; align-items: center; justify-content: space-between; padding: 10px 13px; border-radius: 12px;
-    background: var(--surface); border: 1px solid var(--border); color: var(--text); font-weight: 600; font-size: 0.92rem; cursor: pointer; text-align: left; }
-  .soc-main.static { cursor: default; }
-  button.soc-main:hover { border-color: var(--brand-2); }
-  .soc-go { color: var(--text-faint); }
-  .soc-act { flex: none; padding: 9px 14px; border-radius: 12px; cursor: pointer; font-weight: 800; font-size: 0.82rem; color: #3a2a00;
-    background: var(--brand-grad, linear-gradient(135deg,#fbbf24,#fde047)); border: none; }
-  .soc-act:disabled { opacity: 0.6; cursor: default; }
-  .soc-tag { flex: none; padding: 9px 12px; font-size: 0.8rem; font-weight: 700; color: var(--text-faint); }
-  .badge { font-size: 0.78rem; padding: 5px 10px; border-radius: var(--r-pill); background: var(--surface); border: 1px solid var(--border); color: var(--text-muted); }
+	.badges {
+		margin-top: 6px;
+	}
+	.b-h {
+		color: var(--text-faint);
+		font-size: 0.72rem;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		margin-bottom: 8px;
+	}
+	.b-wrap {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 7px;
+	}
+	.social {
+		margin-top: 18px;
+	}
+	.soc-row {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-bottom: 7px;
+	}
+	.soc-main {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 10px 13px;
+		border-radius: 12px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		font-weight: 600;
+		font-size: 0.92rem;
+		cursor: pointer;
+		text-align: left;
+	}
+	.soc-main.static {
+		cursor: default;
+	}
+	button.soc-main:hover {
+		border-color: var(--brand-2);
+	}
+	.soc-go {
+		color: var(--text-faint);
+	}
+	.soc-act {
+		flex: none;
+		padding: 9px 14px;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.82rem;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+		border: none;
+	}
+	.soc-act:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+	.soc-tag {
+		flex: none;
+		padding: 9px 12px;
+		font-size: 0.8rem;
+		font-weight: 700;
+		color: var(--text-faint);
+	}
+	.badge {
+		font-size: 0.78rem;
+		padding: 5px 10px;
+		border-radius: var(--r-pill);
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text-muted);
+	}
 
-  @media (max-width: 380px) { .grid { grid-template-columns: repeat(3, 1fr); } }
+	@media (max-width: 380px) {
+		.grid {
+			grid-template-columns: repeat(3, 1fr);
+		}
+	}
 </style>

--- a/static/avatar/README.md
+++ b/static/avatar/README.md
@@ -5,16 +5,20 @@ asset pack, or commissioned art). The plumbing is already built — you just add
 list them in the manifest.
 
 ## How the pieces fit
+
 - **`src/lib/avatarKit.js`** — the manifest. Lists every part, its slot, label, and price.
 - **`src/lib/components/KitAvatar.svelte`** — stacks the chosen parts into a figure.
 - **`src/routes/avatar/kit`** — a live preview page to see it + flip parts.
 - The placeholder `.svg` files in here are **throwaway** — replace them with real art.
 
 ## Slots (paint order, back → front)
+
 `body → bottom → top → shoes → hair → accessory`
 
 ## Exporting parts (the only rule that matters)
+
 **Every part must be exported on the SAME canvas** so they line up when stacked:
+
 - Canvas: **360 × 540** (portrait, the value in `CANVAS` in avatarKit.js — change it there
   if your art uses a different size, but keep ALL parts identical).
 - **Transparent background.**
@@ -23,18 +27,26 @@ list them in the manifest.
 - Format: **SVG** (preferred) or transparent PNG.
 
 ## Adding a part
+
 1. Export it onto the 360×540 canvas, transparent.
 2. Save it as `static/avatar/<slot>/<name>.svg` (e.g. `static/avatar/top/varsity.svg`).
 3. Add a line to `PARTS` in `src/lib/avatarKit.js`:
    ```js
    top: [
-     { id: 'tee', label: 'Tee', file: 'tee.svg' },
-     { id: 'varsity', label: 'Varsity Jacket', file: 'varsity.svg', price: 600, cosmeticId: 'kit_top_varsity' },
-   ]
+   	{ id: 'tee', label: 'Tee', file: 'tee.svg' },
+   	{
+   		id: 'varsity',
+   		label: 'Varsity Jacket',
+   		file: 'varsity.svg',
+   		price: 600,
+   		cosmeticId: 'kit_top_varsity'
+   	}
+   ];
    ```
    - No `price` = free. With `price` = a paid cosmetic (wired into the store when ready).
 
 ## Humaaans / Blush workflow
+
 1. Duplicate the **Humaaans** Figma community file (or use the Blush editor).
 2. Pick **one standing pose** as the base.
 3. For that pose, export each swappable layer (head/hair/top/bottom/shoes/accessory) as
@@ -42,6 +54,7 @@ list them in the manifest.
 4. Drop them in the matching slot folder + list them in the manifest.
 
 ## Going live
+
 When the real art is in and looks good, set **`KIT_READY = true`** in `avatarKit.js` and
 tell me — I'll switch the builder + store + profile from the DiceBear bust to this
 full-body kit (and seed the paid parts into the cosmetics catalog).

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,15 +1,15 @@
 {
-  "name": "WordBank",
-  "short_name": "WordBank",
-  "description": "Spend Less. Think More. A daily word-puzzle game.",
-  "start_url": "/",
-  "scope": "/",
-  "display": "standalone",
-  "orientation": "portrait",
-  "background_color": "#0a0e14",
-  "theme_color": "#0a0e14",
-  "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" }
-  ]
+	"name": "WordBank",
+	"short_name": "WordBank",
+	"description": "Spend Less. Think More. A daily word-puzzle game.",
+	"start_url": "/",
+	"scope": "/",
+	"display": "standalone",
+	"orientation": "portrait",
+	"background_color": "#0a0e14",
+	"theme_color": "#0a0e14",
+	"icons": [
+		{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png", "purpose": "any" },
+		{ "src": "/icon-512.png", "sizes": "512x512", "type": "image/png", "purpose": "any" }
+	]
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,15 +3,15 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-    preprocess: vitePreprocess(),
+	preprocess: vitePreprocess(),
 
-    kit: {
-        adapter: adapter(),
-        env: {
-            dir: process.cwd(),
-            publicPrefix: 'VITE_'  // Ensures Vite environment variables are read
-        }
-    }
+	kit: {
+		adapter: adapter(),
+		env: {
+			dir: process.cwd(),
+			publicPrefix: 'VITE_' // Ensures Vite environment variables are read
+		}
+	}
 };
 
 export default config;

--- a/www/index.html
+++ b/www/index.html
@@ -1,30 +1,65 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <title>WordBank</title>
-  <style>
-    html, body { margin: 0; height: 100%; background: #0a0e14; color: #e6edf3;
-      font-family: -apple-system, system-ui, sans-serif; }
-    .wrap { height: 100%; display: flex; flex-direction: column; align-items: center;
-      justify-content: center; gap: 14px; text-align: center; padding: 24px; }
-    .mark { width: 76px; height: 76px; }
-    h1 { font-size: 1.4rem; margin: 0; letter-spacing: -0.02em; }
-    p { color: #8b98a9; margin: 0; font-size: 0.95rem; }
-    .spin { width: 26px; height: 26px; border: 3px solid rgba(163,230,53,0.25);
-      border-top-color: #a3e635; border-radius: 50%; animation: s 0.8s linear infinite; }
-    @keyframes s { to { transform: rotate(360deg); } }
-  </style>
-</head>
-<body>
-  <!-- Offline / load fallback. When online, Capacitor loads the live app via
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+		<title>WordBank</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				height: 100%;
+				background: #0a0e14;
+				color: #e6edf3;
+				font-family: -apple-system, system-ui, sans-serif;
+			}
+			.wrap {
+				height: 100%;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				gap: 14px;
+				text-align: center;
+				padding: 24px;
+			}
+			.mark {
+				width: 76px;
+				height: 76px;
+			}
+			h1 {
+				font-size: 1.4rem;
+				margin: 0;
+				letter-spacing: -0.02em;
+			}
+			p {
+				color: #8b98a9;
+				margin: 0;
+				font-size: 0.95rem;
+			}
+			.spin {
+				width: 26px;
+				height: 26px;
+				border: 3px solid rgba(163, 230, 53, 0.25);
+				border-top-color: #a3e635;
+				border-radius: 50%;
+				animation: s 0.8s linear infinite;
+			}
+			@keyframes s {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<!-- Offline / load fallback. When online, Capacitor loads the live app via
        server.url in capacitor.config.json. -->
-  <div class="wrap">
-    <img class="mark" src="https://wordbanksvelte.vercel.app/logo-mark.png" alt="WordBank" />
-    <h1>WordBank</h1>
-    <div class="spin"></div>
-    <p>Connect to the internet to play.</p>
-  </div>
-</body>
+		<div class="wrap">
+			<img class="mark" src="https://wordbanksvelte.vercel.app/logo-mark.png" alt="WordBank" />
+			<h1>WordBank</h1>
+			<div class="spin"></div>
+			<p>Connect to the internet to play.</p>
+		</div>
+	</body>
 </html>


### PR DESCRIPTION
Formats the repo (prettier), drives svelte-check to **0 errors** (was 35), and promotes prettier + type-check + build to **hard CI gates** (eslint stays informational — 183 unused-CSS flags are risky to auto-strip). Notably, the type-check surfaced a **real live bug**: the Daily 'You'll bank' HUD read `dLive.net`, which Daily V2 removed — so it tweened to NaN. Fixed to `dLive.winnings`. Build ✓, E2E 19/19. 🤖 Generated with [Claude Code](https://claude.com/claude-code)