### PR TITLE
Cash Game V4: the Accumulator (banking run)

### DIFF
--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -112,12 +112,18 @@
 	$: lockedLetters = ($gameStore.lockedLetters || {}) as LockedLetters;
 	$: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
 
+	// The pool letters are bought from: Cash Game spends the per-puzzle BUDGET (not the
+	// accumulated Wallet); every other mode spends the bankroll.
+	$: affordPool =
+		$gameStore.gameMode === 'climb'
+			? Number($gameStore.climbInfo?.budget_left ?? 0)
+			: $gameStore.bankroll;
 	// 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
-	//    Blitz pays in TIME, not Cash, so letters are never gated by bankroll there.
+	//    Blitz pays in TIME, not Cash, so letters are never gated by budget there.
 	$: disabledKeys = Object.keys(letterCosts).filter((letter: string) =>
 		isBlitzKb
 			? incorrectLetters.includes(letter)
-			: (effCosts[letter] ?? 0) > $gameStore.bankroll || incorrectLetters.includes(letter)
+			: (effCosts[letter] ?? 0) > affordPool || incorrectLetters.includes(letter)
 	);
 
 	/**

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -1050,10 +1050,13 @@ export async function matchFold() {
 export function selectLetter(letter) {
 	gameStore.update(
 		/** @param {GameState} state */ (state) => {
-			// Cash Game scales letter cost by the tier stake multiplier (server matches).
-			const climbMult = state.gameMode === 'climb' ? Number(state.climbInfo?.stake ?? 1) || 1 : 1;
+			// Cash Game scales letter cost by the tier stake multiplier, and spends the per-puzzle
+			// BUDGET (not the accumulated Wallet); server matches both.
+			const isClimb = state.gameMode === 'climb';
+			const climbMult = isClimb ? Number(state.climbInfo?.stake ?? 1) || 1 : 1;
 			const cost = (LETTER_COSTS[letter] || 0) * climbMult;
-			if (state.bankroll < cost) {
+			const affordPool = isClimb ? Number(state.climbInfo?.budget_left ?? 0) : state.bankroll;
+			if (affordPool < cost) {
 				console.log(`Insufficient funds to purchase letter ${letter}`);
 				return state;
 			}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -481,7 +481,7 @@
 		_attTimer = setTimeout(() => gameStore.update((s) => ({ ...s, cashToast: null })), 4000);
 	}
 	$: isClimb = $gameStore.gameMode === 'climb';
-	$: climb = $gameStore.climbInfo; // { bounty, heat, spent, position, final_guess, cheapest, wrong_penalty, last_gain, state, pups_locked, equipped }
+	$: climb = $gameStore.climbInfo; // { wallet, bounty, budget_left, solve_reward, spent, heat, must_guess, cheapest, last_gain, state, run_solves, wiped, pups_locked, equipped }
 	// ⚡ Blitz — the live client clock counts down to blitzInfo.remaining_ms (server-authoritative);
 	// each action resyncs it. At 0 we call endBlitz() once.
 	$: isBlitz = $gameStore.gameMode === 'blitz';
@@ -536,15 +536,15 @@
 	// The doubled target payout (matches server: bounty ×2, then × heat, rounded).
 	$: donTarget =
 		isClimb && climb ? Math.round(((climb.bounty ?? 0) * 2 * (climb.heat ?? 100)) / 100) : 0;
-	// Climb live: Spent · Payout (bounty × heat, doubled while armed) · Net.
+	// Climb live (Accumulator): "Solve to Earn" = leftover budget × heat, banked into the
+	// Wallet on solve. Server-computed as solve_reward.
 	$: climbLive =
 		isClimb && climb && climb.state === 'active'
-			? (() => {
-					const m = climb.don_armed ? 2 : 1;
-					const pay = Math.round(((climb.bounty ?? 0) * m * (climb.heat ?? 100)) / 100);
-					const sp = climb.spent ?? 0;
-					return { spent: sp, payout: pay, net: pay - sp };
-				})()
+			? {
+					spent: climb.spent ?? 0,
+					payout: climb.solve_reward ?? 0,
+					net: climb.solve_reward ?? 0
+				}
 			: null;
 	// Challenge live: Spent of your ante budget — lowest spend wins (standard only).
 	$: matchLive =
@@ -2293,15 +2293,7 @@
 {#if loggedIn && hasInitialized && !showMainMenu && foldMode && gameActive}
 	<button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
 {/if}
-<!-- ⏭️ Skip (top-right) — Cash Game only; resets heat. Hidden once Double-or-Nothing is armed (committed). -->
-{#if loggedIn && hasInitialized && !showMainMenu && isClimb && gameActive && !donArmed && climb?.state === 'active'}
-	<button
-		class="giveup-btn"
-		title="Skip this puzzle"
-		aria-label="Skip this puzzle"
-		on:click={confirmFold}>↪</button
-	>
-{/if}
+<!-- Skip retired in Cash Game V4 — Cash Out is the graceful bail. -->
 
 <!-- 💬 Match chat (1v1 + group challenges) — only inside a live match, never on the menu -->
 {#if isMatch && matchInfo && !showMainMenu}
@@ -3987,11 +3979,11 @@
 		<!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
          Solve-to-Earn box; power-ups live in the vault beside Solve. -->
 		{#if isClimb && climb}
-			{#if climb.final_guess && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+			{#if climb.must_guess && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				<div class="climb-stuck">
 					<span class="cs-text"
-						>🎯 Final guess — can't afford another letter. Solve it, or Cash Out to bank your
-						Wallet. A wrong guess busts the run.</span
+						>🎯 Out of budget — you must guess now, or Cash Out to bank your Wallet. A wrong guess
+						wipes it.</span
 					>
 				</div>
 			{/if}
@@ -4351,6 +4343,7 @@
 							{(co.tier ?? '').charAt(0).toUpperCase() + (co.tier ?? '').slice(1)} run · {co.solves ??
 								0} solve{co.solves === 1 ? '' : 's'}
 						</p>
+						{#if co.phrase}<p class="result-sub">Answer: <b>{co.phrase}</b></p>{/if}
 						<div class="win-math">
 							<div class="wm-row">
 								<span>Banked</span><b>${(co.banked ?? 0).toLocaleString()}</b>
@@ -4367,9 +4360,9 @@
 							</div>
 						</div>
 						<p class="win-twist">
-							{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× your buy-in · 🔥 peak ×{(
+							{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× your ante · 🔥 peak ×{(
 								(co.heat ?? 100) / 100
-							).toFixed(1)} — banked to your Cash
+							).toFixed(1)} — banked to your Bank Account
 						</p>
 						<div class="result-actions">
 							<button
@@ -4431,13 +4424,18 @@
 							>
 						</div>
 					{:else if isClimb}
-						<!-- 💥 Busted — lost the buy-in -->
+						<!-- 💥 Wiped — a wrong guess emptied the Wallet -->
 						<div class="result-medal">💥</div>
-						<h2>Busted</h2>
+						<h2>Wiped Out</h2>
 						<p class="result-sub">The answer was {$gameStore.currentPhrase}</p>
 						<p class="arcade-gain">
-							You lost your ${(climb?.buy_in ?? 0).toLocaleString()} buy-in. The Daily always refills
-							your Cash — come back for another run.
+							{#if (climb?.wiped ?? 0) > 0}A wrong guess wiped your <b
+									>${(climb?.wiped ?? 0).toLocaleString()}</b
+								>
+								Wallet and your ${(climb?.buy_in ?? 0).toLocaleString()} ante.{:else}You lost your ${(
+									climb?.buy_in ?? 0
+								).toLocaleString()} ante.{/if} The Daily always refills your Bank Account — come back
+							for another run.
 						</p>
 						<div class="result-actions">
 							<button

--- a/supabase-cashgame-v4-accumulator.sql
+++ b/supabase-cashgame-v4-accumulator.sql
@@ -1,0 +1,225 @@
+-- Cash Game V4: the Accumulator — "Daily, strung into a banking run."
+--
+-- Reframes the run so the cash-out finally MATTERS:
+--   • Buy-in is an ANTE (gone at start). Your Wallet starts at $0.
+--   • Each puzzle hands you a BUDGET = k × Σ letter-costs × stake (k<1, so you can never
+--     buy your way to certainty). You spend the BUDGET on letters — the Wallet is untouched.
+--   • Solve → keep the leftover budget × heat, banked into your Wallet. Heat +0.1.
+--   • Cash out ANYTIME → bank the Wallet, reveal the answer, end the run (profitable cash-out
+--     extends your run streak). This is the safe bail.
+--   • A WRONG GUESS wipes the Wallet ($0) and ends the run. Because you can always cash out
+--     first, every wrong guess is a chosen gamble → fair. Max downside = the ante.
+--   • No skip — cash-out is the graceful exit.
+-- Supersedes the V3 penalty-cap + final-guess (those patched the old single-pool model).
+-- Spec: chat decision 2026-07-07. PITR point logged before apply.
+
+BEGIN;
+
+-- Start: debit the ANTE, seed an EMPTY Wallet (bankroll = 0). buy_in stores the ante.
+CREATE OR REPLACE FUNCTION public.cashgame_start(p_tier text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_tier JSONB; v_buy BIGINT; v_bank BIGINT; v_pid UUID; v_t text := lower(COALESCE(p_tier,''));
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_start: not authenticated'; END IF;
+  v_tier := public._cg_tier(v_t);
+  IF v_tier IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'bad_tier'); END IF;
+  IF NOT public._cg_unlocked(v_uid, v_t) THEN RETURN jsonb_build_object('ok', false, 'reason', 'locked'); END IF;
+  IF EXISTS (SELECT 1 FROM public.climb_state WHERE user_id = v_uid AND state IN ('active','solved')) THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'run_active'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_buy := (v_tier->>'buy_in')::bigint;
+  SELECT bank INTO v_bank FROM public.profiles WHERE id = v_uid;
+  IF v_bank < v_buy THEN RETURN jsonb_build_object('ok', false, 'reason', 'insufficient', 'buy_in', v_buy, 'bank', v_bank); END IF;
+  v_pid := public._pick_casual(v_uid, null, null, 0);
+  IF v_pid IS NULL THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_puzzles'); END IF;
+  PERFORM public._bank_credit(v_uid, -v_buy, 'cashgame_buyin');       -- ante leaves your Bank Account
+  DELETE FROM public.climb_state WHERE user_id = v_uid;
+  INSERT INTO public.climb_state(user_id, position, puzzle_id, bankroll, tier, buy_in, heat_x100, state)
+    VALUES (v_uid, 1, v_pid, 0, v_t, v_buy, 100, 'active');           -- Wallet starts at $0
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid) || jsonb_build_object('ok', true);
+END; $function$;
+
+-- Buy a letter: spend from the PUZZLE BUDGET (bounty − spent), NOT the Wallet.
+CREATE OR REPLACE FUNCTION public.climb_buy_letter(p_letter text)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_letter TEXT; v_cost INT; v_stake INT;
+  v_k NUMERIC; v_bounty INT; v_budget_left INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter);
+  IF public.letter_cost(v_letter) IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_buy_letter: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  v_k := COALESCE((public._cg_tier(cs.tier)->>'k')::numeric, 0.85);
+  v_stake := COALESCE((public._cg_tier(cs.tier)->>'stake')::int, 1);
+  v_cost := public.letter_cost(v_letter) * v_stake;
+  IF 'half_off' = ANY(cs.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  v_bounty := public._climb_bounty(cs.puzzle_id, v_k) * v_stake;
+  v_budget_left := v_bounty - cs.spent;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  IF v_letter = ANY(cs.incorrect_letters) OR v_budget_left < v_cost THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cs.revealed_positions THEN RETURN public._climb_board(v_uid); END IF;
+  IF v_positions IS NULL THEN cs.incorrect_letters := array_append(cs.incorrect_letters, v_letter);
+  ELSE cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.climb_state SET revealed_positions = cs.revealed_positions,
+    incorrect_letters = cs.incorrect_letters, spent = cs.spent + v_cost, pups_locked = true, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- Submit a guess: all-correct → solve. Anything else → WRONG → wipe the Wallet, end the run.
+CREATE OR REPLACE FUNCTION public.climb_submit_guess(p_guess jsonb)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}';
+  v_all BOOLEAN := true; pos INT; v_ch TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_submit_guess: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_submit_guess: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._climb_board(v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_correct) ORDER BY 1);
+    UPDATE public.climb_state SET revealed_positions = cs.revealed_positions, updated_at = now() WHERE user_id = v_uid;
+    RETURN public._climb_resolve(v_uid);
+  END IF;
+  RETURN public._cg_bust(v_uid);    -- wrong guess → wipe the Wallet, reveal the answer, run over
+END; $function$;
+
+-- Resolve after a move: solve → keep the leftover BUDGET × heat, banked into the Wallet.
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_tier JSONB; v_k NUMERIC; v_stake INT; v_cap INT;
+  v_bounty INT; v_keep INT; v_payout INT; v_cat TEXT; v_time INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(p_uid); END IF;
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_cap := COALESCE((v_tier->>'heat_cap')::int, 250); v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    v_bounty := public._climb_bounty(cs.puzzle_id, v_k) * v_stake;
+    v_keep := GREATEST(0, v_bounty - cs.spent);                      -- leftover budget you keep
+    v_payout := round(v_keep * cs.heat_x100 / 100.0)::int;           -- × heat → into the Wallet
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_payout,
+      bankroll = cs.bankroll + v_payout,
+      heat_x100 = LEAST(v_cap, cs.heat_x100 + 10),
+      run_solves = cs.run_solves + 1, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_payout, v_time);
+  ELSE
+    UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- Board: Wallet (accumulated) + this puzzle's budget_left + solve_reward preview + must_guess.
+CREATE OR REPLACE FUNCTION public._climb_board(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_state TEXT; v_board JSONB; v_tier JSONB;
+  v_k NUMERIC; v_stake INT; v_bounty INT; v_budget_left INT; v_cheapest INT; v_solve_reward INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_state := CASE cs.state WHEN 'solved' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  v_bounty := public._climb_bounty(cs.puzzle_id, v_k) * v_stake;
+  v_budget_left := GREATEST(0, v_bounty - cs.spent);
+  v_cheapest := public._cg_cheapest(cs);
+  v_solve_reward := round(v_budget_left * cs.heat_x100 / 100.0)::int;
+  -- Base board shows the WALLET (accumulated winnings) as the headline number.
+  v_board := public._daily_board(v_phrase, v_state, cs.bankroll::int, 99, cs.revealed_positions, cs.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('climb', jsonb_build_object(
+    'wallet', cs.bankroll, 'bankroll', cs.bankroll,
+    'bounty', v_bounty, 'budget_left', v_budget_left, 'solve_reward', v_solve_reward, 'spent', cs.spent,
+    'heat', cs.heat_x100, 'heat_cap', (v_tier->>'heat_cap')::int, 'tier', cs.tier, 'buy_in', cs.buy_in,
+    'tier_label', v_tier->>'label', 'stake', v_stake, 'cheapest', v_cheapest,
+    'must_guess', (cs.state = 'active' AND (v_cheapest IS NULL OR v_budget_left < v_cheapest)),
+    'position', cs.position, 'last_gain', cs.last_gain, 'state', cs.state,
+    'pups_locked', cs.pups_locked, 'equipped', to_jsonb(cs.active_powerups),
+    'run_solves', cs.run_solves, 'run_profit', cs.bankroll - cs.buy_in));
+END; $function$;
+
+-- Cash out: bank the Wallet, reveal the answer, extend the streak if profitable, end the run.
+CREATE OR REPLACE FUNCTION public.cashgame_cashout()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_profit BIGINT; v_mult INT; v_wins jsonb; v_streak INT; v_bestrs INT; v_phrase TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_cashout: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','solved') THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_run'); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_profit := cs.bankroll - cs.buy_in;                              -- Wallet banked minus the ante
+  v_mult := CASE WHEN cs.buy_in > 0 THEN round(cs.bankroll * 100.0 / cs.buy_in)::int ELSE 0 END;
+  IF cs.bankroll > 0 THEN PERFORM public._bank_credit(v_uid, cs.bankroll, 'cashgame_cashout'); END IF;
+  SELECT COALESCE(cg_wins,'{}'::jsonb), COALESCE(cg_run_streak,0), COALESCE(cg_best_run_streak,0)
+    INTO v_wins, v_streak, v_bestrs FROM public.profiles WHERE id = v_uid;
+  IF v_profit > 0 THEN
+    v_wins := jsonb_set(v_wins, ARRAY[cs.tier], to_jsonb(COALESCE((v_wins->>cs.tier)::int,0) + 1), true);
+    v_streak := v_streak + 1;
+  ELSE
+    v_streak := 0;
+  END IF;
+  UPDATE public.profiles SET
+    cg_wins = v_wins,
+    cg_run_streak = v_streak,
+    cg_best_run_streak = GREATEST(v_bestrs, v_streak),
+    cg_best_run = GREATEST(COALESCE(cg_best_run,0), cs.bankroll),
+    cg_best_multiple_x100 = GREATEST(COALESCE(cg_best_multiple_x100,0), v_mult),
+    cg_best_heat_x100 = GREATEST(COALESCE(cg_best_heat_x100,100), cs.heat_x100),
+    cg_lifetime_net = COALESCE(cg_lifetime_net,0) + v_profit
+    WHERE id = v_uid;
+  DELETE FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object('ok', true, 'banked', cs.bankroll, 'buy_in', cs.buy_in, 'profit', v_profit,
+    'multiple_x100', v_mult, 'solves', cs.run_solves, 'tier', cs.tier, 'heat', cs.heat_x100, 'phrase', v_phrase);
+END; $function$;
+
+-- Bust (wrong guess) = wipe the Wallet, reveal the answer, run over. Carries the wiped amount.
+CREATE OR REPLACE FUNCTION public._cg_bust(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase text; v_all int[]; v_cat text; v_board jsonb; v_wiped bigint;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid FOR UPDATE;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_wiped := cs.bankroll;                                            -- accumulated Wallet, now lost
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i) INTO v_all FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) <> ' ';
+  UPDATE public.profiles SET cg_run_streak = 0, cg_lifetime_net = COALESCE(cg_lifetime_net,0) - cs.buy_in WHERE id = p_uid;
+  PERFORM public._log_game_result(p_uid,'climb','lost', cs.puzzle_id, v_cat, 0, 1, cs.spent::int, 0);
+  v_board := public._daily_board(v_phrase, 'lost', 0, 99, COALESCE(v_all,'{}'), cs.incorrect_letters, v_cat, '')
+    || jsonb_build_object('climb', jsonb_build_object('wallet', 0, 'bankroll', 0, 'state', 'busted', 'tier', cs.tier,
+         'buy_in', cs.buy_in, 'run_solves', cs.run_solves, 'busted', true, 'wiped', v_wiped, 'position', cs.position));
+  DELETE FROM public.climb_state WHERE user_id = p_uid;
+  RETURN v_board;
+END; $function$;
+
+-- Skip retired in V4 — cash-out is the graceful bail. No-op (returns the board unchanged).
+CREATE OR REPLACE FUNCTION public.climb_skip()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+BEGIN RETURN public._climb_board(auth.uid()); END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Reframes the run so the cash-out finally matters. **⚠️ The DB migration is already applied to prod — this frontend must deploy to match it (old frontend gates the keyboard on the Wallet, which now starts $0).**

## Model
- Buy-in = **ante** (gone); Wallet starts **$0**.
- Each puzzle = a **budget** (k × Σ letter-costs × stake, k<1 so you can't buy certainty) you spend on letters — the Wallet is untouched.
- **Solve** → keep leftover budget × heat → banked into the Wallet. Heat +0.1.
- **Cash out anytime** → bank the Wallet, reveal the answer, end the run (profitable = streak++). The safe bail.
- **Wrong guess → wipes the Wallet**, run over. Always-available cash-out makes every wrong guess a chosen gamble → fair. Max downside = the ante.
- No skip.

## Frontend
Keyboard + selectLetter gate affordability on **budget_left** (not the $0 Wallet); "Solve to Earn" = server **solve_reward**; **must_guess** banner; cash-out/solve/bust result screens (reveal answer, wipe copy); Wallet is the headline number.

## Verified
DB sim: start→buy(Wallet stays $0)→solve(banks leftover×heat)→advance→cashout(reveals answer); and wrong-guess → wipe. Applied under PITR. Frontend lint/check/build green + data-flow traced.