### PR TITLE
Fix dev crashes: font @import placement + Node heap

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
-		"dev": "NODE_OPTIONS=--max-http-header-size=65536 vite dev",
+		"dev": "NODE_OPTIONS='--max-http-header-size=65536 --max-old-space-size=4096' vite dev",
 		"build": "vite build",
-		"preview": "NODE_OPTIONS=--max-http-header-size=65536 vite preview",
+		"preview": "NODE_OPTIONS='--max-http-header-size=65536 --max-old-space-size=4096' vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src/app.css
+++ b/src/app.css
@@ -2,7 +2,9 @@
    WordBank design system — premium dark neon-arcade aesthetic
    Global tokens + base styles. Imported once in +layout.svelte.
 ============================================================ */
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
+/* All app fonts in one top-level import (font @imports MUST precede all other CSS;
+   keeping them here avoids the invalid mid-stylesheet @imports Vite errors on). */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=VT323&family=Montserrat:wght@500;700&family=Playfair+Display:wght@400;700&family=Orbitron:wght@400;700&display=swap');
 
 :root {
 	/* Brand */

--- a/src/lib/components/GameButtons.svelte
+++ b/src/lib/components/GameButtons.svelte
@@ -116,8 +116,6 @@
 </div>
 
 <style>
-	@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
-
 	@keyframes solvePulse {
 		0%,
 		100% {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4908,8 +4908,6 @@
 </main>
 
 <style>
-	@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
-	@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap');
 
 	.attendance-toast {
 		position: fixed;
@@ -4942,9 +4940,6 @@
 			opacity: 1;
 		}
 	}
-	@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
-	@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
-
 	main {
 		max-width: 600px;
 		margin: 0 auto;


### PR DESCRIPTION
`npm run dev` kept dying (`zsh: killed`).

**Root cause:** font `@import` statements were placed **mid-stylesheet** inside component `<style>` blocks (`+page.svelte`, `GameButtons.svelte`) — invalid CSS. Vite/postcss threw `@import must precede all other statements` on every recompile, and that repeated churn over the very large `+page.svelte` pushed Node past its heap, so the OS OOM-killed it.

**Fix:**
- Consolidated all font families (VT323, Montserrat, Playfair Display, Orbitron) into the single **top-level** `@import` in `app.css` (where `@import` is legal), and removed the mid-stylesheet ones. Same fonts, no error.
- Raised dev/preview Node heap to 4 GB (`--max-old-space-size=4096`) for headroom.

Verified: dev boots clean (HTTP 200, **0** postcss errors) and stays alive.

Gates: svelte-check 0 errors ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)