### PR TITLE
Fix back nav from public profiles + Main Menu button

### DIFF
--- a/src/lib/components/PageNav.svelte
+++ b/src/lib/components/PageNav.svelte
@@ -21,7 +21,7 @@
 			class="pn-home"
 			on:click={() => goto(home)}
 			aria-label="Main menu"
-			title="Main menu">🏠</button
+			title="Main menu">Main Menu</button
 		>{/if}
 </nav>
 
@@ -47,11 +47,10 @@
 		font-size: 0.9rem;
 	}
 	.pn-home {
-		width: 42px;
-		height: 38px;
-		display: grid;
-		place-items: center;
-		font-size: 1.1rem;
+		padding: 0.5rem 1rem;
+		font-size: 0.9rem;
+		font-weight: 700;
+		color: var(--brand-2, #fde047);
 	}
 	.pn-btn:hover,
 	.pn-home:hover {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -111,7 +111,7 @@
 	} from '$lib/pin.js';
 	import { requirePin } from '$lib/pinConfirm.js';
 	import { requireConfirm } from '$lib/confirm.js';
-	import { goto } from '$app/navigation';
+	import { goto, replaceState } from '$app/navigation';
 
 	import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
 	import InventoryList from '$lib/components/InventoryList.svelte';
@@ -1437,10 +1437,10 @@
 				handleMenuMyAccount();
 				params.delete('account');
 			}
-			// Friends & Groups deep link (Profile 👥+ button → /?people=1)
+			// Friends & Groups deep link (Profile 👥+ button → /?people=1).
+			// Keep the param in the URL so browser-back restores the People view.
 			if (params.get('people')) {
 				openCommunity('people');
-				params.delete('people');
 			}
 			const qs = params.toString();
 			window.history.replaceState({}, '', window.location.pathname + (qs ? '?' + qs : ''));
@@ -1948,7 +1948,20 @@
 		communityTab = /** @type {any} */ (tab ?? 'challenges');
 		menuView = 'community';
 		showMainMenu = true;
+		// Reflect the People view in the URL (router-safe) so a profile opened from here
+		// can be returned to via the browser Back button (history restores /?people=1).
+		if (typeof window !== 'undefined') {
+			replaceState(tab === 'people' ? '/?people=1' : '/', {});
+		}
 		[myMatches, myGroups] = await Promise.all([getMyMatches(), getMyGroups()]);
+	}
+	// Leave the community view → home, clearing the ?people=1 flag from the URL.
+	function exitCommunity() {
+		menuView = 'home';
+		fx('tap');
+		if (typeof window !== 'undefined' && window.location.search.includes('people=')) {
+			replaceState('/', {});
+		}
 	}
 	/** Back-compat shim for existing callers (banner "+N more", toasts, result modal). */
 	/** @param {string} [forceTab] */
@@ -3274,13 +3287,7 @@
 				<div class="sub-head">
 					{#if communityTab === 'people'}
 						{#if peopleBackToHome}
-							<button
-								class="sub-back"
-								on:click={() => {
-									menuView = 'home';
-									fx('tap');
-								}}>← Back</button
-							>
+							<button class="sub-back" on:click={exitCommunity}>← Back</button>
 						{:else}
 							<button
 								class="sub-back"
@@ -3292,13 +3299,7 @@
 						{/if}
 						<h2 class="sub-title">People</h2>
 					{:else}
-						<button
-							class="sub-back"
-							on:click={() => {
-								menuView = 'home';
-								fx('tap');
-							}}>← Back</button
-						>
+						<button class="sub-back" on:click={exitCommunity}>← Back</button>
 						<h2 class="sub-title">
 							{communityTab === 'leaderboard' ? '🏆 Leaderboard' : '⚔️ Challenges'}
 						</h2>


### PR DESCRIPTION
**Bug:** from the Friends list → tap a friend → their profile → **Back** dumped you on the home menu, not the friends list.

**Cause:** the People/Friends view is client state on `/` with no URL of its own, so `history.back()` had nothing to return to. (An initial raw `history.replaceState` attempt made it worse — it desynced SvelteKit's router so the view didn't even swap on Back.)

**Fix:**
- `openCommunity` now reflects the People view in the URL with SvelteKit's router-safe **`replaceState('/?people=1')`**; `onMount` reopens People from the param and `exitCommunity` clears it. Back from a profile now restores the friends list.
- **House icon → "Main Menu" button.** `PageNav`'s 🏠 is now a labeled "Main Menu" button in the top-right. Back always goes to the previous screen; Main Menu is the explicit jump home.

Verified: menu → Friends → @edithpink → Back → lands on the Friends list (Your Friends: edithpink/Labitan/sbrand21), and the public profile shows a "Main Menu" button.

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)