### PR TITLE
dev: fix 431 white screen (raise header limit to 64KB)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "vite dev",
+		"dev": "NODE_OPTIONS=--max-http-header-size=65536 vite dev",
 		"build": "vite build",
-		"preview": "vite preview",
+		"preview": "NODE_OPTIONS=--max-http-header-size=65536 vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",


### PR DESCRIPTION
`npm run dev` was returning **431 Request Header Fields Too Large** → white screen.

**Cause:** on `localhost`, cookies aren't isolated by port, so the cookie jar from every localhost dev server (plus accumulated Supabase auth cookies from test sign-ins) all get sent to `:5173` and blow past Node's default **16KB** header limit.

**Fix:** prefix `dev` and `preview` with `NODE_OPTIONS=--max-http-header-size=65536` (64KB).

**Verified:** a 30KB cookie returns 431 on the default limit and 200 with the raised limit.

Note: macOS/Linux syntax; if Windows dev is ever needed we'd switch to `cross-env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)