### PR TITLE
Fix: public-profile friends list Add button

### DIFF
--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -184,17 +184,21 @@
 						<button class="soc-main" onclick={() => goto('/u/' + encodeURIComponent(f.username))}
 							>@{f.username}<span class="soc-go">›</span></button
 						>
-						<button
-							class="soc-act"
-							disabled={!!busyFriend[f.username]}
-							onclick={() => addOne(f.username)}
-						>
-							{busyFriend[f.username] === 'sent'
-								? '✓ Sent'
-								: busyFriend[f.username] === 'err'
-									? 'Failed'
-									: '+ Add'}
-						</button>
+						{#if f.is_self}
+							<span class="soc-tag">You</span>
+						{:else if f.status === 'friends'}
+							<span class="soc-tag ok">✓ Friend</span>
+						{:else if f.status === 'pending_out' || busyFriend[f.username] === 'sent'}
+							<span class="soc-tag">Requested</span>
+						{:else}
+							<button
+								class="soc-act"
+								disabled={!!busyFriend[f.username]}
+								onclick={() => addOne(f.username)}
+							>
+								{busyFriend[f.username] === 'err' ? 'Retry' : '+ Add'}
+							</button>
+						{/if}
 					</div>
 				{/each}
 			</section>
@@ -486,6 +490,25 @@
 		color: #3a2a00;
 		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
 		border: none;
+	}
+	.soc-act:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.soc-tag {
+		flex: none;
+		padding: 8px 13px;
+		border-radius: 12px;
+		font-weight: 700;
+		font-size: 0.8rem;
+		color: var(--text-muted, #aeb8c6);
+		background: var(--surface-2, rgba(255, 255, 255, 0.06));
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+	}
+	.soc-tag.ok {
+		color: #6ee7b7;
+		border-color: rgba(110, 231, 183, 0.4);
+		background: rgba(110, 231, 183, 0.1);
 	}
 	.soc-act:disabled {
 		opacity: 0.6;

--- a/supabase-public-profile-friend-status.sql
+++ b/supabase-public-profile-friend-status.sql
@@ -1,0 +1,45 @@
+-- Public profile: per-friend status (self / friends / pending) so the friends list
+-- shows the right button instead of a stray + Add (incl. for yourself).
+CREATE OR REPLACE FUNCTION public.get_public_profile(p_username text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid(); v_tid uuid; p public.profiles;
+  v_climb int; v_cwins int; v_badges jsonb; v_avg int; v_best int; v_solved int; v_dplayed int; v_dwon int;
+  v_is_friend boolean; v_req_out boolean; v_req_in boolean; v_h2h jsonb;
+BEGIN
+  SELECT id INTO v_tid FROM public.profiles WHERE lower(username) = lower(p_username);
+  IF v_tid IS NULL THEN RETURN NULL; END IF;
+  SELECT * INTO p FROM public.profiles WHERE id = v_tid;
+  SELECT position INTO v_climb FROM public.climb_state WHERE user_id = v_tid;
+  SELECT count(*) INTO v_cwins FROM public.challenge_matches m
+    JOIN public.challenge_participants cp ON cp.match_id = m.id AND cp.user_id = v_tid
+    WHERE m.status = 'settled'
+      AND cp.total_score = (SELECT max(total_score) FROM public.challenge_participants x WHERE x.match_id = m.id);
+  SELECT COALESCE(jsonb_agg(badge), '[]'::jsonb) INTO v_badges FROM public.user_badges WHERE user_id = v_tid;
+  SELECT round(avg(multiple_x100))::int, max(multiple_x100),
+         COALESCE(sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)),0),
+         count(*) FILTER (WHERE game_mode='daily'),
+         count(*) FILTER (WHERE game_mode='daily' AND outcome='won')
+    INTO v_avg, v_best, v_solved, v_dplayed, v_dwon
+    FROM public.game_results WHERE user_id = v_tid;
+  v_is_friend := EXISTS (SELECT 1 FROM public.friendships WHERE user_id = v_uid AND friend_id = v_tid);
+  v_req_out := EXISTS (SELECT 1 FROM public.friend_requests WHERE requester = v_uid AND addressee = v_tid);
+  v_req_in  := EXISTS (SELECT 1 FROM public.friend_requests WHERE requester = v_tid AND addressee = v_uid);
+  IF v_uid IS DISTINCT FROM v_tid THEN v_h2h := public.get_head_to_head(v_tid); END IF;
+  RETURN jsonb_build_object(
+    'id', v_tid, 'username', p.username, 'avatar', p.avatar, 'name', public._display_name(v_tid),
+    'title', p.equipped_title, 'color', p.equipped_color,
+    'net_worth', COALESCE(p.bank,0), 'cash', COALESCE(p.bank,0),
+    'current_streak', COALESCE(p.current_daily_play_streak,0), 'longest_streak', COALESCE(p.best_daily_play_streak,0),
+    'games_played', v_dplayed, 'games_won', v_dwon,
+    'puzzles_solved', v_solved, 'climb_position', COALESCE(v_climb,0),
+    'challenge_wins', COALESCE(v_cwins,0), 'avg_multiple_x100', v_avg, 'best_multiple_x100', v_best,
+    'badges', v_badges,
+    'friends', (SELECT COALESCE(jsonb_agg(jsonb_build_object('username', p2.username, 'name', public._display_name(p2.id), 'is_self', (p2.id = v_uid), 'status', CASE WHEN p2.id = v_uid THEN 'self' WHEN EXISTS(SELECT 1 FROM public.friendships fx WHERE fx.user_id = v_uid AND fx.friend_id = p2.id) THEN 'friends' WHEN EXISTS(SELECT 1 FROM public.friend_requests rq WHERE rq.requester = v_uid AND rq.addressee = p2.id) THEN 'pending_out' WHEN EXISTS(SELECT 1 FROM public.friend_requests rq WHERE rq.requester = p2.id AND rq.addressee = v_uid) THEN 'pending_in' ELSE 'none' END) ORDER BY p2.username), '[]'::jsonb) FROM public.friendships f JOIN public.profiles p2 ON p2.id = f.friend_id WHERE f.user_id = v_tid AND p2.username IS NOT NULL),
+    'groups', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', g.id, 'name', g.name, 'my_status', CASE WHEN g.owner_id = v_uid OR EXISTS(SELECT 1 FROM public.group_members gm2 WHERE gm2.group_id=g.id AND gm2.user_id=v_uid) THEN 'member' WHEN EXISTS(SELECT 1 FROM public.group_join_requests jr WHERE jr.group_id=g.id AND jr.requester_id=v_uid) THEN 'requested' ELSE 'none' END) ORDER BY g.name), '[]'::jsonb) FROM public.group_members gm JOIN public.groups g ON g.id = gm.group_id WHERE gm.user_id = v_tid), 'is_self', (v_uid IS NOT DISTINCT FROM v_tid), 'is_friend', v_is_friend,
+    'request_outgoing', v_req_out, 'request_incoming', v_req_in, 'head_to_head', v_h2h
+  );
+END; $function$


### PR DESCRIPTION
**Bug:** on a public profile (/u/username), the **Friends** list showed "+ Add" next to every friend — including **yourself** (clicking it failed, since you can't friend yourself) and people you're already friends with.

**Cause:** the friends array from `get_public_profile` carried no per-friend status, so the button was always "+ Add".

**Fix:** the RPC now returns `is_self` + `status` per friend (self / friends / pending_out / pending_in / none), mirroring how the groups list already does `my_status`. The UI renders **"You"**, **"✓ Friend"**, or **"Requested"** and only shows **"+ Add"** when it actually applies. Applied the RPC to prod.

Verified: viewing @edithpink's profile as Chefcharles, the @Chefcharles row now shows "You" (was "+ Add").

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)