### PR TITLE
Cash Game: honest must-guess banner at $0 Pending Deposit

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3990,10 +3990,18 @@
 		{#if isClimb && climb}
 			{#if climb.must_guess && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				<div class="climb-stuck">
-					<span class="cs-text"
-						>🎯 Cash Advance spent — guess now, or Deposit your Pending Deposit to bank it. A wrong
-						guess VOIDs it.</span
-					>
+					{#if (climb.wallet ?? climb.bankroll ?? 0) > 0}
+						<span class="cs-text"
+							>🎯 Cash Advance spent — guess now, or Deposit your ${Math.round(
+								climb.wallet ?? climb.bankroll ?? 0
+							).toLocaleString()} to bank it. A wrong guess VOIDs it.</span
+						>
+					{:else}
+						<span class="cs-text"
+							>🎯 Cash Advance spent — you must guess. Nothing's banked yet, so a wrong guess ends
+							the run and loses your Principal.</span
+						>
+					{/if}
 				</div>
 			{/if}
 			<!-- 🏦 Cash Out — bank the run bankroll anytime (the press-your-luck valve). -->


### PR DESCRIPTION
At $0 Pending Deposit the **Deposit button is correctly disabled** (nothing to bank), but the out-of-Cash-Advance banner still offered *"...or Deposit your Pending Deposit to bank it"* — a dead option. Now conditional: with winnings it shows the amount you could bank; at $0 it reads *"you must guess — nothing's banked yet, a wrong guess ends the run and loses your Principal."*