### PR TITLE
Quick-tiles: white scroll chevron

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6046,7 +6046,7 @@
 		height: 22px;
 		border-radius: 999px;
 		background: rgba(0, 0, 0, 0.35);
-		color: var(--brand-2, #fde047);
+		color: #fff;
 		font-size: 1.2rem;
 		font-weight: 700;
 		line-height: 1;


### PR DESCRIPTION
Make the swipe-for-more chevron white instead of gold.

Gates: build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)