### PR TITLE
Fix: Cash Game "New Run" does nothing after void/cash-out

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1703,6 +1703,10 @@
 		const res = await fetchClimbGame();
 		if (res === 'needs_tier') {
 			cgMeta = await getCashgameMeta();
+			// The tier-select modal lives inside the main-menu branch, so it only renders
+			// when showMainMenu is true. Coming from a "New Run" button after a void/cash-out
+			// we're still in the game view — flip to the menu so the picker actually shows.
+			showMainMenu = true;
 			showTierSelect = true;
 		} else if (res) {
 			await enterClimbGame();


### PR DESCRIPTION
**Bug:** After a VOID (wrong guess) or a cash-out, tapping **New Run** on the receipt did nothing.

**Root cause:** The tier-select modal markup lives inside the `{:else if showMainMenu}` branch, so it only renders while the main menu is showing. The receipt's "New Run" button calls `handleMenuClimb()` while the player is still in the game view (`showMainMenu === false`). That path correctly reaches `needs_tier` (both bust and cash-out delete the server run) and sets `showTierSelect = true` — but with `showMainMenu` false the picker never mounts, so the tap looked dead.

**Fix:** In the `needs_tier` branch of `handleMenuClimb`, also set `showMainMenu = true` so the tier picker actually renders. Covers both receipts (both route through `handleMenuClimb`). Safe: the deep-link auto-restore reactive is guarded by `!showMainMenu` and an empty `currentPhrase` (the answer is revealed after a void, so it's non-empty).

Gates: prettier ✓ · svelte-check 0 errors ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)