### PR TITLE
Cash Game phrase-blind bust + Stack/Cash HUD; avatar Buy→PIN

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -170,7 +170,7 @@ export const gameStore = writable(
 		clue: null, // witty one-line hint for the current puzzle
 		challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
 		makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
-		climbInfo: null, // { bounty, heat, attempts, spent, position, stuck, last_gain, state } (climb mode)
+		climbInfo: null, // { bounty, heat, spent, position, bust_risk, wrong_penalty, last_gain, state } (climb mode)
 		blitzInfo: null, // { remaining_ms, combo, solved, winnings, tier, buy_in, base, state } (blitz mode)
 		matchInfo: null, // { position, pack_size, total_score, last_score, done, status } (challenge match)
 		cashToast: null, // { amount, label } — transient Cash-earned toast (attendance / free-play reward)

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -479,7 +479,7 @@
 		_attTimer = setTimeout(() => gameStore.update((s) => ({ ...s, cashToast: null })), 4000);
 	}
 	$: isClimb = $gameStore.gameMode === 'climb';
-	$: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, stuck, last_gain, state, pups_locked, equipped }
+	$: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, bust_risk, wrong_penalty, last_gain, state, pups_locked, equipped }
 	// ⚡ Blitz — the live client clock counts down to blitzInfo.remaining_ms (server-authoritative);
 	// each action resyncs it. At 0 we call endBlitz() once.
 	$: isBlitz = $gameStore.gameMode === 'blitz';
@@ -2237,7 +2237,7 @@
 	<button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
 {/if}
 <!-- ⏭️ Skip (top-right) — Cash Game only; resets heat. Hidden once Double-or-Nothing is armed (committed). -->
-{#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && !donArmed && (climb?.state === 'active' || climb?.state === 'stuck')}
+{#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && !donArmed && climb?.state === 'active'}
 	<button
 		class="giveup-btn"
 		title="Skip this puzzle"
@@ -2405,7 +2405,7 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions a11y_no_noninteractive_tabindex -->
 		<div class="info-card bank-card" on:click|stopPropagation role="dialog" aria-modal="true">
 			<button class="modal-x" on:click={() => (showBank = false)} aria-label="Close">✕</button>
-			<p class="bm-label">Net Worth</p>
+			<p class="bm-label">Cash</p>
 			<div class="info-big">{fmtCash(bankData?.bank ?? netWorth ?? 0)}</div>
 			<p class="info-sub">Your Cash — this is your score</p>
 			{#if bankData}
@@ -2605,7 +2605,7 @@
 					Heat climbs with your <button
 						class="info-inline"
 						on:click|stopPropagation={() => (climbInfo = 'streak')}>win streak</button
-					> and resets to ×1.0 if you get stuck or skip.
+					> and resets to ×1.0 if you bust or skip.
 				</p>
 			{:else if climbInfo === 'streak'}
 				<div class="info-big">🏆 {climbStreak}</div>
@@ -2613,7 +2613,7 @@
 				<p class="info-sub">Cash Game puzzles you've solved in a row.</p>
 				<div class="info-rows">
 					<div class="info-row"><span>Solve a puzzle</span><b class="pos">+1</b></div>
-					<div class="info-row"><span>Get stuck or skip</span><b class="neg">back to 0</b></div>
+					<div class="info-row"><span>Bust or skip</span><b class="neg">back to 0</b></div>
 				</div>
 				<p class="info-note">
 					Powers your <button
@@ -3874,9 +3874,10 @@
 				>
 					{#if isMatch}<span class="tb-wallet-cap">💰 Wallet</span>{:else if isDailyLike}<span
 							class="tb-wallet-cap">🏆 Prize</span
-						>{/if}
+						>{:else if isClimb}<span class="tb-wallet-cap">🪙 Stack</span>{/if}
 					<span class="tb-solo"
 						>{#if isMatch}💰
+						{:else if isClimb}🪙
 						{:else if !isDailyLike}💰
 						{/if}${Math.round($tweenBank).toLocaleString()}</span
 					>
@@ -3926,13 +3927,15 @@
 		<!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
          Solve-to-Earn box; power-ups live in the vault beside Solve. -->
 		{#if isClimb && climb}
-			{#if climb.stuck && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+			{#if climb.bust_risk && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				<div class="climb-stuck">
-					<span class="cs-text">🎯 Final guess — solve it or bust the run</span>
+					<span class="cs-text"
+						>⚠️ Low Stack — a wrong guess busts your run. Cash Out to bank it.</span
+					>
 				</div>
 			{/if}
 			<!-- 🏦 Cash Out — bank the run bankroll anytime (the press-your-luck valve). -->
-			{#if (climb.state === 'active' || climb.state === 'stuck') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+			{#if climb.state === 'active' && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				{@const bankroll = Math.round(climb.bankroll ?? 0)}
 				{@const profit = bankroll - Math.round(climb.buy_in ?? 0)}
 				<button
@@ -3941,10 +3944,7 @@
 					disabled={cgBusy || bankroll <= 0}
 					on:click={cashOut}
 				>
-					🏦 Cash Out <b>${bankroll.toLocaleString()}</b>
-					{#if profit !== 0}<span class="co-profit" class:neg={profit < 0}
-							>{profit > 0 ? '+' : '−'}${Math.abs(profit).toLocaleString()}</span
-						>{/if}
+					🏦 Cash Out
 				</button>
 			{/if}
 		{/if}
@@ -4343,7 +4343,7 @@
 								>
 							</div>
 							<div class="wm-row total">
-								<span>🎰 Run bankroll</span><b>${bankroll.toLocaleString()}</b>
+								<span>🪙 Stack</span><b>${bankroll.toLocaleString()}</b>
 							</div>
 						</div>
 						<p class="win-twist">
@@ -4845,17 +4845,6 @@
 	.cashout-btn:disabled {
 		opacity: 0.45;
 		cursor: default;
-	}
-	.cashout-btn b {
-		color: #d1fae5;
-	}
-	.co-profit {
-		font-size: 0.85rem;
-		color: #34d399;
-		font-weight: 700;
-	}
-	.co-profit.neg {
-		color: #fb7185;
 	}
 	.co-inline {
 		background: linear-gradient(135deg, #6ee7b7, #34d399) !important;

--- a/src/routes/avatar/+page.svelte
+++ b/src/routes/avatar/+page.svelte
@@ -6,6 +6,7 @@
 	import { getMyAvatar, setAvatar, buyCosmetic, getBank } from '$lib/stores/statsStore.js';
 	import { fx } from '$lib/sound.js';
 	import { track } from '$lib/analytics.js';
+	import { requirePin } from '$lib/pinConfirm.js';
 
 	/** @type {any} */ let config = { ...DEFAULT_AVATAR };
 	/** @type {string[]} */ let owned = [];
@@ -15,7 +16,6 @@
 	let activeCat = CATEGORIES[0].key;
 	let dirty = false;
 	let toast = '';
-	/** @type {any} */ let buying = null; // option pending purchase-confirm
 
 	onMount(async () => {
 		track('avatar_open');
@@ -28,8 +28,8 @@
 
 	$: cat = CATEGORIES.find((c) => c.key === activeCat) ?? CATEGORIES[0];
 	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
-	/** @param {any} o */
-	const locked = (o) => !!o.price && !owned.includes(o.cosmeticId);
+	// Reactive on `owned` so a tile's 🔒 clears the instant a purchase lands.
+	$: locked = (/** @type {any} */ o) => !!o.price && !owned.includes(o.cosmeticId);
 	/** preview config with one category overridden @param {string} key @param {string} value */
 	// a shirt design only shows on the Graphic Tee, so equipping a design auto-wears it
 	const withDeps = (/** @type {string} */ key, /** @type {string} */ value) =>
@@ -64,10 +64,10 @@
 		dirty = true;
 	}
 
-	/** @param {string} key @param {any} o */
+	/** Tap a tile face: equip if owned/free, otherwise buy. @param {string} key @param {any} o */
 	function choose(key, o) {
 		if (locked(o)) {
-			buying = { key, o };
+			buyNow(key, o);
 			return;
 		}
 		fx('tap');
@@ -75,20 +75,30 @@
 		dirty = true;
 	}
 
-	async function confirmBuy() {
-		if (!buying) return;
-		const { key, o } = buying;
+	/** Buy → PIN is the only confirmation (no separate sheet). @param {string} key @param {any} o */
+	async function buyNow(key, o) {
+		if (saving) return;
 		if (bank < o.price) {
 			flash('Not enough Cash');
-			buying = null;
 			return;
+		}
+		// 🔐 Vault code IS the confirm step — no intermediate "Unlock for $X" sheet.
+		try {
+			await requirePin(`Unlock ${o.label}`, [{ label: o.label, value: fmt(o.price) }]);
+		} catch {
+			return; // cancelled at the pad
 		}
 		saving = true;
 		const res = await buyCosmetic(o.cosmeticId);
 		saving = false;
 		if (!res.ok) {
-			flash(res.reason === 'insufficient' ? 'Not enough Cash' : 'Could not buy');
-			buying = null;
+			flash(
+				res.reason === 'insufficient'
+					? 'Not enough Cash'
+					: res.reason === 'in_debt'
+						? 'Pay off your loan first'
+						: 'Could not buy'
+			);
 			return;
 		}
 		fx('win');
@@ -96,7 +106,6 @@
 		bank -= o.price;
 		config = { ...config, ...withDeps(key, o.value) };
 		dirty = true;
-		buying = null;
 		flash('Unlocked!');
 	}
 
@@ -153,21 +162,21 @@
 
 		<div class="opt-grid" class:colors={cat.type === 'color'}>
 			{#each cat.options as o (o.value)}
-				<button
-					class="opt"
-					class:sel={config[cat.key] === o.value}
-					class:locked={locked(o)}
-					on:click={() => choose(cat.key, o)}
-					title={o.label}
-				>
-					{#if cat.type === 'color'}
-						<span class="sw" style="background:#{o.value}"></span>
-					{:else}
-						<Avatar config={preview(cat.key, o.value)} fx={cat.type === 'fx'} size={62} />
+				<div class="opt" class:sel={config[cat.key] === o.value} class:locked={locked(o)}>
+					<button class="opt-face" on:click={() => choose(cat.key, o)} title={o.label}>
+						{#if cat.type === 'color'}
+							<span class="sw" style="background:#{o.value}"></span>
+						{:else}
+							<Avatar config={preview(cat.key, o.value)} fx={cat.type === 'fx'} size={62} />
+						{/if}
+						<span class="opt-label">{o.label}</span>
+					</button>
+					{#if locked(o)}
+						<button class="opt-buy" on:click={() => buyNow(cat.key, o)}
+							>🔒 Buy {fmt(o.price)}</button
+						>
 					{/if}
-					<span class="opt-label">{o.label}</span>
-					{#if locked(o)}<span class="opt-price">🔒 {fmt(o.price)}</span>{/if}
-				</button>
+				</div>
 			{/each}
 		</div>
 	{/if}
@@ -178,30 +187,6 @@
 		>{saving ? 'Saving…' : dirty ? 'Save' : 'Saved'}</button
 	>
 </main>
-
-{#if buying}
-	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Unlock item">
-		<button
-			type="button"
-			class="modal-backdrop"
-			aria-label="Cancel"
-			on:click={() => (buying = null)}
-		></button>
-		<div class="buy-card">
-			<Avatar config={preview(buying.key, buying.o.value)} fx size={120} />
-			<h3>{buying.o.label}</h3>
-			<p class="buy-price">{fmt(buying.o.price)}</p>
-			<button class="buy-go" disabled={saving || bank < buying.o.price} on:click={confirmBuy}>
-				{bank < buying.o.price
-					? 'Not enough Cash'
-					: saving
-						? 'Unlocking…'
-						: `Unlock for ${fmt(buying.o.price)}`}
-			</button>
-			<button class="buy-cancel" on:click={() => (buying = null)}>Cancel</button>
-		</div>
-	</div>
-{/if}
 
 <style>
 	.av-page {
@@ -316,10 +301,22 @@
 		gap: 4px;
 		padding: 8px 4px;
 		border-radius: 14px;
-		cursor: pointer;
 		background: var(--surface);
 		border: 1px solid var(--border);
 		color: var(--text);
+	}
+	.opt-face {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 4px;
+		width: 100%;
+		padding: 0;
+		background: none;
+		border: 0;
+		color: inherit;
+		font: inherit;
+		cursor: pointer;
 	}
 	.opt.sel {
 		border-color: var(--brand-2);
@@ -337,10 +334,20 @@
 		text-align: center;
 		line-height: 1.1;
 	}
-	.opt-price {
+	.opt-buy {
+		margin-top: 2px;
+		padding: 4px 12px;
+		border-radius: 999px;
+		border: 1px solid var(--brand-2);
+		background: rgba(251, 191, 36, 0.12);
+		color: var(--brand-2);
 		font-size: 0.68rem;
 		font-weight: 800;
-		color: var(--brand-2);
+		white-space: nowrap;
+		cursor: pointer;
+	}
+	.opt-buy:active {
+		transform: scale(0.96);
 	}
 	.sw {
 		width: 42px;
@@ -391,56 +398,5 @@
 	}
 	.av-save:disabled {
 		cursor: default;
-	}
-
-	.buy-card {
-		position: relative;
-		z-index: 1;
-		width: calc(100% - 3rem);
-		max-width: 320px;
-		margin: auto;
-		padding: 22px;
-		border-radius: 20px;
-		text-align: center;
-		background: var(--surface-strong, rgba(20, 26, 38, 0.95));
-		border: 1px solid var(--border-strong, var(--border));
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 8px;
-	}
-	.buy-card h3 {
-		margin: 6px 0 0;
-		font-family: var(--font-display);
-	}
-	.buy-price {
-		margin: 0;
-		font-family: var(--font-display);
-		font-weight: 800;
-		font-size: 1.3rem;
-		color: var(--brand-2);
-	}
-	.buy-go {
-		width: 100%;
-		height: 48px;
-		border-radius: 14px;
-		border: none;
-		cursor: pointer;
-		font-weight: 800;
-		font-size: 1rem;
-		color: #3a2a00;
-		background: linear-gradient(135deg, #fde047, #f59e0b);
-	}
-	.buy-go:disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-	.buy-cancel {
-		background: none;
-		border: none;
-		color: var(--text-muted);
-		cursor: pointer;
-		font-weight: 600;
-		padding: 4px;
 	}
 </style>

--- a/supabase-cashgame-v3-noleak.sql
+++ b/supabase-cashgame-v3-noleak.sql
@@ -1,0 +1,217 @@
+-- Cash Game V3: remove phrase-aware "stuck / final guess" — it leaked the answer.
+--
+-- Old model computed `_climb_cheapest` = the cheapest letter *that's actually in the
+-- phrase*, and declared you "stuck → one final guess → bust" when your Stack couldn't
+-- afford it. That made the loss threshold depend on the puzzle's contents (an info
+-- leak) and fabricated a solve-or-bust moment on puzzles you could still just guess.
+--
+-- New model (phrase-blind):
+--   • Letters are optional paid hints — buy any you can afford (in the phrase or not).
+--   • Solving is always available; you're never "stuck".
+--   • Stack bleeds only via buying letters (spend) + wrong-guess penalties.
+--   • BUST = a wrong guess drops your Stack to $0 (Stack ≤ penalty). Nothing else.
+--   • Cash Out anytime banks what's left. Buying never busts (capped by affordability).
+--   • `_climb_cheapest` dropped; `stuck` state retired. Board exposes wrong_penalty +
+--     bust_risk (both derived from the already-visible bounty — no phrase peeking).
+-- Spec: chat design decision 2026-07-07. PITR point logged before apply.
+
+BEGIN;
+
+-- Board: no more `stuck`; expose the (visible-bounty-derived) wrong-guess penalty and a
+-- pure-Stack bust_risk flag so the HUD can warn without leaking phrase contents.
+CREATE OR REPLACE FUNCTION public._climb_board(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_state TEXT; v_board JSONB; v_tier JSONB; v_k NUMERIC; v_bounty INT; v_pen INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_state := CASE cs.state WHEN 'solved' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  v_bounty := public._climb_bounty(cs.puzzle_id, v_k);
+  v_pen := GREATEST(10, (round(0.2 * v_bounty / 10.0) * 10)::int);
+  v_board := public._daily_board(v_phrase, v_state, cs.bankroll::int, 99, cs.revealed_positions, cs.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('climb', jsonb_build_object(
+    'bankroll', cs.bankroll, 'bounty', v_bounty, 'heat', cs.heat_x100,
+    'heat_cap', (v_tier->>'heat_cap')::int, 'tier', cs.tier, 'buy_in', cs.buy_in, 'tier_label', v_tier->>'label',
+    'spent', cs.spent, 'position', cs.position, 'last_gain', cs.last_gain,
+    'wrong_penalty', v_pen, 'bust_risk', (cs.state = 'active' AND cs.bankroll <= v_pen),
+    'state', cs.state, 'pups_locked', cs.pups_locked, 'equipped', to_jsonb(cs.active_powerups),
+    'run_solves', cs.run_solves, 'run_profit', cs.bankroll - cs.buy_in));
+END; $function$;
+
+-- Start a run: guard on a live 'active' run (no more 'stuck').
+CREATE OR REPLACE FUNCTION public.cashgame_start(p_tier text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_tier JSONB; v_buy BIGINT; v_bank BIGINT; v_pid UUID; v_t text := lower(COALESCE(p_tier,''));
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_start: not authenticated'; END IF;
+  v_tier := public._cg_tier(v_t);
+  IF v_tier IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'bad_tier'); END IF;
+  IF NOT public._cg_unlocked(v_uid, v_t) THEN RETURN jsonb_build_object('ok', false, 'reason', 'locked'); END IF;
+  IF EXISTS (SELECT 1 FROM public.climb_state WHERE user_id = v_uid AND state = 'active') THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'run_active'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_buy := (v_tier->>'buy_in')::bigint;
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = v_uid;
+  IF v_bank < v_buy THEN RETURN jsonb_build_object('ok', false, 'reason', 'insufficient', 'buy_in', v_buy, 'bank', v_bank); END IF;
+  v_pid := public._pick_casual(v_uid, null, null, 0);
+  IF v_pid IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_puzzles'); END IF;
+  PERFORM public._bank_credit(v_uid, -v_buy, 'cashgame_buyin');       -- stake leaves Cash → the run
+  DELETE FROM public.climb_state WHERE user_id = v_uid;              -- clear any finished remnant
+  INSERT INTO public.climb_state(user_id, position, puzzle_id, bankroll, tier, buy_in, heat_x100, state)
+    VALUES (v_uid, 1, v_pid, v_buy, v_t, v_buy, 100, 'active');
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid) || jsonb_build_object('ok', true);
+END; $function$;
+
+-- Buy a letter: unchanged economics, just the state guard (no 'stuck').
+CREATE OR REPLACE FUNCTION public.climb_buy_letter(p_letter text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_buy_letter: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  IF 'half_off' = ANY(cs.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  IF v_letter = ANY(cs.incorrect_letters) OR cs.bankroll < v_cost THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cs.revealed_positions THEN RETURN public._climb_board(v_uid); END IF;
+  cs.bankroll := cs.bankroll - v_cost;
+  IF v_positions IS NULL THEN cs.incorrect_letters := array_append(cs.incorrect_letters, v_letter);
+  ELSE cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.climb_state SET bankroll = cs.bankroll, revealed_positions = cs.revealed_positions,
+    incorrect_letters = cs.incorrect_letters, spent = cs.spent + v_cost, pups_locked = true, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- Submit a guess: wrong drains the penalty from the Stack; if that empties it → BUST.
+-- No _climb_cheapest, no phrase peeking — the bust trigger is pure Stack math.
+CREATE OR REPLACE FUNCTION public.climb_submit_guess(p_guess jsonb)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}';
+  v_all BOOLEAN := true; pos INT; v_ch TEXT; v_tier JSONB; v_k NUMERIC; v_bounty INT; v_pen INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_submit_guess: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_submit_guess: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._climb_board(v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_correct) ORDER BY 1);
+    UPDATE public.climb_state SET revealed_positions = cs.revealed_positions, updated_at = now() WHERE user_id = v_uid;
+    RETURN public._climb_resolve(v_uid);
+  END IF;
+  -- Wrong guess: drain the penalty. If it takes the Stack to $0 (or below), the run busts.
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_bounty := public._climb_bounty(cs.puzzle_id, v_k);
+  v_pen := GREATEST(10, (round(0.2 * v_bounty / 10.0) * 10)::int);
+  IF cs.bankroll - v_pen <= 0 THEN
+    RETURN public._cg_bust(v_uid);                                   -- Stack hits $0 → run over
+  END IF;
+  cs.bankroll := cs.bankroll - v_pen;
+  UPDATE public.climb_state SET bankroll = cs.bankroll, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- Resolve after a move: solve grows the bankroll; otherwise just keep playing (no 'stuck').
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_tier JSONB; v_k NUMERIC; v_cap INT; v_bounty INT; v_payout INT; v_cat TEXT; v_time INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(p_uid); END IF;
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85); v_cap := COALESCE((v_tier->>'heat_cap')::int, 250);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    v_bounty := public._climb_bounty(cs.puzzle_id, v_k);
+    v_payout := round(v_bounty * cs.heat_x100 / 100.0)::int;
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_payout,
+      bankroll = cs.bankroll + v_payout,
+      heat_x100 = LEAST(v_cap, cs.heat_x100 + 10),
+      run_solves = cs.run_solves + 1, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_payout, v_time);
+  ELSE
+    UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;  -- keep playing
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- Skip: state guard only (no 'stuck').
+CREATE OR REPLACE FUNCTION public.climb_skip()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_skip: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  v_pid := public._pick_casual(v_uid, null, cs.puzzle_id, 0);
+  IF v_pid IS NULL THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.climb_state SET puzzle_id = v_pid, revealed_positions = '{}', incorrect_letters = '{}',
+    spent = 0, last_gain = 0, active_powerups = '{}', pups_locked = false,
+    heat_x100 = 100, state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- Cash out: allow from 'active' or 'solved' (no 'stuck').
+CREATE OR REPLACE FUNCTION public.cashgame_cashout()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_profit BIGINT; v_mult INT; v_wins jsonb; v_streak INT; v_bestrs INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_cashout: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','solved') THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_run'); END IF;
+  v_profit := cs.bankroll - cs.buy_in;
+  v_mult := CASE WHEN cs.buy_in > 0 THEN round(cs.bankroll * 100.0 / cs.buy_in)::int ELSE 0 END;
+  IF cs.bankroll > 0 THEN PERFORM public._bank_credit(v_uid, cs.bankroll, 'cashgame_cashout'); END IF;
+  SELECT COALESCE(cg_wins,'{}'::jsonb), COALESCE(cg_run_streak,0), COALESCE(cg_best_run_streak,0)
+    INTO v_wins, v_streak, v_bestrs FROM public.profiles WHERE id = v_uid;
+  IF v_profit > 0 THEN
+    v_wins := jsonb_set(v_wins, ARRAY[cs.tier], to_jsonb(COALESCE((v_wins->>cs.tier)::int,0) + 1), true);
+    v_streak := v_streak + 1;
+  ELSE
+    v_streak := 0;
+  END IF;
+  UPDATE public.profiles SET
+    cg_wins = v_wins,
+    cg_run_streak = v_streak,
+    cg_best_run_streak = GREATEST(v_bestrs, v_streak),
+    cg_best_run = GREATEST(COALESCE(cg_best_run,0), cs.bankroll),
+    cg_best_multiple_x100 = GREATEST(COALESCE(cg_best_multiple_x100,0), v_mult),
+    cg_best_heat_x100 = GREATEST(COALESCE(cg_best_heat_x100,100), cs.heat_x100),
+    cg_lifetime_net = COALESCE(cg_lifetime_net,0) + v_profit
+    WHERE id = v_uid;
+  DELETE FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object('ok', true, 'banked', cs.bankroll, 'buy_in', cs.buy_in, 'profit', v_profit,
+    'multiple_x100', v_mult, 'solves', cs.run_solves, 'tier', cs.tier, 'heat', cs.heat_x100);
+END; $function$;
+
+-- Retire the phrase-aware helper — nothing references it now.
+DROP FUNCTION IF EXISTS public._climb_cheapest(public.climb_state, text);
+
+COMMIT;


### PR DESCRIPTION
## Cash Game V3 — phrase-blind bust (migration applied to prod under PITR)
Removes the phrase-aware "stuck / final guess" logic that leaked which letters were in the phrase.

- **New model:** buy any letter you can afford (in the phrase or not), always free to attempt a solve, **bust only when a wrong guess drops your Stack to $0**. Buying never busts.
- Dropped `_climb_cheapest` and the `stuck` state; board exposes `bust_risk` + `wrong_penalty` (both from the already-visible bounty).
- psql-sim verified (rolled back) before apply: wrong letter → drains/active · wrong guess at full Stack → drains/active · wrong guess at $10 Stack → **busts**.

## HUD cleanup
- Cash Game run number is now 🪙 **Stack** (distinct from 💰 **Cash** / net worth); Cash Out button stops repeating the balance.
- Old "Final guess" banner → Stack-based low-Stack warning (never phrase-dependent).

## Avatar purchasing
- Each locked item has a **🔒 Buy $X** button → straight to vault-code (PIN) confirm, no intermediate sheet.
- Fixed Svelte reactivity bug so the 🔒 clears the instant a purchase lands.
- Debt lockout shows "Pay off your loan first".

## Follow-up (not in this PR)
Micro tier starts in `bust_risk` because its wrong-guess penalty ($110–130) exceeds the $100 buy-in — tier tuning to address separately.