### PR TITLE
Reconcile money screens into one "My Account"

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3124,14 +3124,14 @@
 					class="menu-card-wrap"
 					role="button"
 					tabindex="0"
-					on:click={openBankModal}
+					on:click={() => goto('/bank')}
 					on:keydown={(e) => {
 						if (e.key === 'Enter' || e.key === ' ') {
 							e.preventDefault();
-							openBankModal();
+							goto('/bank');
 						}
 					}}
-					aria-label="Open Bank"
+					aria-label="Open My Account"
 				>
 					<AccountCard
 						holder={$userProfile?.username ?? myUsername}

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,16 +1,16 @@
 <script>
 	import { onMount } from 'svelte';
 	import PageNav from '$lib/components/PageNav.svelte';
-	import { getBank } from '$lib/stores/statsStore.js';
-	import InventoryList from '$lib/components/InventoryList.svelte';
+	import { getBank, getProfileDetail } from '$lib/stores/statsStore.js';
+	import AccountCard from '$lib/components/AccountCard.svelte';
 	import LoanPanel from '$lib/components/LoanPanel.svelte';
 	import { track } from '$lib/analytics.js';
 
 	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
 	let b = null;
+	/** @type {any} */
+	let prof = null;
 	let loading = true;
-	/** @type {{title:string, desc:string}|null} */
-	let info = null;
 
 	async function load() {
 		b = await getBank(500);
@@ -18,7 +18,7 @@
 	onMount(async () => {
 		track('bank_view');
 		try {
-			await load();
+			[prof] = await Promise.all([getProfileDetail(), load()]);
 		} finally {
 			loading = false;
 		}
@@ -84,40 +84,31 @@
 	}
 </script>
 
-<svelte:head><title>WordBank — Bank</title></svelte:head>
+<svelte:head><title>WordBank — My Account</title></svelte:head>
 
 <main class="bank-page">
-	<PageNav back="/" />
-	<h1 class="bank-title">🏦 Bank</h1>
+	<PageNav />
+	<h1 class="bank-title">My Account</h1>
 
 	{#if loading}
 		<p class="loading">Loading…</p>
 	{:else if b}
-		<!-- Balances -->
-		<div class="balances">
-			<button
-				class="bal cash"
-				onclick={() =>
-					(info = {
-						title: '💰 Available Balance',
-						desc: 'Your main balance — and your score. Earn it by solving puzzles in the Daily, Cash Game, and challenges. You move some into a Wallet to play Cash Game, and spend it on power-ups & cosmetics in the Store. It can’t be bought with real money.'
-					})}
-			>
-				<span class="bal-label">💰 Available Balance <span class="bal-i">ⓘ</span></span>
-				<span class="bal-value">{fmt(b.bank)}</span>
-			</button>
+		<!-- 💳 Account card hero — balance + identity -->
+		<div class="ac-hero">
+			<AccountCard
+				holder={prof?.username ?? ''}
+				account={prof?.account_number ?? ''}
+				member={prof?.member_no ?? null}
+				balance={b.bank}
+			/>
 		</div>
 
 		<!-- 💸 Loan Shark -->
 		<LoanPanel bank={b} on:changed={load} />
 
-		<!-- Items (your vault) -->
-		<h2 class="hist-title">🎒 Your Items</h2>
-		<InventoryList addHref="/shop?from=bank" />
-
 		<!-- Ledger -->
 		<div class="led-head">
-			<h2 class="hist-title">📄 Statement</h2>
+			<h2 class="hist-title">Statement</h2>
 			{#if b.ledger.length}
 				<div class="led-filters">
 					<div class="led-dd">
@@ -188,25 +179,6 @@
 			</div>
 		{/if}
 	{/if}
-
-	{#if info}
-		<div
-			class="si-overlay"
-			role="button"
-			tabindex="0"
-			onclick={() => (info = null)}
-			onkeydown={(e) => {
-				if (e.key === 'Escape' || e.key === 'Enter') info = null;
-			}}
-		>
-			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions a11y_no_noninteractive_tabindex -->
-			<div class="si-card" role="document" onclick={(e) => e.stopPropagation()}>
-				<h3 class="si-title">{info.title}</h3>
-				<p class="si-desc">{info.desc}</p>
-				<button class="si-close" onclick={() => (info = null)}>Got it</button>
-			</div>
-		</div>
-	{/if}
 </main>
 
 <style>
@@ -227,92 +199,8 @@
 		text-align: center;
 	}
 
-	.balances {
-		display: grid;
-		grid-template-columns: 1fr;
-		gap: 10px;
+	.ac-hero {
 		margin-bottom: 14px;
-	}
-	.bal {
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-		padding: 14px;
-		border-radius: 16px;
-		background: var(--surface);
-		border: 1px solid var(--border);
-		text-align: left;
-		cursor: pointer;
-		font: inherit;
-		color: inherit;
-	}
-	.bal:hover {
-		border-color: var(--brand-2);
-	}
-	.bal:active {
-		transform: scale(0.98);
-	}
-	.bal-label {
-		font-size: 0.78rem;
-		color: var(--text-muted);
-		font-weight: 700;
-	}
-	.bal-i {
-		color: var(--text-faint);
-		font-size: 0.72rem;
-	}
-
-	/* balance explanation popup */
-	.si-overlay {
-		position: fixed;
-		inset: 0;
-		z-index: 4000;
-		display: grid;
-		place-items: center;
-		padding: 24px;
-		background: rgba(4, 8, 14, 0.72);
-		backdrop-filter: blur(6px);
-		border: none;
-	}
-	.si-card {
-		width: 100%;
-		max-width: 320px;
-		padding: 22px;
-		border-radius: 18px;
-		text-align: center;
-		background: var(--surface-strong, rgba(20, 26, 38, 0.96));
-		border: 1px solid var(--border-strong, rgba(255, 255, 255, 0.16));
-		box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
-	}
-	.si-title {
-		font-family: var(--font-display);
-		font-size: 1.15rem;
-		margin: 0;
-	}
-	.si-desc {
-		font-size: 0.92rem;
-		line-height: 1.5;
-		color: var(--text-muted);
-		margin: 0;
-	}
-	.si-close {
-		margin-top: 4px;
-		height: 44px;
-		border-radius: 12px;
-		border: none;
-		cursor: pointer;
-		font-weight: 800;
-		color: #3a2a00;
-		background: linear-gradient(135deg, #fde047, #f59e0b);
-	}
-	.bal-value {
-		font-family: 'Orbitron', var(--font-display);
-		font-weight: 800;
-		font-size: 1.7rem;
-		color: var(--brand-2);
 	}
 
 	.led-head {


### PR DESCRIPTION
The home credit-card modal and the profile→/bank route were two overlapping views of the same thing. Unified on the `/bank` route, retitled **My Account**.

**One screen, two entry points**
- Home card tap now goes to `/bank` (was the modal); profile balance already did. Both land on the same place. Back returns to origin (bare PageNav → history).
- The in-game top-bar peek modal is left alone — mid-game "Back to game" is a genuinely different context.

**Include list (per decisions)**
- **AccountCard hero** (balance + identity) replaces the plain gold balance pill + info popup.
- **Need Cash / Borrow** kept.
- **Statement** kept (date + type filter + sort).
- **Your Items removed** — money screen stays money-only (Bank-vs-Store IA); items stay on Profile + Store.

Gates: prettier ✓ · svelte-check 0 ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)