### PR TITLE
Friends/Groups: alphabetize + live filter for long lists

### DIFF
--- a/src/lib/components/FriendsPanel.svelte
+++ b/src/lib/components/FriendsPanel.svelte
@@ -122,6 +122,24 @@
 	}
 
 	const label = (/** @type {any} */ u) => (u.username ? '@' + u.username : u.name || 'Player');
+
+	// Long-list handling: alphabetize your friends and let you filter them live.
+	// The top search box adds NEW people; this narrows the ones you already have.
+	let listFilter = $state('');
+	const sortedFriends = $derived(
+		[...friends].sort((a, b) =>
+			(a.username || a.name || '').localeCompare(b.username || b.name || '', undefined, {
+				sensitivity: 'base'
+			})
+		)
+	);
+	const shownFriends = $derived.by(() => {
+		const q = listFilter.trim().toLowerCase();
+		if (!q) return sortedFriends;
+		return sortedFriends.filter((u) =>
+			((u.username || '') + ' ' + (u.name || '')).toLowerCase().includes(q)
+		);
+	});
 </script>
 
 <div class="search-wrap">
@@ -193,8 +211,20 @@
 	{#if friends.length === 0}
 		<p class="muted small pad">No friends yet — search above to add some.</p>
 	{:else}
+		{#if friends.length > 8}
+			<input
+				class="list-filter"
+				type="text"
+				placeholder="Filter your friends…"
+				bind:value={listFilter}
+				aria-label="Filter your friends"
+			/>
+			{#if listFilter.trim()}
+				<div class="filter-count">Showing {shownFriends.length} of {friends.length}</div>
+			{/if}
+		{/if}
 		<div class="list">
-			{#each friends as u}
+			{#each shownFriends as u}
 				<div class="row card">
 					<button
 						class="uname namelink"
@@ -215,6 +245,9 @@
 					</div>
 				</div>
 			{/each}
+			{#if shownFriends.length === 0}
+				<p class="muted small pad">No friends match “{listFilter.trim()}”.</p>
+			{/if}
 		</div>
 	{/if}
 
@@ -246,6 +279,25 @@
 	.search:focus {
 		outline: none;
 		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.list-filter {
+		width: 100%;
+		margin-bottom: 0.6rem;
+		padding: 0.6rem 0.9rem;
+		border-radius: 12px;
+		font-size: 0.9rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.list-filter:focus {
+		outline: none;
+		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.filter-count {
+		font-size: 0.72rem;
+		color: var(--text-muted);
+		margin: -0.2rem 0 0.5rem 0.2rem;
 	}
 	.results {
 		margin-top: 0.5rem;

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -29,6 +29,19 @@
 	/** @type {any|null} */
 	let open = $state(null);
 	let loading = $state(true);
+
+	// Long-list handling: alphabetize groups + live filter (shown once you have a few).
+	let groupFilter = $state('');
+	const sortedGroups = $derived(
+		[...groups].sort((a, b) =>
+			(a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' })
+		)
+	);
+	const shownGroups = $derived.by(() => {
+		const q = groupFilter.trim().toLowerCase();
+		if (!q) return sortedGroups;
+		return sortedGroups.filter((g) => (g.name || '').toLowerCase().includes(q));
+	});
 	let busy = $state(false);
 	let newName = $state('');
 	let msg = $state('');
@@ -442,8 +455,20 @@
 			<p class="loading">Loading…</p>
 		{:else}
 			{#if groups.length}
+				{#if groups.length > 8}
+					<input
+						class="g-filter"
+						type="text"
+						placeholder="Filter your groups…"
+						bind:value={groupFilter}
+						aria-label="Filter your groups"
+					/>
+					{#if groupFilter.trim()}
+						<div class="g-filter-count">Showing {shownGroups.length} of {groups.length}</div>
+					{/if}
+				{/if}
 				<div class="g-list">
-					{#each groups as g}
+					{#each shownGroups as g}
 						<button class="g-card" onclick={() => view(g.id)}>
 							<div class="gc-body">
 								<span class="gc-name">{g.name}</span><span class="gc-meta"
@@ -453,6 +478,9 @@
 							<span class="gc-arrow">→</span>
 						</button>
 					{/each}
+					{#if shownGroups.length === 0}
+						<p class="empty">No groups match “{groupFilter.trim()}”.</p>
+					{/if}
 				</div>
 			{:else}
 				<p class="empty">No groups yet — create one and add your friends.</p>
@@ -603,6 +631,25 @@
 		font-size: 1.1rem;
 		font-family: var(--font-display);
 		font-weight: 700;
+	}
+	.g-filter {
+		width: 100%;
+		margin-bottom: 0.6rem;
+		padding: 0.6rem 0.9rem;
+		border-radius: 12px;
+		font-size: 0.9rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		color: var(--text);
+	}
+	.g-filter:focus {
+		outline: none;
+		border-color: rgba(251, 191, 36, 0.5);
+	}
+	.g-filter-count {
+		font-size: 0.72rem;
+		color: var(--text-muted);
+		margin: -0.2rem 0 0.5rem 0.2rem;
 	}
 	.g-list {
 		display: flex;


### PR DESCRIPTION
Handles long friend/group lists (30–100+) gracefully.

Before: a flat, unsorted list you just page-scrolled — no way to find a specific friend; the top search box only *adds new* people.

Now:
- **Alphabetized A–Z** by @username / name — predictable and scannable.
- **Live filter** — once you have >8 friends/groups, a "Filter your …" box narrows the list as you type (matches username + name), with a **"Showing N of M"** count and a friendly empty state.
- Kept normal page scroll — no nested scroll boxes, no pagination/virtualization (unneeded at this data size).

Applied to both `FriendsPanel` and `GroupsPanel` (used in the Community ▸ People tabs and the /friends, /groups, /my-friends, /my-groups pages).

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)