### PR TITLE
Menu: center Resume text + drop @ from greeting

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3051,7 +3051,7 @@
 			<!-- 🏦 Bank-app header: greeting + notifications + profile monogram -->
 			<div class="menu-hero">
 				<div class="hero-greet">
-					Hi, <span class="hg-name">@{$userProfile?.username ?? myUsername ?? 'wordbanker'}</span>
+					Hi, <span class="hg-name">{$userProfile?.username ?? myUsername ?? 'wordbanker'}</span>
 				</div>
 				<div class="hero-actions">
 					<button
@@ -6361,7 +6361,7 @@
 	}
 	.rs-label {
 		flex: 1;
-		text-align: left;
+		text-align: center;
 		color: #d1fae5;
 	}
 	.rs-go {


### PR DESCRIPTION
Two small menu tweaks:
- **Resume strip** text is now centered (was left-aligned).
- **Greeting** reads "Hi, Chefcharles" instead of "Hi, @Chefcharles".

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)