### PR TITLE
Friends/Groups: A–Z / Recently-added sort toggle

### DIFF
--- a/src/lib/components/FriendsPanel.svelte
+++ b/src/lib/components/FriendsPanel.svelte
@@ -17,7 +17,7 @@
 	/** Optional: called to start a challenge with a friend (username). */
 	let { onChallenge = null } = $props();
 
-	/** @type {{id?:string,username:string,name:string}[]} */
+	/** @type {{id?:string,username:string,name:string,added_at?:string}[]} */
 	let friends = $state([]);
 	/** @type {{id?:string,username:string,name:string}[]} */
 	let incoming = $state([]);
@@ -123,16 +123,23 @@
 
 	const label = (/** @type {any} */ u) => (u.username ? '@' + u.username : u.name || 'Player');
 
-	// Long-list handling: alphabetize your friends and let you filter them live.
+	// Long-list handling: sort your friends (A–Z or recently added) + filter live.
 	// The top search box adds NEW people; this narrows the ones you already have.
 	let listFilter = $state('');
-	const sortedFriends = $derived(
-		[...friends].sort((a, b) =>
+	/** @type {'az'|'recent'} */
+	let sortMode = $state('az');
+	const sortedFriends = $derived.by(() => {
+		const arr = [...friends];
+		if (sortMode === 'recent') {
+			// added_at is an ISO string → lexical compare desc = newest first
+			return arr.sort((a, b) => (b.added_at || '').localeCompare(a.added_at || ''));
+		}
+		return arr.sort((a, b) =>
 			(a.username || a.name || '').localeCompare(b.username || b.name || '', undefined, {
 				sensitivity: 'base'
 			})
-		)
-	);
+		);
+	});
 	const shownFriends = $derived.by(() => {
 		const q = listFilter.trim().toLowerCase();
 		if (!q) return sortedFriends;
@@ -207,7 +214,17 @@
 		</div>
 	{/if}
 
-	<h2 class="sec">Your Friends <span class="count">{friends.length}</span></h2>
+	<div class="sec-row">
+		<h2 class="sec">Your Friends <span class="count">{friends.length}</span></h2>
+		{#if friends.length > 1}
+			<div class="sort-toggle" role="group" aria-label="Sort friends">
+				<button class:on={sortMode === 'az'} onclick={() => (sortMode = 'az')}>A–Z</button>
+				<button class:on={sortMode === 'recent'} onclick={() => (sortMode = 'recent')}
+					>Recent</button
+				>
+			</div>
+		{/if}
+	</div>
 	{#if friends.length === 0}
 		<p class="muted small pad">No friends yet — search above to add some.</p>
 	{:else}
@@ -298,6 +315,35 @@
 		font-size: 0.72rem;
 		color: var(--text-muted);
 		margin: -0.2rem 0 0.5rem 0.2rem;
+	}
+	.sec-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+	}
+	.sort-toggle {
+		display: inline-flex;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		overflow: hidden;
+		flex: none;
+	}
+	.sort-toggle button {
+		padding: 4px 10px;
+		font-size: 0.74rem;
+		font-weight: 700;
+		background: var(--surface);
+		color: var(--text-muted);
+		border: none;
+		cursor: pointer;
+	}
+	.sort-toggle button + button {
+		border-left: 1px solid var(--border);
+	}
+	.sort-toggle button.on {
+		background: rgba(251, 191, 36, 0.18);
+		color: #fcd34d;
 	}
 	.results {
 		margin-top: 0.5rem;

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -30,13 +30,19 @@
 	let open = $state(null);
 	let loading = $state(true);
 
-	// Long-list handling: alphabetize groups + live filter (shown once you have a few).
+	// Long-list handling: sort groups (A–Z or recently added) + live filter.
 	let groupFilter = $state('');
-	const sortedGroups = $derived(
-		[...groups].sort((a, b) =>
+	/** @type {'az'|'recent'} */
+	let groupSort = $state('az');
+	const sortedGroups = $derived.by(() => {
+		const arr = [...groups];
+		if (groupSort === 'recent') {
+			return arr.sort((a, b) => (b.added_at || '').localeCompare(a.added_at || ''));
+		}
+		return arr.sort((a, b) =>
 			(a.name || '').localeCompare(b.name || '', undefined, { sensitivity: 'base' })
-		)
-	);
+		);
+	});
 	const shownGroups = $derived.by(() => {
 		const q = groupFilter.trim().toLowerCase();
 		if (!q) return sortedGroups;
@@ -455,6 +461,17 @@
 			<p class="loading">Loading…</p>
 		{:else}
 			{#if groups.length}
+				{#if groups.length > 1}
+					<div class="g-sec-row">
+						<span class="g-count">{groups.length} group{groups.length === 1 ? '' : 's'}</span>
+						<div class="sort-toggle" role="group" aria-label="Sort groups">
+							<button class:on={groupSort === 'az'} onclick={() => (groupSort = 'az')}>A–Z</button>
+							<button class:on={groupSort === 'recent'} onclick={() => (groupSort = 'recent')}
+								>Recent</button
+							>
+						</div>
+					</div>
+				{/if}
 				{#if groups.length > 8}
 					<input
 						class="g-filter"
@@ -650,6 +667,41 @@
 		font-size: 0.72rem;
 		color: var(--text-muted);
 		margin: -0.2rem 0 0.5rem 0.2rem;
+	}
+	.g-sec-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+		margin-bottom: 0.6rem;
+	}
+	.g-count {
+		font-size: 0.8rem;
+		font-weight: 700;
+		color: var(--text-muted);
+	}
+	.sort-toggle {
+		display: inline-flex;
+		border: 1px solid var(--border);
+		border-radius: 10px;
+		overflow: hidden;
+		flex: none;
+	}
+	.sort-toggle button {
+		padding: 4px 10px;
+		font-size: 0.74rem;
+		font-weight: 700;
+		background: var(--surface);
+		color: var(--text-muted);
+		border: none;
+		cursor: pointer;
+	}
+	.sort-toggle button + button {
+		border-left: 1px solid var(--border);
+	}
+	.sort-toggle button.on {
+		background: rgba(251, 191, 36, 0.18);
+		color: #fcd34d;
 	}
 	.g-list {
 		display: flex;

--- a/supabase-friends-groups-added-at.sql
+++ b/supabase-friends-groups-added-at.sql
@@ -1,0 +1,33 @@
+-- Expose when a friend/group was added so the client can offer an "A–Z / Recently added" sort.
+-- list_friends → added_at = friendships.created_at; get_my_groups → added_at = my joined_at.
+
+CREATE OR REPLACE FUNCTION public.list_friends()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); v_rows jsonb;
+begin
+  if v_uid is null then return '[]'::jsonb; end if;
+  select coalesce(jsonb_agg(jsonb_build_object(
+           'id', pr.id, 'username', pr.username, 'name', public._display_name(pr.id),
+           'added_at', f.created_at)
+           order by lower(public._display_name(pr.id))), '[]'::jsonb) into v_rows
+  from public.friendships f join public.profiles pr on pr.id = f.friend_id
+  where f.user_id = v_uid;
+  return v_rows;
+end; $function$;
+
+CREATE OR REPLACE FUNCTION public.get_my_groups()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('id', g.id, 'name', g.name, 'join_code', g.join_code,
+    'members', (SELECT count(*) FROM public.group_members gm2 WHERE gm2.group_id = g.id),
+    'is_owner', g.owner_id = v_uid,
+    'added_at', (SELECT gm3.joined_at FROM public.group_members gm3
+                 WHERE gm3.group_id = g.id AND gm3.user_id = v_uid)) ORDER BY g.created_at), '[]'::jsonb)
+  INTO v_rows FROM public.groups g
+  WHERE EXISTS (SELECT 1 FROM public.group_members gm WHERE gm.group_id = g.id AND gm.user_id = v_uid);
+  RETURN v_rows;
+END; $function$;


### PR DESCRIPTION
Adds a segmented **A–Z | Recent** sort toggle to both the Friends and Groups lists (next to the count header). Default stays A–Z; **Recent** sorts by when you added the friend / joined the group, newest first.

DB: exposed `added_at` from `list_friends` (friendships.created_at) and `get_my_groups` (my joined_at) — applied to prod under PITR. Client sorts on it.

Shows once you have 2+ items. Works everywhere the panels are used (Community ▸ People, /friends, /groups, /my-friends, /my-groups).

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)