### PR TITLE
Fix: Back button on Streak/Badges/Activity → menu

### DIFF
--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -9,7 +9,7 @@
 <svelte:head><title>WordBank — Activity</title></svelte:head>
 
 <main class="a-page">
-	<PageNav />
+	<PageNav back="/" />
 	<h1>📣 Activity</h1>
 	<p class="sub">You, your friends, and your groups.</p>
 	<ActivityPanel />

--- a/src/routes/badges/+page.svelte
+++ b/src/routes/badges/+page.svelte
@@ -6,7 +6,7 @@
 <svelte:head><title>WordBank — Badges</title></svelte:head>
 
 <main class="badges-page">
-	<PageNav />
+	<PageNav back="/" />
 	<h1>🏅 Badges</h1>
 	<BadgesPanel />
 </main>

--- a/src/routes/streak/+page.svelte
+++ b/src/routes/streak/+page.svelte
@@ -98,7 +98,7 @@
 <svelte:head><title>WordBank — Daily Calendar</title></svelte:head>
 
 <main class="streak-page">
-	<PageNav />
+	<PageNav back="/" />
 
 	{#if loading}
 		<p class="loading">Loading…</p>


### PR DESCRIPTION
The Streak, Badges, and Activity pages (all reached from the menu tiles) used bare `<PageNav />`, which falls back to `window.history.back()` — unreliable once history accumulates (PageNav's own comment says so). Their Back button did nothing / didn't return to the menu.

Fix: pass `back="/"` so **← Back** deterministically goes to the main menu, matching `/bank` and `/loans`.

Verified end-to-end against a production build: menu → page → Back → menu (route `/`, menu visible) for all three.

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)