### PR TITLE
Menu: compact game-button width for main CTAs

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6040,7 +6040,8 @@
 		flex-direction: column;
 		gap: 0.85rem;
 		width: 100%;
-		max-width: 360px;
+		max-width: 264px;
+		margin: 0 auto;
 	}
 	/* ── Gold bullion bars ─────────────────────────────────────────────── */
 	.menu-card {


### PR DESCRIPTION
Trims the Resume / Play Now / Challenge Friends buttons from a 360px full-width stack down to a centered 264px column so they read like actual game buttons.

- `.main-menu-buttons` max-width 360 → 264, `margin: 0 auto`.
- Account card and swipeable quick-tiles are separate siblings — unaffected.

Gates: prettier ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)