### PR TITLE
Loans: brutal rate curve (5/8/12/15%/day)

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -24,9 +24,9 @@
 	$: owed = bank?.loan ?? 0;
 	/** @param {number} amt @param {number} cap */
 	function rateBpFor(amt, cap) {
-		if (cap <= 0) return 800;
+		if (cap <= 0) return 1500;
 		const p = amt / cap;
-		return p <= 0.25 ? 200 : p <= 0.5 ? 400 : p <= 0.75 ? 600 : 800;
+		return p <= 0.25 ? 500 : p <= 0.5 ? 800 : p <= 0.75 ? 1200 : 1500;
 	}
 	$: rateBp = rateBpFor(borrowAmt, loanCap);
 	$: ratePct = rateBp / 100; // 2 / 4 / 6 / 8 (%/day)

--- a/src/routes/loans/+page.svelte
+++ b/src/routes/loans/+page.svelte
@@ -52,10 +52,10 @@
 		<div class="rate-card">
 			<div class="rc-head">Daily interest — the more you borrow, the higher the rate</div>
 			<div class="rc-rows">
-				<div class="rc-row"><span>Up to 25% of your limit</span><b>2% / day</b></div>
-				<div class="rc-row"><span>Up to 50%</span><b>4% / day</b></div>
-				<div class="rc-row"><span>Up to 75%</span><b>6% / day</b></div>
-				<div class="rc-row"><span>Above 75%</span><b class="hot">8% / day</b></div>
+				<div class="rc-row"><span>Up to 25% of your limit</span><b>5% / day</b></div>
+				<div class="rc-row"><span>Up to 50%</span><b>8% / day</b></div>
+				<div class="rc-row"><span>Up to 75%</span><b class="hot">12% / day</b></div>
+				<div class="rc-row"><span>Above 75%</span><b class="hot">15% / day</b></div>
 			</div>
 			<p class="rc-note">
 				Compounds daily · never grows past <b>2.5×</b> what you borrowed · half of every payout auto-pays

--- a/supabase-loans-brutal-rate.sql
+++ b/supabase-loans-brutal-rate.sql
@@ -1,0 +1,14 @@
+-- 🦈 Loans: crank the daily rate curve to "brutal" (was 2/4/6/8%/day).
+-- Only the rate table changes; accrual/cap/flow are unchanged. Existing loans keep
+-- their locked rate; new loans use the steeper curve.
+CREATE OR REPLACE FUNCTION public._loan_daily_rate_bp(p_amount bigint, p_cap bigint)
+  RETURNS integer LANGUAGE sql IMMUTABLE
+AS $fn$
+  SELECT CASE
+    WHEN p_cap <= 0 THEN 1500
+    WHEN p_amount::numeric / p_cap <= 0.25 THEN 500    -- 5%/day
+    WHEN p_amount::numeric / p_cap <= 0.50 THEN 800    -- 8%/day
+    WHEN p_amount::numeric / p_cap <= 0.75 THEN 1200   -- 12%/day
+    ELSE 1500                                          -- 15%/day
+  END;
+$fn$;


### PR DESCRIPTION
Cranks the daily loan rate from 2/4/6/8%/day to **5/8/12/15%/day** per your call. Only the rate table changes — compounding, the 2.5× cap, and the borrow/repay flow are untouched. Existing loans keep their locked rate; new loans get the steeper curve.

DB `_loan_daily_rate_bp` applied to prod under PITR (verified 500/800/1200/1500 bp); client-side mirror in LoanPanel + the /loans rate card updated to match.

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)