### PR TITLE
Bank Account + Wallet naming; unified money hub + inline borrow

### DIFF
--- a/docs/superpowers/specs/2026-07-07-bank-account-loans-ui-design.md
+++ b/docs/superpowers/specs/2026-07-07-bank-account-loans-ui-design.md
@@ -14,10 +14,10 @@ No DB changes — the loan RPCs (`take_loan`, `repay_loan`, `get_bank`) already 
 
 ## Naming
 
-| Concept | Old | New |
-|---|---|---|
-| Persistent money / net worth | "Cash" 💰 | **Bank Account** 💰 |
-| Cash Game run number | "Stack" 🪙 | **Wallet** 👛 |
+| Concept                      | Old        | New                 |
+| ---------------------------- | ---------- | ------------------- |
+| Persistent money / net worth | "Cash" 💰  | **Bank Account** 💰 |
+| Cash Game run number         | "Stack" 🪙 | **Wallet** 👛       |
 
 Mental model: your **Bank Account** is safe savings; you move money into a **Wallet** to
 gamble in Cash Game; cashing out drops it back into your Bank Account. The Challenge ante
@@ -44,6 +44,7 @@ awkward "Not enough in your Bank Account" phrasing — those stay "Not enough Ca
 ## Buy-in wall → inline borrow
 
 When starting a Cash Game / challenge with too little Bank Account:
+
 - Compute `shortfall = buy_in − bank`.
 - If `shortfall > loan_cap` → block with "You can only borrow up to $X" (can't cover it).
 - Else prompt: shows shortfall, pre-fills `borrow = shortfall` (fee = 25%), `requirePin`,

--- a/docs/superpowers/specs/2026-07-07-bank-account-loans-ui-design.md
+++ b/docs/superpowers/specs/2026-07-07-bank-account-loans-ui-design.md
@@ -1,0 +1,64 @@
+# Bank Account + Loans UI redesign
+
+Date: 2026-07-07
+
+## Goal
+
+Money and loans are scattered across three inconsistent surfaces today (a read-only
+in-game modal, the full `/bank` page, and a buy-in prompt that dumps you onto `/bank`).
+Unify them into one **Bank Account hub** reachable from the top money chip, add an
+**inline borrow flow** at the buy-in wall, rename the two money concepts, and fix stale
+ledger labels.
+
+No DB changes — the loan RPCs (`take_loan`, `repay_loan`, `get_bank`) already exist.
+
+## Naming
+
+| Concept | Old | New |
+|---|---|---|
+| Persistent money / net worth | "Cash" 💰 | **Bank Account** 💰 |
+| Cash Game run number | "Stack" 🪙 | **Wallet** 👛 |
+
+Mental model: your **Bank Account** is safe savings; you move money into a **Wallet** to
+gamble in Cash Game; cashing out drops it back into your Bank Account. The Challenge ante
+also reads "Wallet" (same idea — in-play money).
+
+Scope of rename: prominent **labels/headers and clear references** to the balance become
+"Bank Account". `$`-denominated amounts and incidental shorthand are left as-is (avoid
+awkward "Not enough in your Bank Account" phrasing — those stay "Not enough Cash" or use
+`$`). The compact top chip keeps `💰 $12,340`; the word "Bank Account" appears in the hub.
+
+## Components
+
+- **`LoanPanel.svelte`** (new): the borrow/repay UI extracted from `bank/+page.svelte` —
+  dial + slider + PIN confirm, both the no-debt (borrow) and in-debt (repay) states.
+  Props: `bank` (the `get_bank` payload) + `on:changed` to trigger a reload. Reused by
+  both the hub sheet and the `/bank` page (single source of truth).
+- **Bank Account hub sheet** (extend the existing in-page `showBank` modal): big balance
+  labelled "Bank Account", `<LoanPanel>`, recent activity (8 rows), and a "See full
+  ledger" link → `/bank`.
+- **Menu money chip**: opens the hub sheet (was `goto('/bank')`).
+- **`/bank` page**: stays as the deep "full ledger + items" view; reuses `LoanPanel`;
+  labels renamed to "Bank Account".
+
+## Buy-in wall → inline borrow
+
+When starting a Cash Game / challenge with too little Bank Account:
+- Compute `shortfall = buy_in − bank`.
+- If `shortfall > loan_cap` → block with "You can only borrow up to $X" (can't cover it).
+- Else prompt: shows shortfall, pre-fills `borrow = shortfall` (fee = 25%), `requirePin`,
+  `take_loan(borrow)`; on `ok` → immediately proceed with `cashgame_start`/challenge start.
+
+## Ledger label fixes
+
+Rebuild `reasonLabel` against live reason strings: `cashgame_buyin` → "Cash Game buy-in",
+`cashgame_cashout` → "Cash Game cash-out", `climb_bounty` → "Cash Game bounty",
+`climb_letter` → "Cash Game letter", `blitz_buyin`/`blitz_payout`, `loan_take`/
+`loan_repay`/`loan_skim`, `quest_reward`, `wager_*`, `attendance`, `daily_reward`,
+`cosmetic_buy`, `powerup_buy`, `challenge_payout`, `makeup_reward`. Removed-feature
+reasons (`arcade_cashout`, `freeplay_*`, `buy_credits`) keep a readable historical label.
+
+## Out of scope
+
+- Any DB migration (loans already shipped).
+- Micro-tier economics (penalty > buy-in) — tracked separately.

--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -1,0 +1,325 @@
+<script>
+	import { createEventDispatcher } from 'svelte';
+	import { takeLoan, repayLoan } from '$lib/stores/statsStore.js';
+	import { requirePin } from '$lib/pinConfirm.js';
+	import { track } from '$lib/analytics.js';
+	import { fx } from '$lib/sound.js';
+
+	/** The get_bank payload: { bank, loan, loan_cap, in_the_red, net_worth }
+	 * @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean }|null} */
+	export let bank = null;
+
+	const dispatch = createEventDispatcher();
+
+	// 💸 Loan Shark
+	let borrowAmt = 100; // $ to borrow (dial)
+	let repayAmt = 0; // $ to repay (dial)
+	let loanBusy = '';
+	let loanMsg = '';
+	$: loanCap = bank?.loan_cap ?? 0;
+	$: owed = bank?.loan ?? 0;
+	$: feeOnBorrow = Math.round(borrowAmt * 0.25);
+	$: if (borrowAmt > loanCap) borrowAmt = loanCap;
+	$: if (borrowAmt < 10 && loanCap >= 10) borrowAmt = 10;
+	$: maxRepay = Math.max(0, Math.min(owed, bank?.bank ?? 0));
+	$: if (repayAmt > maxRepay) repayAmt = maxRepay;
+	// seed the repay dial when we (re)load into a debt state
+	$: if (bank) repayAmt = Math.min(repayAmt || maxRepay, maxRepay);
+
+	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+
+	async function borrow() {
+		if (loanBusy || borrowAmt < 10) return;
+		const total = borrowAmt + Math.round(borrowAmt * 0.25);
+		try {
+			await requirePin(
+				`Borrow $${borrowAmt.toLocaleString()} — you'll owe $${total.toLocaleString()}`,
+				[
+					{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
+					{ label: 'Fee (25%)', value: '$' + Math.round(borrowAmt * 0.25).toLocaleString() },
+					{ label: 'You owe', value: '$' + total.toLocaleString() }
+				]
+			);
+		} catch {
+			return;
+		}
+		loanBusy = 'borrow';
+		loanMsg = '';
+		const res = await takeLoan(borrowAmt);
+		loanBusy = '';
+		if (res?.ok) {
+			fx('win');
+			track('take_loan', { amount: borrowAmt, owed: res.owed });
+			dispatch('changed');
+		} else {
+			loanMsg =
+				res?.reason === 'active_loan'
+					? 'Pay off your current loan first.'
+					: res?.reason === 'over_cap'
+						? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.`
+						: 'Could not borrow right now.';
+		}
+	}
+
+	async function repay(/** @type {number|null} */ amt) {
+		if (loanBusy) return;
+		const pay = amt ?? maxRepay;
+		if (pay <= 0) return;
+		loanBusy = 'repay';
+		loanMsg = '';
+		const res = await repayLoan(amt);
+		loanBusy = '';
+		if (res?.ok) {
+			fx('tap');
+			track('repay_loan', { amount: res.paid, cleared: res.cleared });
+			dispatch('changed');
+		} else {
+			loanMsg =
+				res?.reason === 'insufficient' ? 'Not enough Cash to repay.' : 'Could not repay right now.';
+		}
+	}
+</script>
+
+{#if bank?.in_the_red}
+	<!-- In debt: repay panel + the teeth -->
+	<div class="loan-card debt">
+		<div class="loan-head">
+			<span class="loan-title">🦈 You owe the Shark</span>
+			<span class="loan-owed">{fmt(owed)}</span>
+		</div>
+		<p class="loan-note">
+			Store is locked and half of every payout auto-pays your debt until it's clear. Your net worth
+			is <b class="neg">{fmt(bank.net_worth)}</b>.
+		</p>
+		{#if maxRepay > 0}
+			<div class="loan-dial">
+				<button
+					class="loan-step"
+					on:click={() => (repayAmt = Math.max(0, repayAmt - 50))}
+					aria-label="Less"
+					disabled={repayAmt <= 0}>−</button
+				>
+				<div class="loan-amt">
+					<span class="loan-usd">{fmt(repayAmt)}</span><span class="loan-sub"
+						>of {fmt(owed)} owed</span
+					>
+				</div>
+				<button
+					class="loan-step"
+					on:click={() => (repayAmt = Math.min(maxRepay, repayAmt + 50))}
+					aria-label="More"
+					disabled={repayAmt >= maxRepay}>+</button
+				>
+			</div>
+			<input
+				class="loan-slider"
+				type="range"
+				min="0"
+				max={maxRepay}
+				step="10"
+				bind:value={repayAmt}
+			/>
+			<div class="loan-actions">
+				<button
+					class="loan-btn ghost"
+					disabled={!!loanBusy || repayAmt <= 0}
+					on:click={() => repay(repayAmt)}>Repay {fmt(repayAmt)}</button
+				>
+				<button class="loan-btn pay" disabled={!!loanBusy} on:click={() => repay(null)}
+					>Pay max ({fmt(maxRepay)})</button
+				>
+			</div>
+		{:else}
+			<p class="loan-note">Earn some Cash (play the Daily) then come back to repay.</p>
+		{/if}
+		{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
+	</div>
+{:else if loanCap > 0}
+	<!-- No debt: borrow panel -->
+	<details class="loan-card">
+		<summary class="loan-summary"
+			>🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary
+		>
+		<p class="loan-note">
+			A 25% fee, one loan at a time. While you owe, the Store locks and half of every payout
+			auto-pays it down.
+		</p>
+		<div class="loan-dial">
+			<button
+				class="loan-step"
+				on:click={() => (borrowAmt = Math.max(10, borrowAmt - 50))}
+				aria-label="Less"
+				disabled={borrowAmt <= 10}>−</button
+			>
+			<div class="loan-amt">
+				<span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub"
+					>you'll owe {fmt(borrowAmt + feeOnBorrow)}</span
+				>
+			</div>
+			<button
+				class="loan-step"
+				on:click={() => (borrowAmt = Math.min(loanCap, borrowAmt + 50))}
+				aria-label="More"
+				disabled={borrowAmt >= loanCap}>+</button
+			>
+		</div>
+		<input
+			class="loan-slider"
+			type="range"
+			min="10"
+			max={loanCap}
+			step="10"
+			bind:value={borrowAmt}
+		/>
+		<button class="loan-btn borrow" disabled={!!loanBusy || borrowAmt < 10} on:click={borrow}
+			>🦈 Borrow {fmt(borrowAmt)} (fee {fmt(feeOnBorrow)})</button
+		>
+		{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
+	</details>
+{/if}
+
+<style>
+	.loan-card {
+		border-radius: 16px;
+		padding: 14px 16px;
+		margin: 0 0 14px;
+		border: 1px solid var(--border);
+		background: var(--surface);
+	}
+	.loan-card.debt {
+		border-color: rgba(248, 113, 113, 0.5);
+		background: linear-gradient(135deg, rgba(248, 113, 113, 0.12), rgba(248, 113, 113, 0.03));
+	}
+	.loan-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 10px;
+	}
+	.loan-title {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1rem;
+	}
+	.loan-owed {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.5rem;
+		color: #fb7185;
+	}
+	.loan-summary {
+		cursor: pointer;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.95rem;
+		list-style: none;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+	.loan-summary::-webkit-details-marker {
+		display: none;
+	}
+	.loan-cv {
+		color: var(--text-faint);
+		font-size: 0.8rem;
+	}
+	.loan-note {
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		margin: 8px 0;
+		line-height: 1.4;
+	}
+	.loan-note .neg {
+		color: #fb7185;
+	}
+	.loan-dial {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 12px;
+		width: 100%;
+		max-width: 320px;
+		margin: 4px auto 0;
+	}
+	.loan-step {
+		width: 44px;
+		height: 44px;
+		flex: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-size: 1.5rem;
+		font-weight: 800;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+		display: grid;
+		place-items: center;
+	}
+	.loan-step:disabled {
+		opacity: 0.3;
+		cursor: default;
+	}
+	.loan-amt {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 1px;
+	}
+	.loan-usd {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		color: var(--brand-2);
+		font-size: 1.6rem;
+		line-height: 1;
+	}
+	.loan-sub {
+		font-size: 0.68rem;
+		color: var(--text-faint);
+	}
+	.loan-slider {
+		width: 100%;
+		max-width: 320px;
+		display: block;
+		margin: 12px auto;
+		accent-color: #fb7185;
+	}
+	.loan-actions {
+		display: flex;
+		gap: 8px;
+	}
+	.loan-btn {
+		flex: 1;
+		padding: 0.8rem;
+		border: none;
+		border-radius: 12px;
+		cursor: pointer;
+		font-weight: 800;
+		font-size: 0.92rem;
+	}
+	.loan-btn.borrow {
+		width: 100%;
+		color: #2a1005;
+		background: linear-gradient(135deg, #fbbf24, #f59e0b);
+	}
+	.loan-btn.pay {
+		color: #06281d;
+		background: linear-gradient(135deg, #6ee7b7, #34d399);
+	}
+	.loan-btn.ghost {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.loan-btn:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+	.msg {
+		font-size: 0.8rem;
+		color: #fb7185;
+		margin: 8px 0 0;
+		text-align: center;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,6 +60,7 @@
 		getMyUsername,
 		setUsername,
 		getBank,
+		takeLoan,
 		getDailyBoard,
 		getMatchMessages,
 		sendMatchMessage,
@@ -115,6 +116,7 @@
 	import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
 	import InventoryList from '$lib/components/InventoryList.svelte';
 	import VaultReveal from '$lib/components/VaultReveal.svelte';
+	import LoanPanel from '$lib/components/LoanPanel.svelte';
 	import Keyboard from '$lib/components/Keyboard.svelte';
 	import GameButtons from '$lib/components/GameButtons.svelte';
 	import Auth from '$lib/components/Auth.svelte';
@@ -616,9 +618,9 @@
 		tick().then(playDailyIntroIfArmed);
 	}
 
-	// 💰 In-game bank: a modal (not a route) so closing it returns to the game, not the menu.
+	// 💰 Bank Account hub: a modal (not a route) so closing it returns to where you were.
 	let showBank = false;
-	/** @type {{ bank:number, net_worth:number, ledger:any[] }|null} */
+	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
 	let bankData = null;
 	async function openBankModal() {
 		fx('tap');
@@ -629,6 +631,15 @@
 			bankData = null;
 		}
 	}
+	// After a borrow/repay inside the hub: refresh the sheet + the top Bank Account chip.
+	async function reloadBank() {
+		try {
+			bankData = await getBank();
+		} catch {
+			/* keep last */
+		}
+		refreshBank();
+	}
 	const fmtCash = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
 	/** @param {string} reason */
 	const bankReason = (reason) =>
@@ -636,11 +647,19 @@
 			daily_win: 'Daily reward',
 			daily_reward: 'Daily reward',
 			attendance: 'Daily attendance reward',
-			arcade_cashout: 'Cash Game cash-out',
-			climb_bounty: 'Climb bounty',
-			freeplay_reward: 'Free Play reward',
-			cosmetic_buy: 'Shop purchase',
+			makeup_reward: 'Make-up Daily',
+			cashgame_buyin: 'Cash Game buy-in',
+			cashgame_cashout: 'Cash Game cash-out',
+			climb_bounty: 'Cash Game bounty',
+			climb_letter: 'Cash Game letter',
+			blitz_buyin: 'Blitz buy-in',
+			blitz_payout: 'Blitz payout',
+			challenge_payout: 'Challenge payout',
+			cosmetic_buy: 'Store purchase',
 			powerup_buy: 'Power-up purchase',
+			loan_take: 'Loan received',
+			loan_repay: 'Loan repayment',
+			loan_skim: 'Loan auto-payment',
 			wager_win: 'Won a wager',
 			wager_stake: 'Wager staked',
 			wager_refund: 'Wager refunded'
@@ -1696,16 +1715,54 @@
 		if (res?.ok) {
 			await enterClimbGame();
 		} else if (res?.reason === 'insufficient') {
-			// Can't afford the buy-in → offer the Loan Shark.
-			if (
-				confirm(
-					`You need $${(res.buy_in ?? 0).toLocaleString()} to buy in (you have $${(res.bank ?? 0).toLocaleString()}). Borrow from the Bank?`
-				)
-			) {
-				showTierSelect = false;
-				goto('/bank');
-			}
+			await borrowToBuyIn(tier, res.buy_in ?? 0, res.bank ?? 0);
 		} else if (res?.reason === 'locked') {
+			fx('wrong');
+		}
+	}
+	// 🦈 Buy-in wall → borrow exactly the shortfall (+25% fee), confirm with PIN, auto-start.
+	/** @param {string} tier @param {number} buyIn @param {number} have */
+	async function borrowToBuyIn(tier, buyIn, have) {
+		const shortfall = Math.max(10, Math.ceil((buyIn - have) / 10) * 10);
+		const info = await getBank().catch(() => null);
+		if ((info?.loan ?? 0) > 0) {
+			alert('Pay off your current loan first, then you can buy in.');
+			return;
+		}
+		const cap = info?.loan_cap ?? 0;
+		if (shortfall > cap) {
+			alert(
+				`You're $${(buyIn - have).toLocaleString()} short of the $${buyIn.toLocaleString()} buy-in and can only borrow up to $${cap.toLocaleString()}. Try a lower tier.`
+			);
+			return;
+		}
+		const fee = Math.round(shortfall * 0.25);
+		try {
+			await requirePin(`Borrow $${shortfall.toLocaleString()} to buy in`, [
+				{ label: 'Buy-in', value: '$' + buyIn.toLocaleString() },
+				{ label: 'You have', value: '$' + have.toLocaleString() },
+				{
+					label: 'Borrow (25% fee)',
+					value: `$${shortfall.toLocaleString()} → owe $${(shortfall + fee).toLocaleString()}`
+				}
+			]);
+		} catch {
+			return; // cancelled at the pad
+		}
+		cgBusy = true;
+		const loanRes = await takeLoan(shortfall);
+		if (!loanRes?.ok) {
+			cgBusy = false;
+			fx('wrong');
+			alert('Could not borrow right now.');
+			return;
+		}
+		const retry = await startCashGame(tier);
+		cgBusy = false;
+		if (retry?.ok) {
+			fx('win');
+			await enterClimbGame();
+		} else {
 			fx('wrong');
 		}
 	}
@@ -2405,15 +2462,17 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions a11y_no_noninteractive_tabindex -->
 		<div class="info-card bank-card" on:click|stopPropagation role="dialog" aria-modal="true">
 			<button class="modal-x" on:click={() => (showBank = false)} aria-label="Close">✕</button>
-			<p class="bm-label">Cash</p>
+			<p class="bm-label">🏦 Bank Account</p>
 			<div class="info-big">{fmtCash(bankData?.bank ?? netWorth ?? 0)}</div>
-			<p class="info-sub">Your Cash — this is your score</p>
+			<p class="info-sub">Your Bank Account — this is your score</p>
+			<!-- 🦈 Borrow / Repay, inline -->
+			<LoanPanel bank={bankData} on:changed={reloadBank} />
 			{#if bankData}
 				<div class="bm-hist-h">Recent activity</div>
 				{#if (bankData.ledger ?? []).length === 0}
 					<p class="info-note" style="text-align:center">
 						No transactions yet. Win the Daily, show up for attendance, or climb the Cash Game to
-						grow your Cash.
+						grow your Bank Account.
 					</p>
 				{:else}
 					<div class="bm-ledger">
@@ -2426,6 +2485,7 @@
 							</div>
 						{/each}
 					</div>
+					<button class="bm-fullledger" on:click={() => goto('/bank')}>See full ledger →</button>
 				{/if}
 			{/if}
 			<button class="info-close" on:click={() => (showBank = false)}>Back to game</button>
@@ -2954,7 +3014,7 @@
 								>{$unreadCount > 99 ? '99+' : $unreadCount}</span
 							>{/if}
 					</button>
-					<button class="bank-chip" on:click={() => goto('/bank')} title="Your Cash">
+					<button class="bank-chip" on:click={openBankModal} title="Bank Account">
 						<span class="bc-coin">💰</span>{netWorth == null
 							? '—'
 							: '$' + Math.round(netWorth).toLocaleString()}
@@ -3869,15 +3929,15 @@
 					class="top-bank solo"
 					class:pop-up={bankFlash === 'up'}
 					class:pop-down={bankFlash === 'down'}
-					title={isDailyLike ? 'Prize remaining — spend it, keep the rest' : 'Your Cash'}
+					title={isDailyLike ? 'Prize remaining — spend it, keep the rest' : 'Bank Account'}
 					on:click={openBankModal}
 				>
-					{#if isMatch}<span class="tb-wallet-cap">💰 Wallet</span>{:else if isDailyLike}<span
+					{#if isMatch}<span class="tb-wallet-cap">👛 Wallet</span>{:else if isDailyLike}<span
 							class="tb-wallet-cap">🏆 Prize</span
-						>{:else if isClimb}<span class="tb-wallet-cap">🪙 Stack</span>{/if}
+						>{:else if isClimb}<span class="tb-wallet-cap">👛 Wallet</span>{/if}
 					<span class="tb-solo"
-						>{#if isMatch}💰
-						{:else if isClimb}🪙
+						>{#if isMatch}👛
+						{:else if isClimb}👛
 						{:else if !isDailyLike}💰
 						{/if}${Math.round($tweenBank).toLocaleString()}</span
 					>
@@ -3930,7 +3990,7 @@
 			{#if climb.bust_risk && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				<div class="climb-stuck">
 					<span class="cs-text"
-						>⚠️ Low Stack — a wrong guess busts your run. Cash Out to bank it.</span
+						>⚠️ Low Wallet — a wrong guess busts your run. Cash Out to bank it.</span
 					>
 				</div>
 			{/if}
@@ -4079,8 +4139,8 @@
 					<span class="bp-label"
 						>{isMatch
 							? matchLeft > 0
-								? '💰 Left to Spend'
-								: '🪙 Out of ante'
+								? '👛 Wallet'
+								: '👛 Wallet empty'
 							: $gameStore.gameMode === 'daily'
 								? "You'll bank"
 								: soloHero.net >= 0
@@ -4343,7 +4403,7 @@
 								>
 							</div>
 							<div class="wm-row total">
-								<span>🪙 Stack</span><b>${bankroll.toLocaleString()}</b>
+								<span>👛 Wallet</span><b>${bankroll.toLocaleString()}</b>
 							</div>
 						</div>
 						<p class="win-twist">
@@ -7645,6 +7705,19 @@
 		gap: 10px;
 		padding: 9px 11px;
 		background: var(--surface);
+	}
+	.bm-fullledger {
+		display: block;
+		width: 100%;
+		margin: -6px 0 12px;
+		padding: 4px;
+		background: none;
+		border: none;
+		color: var(--brand-2);
+		font-size: 0.82rem;
+		font-weight: 700;
+		cursor: pointer;
+		text-align: center;
 	}
 	.bm-reason {
 		color: var(--text-muted);

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,11 +1,10 @@
 <script>
 	import { onMount } from 'svelte';
 	import PageNav from '$lib/components/PageNav.svelte';
-	import { getBank, takeLoan, repayLoan } from '$lib/stores/statsStore.js';
+	import { getBank } from '$lib/stores/statsStore.js';
 	import InventoryList from '$lib/components/InventoryList.svelte';
-	import { requirePin } from '$lib/pinConfirm.js';
+	import LoanPanel from '$lib/components/LoanPanel.svelte';
 	import { track } from '$lib/analytics.js';
-	import { fx } from '$lib/sound.js';
 
 	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
 	let b = null;
@@ -13,22 +12,8 @@
 	/** @type {{title:string, desc:string}|null} */
 	let info = null;
 
-	// 💸 Loan Shark
-	let borrowAmt = 100; // $ to borrow (dial)
-	let repayAmt = 0; // $ to repay (dial)
-	let loanBusy = '';
-	let loanMsg = '';
-	$: loanCap = b?.loan_cap ?? 0;
-	$: owed = b?.loan ?? 0;
-	$: feeOnBorrow = Math.round(borrowAmt * 0.25);
-	$: if (borrowAmt > loanCap) borrowAmt = loanCap;
-	$: if (borrowAmt < 10 && loanCap >= 10) borrowAmt = 10;
-	$: maxRepay = Math.max(0, Math.min(owed, b?.bank ?? 0));
-	$: if (repayAmt > maxRepay) repayAmt = maxRepay;
-
 	async function load() {
 		b = await getBank(500);
-		repayAmt = Math.max(0, Math.min(b?.loan ?? 0, b?.bank ?? 0));
 	}
 	onMount(async () => {
 		track('bank_view');
@@ -38,56 +23,6 @@
 			loading = false;
 		}
 	});
-
-	async function borrow() {
-		if (loanBusy || borrowAmt < 10) return;
-		const total = borrowAmt + Math.round(borrowAmt * 0.25);
-		try {
-			await requirePin(
-				`Borrow $${borrowAmt.toLocaleString()} — you'll owe $${total.toLocaleString()}`,
-				[
-					{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
-					{ label: 'Fee (25%)', value: '$' + Math.round(borrowAmt * 0.25).toLocaleString() },
-					{ label: 'You owe', value: '$' + total.toLocaleString() }
-				]
-			);
-		} catch {
-			return;
-		}
-		loanBusy = 'borrow';
-		loanMsg = '';
-		const res = await takeLoan(borrowAmt);
-		loanBusy = '';
-		if (res?.ok) {
-			fx('win');
-			track('take_loan', { amount: borrowAmt, owed: res.owed });
-			await load();
-		} else {
-			loanMsg =
-				res?.reason === 'active_loan'
-					? 'Pay off your current loan first.'
-					: res?.reason === 'over_cap'
-						? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.`
-						: 'Could not borrow right now.';
-		}
-	}
-	async function repay(/** @type {number|null} */ amt) {
-		if (loanBusy) return;
-		const pay = amt ?? maxRepay;
-		if (pay <= 0) return;
-		loanBusy = 'repay';
-		loanMsg = '';
-		const res = await repayLoan(amt);
-		loanBusy = '';
-		if (res?.ok) {
-			fx('tap');
-			track('repay_loan', { amount: res.paid, cleared: res.cleared });
-			await load();
-		} else {
-			loanMsg =
-				res?.reason === 'insufficient' ? 'Not enough Cash to repay.' : 'Could not repay right now.';
-		}
-	}
 
 	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
 	const dateOnly = (/** @type {string} */ at) =>
@@ -123,20 +58,27 @@
 				daily_win: 'Daily reward',
 				daily_reward: 'Daily reward',
 				attendance: 'Attendance reward',
-				arcade_cashout: 'Cash Game cash-out',
+				makeup_reward: 'Make-up Daily',
+				cashgame_buyin: 'Cash Game buy-in',
+				cashgame_cashout: 'Cash Game cash-out',
 				climb_bounty: 'Cash Game bounty',
-				freeplay_reward: 'Free Play reward',
-				freeplay_cashout: 'Exchanged credits → Cash',
+				climb_letter: 'Cash Game letter',
+				blitz_buyin: 'Blitz buy-in',
+				blitz_payout: 'Blitz payout',
+				challenge_payout: 'Challenge payout',
+				wager_win: 'Won a wager',
+				wager_stake: 'Wager staked',
+				wager_refund: 'Wager refunded',
 				cosmetic_buy: 'Store purchase',
 				powerup_buy: 'Power-up purchase',
 				loan_take: 'Loan received',
 				loan_repay: 'Loan repayment',
 				loan_skim: 'Loan auto-payment',
-				wager_win: 'Won a wager',
-				wager_stake: 'Wager staked',
-				wager_refund: 'Wager refunded',
-				makeup_reward: 'Make-up Daily',
-				challenge_payout: 'Challenge payout'
+				quest_reward: 'Quest reward',
+				buy_credits: 'Bought credits',
+				arcade_cashout: 'Arcade cash-out',
+				freeplay_reward: 'Free Play reward',
+				freeplay_cashout: 'Exchanged credits'
 			}[reason] || reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 		);
 	}
@@ -157,113 +99,17 @@
 				class="bal cash"
 				onclick={() =>
 					(info = {
-						title: '💰 Cash',
-						desc: 'Your main currency — and your score. Earn it by solving puzzles in the Daily, Cash Game, and challenges. Spend it on letters mid-game and on power-ups & cosmetics in the Store. It can’t be bought with real money.'
+						title: '💰 Bank Account',
+						desc: 'Your main balance — and your score. Earn it by solving puzzles in the Daily, Cash Game, and challenges. You move some into a Wallet to play Cash Game, and spend it on power-ups & cosmetics in the Store. It can’t be bought with real money.'
 					})}
 			>
-				<span class="bal-label">💰 Cash <span class="bal-i">ⓘ</span></span>
+				<span class="bal-label">💰 Bank Account <span class="bal-i">ⓘ</span></span>
 				<span class="bal-value">{fmt(b.bank)}</span>
 			</button>
 		</div>
 
 		<!-- 💸 Loan Shark -->
-		{#if b.in_the_red}
-			<!-- In debt: repay panel + the teeth -->
-			<div class="loan-card debt">
-				<div class="loan-head">
-					<span class="loan-title">🦈 You owe the Shark</span>
-					<span class="loan-owed">{fmt(owed)}</span>
-				</div>
-				<p class="loan-note">
-					Store is locked and half of every payout auto-pays your debt until it's clear. Your net
-					worth is <b class="neg">{fmt(b.net_worth)}</b>.
-				</p>
-				{#if maxRepay > 0}
-					<div class="loan-dial">
-						<button
-							class="loan-step"
-							onclick={() => (repayAmt = Math.max(0, repayAmt - 50))}
-							aria-label="Less"
-							disabled={repayAmt <= 0}>−</button
-						>
-						<div class="loan-amt">
-							<span class="loan-usd">{fmt(repayAmt)}</span><span class="loan-sub"
-								>of {fmt(owed)} owed</span
-							>
-						</div>
-						<button
-							class="loan-step"
-							onclick={() => (repayAmt = Math.min(maxRepay, repayAmt + 50))}
-							aria-label="More"
-							disabled={repayAmt >= maxRepay}>+</button
-						>
-					</div>
-					<input
-						class="loan-slider"
-						type="range"
-						min="0"
-						max={maxRepay}
-						step="10"
-						bind:value={repayAmt}
-					/>
-					<div class="loan-actions">
-						<button
-							class="loan-btn ghost"
-							disabled={!!loanBusy || repayAmt <= 0}
-							onclick={() => repay(repayAmt)}>Repay {fmt(repayAmt)}</button
-						>
-						<button class="loan-btn pay" disabled={!!loanBusy} onclick={() => repay(null)}
-							>Pay max ({fmt(maxRepay)})</button
-						>
-					</div>
-				{:else}
-					<p class="loan-note">Earn some Cash (play the Daily) then come back to repay.</p>
-				{/if}
-				{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
-			</div>
-		{:else if loanCap > 0}
-			<!-- No debt: borrow panel -->
-			<details class="loan-card">
-				<summary class="loan-summary"
-					>🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary
-				>
-				<p class="loan-note">
-					A 25% fee, one loan at a time. While you owe, the Store locks and half of every payout
-					auto-pays it down.
-				</p>
-				<div class="loan-dial">
-					<button
-						class="loan-step"
-						onclick={() => (borrowAmt = Math.max(10, borrowAmt - 50))}
-						aria-label="Less"
-						disabled={borrowAmt <= 10}>−</button
-					>
-					<div class="loan-amt">
-						<span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub"
-							>you'll owe {fmt(borrowAmt + feeOnBorrow)}</span
-						>
-					</div>
-					<button
-						class="loan-step"
-						onclick={() => (borrowAmt = Math.min(loanCap, borrowAmt + 50))}
-						aria-label="More"
-						disabled={borrowAmt >= loanCap}>+</button
-					>
-				</div>
-				<input
-					class="loan-slider"
-					type="range"
-					min="10"
-					max={loanCap}
-					step="10"
-					bind:value={borrowAmt}
-				/>
-				<button class="loan-btn borrow" disabled={!!loanBusy || borrowAmt < 10} onclick={borrow}
-					>🦈 Borrow {fmt(borrowAmt)} (fee {fmt(feeOnBorrow)})</button
-				>
-				{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
-			</details>
-		{/if}
+		<LoanPanel bank={b} on:changed={load} />
 
 		<!-- Items (your vault) -->
 		<h2 class="hist-title">🎒 Your Items</h2>
@@ -467,145 +313,6 @@
 		font-weight: 800;
 		font-size: 1.7rem;
 		color: var(--brand-2);
-	}
-
-	/* 💸 Loan Shark */
-	.loan-card {
-		border-radius: 16px;
-		padding: 14px 16px;
-		margin: 0 0 14px;
-		border: 1px solid var(--border);
-		background: var(--surface);
-	}
-	.loan-card.debt {
-		border-color: rgba(248, 113, 113, 0.5);
-		background: linear-gradient(135deg, rgba(248, 113, 113, 0.12), rgba(248, 113, 113, 0.03));
-	}
-	.loan-head {
-		display: flex;
-		align-items: baseline;
-		justify-content: space-between;
-		gap: 10px;
-	}
-	.loan-title {
-		font-family: var(--font-display);
-		font-weight: 800;
-		font-size: 1rem;
-	}
-	.loan-owed {
-		font-family: 'Orbitron', var(--font-display);
-		font-weight: 800;
-		font-size: 1.5rem;
-		color: #fb7185;
-	}
-	.loan-summary {
-		cursor: pointer;
-		font-family: var(--font-display);
-		font-weight: 700;
-		font-size: 0.95rem;
-		list-style: none;
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-	}
-	.loan-summary::-webkit-details-marker {
-		display: none;
-	}
-	.loan-cv {
-		color: var(--text-faint);
-		font-size: 0.8rem;
-	}
-	.loan-note {
-		font-size: 0.78rem;
-		color: var(--text-muted);
-		margin: 8px 0;
-		line-height: 1.4;
-	}
-	.loan-note .neg {
-		color: #fb7185;
-	}
-	.loan-dial {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 12px;
-		width: 100%;
-		max-width: 320px;
-		margin: 4px auto 0;
-	}
-	.loan-step {
-		width: 44px;
-		height: 44px;
-		flex: none;
-		border-radius: 12px;
-		cursor: pointer;
-		font-size: 1.5rem;
-		font-weight: 800;
-		background: var(--surface);
-		border: 1px solid var(--border);
-		color: var(--text);
-		display: grid;
-		place-items: center;
-	}
-	.loan-step:disabled {
-		opacity: 0.3;
-		cursor: default;
-	}
-	.loan-amt {
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		gap: 1px;
-	}
-	.loan-usd {
-		font-family: 'Orbitron', var(--font-display);
-		font-weight: 800;
-		color: var(--brand-2);
-		font-size: 1.6rem;
-		line-height: 1;
-	}
-	.loan-sub {
-		font-size: 0.68rem;
-		color: var(--text-faint);
-	}
-	.loan-slider {
-		width: 100%;
-		max-width: 320px;
-		display: block;
-		margin: 12px auto;
-		accent-color: #fb7185;
-	}
-	.loan-actions {
-		display: flex;
-		gap: 8px;
-	}
-	.loan-btn {
-		flex: 1;
-		padding: 0.8rem;
-		border: none;
-		border-radius: 12px;
-		cursor: pointer;
-		font-weight: 800;
-		font-size: 0.92rem;
-	}
-	.loan-btn.borrow {
-		width: 100%;
-		color: #2a1005;
-		background: linear-gradient(135deg, #fbbf24, #f59e0b);
-	}
-	.loan-btn.pay {
-		color: #06281d;
-		background: linear-gradient(135deg, #6ee7b7, #34d399);
-	}
-	.loan-btn.ghost {
-		background: var(--surface);
-		border: 1px solid var(--border);
-		color: var(--text);
-	}
-	.loan-btn:disabled {
-		opacity: 0.45;
-		cursor: default;
 	}
 
 	.led-head {


### PR DESCRIPTION
Implements the approved design (`docs/superpowers/specs/2026-07-07-bank-account-loans-ui-design.md`). No DB changes.

## Naming
- Persistent money → **Bank Account** 💰 (was "Cash")
- Cash Game run + challenge ante → **Wallet** 👛 (was "Stack" 🪙)
- Mental model: Bank Account = savings; move money into a Wallet to play.

## Unified money hub
Tapping your Bank Account (top money — menu **and** mid-game) opens one sheet: balance + **Borrow/Repay** + recent activity + **See full ledger →** `/bank`. The menu chip now opens the hub instead of routing away.

## Inline borrow at the buy-in wall
Short on a Cash Game buy-in → borrow **exactly the shortfall** (+25% fee), confirm with PIN, run auto-starts. No detour. Blocks cleanly if you already owe or the shortfall exceeds your loan cap.

## Shared LoanPanel
Borrow/repay UI extracted into `LoanPanel.svelte`, reused by both `/bank` and the hub (one implementation).

## Ledger labels
Remapped to live V2 reason strings (`cashgame_buyin`/`cashout`, `blitz_*`, `loan_*`, `climb_letter`, …); dropped the ugly auto-formatted fallbacks and stale removed-feature entries.

## Scoped out (noted)
- Inline borrow on **challenge** wagers — wagers are player-chosen (just lower the number), so it's far less valuable than at the fixed Cash Game buy-in. Left as a clear "Not enough Cash" message.