### PR TITLE
Badges: Duolingo-style redesign

### DIFF
--- a/src/lib/components/BadgesPanel.svelte
+++ b/src/lib/components/BadgesPanel.svelte
@@ -10,6 +10,8 @@
 	/** @type {string[]} */
 	let earnedBadges = $state([]);
 	let loaded = $state(false);
+	/** @type {'categories'|'achievements'} */
+	let tab = $state('categories');
 
 	onMount(async () => {
 		const [stats, earned] = await Promise.all([getCategoryStats(), getUserBadges()]);
@@ -34,167 +36,301 @@
 		})),
 		{ emoji: COLLECTOR.emoji, name: COLLECTOR.name, desc: COLLECTOR.desc, earned: goldCount >= 12 }
 	]);
+	// Earned first, so unlocked badges lead instead of being buried under locked ones.
+	let achSorted = $derived(
+		[...achievements].sort((a, b) => (b.earned ? 1 : 0) - (a.earned ? 1 : 0))
+	);
+	let earnedCount = $derived(achievements.filter((a) => a.earned).length);
+	let rankedCats = $derived(rows.filter((r) => r.current).length);
+
+	// SVG progress ring geometry (r = 19 → circumference ≈ 119.38)
+	const CIRC = 2 * Math.PI * 19;
 </script>
 
 <div class="bp">
-	<p class="badges-total">{total} {total === 1 ? 'puzzle' : 'puzzles'} solved all-time</p>
+	<!-- 🏅 Progress hero -->
+	<div class="bp-hero">
+		<div class="bp-hero-count">
+			<span class="bp-hero-num">{earnedCount}</span><span class="bp-hero-den"
+				>/ {achievements.length}</span
+			>
+		</div>
+		<div class="bp-hero-lbl">badges unlocked</div>
+		<div class="bp-hero-bar">
+			<div
+				class="bp-hero-fill"
+				style="width:{Math.round((earnedCount / achievements.length) * 100)}%"
+			></div>
+		</div>
+		<div class="bp-hero-sub">
+			{total}
+			{total === 1 ? 'puzzle' : 'puzzles'} solved · {rankedCats}/{rows.length} categories ranked
+		</div>
+	</div>
 
-	<p class="bm-section-title">Category Levels</p>
-	<div class="bm-cats">
-		{#each rows as r (r.value)}
-			<div class="bm-cat">
-				<span class="bm-cat-emoji">{r.emoji}</span>
-				<div class="bm-cat-body">
-					<div class="bm-cat-top">
-						<span class="bm-cat-name">{r.label}</span>
-						<span class="bm-cat-tier"
-							>{r.current ? r.current.medal + ' ' + r.current.name : '—'}</span
-						>
+	<!-- Tabs -->
+	<div class="bp-tabs" role="tablist">
+		<button class:on={tab === 'categories'} onclick={() => (tab = 'categories')}>Categories</button>
+		<button class:on={tab === 'achievements'} onclick={() => (tab = 'achievements')}
+			>Achievements <span class="bp-tab-count">{earnedCount}</span></button
+		>
+	</div>
+
+	{#if tab === 'categories'}
+		<div class="cat-grid">
+			{#each rows as r (r.value)}
+				<div class="cat-tile" class:ranked={r.current}>
+					<div class="ring-wrap">
+						<svg class="ring" viewBox="0 0 44 44">
+							<circle class="ring-bg" cx="22" cy="22" r="19" />
+							<circle
+								class="ring-fg"
+								cx="22"
+								cy="22"
+								r="19"
+								style="stroke-dasharray:{CIRC};stroke-dashoffset:{CIRC * (1 - r.progress)}"
+							/>
+						</svg>
+						<span class="ring-emoji">{r.emoji}</span>
+						{#if r.current}<span class="ring-medal">{r.current.medal}</span>{/if}
 					</div>
-					<div class="bm-bar">
-						<div class="bm-bar-fill" style="width:{Math.round(r.progress * 100)}%"></div>
+					<div class="cat-name">{r.label}</div>
+					<div class="cat-sub">
+						{#if r.next}
+							{r.toNext} → {r.next.medal}
+						{:else}
+							💎 Maxed · {r.solves}
+						{/if}
 					</div>
-					<span class="bm-cat-sub">
-						{#if r.next}{r.toNext} more → {r.next.medal} {r.next.name}{:else}Maxed out 💎 · {r.solves}
-							solved{/if}
-					</span>
 				</div>
-			</div>
-		{/each}
-	</div>
+			{/each}
+		</div>
+	{:else}
+		<div class="ach-grid">
+			{#each achSorted as a}
+				<div class="ach {a.earned ? 'earned' : 'locked'}" title={a.desc}>
+					<span class="ach-emoji">{a.emoji}</span>
+					<span class="ach-name">{a.name}</span>
+					<span class="ach-desc">{a.desc}</span>
+				</div>
+			{/each}
+		</div>
+	{/if}
 
-	<p class="bm-section-title">Achievements</p>
-	<div class="bm-ach-grid">
-		{#each achievements as a}
-			<div class="bm-ach {a.earned ? 'earned' : 'locked'}" title={a.desc}>
-				<span class="bm-ach-emoji">{a.emoji}</span>
-				<span class="bm-ach-name">{a.name}</span>
-				<span class="bm-ach-desc">{a.desc}</span>
-			</div>
-		{/each}
-	</div>
-
-	{#if !loaded}<p class="bm-loading">Loading…</p>{/if}
+	{#if !loaded}<p class="bp-loading">Loading…</p>{/if}
 </div>
 
 <style>
-	.badges-total {
-		font-size: 0.9rem;
-		color: var(--text-muted);
-		margin: 0 0 14px;
+	/* 🏅 Progress hero */
+	.bp-hero {
 		text-align: center;
+		padding: 16px 18px 18px;
+		border-radius: 18px;
+		margin-bottom: 16px;
+		background: linear-gradient(180deg, rgba(251, 191, 36, 0.12), rgba(251, 191, 36, 0.02));
+		border: 1px solid rgba(251, 191, 36, 0.28);
 	}
-	.bm-section-title {
+	.bp-hero-count {
+		display: flex;
+		align-items: baseline;
+		justify-content: center;
+		gap: 4px;
+	}
+	.bp-hero-num {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 2.4rem;
+		line-height: 1;
+		color: #fde047;
+	}
+	.bp-hero-den {
 		font-family: var(--font-display);
 		font-weight: 700;
-		font-size: 0.7rem;
+		font-size: 1.1rem;
+		color: var(--text-muted);
+	}
+	.bp-hero-lbl {
+		font-size: 0.72rem;
 		letter-spacing: 0.14em;
 		text-transform: uppercase;
-		color: var(--brand-2, #fde047);
-		text-align: left;
-		margin: 22px 0 10px;
+		color: var(--text-muted);
+		margin-top: 2px;
 	}
-	.bm-cats {
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-	}
-	.bm-cat {
-		display: flex;
-		align-items: center;
-		gap: 12px;
-		text-align: left;
-		padding: 10px 12px;
-		border-radius: var(--r-md, 12px);
-		background: var(--surface, rgba(255, 255, 255, 0.05));
-		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
-	}
-	.bm-cat-emoji {
-		font-size: 1.5rem;
-		line-height: 1;
-	}
-	.bm-cat-body {
-		flex: 1;
-		min-width: 0;
-	}
-	.bm-cat-top {
-		display: flex;
-		justify-content: space-between;
-		align-items: baseline;
-		gap: 8px;
-	}
-	.bm-cat-name {
-		font-family: var(--font-display);
-		font-weight: 600;
-		font-size: 0.9rem;
-	}
-	.bm-cat-tier {
-		font-family: var(--font-display);
-		font-weight: 700;
-		font-size: 0.78rem;
-		color: #fcd34d;
-		white-space: nowrap;
-	}
-	.bm-bar {
-		height: 6px;
+	.bp-hero-bar {
+		height: 8px;
 		border-radius: 999px;
-		background: var(--border, rgba(255, 255, 255, 0.12));
-		margin: 6px 0 4px;
+		background: rgba(255, 255, 255, 0.12);
 		overflow: hidden;
+		margin: 12px auto 8px;
+		max-width: 260px;
 	}
-	.bm-bar-fill {
+	.bp-hero-fill {
 		height: 100%;
 		border-radius: 999px;
-		background: var(--brand-grad, linear-gradient(90deg, #fbbf24, #fde047));
-		transition: width 0.4s var(--ease-spring, ease);
+		background: linear-gradient(90deg, #fbbf24, #fde047);
+		transition: width 0.5s var(--ease-spring, ease);
 	}
-	.bm-cat-sub {
-		font-family: var(--font-ui);
-		font-size: 0.72rem;
+	.bp-hero-sub {
+		font-size: 0.74rem;
 		color: var(--text-muted);
 	}
 
-	.bm-ach-grid {
+	/* Tabs */
+	.bp-tabs {
+		display: flex;
+		gap: 6px;
+		padding: 4px;
+		border-radius: 12px;
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+		margin-bottom: 16px;
+	}
+	.bp-tabs button {
+		flex: 1;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 6px;
+		padding: 8px 10px;
+		border: none;
+		border-radius: 9px;
+		cursor: pointer;
+		background: transparent;
+		color: var(--text-muted);
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.85rem;
+		transition:
+			background 0.15s,
+			color 0.15s;
+	}
+	.bp-tabs button.on {
+		background: rgba(251, 191, 36, 0.16);
+		color: #fde047;
+	}
+	.bp-tab-count {
+		min-width: 18px;
+		height: 18px;
+		padding: 0 5px;
+		border-radius: 999px;
+		display: grid;
+		place-items: center;
+		font-size: 0.66rem;
+		font-weight: 800;
+		background: rgba(251, 191, 36, 0.25);
+		color: #fde047;
+	}
+
+	/* Category grid — progress-ring tiles */
+	.cat-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 10px;
+	}
+	.cat-tile {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 3px;
+		padding: 14px 10px 12px;
+		border-radius: 16px;
+		background: var(--surface, rgba(255, 255, 255, 0.05));
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+		text-align: center;
+	}
+	.cat-tile.ranked {
+		border-color: rgba(251, 191, 36, 0.35);
+	}
+	.ring-wrap {
+		position: relative;
+		width: 60px;
+		height: 60px;
+		margin-bottom: 4px;
+	}
+	.ring {
+		width: 60px;
+		height: 60px;
+		transform: rotate(-90deg);
+	}
+	.ring-bg {
+		fill: none;
+		stroke: rgba(255, 255, 255, 0.12);
+		stroke-width: 3.5;
+	}
+	.ring-fg {
+		fill: none;
+		stroke: #fbbf24;
+		stroke-width: 3.5;
+		stroke-linecap: round;
+		transition: stroke-dashoffset 0.6s var(--ease-spring, ease);
+	}
+	.ring-emoji {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: 1.5rem;
+	}
+	.ring-medal {
+		position: absolute;
+		right: -2px;
+		bottom: -2px;
+		font-size: 0.9rem;
+		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.5));
+	}
+	.cat-name {
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.82rem;
+		line-height: 1.15;
+	}
+	.cat-sub {
+		font-size: 0.7rem;
+		color: var(--text-muted);
+	}
+
+	/* Achievement grid */
+	.ach-grid {
 		display: grid;
 		grid-template-columns: repeat(2, 1fr);
 		gap: 8px;
 	}
-	.bm-ach {
+	.ach {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
 		gap: 3px;
 		text-align: center;
-		padding: 12px 8px;
-		border-radius: var(--r-md, 12px);
+		padding: 14px 8px;
+		border-radius: 14px;
 		background: var(--surface, rgba(255, 255, 255, 0.05));
 		border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
 	}
-	.bm-ach.earned {
-		border-color: rgba(253, 224, 71, 0.45);
-		box-shadow: 0 0 14px rgba(251, 191, 36, 0.14);
+	.ach.earned {
+		border-color: rgba(253, 224, 71, 0.5);
+		box-shadow: 0 0 14px rgba(251, 191, 36, 0.16);
 	}
-	.bm-ach.locked {
+	.ach.locked {
 		opacity: 0.45;
 		filter: grayscale(0.7);
 	}
-	.bm-ach-emoji {
-		font-size: 1.5rem;
+	.ach-emoji {
+		font-size: 1.6rem;
 		line-height: 1;
 	}
-	.bm-ach-name {
+	.ach-name {
 		font-family: var(--font-display);
 		font-weight: 700;
 		font-size: 0.78rem;
 	}
-	.bm-ach-desc {
-		font-family: var(--font-ui);
+	.ach-desc {
 		font-size: 0.66rem;
 		color: var(--text-muted);
 		line-height: 1.2;
 	}
-	.bm-loading {
+	.bp-loading {
 		color: var(--text-muted);
 		font-size: 0.85rem;
+		text-align: center;
 	}
 </style>


### PR DESCRIPTION
The badges page was ~3 screens of scroll (2758px) — 12 near-identical full-width category rows then 29 mostly-locked achievement cards. Rebuilt it Duolingo-style:

- **Progress hero** — "X / 29 badges unlocked" with a bar + "N solved · M/12 categories ranked".
- **Segmented tabs** (Categories · Achievements) — you see one section at a time, cutting the default view from **2758px → 1227px**.
- **Categories → progress-ring tiles** — a 2-col grid where each category emoji sits inside an SVG progress ring showing how close you are to the next tier (with the current medal), instead of 12 repetitive "3 more → Bronze" rows.
- **Achievements → earned-first grid** with an unlocked count on the tab.

Verified against Chefcharles's real data on a production preview (both tabs).

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)