### PR TITLE
Loans: /loans page + progressive daily interest

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -5,22 +5,40 @@
 	import { track } from '$lib/analytics.js';
 	import { fx } from '$lib/sound.js';
 
-	/** The get_bank payload: { bank, loan, loan_cap, in_the_red, net_worth }
-	 * @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean }|null} */
+	/** The get_bank payload (loan detail added in loans-v3)
+	 * @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean,
+	 *   loan_principal?:number, loan_rate_bp?:number, loan_days?:number, loan_owed_tomorrow?:number }|null} */
 	export let bank = null;
+	/** Open the borrow panel by default (used on the dedicated /loans page). */
+	export let expanded = false;
 
 	const dispatch = createEventDispatcher();
 
-	// 💸 Loan Shark
+	// 🦈 Loan Shark — progressive daily interest (rate scales with amount vs cap; mirrors _loan_daily_rate_bp)
+	const MIN_BORROW = 50;
 	let borrowAmt = 100; // $ to borrow (dial)
 	let repayAmt = 0; // $ to repay (dial)
 	let loanBusy = '';
 	let loanMsg = '';
 	$: loanCap = bank?.loan_cap ?? 0;
 	$: owed = bank?.loan ?? 0;
-	$: feeOnBorrow = Math.round(borrowAmt * 0.25);
+	/** @param {number} amt @param {number} cap */
+	function rateBpFor(amt, cap) {
+		if (cap <= 0) return 800;
+		const p = amt / cap;
+		return p <= 0.25 ? 200 : p <= 0.5 ? 400 : p <= 0.75 ? 600 : 800;
+	}
+	$: rateBp = rateBpFor(borrowAmt, loanCap);
+	$: ratePct = rateBp / 100; // 2 / 4 / 6 / 8 (%/day)
+	$: proj7 = Math.min(
+		Math.round(borrowAmt * Math.pow(1 + rateBp / 10000, 7)),
+		Math.round(borrowAmt * 2.5)
+	);
+	$: activeRatePct = (bank?.loan_rate_bp ?? 0) / 100;
+	$: owedTomorrow = bank?.loan_owed_tomorrow ?? owed;
+	$: loanDays = bank?.loan_days ?? 0;
 	$: if (borrowAmt > loanCap) borrowAmt = loanCap;
-	$: if (borrowAmt < 10 && loanCap >= 10) borrowAmt = 10;
+	$: if (borrowAmt < MIN_BORROW && loanCap >= MIN_BORROW) borrowAmt = MIN_BORROW;
 	$: maxRepay = Math.max(0, Math.min(owed, bank?.bank ?? 0));
 	// Can you fully clear the loan right now? (Bank covers the whole owed amount.)
 	$: canClear = owed > 0 && (bank?.bank ?? 0) >= owed;
@@ -31,17 +49,13 @@
 	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
 
 	async function borrow() {
-		if (loanBusy || borrowAmt < 10) return;
-		const total = borrowAmt + Math.round(borrowAmt * 0.25);
+		if (loanBusy || borrowAmt < MIN_BORROW) return;
 		try {
-			await requirePin(
-				`Borrow $${borrowAmt.toLocaleString()} — you'll owe $${total.toLocaleString()}`,
-				[
-					{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
-					{ label: 'Fee (25%)', value: '$' + Math.round(borrowAmt * 0.25).toLocaleString() },
-					{ label: 'You owe', value: '$' + total.toLocaleString() }
-				]
-			);
+			await requirePin(`Borrow $${borrowAmt.toLocaleString()} from the Shark`, [
+				{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
+				{ label: 'Interest', value: ratePct + '%/day, compounding' },
+				{ label: '~Owe in a week', value: '$' + proj7.toLocaleString() }
+			]);
 		} catch {
 			return;
 		}
@@ -89,9 +103,14 @@
 			<span class="loan-title">🦈 You owe the Shark</span>
 			<span class="loan-owed">{fmt(owed)}</span>
 		</div>
+		<div class="loan-facts">
+			<span>📈 {activeRatePct}%/day</span>
+			<span>⏳ {loanDays}d out</span>
+			<span>→ {fmt(owedTomorrow)} tomorrow</span>
+		</div>
 		<p class="loan-note">
-			Store is locked and half of every payout auto-pays your debt until it's clear. Your net worth
-			is <b class="neg">{fmt(bank.net_worth)}</b>.
+			Interest compounds daily. The Store is locked and half of every payout auto-pays your debt
+			until it's clear. Your net worth is <b class="neg">{fmt(bank.net_worth)}</b>.
 		</p>
 		{#if maxRepay > 0}
 			<div class="loan-dial">
@@ -151,24 +170,24 @@
 	</div>
 {:else if loanCap > 0}
 	<!-- No debt: borrow panel -->
-	<details class="loan-card">
+	<details class="loan-card" open={expanded}>
 		<summary class="loan-summary"
 			>🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary
 		>
 		<p class="loan-note">
-			A 25% fee, one loan at a time. While you owe, the Store locks and half of every payout
-			auto-pays it down.
+			Interest compounds daily — the more you take, the higher the rate. One loan at a time; while
+			you owe, the Store locks and half of every payout auto-pays it down.
 		</p>
 		<div class="loan-dial">
 			<button
 				class="loan-step"
-				on:click={() => (borrowAmt = Math.max(10, borrowAmt - 50))}
+				on:click={() => (borrowAmt = Math.max(MIN_BORROW, borrowAmt - 50))}
 				aria-label="Less"
-				disabled={borrowAmt <= 10}>−</button
+				disabled={borrowAmt <= MIN_BORROW}>−</button
 			>
 			<div class="loan-amt">
 				<span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub"
-					>you'll owe {fmt(borrowAmt + feeOnBorrow)}</span
+					>{ratePct}%/day · ~{fmt(proj7)} in a week</span
 				>
 			</div>
 			<button
@@ -181,13 +200,15 @@
 		<input
 			class="loan-slider"
 			type="range"
-			min="10"
+			min={MIN_BORROW}
 			max={loanCap}
 			step="10"
 			bind:value={borrowAmt}
 		/>
-		<button class="loan-btn borrow" disabled={!!loanBusy || borrowAmt < 10} on:click={borrow}
-			>🦈 Borrow {fmt(borrowAmt)} (fee {fmt(feeOnBorrow)})</button
+		<button
+			class="loan-btn borrow"
+			disabled={!!loanBusy || borrowAmt < MIN_BORROW}
+			on:click={borrow}>🦈 Borrow {fmt(borrowAmt)}</button
 		>
 		{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
 	</details>
@@ -247,6 +268,16 @@
 	}
 	.loan-note .neg {
 		color: #fb7185;
+	}
+	.loan-facts {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 6px 14px;
+		margin: 8px 0 2px;
+		font-family: var(--font-display);
+		font-size: 0.76rem;
+		font-weight: 700;
+		color: #fca5a5;
 	}
 	.loan-dial {
 		display: flex;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3102,8 +3102,11 @@
 				</div>
 				<!-- ⚡ Bank-app quick actions — horizontally swipeable -->
 				<div class="quick-tiles">
-					<button class="qt" on:click={() => goto('/bank')}>
-						<span class="qt-ic">💵</span><span class="qt-l">Loans</span>
+					<button class="qt" on:click={openBankModal}>
+						<span class="qt-ic">🔒</span><span class="qt-l">Vault</span>
+					</button>
+					<button class="qt" on:click={() => goto('/loans')}>
+						<span class="qt-ic">🦈</span><span class="qt-l">Loans</span>
 					</button>
 					<button class="qt" on:click={() => goto('/shop')}>
 						<span class="qt-ic">🛍️</span><span class="qt-l">Store</span>

--- a/src/routes/loans/+page.svelte
+++ b/src/routes/loans/+page.svelte
@@ -1,0 +1,162 @@
+<script>
+	import { onMount } from 'svelte';
+	import PageNav from '$lib/components/PageNav.svelte';
+	import LoanPanel from '$lib/components/LoanPanel.svelte';
+	import { getBank } from '$lib/stores/statsStore.js';
+	import { track } from '$lib/analytics.js';
+
+	/** @type {any} */
+	let b = null;
+	let loading = true;
+
+	async function load() {
+		b = await getBank(1);
+	}
+	onMount(async () => {
+		track('loans_view');
+		try {
+			await load();
+		} finally {
+			loading = false;
+		}
+	});
+
+	$: inDebt = !!b?.in_the_red;
+</script>
+
+<svelte:head><title>WordBank — Loans</title></svelte:head>
+
+<main class="loans-page">
+	<PageNav back="/" />
+
+	<!-- 🦈 Shark hero — placeholder art now; animation pass lands here later -->
+	<div class="shark-hero" class:owe={inDebt}>
+		<div class="shark-art" aria-hidden="true">🦈</div>
+		<h1 class="shark-title">Loan Shark</h1>
+		<p class="shark-sub">
+			{#if inDebt}
+				The Shark's circling. Interest compounds every day it's out — pay it down before it bites.
+			{:else}
+				Need Cash fast? Borrow on the spot. Interest compounds daily and the more you take, the
+				steeper the rate — so borrow smart and pay it back quick.
+			{/if}
+		</p>
+	</div>
+
+	{#if loading}
+		<p class="loading">Loading…</p>
+	{:else if b}
+		<LoanPanel bank={b} expanded on:changed={load} />
+
+		<!-- How the Shark charges -->
+		<div class="rate-card">
+			<div class="rc-head">Daily interest — the more you borrow, the higher the rate</div>
+			<div class="rc-rows">
+				<div class="rc-row"><span>Up to 25% of your limit</span><b>2% / day</b></div>
+				<div class="rc-row"><span>Up to 50%</span><b>4% / day</b></div>
+				<div class="rc-row"><span>Up to 75%</span><b>6% / day</b></div>
+				<div class="rc-row"><span>Above 75%</span><b class="hot">8% / day</b></div>
+			</div>
+			<p class="rc-note">
+				Compounds daily · never grows past <b>2.5×</b> what you borrowed · half of every payout auto-pays
+				it down.
+			</p>
+		</div>
+	{/if}
+</main>
+
+<style>
+	.loans-page {
+		max-width: 460px;
+		margin: 0 auto;
+		padding: 12px 16px 40px;
+	}
+	.shark-hero {
+		text-align: center;
+		padding: 8px 6px 18px;
+	}
+	.shark-art {
+		font-size: 4.6rem;
+		line-height: 1;
+		filter: drop-shadow(0 8px 22px rgba(56, 189, 248, 0.4));
+		animation: sharkBob 3.4s ease-in-out infinite;
+	}
+	.shark-hero.owe .shark-art {
+		filter: drop-shadow(0 8px 22px rgba(248, 113, 113, 0.5));
+	}
+	@keyframes sharkBob {
+		0%,
+		100% {
+			transform: translateY(0) rotate(-2deg);
+		}
+		50% {
+			transform: translateY(-8px) rotate(2deg);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.shark-art {
+			animation: none;
+		}
+	}
+	.shark-title {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1.7rem;
+		margin: 8px 0 4px;
+		color: var(--text, #f4f6fb);
+	}
+	.shark-sub {
+		font-size: 0.9rem;
+		line-height: 1.5;
+		color: var(--text-muted, #aeb8c6);
+		max-width: 340px;
+		margin: 0 auto;
+	}
+	.loading {
+		text-align: center;
+		color: var(--text-muted);
+		padding: 24px;
+	}
+	.rate-card {
+		margin-top: 16px;
+		border-radius: 16px;
+		padding: 14px 16px;
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+	}
+	.rc-head {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.82rem;
+		color: var(--text, #f4f6fb);
+		margin-bottom: 10px;
+	}
+	.rc-rows {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+	.rc-row {
+		display: flex;
+		justify-content: space-between;
+		font-size: 0.84rem;
+		color: var(--text-muted, #aeb8c6);
+	}
+	.rc-row b {
+		font-family: var(--font-display);
+		color: var(--text, #f4f6fb);
+		font-variant-numeric: tabular-nums;
+	}
+	.rc-row b.hot {
+		color: #fb7185;
+	}
+	.rc-note {
+		font-size: 0.74rem;
+		line-height: 1.45;
+		color: var(--text-faint, #8a93a3);
+		margin: 10px 0 0;
+	}
+	.rc-note b {
+		color: var(--text-muted, #aeb8c6);
+	}
+</style>

--- a/supabase-loans-daily-interest.sql
+++ b/supabase-loans-daily-interest.sql
@@ -1,0 +1,157 @@
+-- 🦈 Loans v3 — progressive daily interest (replaces the flat 25% origination fee).
+-- Borrow amount is a slider up to your cap; the daily rate scales with how much you
+-- take (relative to cap) and is LOCKED at borrow time. Interest COMPOUNDS daily,
+-- accrued lazily on read, capped at 2.5× principal so a forgotten loan can't run away.
+-- PITR checkpoint logged before apply.
+
+BEGIN;
+
+-- New per-loan state
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS loan_principal bigint;
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS loan_rate_bp integer; -- daily rate, basis points
+ALTER TABLE public.profiles ADD COLUMN IF NOT EXISTS loan_taken_at timestamptz;
+
+-- Progressive daily rate (basis points) by loan size relative to cap.
+CREATE OR REPLACE FUNCTION public._loan_daily_rate_bp(p_amount bigint, p_cap bigint)
+  RETURNS integer LANGUAGE sql IMMUTABLE
+AS $fn$
+  SELECT CASE
+    WHEN p_cap <= 0 THEN 800
+    WHEN p_amount::numeric / p_cap <= 0.25 THEN 200   -- 2%/day
+    WHEN p_amount::numeric / p_cap <= 0.50 THEN 400   -- 4%/day
+    WHEN p_amount::numeric / p_cap <= 0.75 THEN 600   -- 6%/day
+    ELSE 800                                          -- 8%/day
+  END;
+$fn$;
+
+-- Lazy daily compounding: apply whole elapsed days, advance the clock by that many
+-- days (remainder carries), cap owed at 2.5× principal. No-op if <1 day or no loan.
+CREATE OR REPLACE FUNCTION public._accrue_loan(p_uid uuid)
+  RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $fn$
+DECLARE p public.profiles; v_days int; v_rate numeric; v_new bigint; v_cap bigint;
+BEGIN
+  SELECT * INTO p FROM public.profiles WHERE id = p_uid FOR UPDATE;
+  IF NOT FOUND OR COALESCE(p.loan,0) <= 0 OR p.loan_accrued_at IS NULL OR COALESCE(p.loan_rate_bp,0) = 0 THEN
+    RETURN;
+  END IF;
+  v_days := floor(extract(epoch FROM now() - p.loan_accrued_at) / 86400)::int;
+  IF v_days < 1 THEN RETURN; END IF;
+  v_rate := p.loan_rate_bp / 10000.0;
+  v_new := round(p.loan * power(1 + v_rate, v_days))::bigint;
+  v_cap := round(COALESCE(p.loan_principal, p.loan) * 2.5)::bigint;   -- runaway guard
+  v_new := LEAST(v_new, v_cap);
+  UPDATE public.profiles
+    SET loan = v_new,
+        loan_accrued_at = p.loan_accrued_at + (v_days || ' days')::interval
+    WHERE id = p_uid;
+END;
+$fn$;
+
+-- Take a loan: pick amount (≤ cap), rate locked from size, owed starts = principal
+-- (no upfront fee — interest accrues daily from now).
+CREATE OR REPLACE FUNCTION public.take_loan(p_amount bigint)
+  RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_loan bigint; v_cap bigint; v_rate int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  IF p_amount IS NULL OR p_amount < 50 THEN RETURN jsonb_build_object('ok',false,'reason','bad_amount'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT COALESCE(loan,0) INTO v_loan FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan > 0 THEN RETURN jsonb_build_object('ok',false,'reason','active_loan'); END IF;
+  v_cap := public._loan_cap(v_uid);
+  IF p_amount > v_cap THEN RETURN jsonb_build_object('ok',false,'reason','over_cap','cap',v_cap); END IF;
+  v_rate := public._loan_daily_rate_bp(p_amount, v_cap);
+  UPDATE public.profiles
+    SET loan = p_amount, loan_principal = p_amount, loan_rate_bp = v_rate,
+        loan_taken_at = now(), loan_accrued_at = now()
+    WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, p_amount, 'loan_take');   -- principal to Cash (skim-exempt)
+  RETURN jsonb_build_object('ok',true,'borrowed',p_amount,'owed',p_amount,'rate_bp',v_rate,'cap',v_cap);
+END; $function$;
+
+-- Repay: accrue first, then pay down from Cash (capped).
+CREATE OR REPLACE FUNCTION public.repay_loan(p_amount bigint DEFAULT NULL::bigint)
+  RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_loan bigint; v_bank bigint; v_pay bigint;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  PERFORM public._accrue_loan(v_uid);
+  SELECT COALESCE(loan,0), COALESCE(bank,0) INTO v_loan, v_bank FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','no_loan'); END IF;
+  v_pay := LEAST(COALESCE(p_amount, v_loan), v_loan, v_bank);
+  IF v_pay <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+  UPDATE public.profiles
+    SET loan = v_loan - v_pay,
+        loan_accrued_at  = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_accrued_at END,
+        loan_principal   = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_principal  END,
+        loan_rate_bp     = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_rate_bp    END,
+        loan_taken_at    = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_taken_at   END
+    WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, -v_pay, 'loan_repay');
+  IF v_loan - v_pay <= 0 THEN PERFORM public._award_badge(v_uid, 'paid_in_full'); END IF;
+  RETURN jsonb_build_object('ok',true,'paid',v_pay,'remaining',v_loan - v_pay,'cleared',(v_loan - v_pay) <= 0);
+END; $function$;
+
+-- Payout auto-skim: accrue before skimming, and reset loan state when a skim clears it.
+CREATE OR REPLACE FUNCTION public._bank_credit(p_uid uuid, p_delta bigint, p_reason text)
+  RETURNS bigint LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_new bigint; v_loan bigint; v_skim bigint;
+BEGIN
+  PERFORM public._ensure_bank(p_uid);
+  INSERT INTO public.networth_snapshots(user_id, week_start, net_worth)
+    SELECT p_uid, date_trunc('week', CURRENT_DATE)::date, COALESCE(bank,0)
+    FROM public.profiles WHERE id = p_uid
+    ON CONFLICT DO NOTHING;
+  UPDATE public.profiles SET bank = GREATEST(0, COALESCE(bank,0) + p_delta) WHERE id = p_uid RETURNING bank INTO v_new;
+  INSERT INTO public.bank_ledger(user_id, delta, reason, balance_after) VALUES (p_uid, p_delta, p_reason, v_new);
+  IF p_delta > 0 AND p_reason NOT IN ('loan_take','loan_repay','loan_skim') THEN
+    PERFORM public._accrue_loan(p_uid);
+    SELECT COALESCE(loan,0) INTO v_loan FROM public.profiles WHERE id = p_uid;
+    IF v_loan > 0 THEN
+      v_skim := LEAST(v_loan, floor(p_delta * 0.5)::bigint);
+      IF v_skim > 0 THEN
+        UPDATE public.profiles SET bank = GREATEST(0, COALESCE(bank,0) - v_skim),
+          loan = v_loan - v_skim,
+          loan_accrued_at = CASE WHEN v_loan - v_skim <= 0 THEN NULL ELSE loan_accrued_at END,
+          loan_principal  = CASE WHEN v_loan - v_skim <= 0 THEN NULL ELSE loan_principal  END,
+          loan_rate_bp    = CASE WHEN v_loan - v_skim <= 0 THEN NULL ELSE loan_rate_bp    END,
+          loan_taken_at   = CASE WHEN v_loan - v_skim <= 0 THEN NULL ELSE loan_taken_at   END
+          WHERE id = p_uid RETURNING bank INTO v_new;
+        INSERT INTO public.bank_ledger(user_id, delta, reason, balance_after) VALUES (p_uid, -v_skim, 'loan_skim', v_new);
+      END IF;
+    END IF;
+  END IF;
+  RETURN v_new;
+END; $function$;
+
+-- get_bank: accrue first, expose loan detail (principal, rate, days out, projected).
+CREATE OR REPLACE FUNCTION public.get_bank(p_limit integer DEFAULT 12)
+  RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); p public.profiles; v_led jsonb; v_rate numeric; v_tomorrow bigint; v_days int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  PERFORM public._accrue_loan(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('delta',delta,'reason',reason,'balance_after',balance_after,'at',created_at) ORDER BY created_at DESC), '[]'::jsonb)
+    INTO v_led FROM (SELECT * FROM public.bank_ledger WHERE user_id = v_uid ORDER BY created_at DESC LIMIT GREATEST(p_limit, 1)) t;
+  v_rate := COALESCE(p.loan_rate_bp,0) / 10000.0;
+  v_tomorrow := CASE WHEN COALESCE(p.loan,0) > 0
+    THEN LEAST(round(p.loan * (1 + v_rate))::bigint, round(COALESCE(p.loan_principal, p.loan) * 2.5)::bigint)
+    ELSE 0 END;
+  v_days := CASE WHEN p.loan_taken_at IS NOT NULL THEN floor(extract(epoch FROM now() - p.loan_taken_at)/86400)::int ELSE 0 END;
+  RETURN jsonb_build_object(
+    'bank', COALESCE(p.bank,0), 'net_worth', COALESCE(p.bank,0) - COALESCE(p.loan,0),
+    'loan', COALESCE(p.loan,0), 'auto_repay', COALESCE(p.loan,0) > 0, 'in_the_red', COALESCE(p.loan,0) > 0,
+    'loan_cap', public._loan_cap(v_uid), 'ledger', v_led,
+    'loan_principal', COALESCE(p.loan_principal,0), 'loan_rate_bp', COALESCE(p.loan_rate_bp,0),
+    'loan_taken_at', p.loan_taken_at, 'loan_days', v_days, 'loan_owed_tomorrow', v_tomorrow);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Replaces the flat 25% loan fee with a **daily-compounding, size-scaled interest** system, and gives loans their **own page** with room for the shark character/animation later.

## Economy model
- **Sliding amount** up to your cap (highest unlocked Cash Game tier buy-in), min $50.
- **Progressive daily rate**, locked at borrow time: 2% / 4% / 6% / 8% per day by loan size vs cap.
- **Compounds daily**, accrued lazily on read (no cron); **capped at 2.5× principal** so a forgotten loan can't run away.
- No upfront fee anymore — owed starts = principal, interest builds from day one. 50% payout auto-skim + Store-lock while owing stay.

## DB (applied to prod under PITR, sim-verified)
`loan_principal` / `loan_rate_bp` / `loan_taken_at` columns · `_loan_daily_rate_bp` · `_accrue_loan` (lazy compounding, 2.5× cap) wired into `get_bank` / `take_loan` / `repay_loan` / the skim. `get_bank` now returns loan detail + `loan_owed_tomorrow` projection.

**Verified:** full-cap loan → 8%/day, $1000→$1260 in 3 days, caps at $2500; small loan → 2%/day; repay clears all state.

## Frontend
- **`/loans` page** — shark hero (bob animation, placeholder for the real character/animation), expanded borrow panel, rate-tier explainer.
- **LoanPanel** upgraded: live rate + ~week projection on the borrow dial; rate/day + days-out + owe-tomorrow on the debt card; 25%-fee copy gone. Shared by /loans, Bank hub, /bank.
- **Menu tiles:** Loans → /loans; added **Vault** tile → Bank hub.

Chosen defaults (all easily tunable): compound daily, shark rate (2→8%/day), Vault → bank hub.

Verified against a production preview build. Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)