### PR TITLE
Phase 2: account identity (account #, Member #, debit card)

### DIFF
--- a/src/lib/components/AccountCard.svelte
+++ b/src/lib/components/AccountCard.svelte
@@ -1,0 +1,139 @@
+<script>
+	// 💳 Phase 2 Account card — a debit-card view of the player's identity + balance.
+	// Reused on the main menu, the Bank hub sheet, and /profile.
+	/** @type {any} */ export let holder = '';
+	/** @type {any} */ export let account = '';
+	/** @type {any} */ export let member = null;
+	/** @type {any} */ export let balance = 0;
+
+	$: last4 = (account ?? '').toString().slice(-4) || '••••';
+	$: holderName = (holder ? String(holder) : 'Wordbanker').toUpperCase();
+	$: memberLabel = member != null ? '#' + String(member).padStart(4, '0') : '—';
+	$: amount = Math.round(Number(balance) || 0).toLocaleString();
+</script>
+
+<div class="acct-card">
+	<div class="ac-sheen"></div>
+	<div class="ac-inner">
+		<div class="ac-top">
+			<span class="ac-brand"><span class="ac-gold">WORD</span>BANK</span>
+			<span class="ac-chip" aria-hidden="true"></span>
+		</div>
+		<div class="ac-bal">
+			<div class="ac-cap">Available Balance</div>
+			<div class="ac-amt">${amount}</div>
+		</div>
+		<div class="ac-num">•••• •••• •••• {last4}</div>
+		<div class="ac-foot">
+			<div>
+				<div class="ac-cap sm">Account Holder</div>
+				<div class="ac-name">{holderName}</div>
+			</div>
+			<div class="ac-mem">
+				<div class="ac-cap sm">Member</div>
+				<div class="ac-mno">{memberLabel}</div>
+			</div>
+		</div>
+	</div>
+</div>
+
+<style>
+	.acct-card {
+		position: relative;
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto;
+		aspect-ratio: 1.586;
+		border-radius: 18px;
+		padding: 20px 22px;
+		overflow: hidden;
+		color: #f4ecdf;
+		background: linear-gradient(135deg, #1c1a2e 0%, #2a2140 45%, #3a2a1a 100%);
+		border: 1px solid rgba(251, 191, 36, 0.25);
+		box-shadow:
+			0 18px 44px rgba(0, 0, 0, 0.55),
+			inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	}
+	.ac-sheen {
+		position: absolute;
+		inset: 0;
+		background: radial-gradient(120% 80% at 85% -10%, rgba(251, 191, 36, 0.22), transparent 55%);
+		pointer-events: none;
+	}
+	.ac-inner {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		justify-content: space-between;
+	}
+	.ac-top {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+	.ac-brand {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 800;
+		letter-spacing: 0.14em;
+		font-size: 0.82rem;
+	}
+	.ac-gold {
+		color: #fbbf24;
+	}
+	.ac-chip {
+		width: 34px;
+		height: 26px;
+		border-radius: 6px;
+		background: linear-gradient(135deg, #f7d774, #c99a2e);
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		background-image:
+			linear-gradient(#0000 45%, rgba(0, 0, 0, 0.25) 46% 54%, #0000 55%),
+			linear-gradient(90deg, #0000 45%, rgba(0, 0, 0, 0.25) 46% 54%, #0000 55%),
+			linear-gradient(135deg, #f7d774, #c99a2e);
+	}
+	.ac-cap {
+		font-size: 0.58rem;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: #b8ac97;
+	}
+	.ac-cap.sm {
+		font-size: 0.52rem;
+		letter-spacing: 0.18em;
+	}
+	.ac-amt {
+		font-family: var(--font-display, sans-serif);
+		font-size: 2.1rem;
+		font-weight: 800;
+		line-height: 1.05;
+		letter-spacing: 0.01em;
+		font-variant-numeric: tabular-nums;
+	}
+	.ac-num {
+		font-family: 'Courier New', 'Courier', ui-monospace, monospace;
+		font-size: 1.02rem;
+		letter-spacing: 0.16em;
+	}
+	.ac-foot {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-end;
+	}
+	.ac-name {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		font-size: 0.9rem;
+	}
+	.ac-mem {
+		text-align: right;
+	}
+	.ac-mno {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: #fbbf24;
+		font-variant-numeric: tabular-nums;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -122,6 +122,7 @@
 	import Auth from '$lib/components/Auth.svelte';
 	import Tutorial from '$lib/components/Tutorial.svelte';
 	import ObjectiveCard from '$lib/components/ObjectiveCard.svelte';
+	import AccountCard from '$lib/components/AccountCard.svelte';
 	import StandingStrip from '$lib/components/StandingStrip.svelte';
 	import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
 	import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
@@ -491,12 +492,14 @@
 	// (deterministic, no DB), the account holder, and a timestamp captured when a
 	// result slip opens so the printed DATE/TIME stays fixed while it's on screen.
 	let myUsername = '';
-	$: acctNo = (() => {
-		const id = $user?.id ?? '';
-		let h = 5381;
-		for (let i = 0; i < id.length; i++) h = ((h << 5) + h + id.charCodeAt(i)) >>> 0;
-		return String(h % 10000).padStart(4, '0');
-	})();
+	$: acctNo =
+		($userProfile?.account_number ?? '').toString().slice(-4) ||
+		(() => {
+			const id = $user?.id ?? '';
+			let h = 5381;
+			for (let i = 0; i < id.length; i++) h = ((h << 5) + h + id.charCodeAt(i)) >>> 0;
+			return String(h % 10000).padStart(4, '0');
+		})();
 	/** @type {Date|null} */
 	let receiptStamp = null;
 	$: if (showResultModal && !receiptStamp) receiptStamp = new Date();
@@ -2185,6 +2188,9 @@
 		claimBusy = false;
 		if (res.ok) {
 			maUsername = res.username ?? name;
+			myUsername = res.username ?? name;
+			// Reflect the freshly-claimed name on the Account card without a reload.
+			userProfile.update((p) => ({ ...p, username: res.username ?? name }));
 			needsUsername = false;
 			track('username_set', { at: 'signup' });
 			fx('win');
@@ -2494,9 +2500,14 @@
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions a11y_no_noninteractive_tabindex -->
 		<div class="info-card bank-card" on:click|stopPropagation role="dialog" aria-modal="true">
 			<button class="modal-x" on:click={() => (showBank = false)} aria-label="Close">✕</button>
-			<p class="bm-label">💰 Available Balance</p>
-			<div class="info-big">{fmtCash(bankData?.bank ?? netWorth ?? 0)}</div>
-			<p class="info-sub">Your Available Balance — this is your score</p>
+			<div class="bm-card-wrap">
+				<AccountCard
+					holder={$userProfile?.username ?? myUsername}
+					account={$userProfile?.account_number ?? ''}
+					member={$userProfile?.member_no ?? null}
+					balance={bankData?.bank ?? menuBank ?? netWorth ?? 0}
+				/>
+			</div>
 			<!-- 🦈 Borrow / Repay, inline -->
 			<LoanPanel bank={bankData} on:changed={reloadBank} />
 			{#if bankData}
@@ -3086,6 +3097,15 @@
 				/>
 			</div>
 			{#if menuView === 'home'}
+				<!-- 💳 Account card -->
+				<div class="menu-card-wrap">
+					<AccountCard
+						holder={$userProfile?.username ?? myUsername}
+						account={$userProfile?.account_number ?? ''}
+						member={$userProfile?.member_no ?? null}
+						balance={menuBank ?? $userProfile?.bank ?? 0}
+					/>
+				</div>
 				<div class="main-menu-buttons stagger">
 					<!-- 🦈 Debt banner — you owe the Loan Shark; Store locked + payouts auto-skim. -->
 					{#if menuLoan > 0}
@@ -5964,6 +5984,11 @@
 		margin: 2px 0 0;
 		filter: drop-shadow(0 2px 14px rgba(0, 0, 0, 0.5));
 	}
+	.menu-card-wrap {
+		width: 100%;
+		max-width: 360px;
+		margin: 0 auto 1.1rem;
+	}
 	.main-menu-buttons {
 		display: flex;
 		flex-direction: column;
@@ -7972,12 +7997,8 @@
 		background: linear-gradient(135deg, #fde047, #f59e0b);
 	}
 	/* in-game bank modal */
-	.bm-label {
-		font-size: 0.72rem;
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-		color: var(--text-faint);
-		margin: 0 0 2px;
+	.bm-card-wrap {
+		margin: 4px 0 14px;
 	}
 	.bm-hist-h {
 		font-family: var(--font-display);

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -5,6 +5,7 @@
 	import { getProfileDetail, getMyAvatar, getUserBadges } from '$lib/stores/statsStore.js';
 	import { badgeInfo } from '$lib/badges.js';
 	import Avatar from '$lib/components/Avatar.svelte';
+	import AccountCard from '$lib/components/AccountCard.svelte';
 	import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
 	import { unreadCount, requestInbox } from '$lib/stores/notificationStore.js';
 	import { track } from '$lib/analytics.js';
@@ -142,6 +143,16 @@
 						<button class="ov-social-btn" onclick={() => goto('/my-groups')}>👥 My Groups ›</button>
 					</div>
 				</div>
+			</div>
+
+			<!-- 💳 Account card -->
+			<div class="prof-card-wrap">
+				<AccountCard
+					holder={d.username}
+					account={d.account_number}
+					member={d.member_no}
+					balance={d.net_worth}
+				/>
 			</div>
 
 			<div class="grid ov-summary">
@@ -555,6 +566,10 @@
 		font-size: 1.7rem;
 	}
 
+	.prof-card-wrap {
+		margin: 4px auto 16px;
+		max-width: 360px;
+	}
 	.ov-summary {
 		margin-bottom: 4px;
 	}

--- a/supabase-account-identity.sql
+++ b/supabase-account-identity.sql
@@ -1,0 +1,64 @@
+-- Phase 2 — Account identity: account_number (masked ••••NNNN) + sequential Member #.
+-- Adds two columns to profiles, backfills all existing accounts (member_no in signup
+-- order via auth.users.created_at), and sets column DEFAULTs so any future INSERT —
+-- the on-signup trigger OR the client ensureProfileExists() fallback — auto-populates.
+-- PITR checkpoint logged before apply.
+
+BEGIN;
+
+-- 1) Columns
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS account_number text;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS member_no integer;
+
+-- 2) Sequence backing the sequential Member #
+CREATE SEQUENCE IF NOT EXISTS public.member_no_seq;
+
+-- 3) Unique 12-digit account-number generator. SECURITY DEFINER so the uniqueness
+--    check sees every row even when called from a client-side (RLS-scoped) INSERT.
+CREATE OR REPLACE FUNCTION public._gen_account_number()
+  RETURNS text
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = public
+AS $fn$
+DECLARE n text;
+BEGIN
+  LOOP
+    n := lpad((floor(random() * 1e12))::bigint::text, 12, '0');
+    EXIT WHEN NOT EXISTS (SELECT 1 FROM public.profiles WHERE account_number = n);
+  END LOOP;
+  RETURN n;
+END;
+$fn$;
+
+-- 4) Backfill Member # in signup order (earliest = #1)
+WITH ordered AS (
+  SELECT p.id, row_number() OVER (ORDER BY u.created_at, p.id) AS rn
+  FROM public.profiles p
+  JOIN auth.users u ON u.id = p.id
+  WHERE p.member_no IS NULL
+)
+UPDATE public.profiles p
+SET member_no = o.rn
+FROM ordered o
+WHERE p.id = o.id;
+
+-- Advance the sequence past the highest assigned Member # (is_called = true → next is max+1)
+SELECT setval('public.member_no_seq', COALESCE((SELECT MAX(member_no) FROM public.profiles), 0), true);
+
+-- 5) Backfill account numbers
+UPDATE public.profiles
+SET account_number = public._gen_account_number()
+WHERE account_number IS NULL;
+
+-- 6) Defaults so future signups auto-populate (trigger insert + client fallback both omit these)
+ALTER TABLE public.profiles ALTER COLUMN account_number SET DEFAULT public._gen_account_number();
+ALTER TABLE public.profiles ALTER COLUMN member_no SET DEFAULT nextval('public.member_no_seq');
+
+-- 7) Integrity
+ALTER TABLE public.profiles ALTER COLUMN account_number SET NOT NULL;
+ALTER TABLE public.profiles ALTER COLUMN member_no SET NOT NULL;
+ALTER TABLE public.profiles ADD CONSTRAINT profiles_account_number_key UNIQUE (account_number);
+ALTER TABLE public.profiles ADD CONSTRAINT profiles_member_no_key UNIQUE (member_no);
+
+COMMIT;

--- a/supabase-profile-detail-account.sql
+++ b/supabase-profile-detail-account.sql
@@ -1,0 +1,61 @@
+-- Phase 2: expose account_number + member_no on get_profile_detail (for the /profile Account card).
+CREATE OR REPLACE FUNCTION public.get_profile_detail()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); p public.profiles; v_climb int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  SELECT position INTO v_climb FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object(
+    'username', p.username, 'color', p.equipped_color, 'title', p.equipped_title,
+    'account_number', p.account_number, 'member_no', p.member_no,
+    'net_worth', COALESCE(p.bank,0), 'cash', COALESCE(p.bank,0),
+    'overall', (SELECT jsonb_build_object(
+        'puzzles_solved', COALESCE(sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)),0),
+        'games_played', count(*), 'earned', COALESCE(sum(earned),0), 'spent', COALESCE(sum(spent),0),
+        'avg_multiple', round(avg(multiple_x100) FILTER (WHERE multiple_x100 IS NOT NULL))::int,
+        'best_multiple', max(multiple_x100), 'clean_solves', count(*) FILTER (WHERE clean))
+      FROM public.game_results WHERE user_id = v_uid),
+    -- Daily includes make-ups (a make-up IS a daily, just played late).
+    'daily', (SELECT jsonb_build_object(
+        'current_streak', COALESCE(p.current_daily_play_streak,0), 'best_streak', COALESCE(p.best_daily_play_streak,0), 'win_streak', (CASE WHEN p.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(p.current_daily_solve_streak,0) ELSE 0 END), 'best_win_streak', COALESCE(p.best_daily_solve_streak,0),
+        'played', count(*), 'won', count(*) FILTER (WHERE outcome='won'),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'), 'best_bounty', COALESCE(max(net) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode IN ('daily','makeup')),
+    'cash_game', jsonb_build_object('position', COALESCE(v_climb,0)) ||
+      (SELECT jsonb_build_object('solved', count(*) FILTER (WHERE outcome='won'),
+        'earned', COALESCE(sum(earned) FILTER (WHERE outcome='won'),0),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'))
+       FROM public.game_results WHERE user_id = v_uid AND game_mode='climb'),
+    -- 1v1 = challenge rows with no group; record vs people
+    'challenges_1v1', (SELECT jsonb_build_object(
+        'wins', count(*) FILTER (WHERE outcome='won'), 'losses', count(*) FILTER (WHERE outcome='lost'),
+        'ties', count(*) FILTER (WHERE outcome='tie'), 'played', count(*),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NULL),
+    -- group challenges = your placement in the pack
+    'challenges_group', (SELECT jsonb_build_object(
+        'played', count(*), 'wins', count(*) FILTER (WHERE rank = 1),
+        'podiums', count(*) FILTER (WHERE rank <= 3),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NOT NULL),
+    'categories', (SELECT COALESCE(jsonb_agg(jsonb_build_object('category', category, 'solves', solves, 'best_multiple', bm) ORDER BY solves DESC), '[]'::jsonb)
+      FROM (SELECT category, sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) AS solves, max(multiple_x100) AS bm
+            FROM public.game_results WHERE user_id = v_uid AND category IS NOT NULL
+            GROUP BY category HAVING sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) > 0) c),
+    -- Rivals: your head-to-head record vs each 1v1 opponent
+    'rivals', (SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'name', public._display_name(opponent_id), 'wins', wins, 'losses', losses, 'ties', ties) ORDER BY played DESC, wins DESC), '[]'::jsonb)
+      FROM (SELECT opponent_id, count(*) AS played,
+              count(*) FILTER (WHERE outcome='won') AS wins,
+              count(*) FILTER (WHERE outcome='lost') AS losses,
+              count(*) FILTER (WHERE outcome='tie') AS ties
+            FROM public.game_results
+            WHERE user_id = v_uid AND game_mode='challenge' AND opponent_id IS NOT NULL
+            GROUP BY opponent_id ORDER BY played DESC LIMIT 8) r)
+  );
+END; $function$


### PR DESCRIPTION
Implements roadmap **Phase 2 — Account identity**: a real account number, a sequential Member #, and a debit-card view of them.

## Database (applied to prod under PITR)
- `profiles.account_number` — unique 12-digit, shown masked `••••NNNN`.
- `profiles.member_no` — sequential Member # (OG flex), shown in full.
- Backfilled all **84** existing accounts — `member_no` assigned in signup order (`auth.users.created_at`), unique account numbers generated. Verified: 84/84 populated, no dupes.
- Column **DEFAULTs** auto-populate future signups through both the on-signup trigger and the client `ensureProfileExists` fallback. `_gen_account_number()` is `SECURITY DEFINER` so the uniqueness check sees every row even from an RLS-scoped client insert.
- `get_profile_detail` now returns `account_number` + `member_no`.
- Migrations: `supabase-account-identity.sql`, `supabase-profile-detail-account.sql`.

## Frontend
- New reusable **`<AccountCard>`** — WORDBANK wordmark, EMV chip, Available Balance hero, masked number, holder + Member #.
- Placed in all three requested spots: **main menu** (home view), **Bank hub sheet** (replaces the plain balance label), and **/profile**.
- Receipt account number now uses the real stored `account_number` (hash fallback until the profile loads).
- Claiming a username updates the holder on the card immediately (no reload).

## Verified live (dev server, fresh signup)
Card renders with real data — Member #0087, masked `••••9771`, `$2,000`, holder from username. Sequence correctly continued past the 84 backfilled.

Gates: prettier ✓ · svelte-check 0 errors ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)