### PR TITLE
Stats: Cash Game Net P&L + tappable categories

### DIFF
--- a/src/lib/components/BadgesPanel.svelte
+++ b/src/lib/components/BadgesPanel.svelte
@@ -32,6 +32,15 @@
 		loaded = true;
 		await tick();
 		celebrateNewUnlocks();
+		// Deep link from Full Stats: /badges?cat=<value> opens that category's detail.
+		const cat = new URLSearchParams(location.search).get('cat');
+		if (cat) {
+			const row = rows.find((r) => r.value === cat);
+			if (row) {
+				tab = 'categories';
+				detail = row;
+			}
+		}
 	});
 
 	// 🎉 Celebrate badges earned since the last visit. First visit seeds silently so

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -232,6 +232,7 @@
 			</div>
 		{:else if tab === 'stats'}
 			{@const net = Number(d.overall.earned ?? 0) - Number(d.overall.spent ?? 0)}
+			{@const cgNet = Number(d.cash_game.net ?? 0)}
 			<!-- 💹 Lifetime net hero -->
 			<div class="st-hero">
 				<div class="st-hero-lbl">Lifetime Net</div>
@@ -267,6 +268,11 @@
 				{@render chip('#' + (d.cash_game.position ?? 0), 'Furthest')}
 				{@render chip(d.cash_game.solved ?? 0, 'Solved')}
 				{@render chip(fmt(d.cash_game.earned), 'Earned')}
+				<div class="stat">
+					<span class="sv" class:pos={cgNet >= 0} class:neg={cgNet < 0}
+						>{cgNet >= 0 ? '+' : '−'}{fmt(Math.abs(cgNet))}</span
+					><span class="sc">Net P&amp;L</span>
+				</div>
 				{@render chip(mult(d.cash_game.best_multiple), 'Best ×')}
 				{@render chip(time(d.cash_game.fastest_ms), 'Fastest')}
 			</div>
@@ -323,16 +329,19 @@
 			{/if}
 
 			{#if (d.categories ?? []).length}
-				<div class="sec-title">🗂️ Categories</div>
+				<div class="sec-title">🗂️ Categories <span class="sec-hint">(tap for tiers)</span></div>
 				<div class="cats">
 					{#each d.categories as c}
-						<div class="cat-row">
+						<button
+							class="cat-row cat-link"
+							onclick={() => goto('/badges?cat=' + encodeURIComponent(c.category))}
+						>
 							<span class="cat-name">{c.category}</span>
 							<span class="cat-meta"
 								>{c.solves} solved{#if c.best_multiple}
-									· best {mult(c.best_multiple)}{/if}</span
+									· best {mult(c.best_multiple)}{/if}<span class="arrow"> ›</span></span
 							>
-						</div>
+						</button>
 					{/each}
 				</div>
 			{/if}
@@ -764,6 +773,12 @@
 		font-size: 1.02rem;
 		color: var(--text);
 	}
+	.sv.pos {
+		color: #4ade80;
+	}
+	.sv.neg {
+		color: #fb7185;
+	}
 	.sc {
 		font-size: 0.58rem;
 		text-transform: uppercase;
@@ -785,6 +800,23 @@
 		background: var(--surface);
 		border: 1px solid var(--border);
 		border-radius: 10px;
+	}
+	.cat-link {
+		width: 100%;
+		cursor: pointer;
+		text-align: left;
+		font: inherit;
+		color: inherit;
+		transition:
+			transform 0.15s,
+			border-color 0.2s;
+	}
+	.cat-link:hover {
+		transform: translateX(2px);
+		border-color: rgba(251, 191, 36, 0.4);
+	}
+	.cat-link:active {
+		transform: scale(0.99);
 	}
 	.cat-name {
 		font-weight: 600;

--- a/supabase-profile-cashgame-net.sql
+++ b/supabase-profile-cashgame-net.sql
@@ -1,0 +1,61 @@
+-- Expose Cash Game lifetime net (P&L after buy-ins) on get_profile_detail.
+CREATE OR REPLACE FUNCTION public.get_profile_detail()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); p public.profiles; v_climb int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  SELECT position INTO v_climb FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object(
+    'username', p.username, 'color', p.equipped_color, 'title', p.equipped_title,
+    'account_number', p.account_number, 'member_no', p.member_no,
+    'net_worth', COALESCE(p.bank,0), 'cash', COALESCE(p.bank,0),
+    'overall', (SELECT jsonb_build_object(
+        'puzzles_solved', COALESCE(sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)),0),
+        'games_played', count(*), 'earned', COALESCE(sum(earned),0), 'spent', COALESCE(sum(spent),0),
+        'avg_multiple', round(avg(multiple_x100) FILTER (WHERE multiple_x100 IS NOT NULL))::int,
+        'best_multiple', max(multiple_x100), 'clean_solves', count(*) FILTER (WHERE clean))
+      FROM public.game_results WHERE user_id = v_uid),
+    -- Daily includes make-ups (a make-up IS a daily, just played late).
+    'daily', (SELECT jsonb_build_object(
+        'current_streak', COALESCE(p.current_daily_play_streak,0), 'best_streak', COALESCE(p.best_daily_play_streak,0), 'win_streak', (CASE WHEN p.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(p.current_daily_solve_streak,0) ELSE 0 END), 'best_win_streak', COALESCE(p.best_daily_solve_streak,0),
+        'played', count(*), 'won', count(*) FILTER (WHERE outcome='won'),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'), 'best_bounty', COALESCE(max(net) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode IN ('daily','makeup')),
+    'cash_game', jsonb_build_object('position', COALESCE(v_climb,0)) ||
+      (SELECT jsonb_build_object('solved', count(*) FILTER (WHERE outcome='won'),
+        'earned', COALESCE(sum(earned) FILTER (WHERE outcome='won'),0),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'))
+       FROM public.game_results WHERE user_id = v_uid AND game_mode='climb') || jsonb_build_object('net', COALESCE(p.cg_lifetime_net,0)),
+    -- 1v1 = challenge rows with no group; record vs people
+    'challenges_1v1', (SELECT jsonb_build_object(
+        'wins', count(*) FILTER (WHERE outcome='won'), 'losses', count(*) FILTER (WHERE outcome='lost'),
+        'ties', count(*) FILTER (WHERE outcome='tie'), 'played', count(*),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NULL),
+    -- group challenges = your placement in the pack
+    'challenges_group', (SELECT jsonb_build_object(
+        'played', count(*), 'wins', count(*) FILTER (WHERE rank = 1),
+        'podiums', count(*) FILTER (WHERE rank <= 3),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NOT NULL),
+    'categories', (SELECT COALESCE(jsonb_agg(jsonb_build_object('category', category, 'solves', solves, 'best_multiple', bm) ORDER BY solves DESC), '[]'::jsonb)
+      FROM (SELECT category, sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) AS solves, max(multiple_x100) AS bm
+            FROM public.game_results WHERE user_id = v_uid AND category IS NOT NULL
+            GROUP BY category HAVING sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) > 0) c),
+    -- Rivals: your head-to-head record vs each 1v1 opponent
+    'rivals', (SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'name', public._display_name(opponent_id), 'wins', wins, 'losses', losses, 'ties', ties) ORDER BY played DESC, wins DESC), '[]'::jsonb)
+      FROM (SELECT opponent_id, count(*) AS played,
+              count(*) FILTER (WHERE outcome='won') AS wins,
+              count(*) FILTER (WHERE outcome='lost') AS losses,
+              count(*) FILTER (WHERE outcome='tie') AS ties
+            FROM public.game_results
+            WHERE user_id = v_uid AND game_mode='challenge' AND opponent_id IS NOT NULL
+            GROUP BY opponent_id ORDER BY played DESC LIMIT 8) r)
+  );
+END; $function$


### PR DESCRIPTION
Two follow-ons to the stats screen.

**1. Cash Game Net P&L** — the section showed gross **Earned** ($8,023) but not whether you're actually up after buy-ins. Added a green/red **Net P&L** chip fed by `cg_lifetime_net` (cashout adds profit, bust subtracts buy-in). For Chefcharles: **−$134** — a very different story than $8,023 gross. Exposed via `get_profile_detail.cash_game.net` (applied to prod).

**2. Tappable categories → badge tiers** — each category row in Full Stats now deep-links to `/badges?cat=<value>`, and BadgesPanel opens that category's tier-ladder detail on arrival (Bronze/Silver/Gold/Diamond + how many more). `c.category` already equals `CATEGORIES[].value`, so it matches directly.

Verified: net chip **−$134**; tapping "Movies & TV" → /badges → Movies & TV detail modal open.

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)