### PR TITLE
Bell: white + matched on menu and profile

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5891,10 +5891,10 @@
 			border-color 0.2s;
 	}
 	.hero-bell-ic {
-		width: 22px;
-		height: 22px;
+		width: 21px;
+		height: 21px;
 		fill: none;
-		stroke: currentColor;
+		stroke: #fff;
 		stroke-width: 1.8;
 		stroke-linecap: round;
 		stroke-linejoin: round;

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -628,7 +628,7 @@
 		border: none;
 		cursor: pointer;
 		padding: 2px;
-		color: var(--text-muted);
+		color: #fff;
 	}
 	.bell-btn:hover {
 		color: var(--text);


### PR DESCRIPTION
Notification bell is now white on both surfaces and identical: menu header stroke `#fff` at 21px (matching the profile size), profile bell color `#fff` instead of muted grey.

Gates: svelte-check 0 ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)