### PR TITLE
Credit score Phase 1: score model + read-only gauge

### DIFF
--- a/docs/superpowers/plans/2026-07-08-credit-score-phase1.md
+++ b/docs/superpowers/plans/2026-07-08-credit-score-phase1.md
@@ -35,11 +35,14 @@
 - Modify `src/routes/bank/+page.svelte` — mount `<CreditGauge>` under the account card; load `getCreditDetail()`.
 
 Helper for all DB steps — open a psql session with:
+
 ```bash
 set -a; . ./.env; set +a
 psql "$SUPABASE_DB_URL"
 ```
+
 Simulate a user inside psql with:
+
 ```sql
 SELECT set_config('request.jwt.claims', json_build_object('sub', '<UID>')::text, true);
 ```
@@ -49,14 +52,17 @@ SELECT set_config('request.jwt.claims', json_build_object('sub', '<UID>')::text,
 ## Task 1: DB schema + tier helper
 
 **Files:**
+
 - Create: `supabase-credit-score-schema.sql`
 
 **Interfaces:**
+
 - Produces: `profiles.credit_score int`, `profiles.credit_updated_at timestamptz`, `profiles.credit_derog_until timestamptz`; table `public.credit_history(user_id, at, score, target, tier, components)`; function `public._credit_tier(int) → text` returning one of `Excellent|Good|Fair|Poor|Bad`.
 
 - [ ] **Step 1: Write the migration file**
 
 Create `supabase-credit-score-schema.sql`:
+
 ```sql
 -- Credit Score Phase 1 — storage + tier helper. Read-only; no loan effects yet.
 -- PITR point logged before apply (see below).
@@ -96,11 +102,13 @@ COMMIT;
 - [ ] **Step 2: Log the PITR point (verify-it-fails analogue)**
 
 Run in psql — capture the current time so we can roll back if needed, and prove the columns do NOT yet exist:
+
 ```sql
 SELECT now() AT TIME ZONE 'utc' AS pitr_point;
 SELECT column_name FROM information_schema.columns
  WHERE table_name='profiles' AND column_name LIKE 'credit%';
 ```
+
 Expected: `pitr_point` prints; the second query returns **0 rows**.
 
 - [ ] **Step 3: Apply the migration**
@@ -109,11 +117,13 @@ Expected: `pitr_point` prints; the second query returns **0 rows**.
 set -a; . ./.env; set +a
 psql "$SUPABASE_DB_URL" -f supabase-credit-score-schema.sql
 ```
+
 Expected: `BEGIN … COMMIT`, no errors.
 
 - [ ] **Step 4: Verify schema + tier boundaries**
 
 Run in psql:
+
 ```sql
 SELECT column_name FROM information_schema.columns
  WHERE table_name='profiles' AND column_name LIKE 'credit%' ORDER BY 1;
@@ -122,6 +132,7 @@ SELECT public._credit_tier(850) AS s850, public._credit_tier(780) AS s780,
        public._credit_tier(580) AS s580, public._credit_tier(400) AS s400,
        public._credit_tier(399) AS s399;
 ```
+
 Expected: 3 credit columns listed; tiers = `Excellent, Excellent, Good, Good, Fair, Poor, Bad`.
 
 - [ ] **Step 5: Commit**
@@ -136,15 +147,18 @@ git commit -m "Credit score: profiles columns + credit_history + _credit_tier"
 ## Task 2: `_recompute_credit` function
 
 **Files:**
+
 - Create: `supabase-credit-score-recompute.sql`
 
 **Interfaces:**
+
 - Consumes: `_credit_tier(int)`, `_loan_cap(uuid)`, `_ensure_bank(uuid)`, `bank_ledger`, `profiles(credit_score, credit_updated_at, credit_derog_until, created_at, bank, loan, streak)`.
 - Produces: `public._recompute_credit(p_uid UUID, p_event TEXT DEFAULT NULL, p_event_delta INT DEFAULT 0) → INT` (new score). Writes `profiles.credit_score`/`credit_updated_at`, appends `credit_history`. Applies grace, per-day ease clamp, and multi-day catch-up (≤7 eases).
 
 - [ ] **Step 1: Write the function file**
 
 Create `supabase-credit-score-recompute.sql`:
+
 ```sql
 -- Credit Score Phase 1 — core recompute. Derives 5 discipline components from a
 -- 14-day bank_ledger window, eases the stored score toward a target (bounded per
@@ -255,10 +269,12 @@ COMMIT;
 - [ ] **Step 2: Log PITR + prove it fails**
 
 In psql:
+
 ```sql
 SELECT now() AT TIME ZONE 'utc' AS pitr_point;
 SELECT public._recompute_credit('00000000-0000-0000-0000-000000000000');
 ```
+
 Expected: `pitr_point` prints; the call ERRORs with `function public._recompute_credit(...) does not exist`.
 
 - [ ] **Step 3: Apply**
@@ -266,11 +282,13 @@ Expected: `pitr_point` prints; the call ERRORs with `function public._recompute_
 ```bash
 psql "$SUPABASE_DB_URL" -f supabase-credit-score-recompute.sql
 ```
+
 Expected: `BEGIN … COMMIT`.
 
 - [ ] **Step 4: Verify with a real user (grace + normal paths)**
 
 Pick a real UID (`SELECT id, created_at FROM public.profiles LIMIT 1;`). Then:
+
 ```sql
 -- Force out of grace so we exercise the real math: backdate created_at in a tx we roll back.
 BEGIN;
@@ -282,6 +300,7 @@ SELECT score, target, tier, components FROM public.credit_history
  WHERE user_id = '<UID>' ORDER BY at DESC LIMIT 1;
 ROLLBACK;
 ```
+
 Expected: `new_score` in [300,850]; a `credit_history` row with `components` containing `U/S/R/B/C`; `tier` matching the score band. (ROLLBACK restores `created_at`.)
 
 - [ ] **Step 5: Verify the daily-drop cap**
@@ -295,6 +314,7 @@ UPDATE public.profiles SET created_at = now() - INTERVAL '30 days',
 SELECT public._recompute_credit('<UID>') AS after_one_day;  -- expect ~820-120=700, not a full crash
 ROLLBACK;
 ```
+
 Expected: `after_one_day` ≈ `700` (drop clamped to 120), **not** near 300.
 
 - [ ] **Step 6: Commit**
@@ -309,9 +329,11 @@ git commit -m "Credit score: _recompute_credit (components, ease, grace, derog)"
 ## Task 3: Lazy recompute in `get_bank` + `get_credit_detail()`
 
 **Files:**
+
 - Create: `supabase-credit-score-getbank.sql`
 
 **Interfaces:**
+
 - Consumes: `_recompute_credit`, `_credit_tier`, existing `get_bank(p_limit)`.
 - Produces: `get_bank` JSON gains `credit_score INT`, `credit_tier TEXT`, `credit_delta INT` (vs the prior `credit_history` row). New RPC `public.get_credit_detail() → JSONB` = `{ score, target, tier, delta, components:{utilization,solvency,repayment,restraint,consistency}, history:[{at,score}] }` where each component is `{ value:0..1, label, hint }`.
 
@@ -322,6 +344,7 @@ Run: `psql "$SUPABASE_DB_URL" -c "\sf public.get_bank"` (note: there is a `p_lim
 - [ ] **Step 2: Write the patch file**
 
 Create `supabase-credit-score-getbank.sql` (adjust the `get_bank` signature/body to match Step 1's output; the credit additions are the point):
+
 ```sql
 -- Credit Score Phase 1 — surface credit in get_bank (lazy daily recompute) and add
 -- get_credit_detail() for the gauge breakdown. PITR point logged before apply.
@@ -404,17 +427,20 @@ COMMIT;
 psql "$SUPABASE_DB_URL" -c "SELECT now() AT TIME ZONE 'utc';"
 psql "$SUPABASE_DB_URL" -f supabase-credit-score-getbank.sql
 ```
+
 Expected: `BEGIN … COMMIT`.
 
 - [ ] **Step 4: Verify payload + detail as a real user**
 
 In psql:
+
 ```sql
 SELECT set_config('request.jwt.claims', json_build_object('sub','<UID>')::text, true);
 SELECT public.get_bank(5) -> 'credit_score' AS score,
        public.get_bank(5) -> 'credit_tier'  AS tier;
 SELECT public.get_credit_detail() -> 'components' -> 'utilization';
 ```
+
 Expected: `score` is a number 300–850; `tier` a band string; the component object has `value/label/hint`.
 
 - [ ] **Step 5: Commit**
@@ -429,15 +455,18 @@ git commit -m "Credit score: lazy recompute in get_bank + get_credit_detail RPC"
 ## Task 4: Store getter + types
 
 **Files:**
+
 - Modify: `src/lib/stores/statsStore.js`
 
 **Interfaces:**
+
 - Consumes: `get_bank` (now returns credit fields), `get_credit_detail`.
 - Produces: `getCreditDetail()` → the detail object (or `null`); `getBank`'s JSDoc return type documents `credit_score`, `credit_tier`, `credit_delta`.
 
 - [ ] **Step 1: Add the getter next to `getBank`**
 
 In `src/lib/stores/statsStore.js`, immediately after the `getBank` function, add:
+
 ```js
 /** Full credit-score breakdown for the gauge detail view. Returns null if signed out. */
 export async function getCreditDetail() {
@@ -457,10 +486,12 @@ Find the JSDoc `@returns` (or the type comment) on `getBank` and append the thre
 - [ ] **Step 3: Gate**
 
 Run:
+
 ```bash
 npx prettier --write src/lib/stores/statsStore.js
 npm run check
 ```
+
 Expected: prettier reformats/clean; svelte-check `0 errors`.
 
 - [ ] **Step 4: Commit**
@@ -475,15 +506,18 @@ git commit -m "Credit score: getCreditDetail() store getter"
 ## Task 5: `CreditGauge.svelte` component
 
 **Files:**
+
 - Create: `src/lib/components/CreditGauge.svelte`
 
 **Interfaces:**
+
 - Consumes (props): `score:number`, `tier:string`, `delta:number = 0`, and `detail` (the `getCreditDetail()` object, or `null` while loading).
 - Produces: a self-contained gauge; tapping it toggles an inline breakdown panel built from `detail.components`. No external calls (parent passes data in).
 
 - [ ] **Step 1: Write the component**
 
 Create `src/lib/components/CreditGauge.svelte`:
+
 ```svelte
 <script>
 	// 💳 Credit score gauge — 300–850 arc dial + tier + delta, tap for breakdown.
@@ -493,37 +527,63 @@ Create `src/lib/components/CreditGauge.svelte`:
 	/** @type {any} */ export let detail = null;
 
 	let open = false;
-	const MIN = 300, MAX = 850;
+	const MIN = 300,
+		MAX = 850;
 	// Arc: 300° sweep from 120° (bottom-left) clockwise. Map score → angle → dash.
 	$: pct = Math.max(0, Math.min(1, (score - MIN) / (MAX - MIN)));
-	const R = 80, C = 2 * Math.PI * R, SWEEP = 0.75; // 3/4 circle
+	const R = 80,
+		C = 2 * Math.PI * R,
+		SWEEP = 0.75; // 3/4 circle
 	$: dash = pct * C * SWEEP;
 	$: tierColor =
-		tier === 'Excellent' ? '#34d399'
-		: tier === 'Good' ? '#fbbf24'
-		: tier === 'Fair' ? '#f59e0b'
-		: tier === 'Poor' ? '#fb7185'
-		: '#ef4444';
+		tier === 'Excellent'
+			? '#34d399'
+			: tier === 'Good'
+				? '#fbbf24'
+				: tier === 'Fair'
+					? '#f59e0b'
+					: tier === 'Poor'
+						? '#fb7185'
+						: '#ef4444';
 	$: comps = detail?.components
-		? [detail.components.utilization, detail.components.solvency, detail.components.repayment,
-		   detail.components.restraint, detail.components.consistency].filter(Boolean)
+		? [
+				detail.components.utilization,
+				detail.components.solvency,
+				detail.components.repayment,
+				detail.components.restraint,
+				detail.components.consistency
+			].filter(Boolean)
 		: [];
 </script>
 
 <div class="cg">
 	<button class="cg-face" on:click={() => (open = !open)} aria-expanded={open}>
 		<svg viewBox="0 0 200 200" class="cg-svg">
-			<circle class="cg-track" cx="100" cy="100" r="80"
-				stroke-dasharray="{C * 0.75} {C}" transform="rotate(135 100 100)" />
-			<circle class="cg-fill" cx="100" cy="100" r="80" stroke={tierColor}
-				stroke-dasharray="{dash} {C}" transform="rotate(135 100 100)" />
+			<circle
+				class="cg-track"
+				cx="100"
+				cy="100"
+				r="80"
+				stroke-dasharray="{C * 0.75} {C}"
+				transform="rotate(135 100 100)"
+			/>
+			<circle
+				class="cg-fill"
+				cx="100"
+				cy="100"
+				r="80"
+				stroke={tierColor}
+				stroke-dasharray="{dash} {C}"
+				transform="rotate(135 100 100)"
+			/>
 		</svg>
 		<div class="cg-center">
 			<span class="cg-score">{score}</span>
 			<span class="cg-tier" style="color:{tierColor}">{tier}</span>
 			{#if delta !== 0}
 				<span class="cg-delta" class:pos={delta > 0} class:neg={delta < 0}
-					>{delta > 0 ? '▲' : '▼'} {Math.abs(delta)}</span>
+					>{delta > 0 ? '▲' : '▼'} {Math.abs(delta)}</span
+				>
 			{/if}
 		</div>
 	</button>
@@ -532,8 +592,12 @@ Create `src/lib/components/CreditGauge.svelte`:
 			{#each comps as c}
 				<div class="cg-row">
 					<span class="cg-rlabel">{c.label}</span>
-					<span class="cg-bar"><span class="cg-barfill"
-						style="width:{Math.round((c.value ?? 0) * 100)}%; background:{tierColor}"></span></span>
+					<span class="cg-bar"
+						><span
+							class="cg-barfill"
+							style="width:{Math.round((c.value ?? 0) * 100)}%; background:{tierColor}"
+						></span></span
+					>
 					<span class="cg-rhint">{c.hint}</span>
 				</div>
 			{/each}
@@ -542,40 +606,114 @@ Create `src/lib/components/CreditGauge.svelte`:
 </div>
 
 <style>
-	.cg { width: 100%; }
+	.cg {
+		width: 100%;
+	}
 	.cg-face {
-		position: relative; width: 200px; max-width: 60%; margin: 0 auto; display: block;
-		background: none; border: none; cursor: pointer; padding: 0;
+		position: relative;
+		width: 200px;
+		max-width: 60%;
+		margin: 0 auto;
+		display: block;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
 	}
-	.cg-svg { width: 100%; height: auto; display: block; }
-	.cg-track { fill: none; stroke: var(--border, rgba(255,255,255,0.1)); stroke-width: 14; stroke-linecap: round; }
-	.cg-fill { fill: none; stroke-width: 14; stroke-linecap: round; transition: stroke-dasharray 0.6s var(--ease-spring, ease); }
+	.cg-svg {
+		width: 100%;
+		height: auto;
+		display: block;
+	}
+	.cg-track {
+		fill: none;
+		stroke: var(--border, rgba(255, 255, 255, 0.1));
+		stroke-width: 14;
+		stroke-linecap: round;
+	}
+	.cg-fill {
+		fill: none;
+		stroke-width: 14;
+		stroke-linecap: round;
+		transition: stroke-dasharray 0.6s var(--ease-spring, ease);
+	}
 	.cg-center {
-		position: absolute; inset: 0; display: flex; flex-direction: column;
-		align-items: center; justify-content: center; gap: 2px;
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 2px;
 	}
-	.cg-score { font-family: var(--font-display, sans-serif); font-size: 2rem; font-weight: 800; }
-	.cg-tier { font-size: 0.8rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
-	.cg-delta { font-size: 0.72rem; font-weight: 700; }
-	.cg-delta.pos { color: #34d399; } .cg-delta.neg { color: #fb7185; }
-	.cg-breakdown { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; }
-	.cg-row { display: grid; grid-template-columns: 84px 1fr; grid-template-rows: auto auto;
-		gap: 2px 8px; align-items: center; }
-	.cg-rlabel { font-size: 0.78rem; font-weight: 700; color: var(--text); }
-	.cg-bar { height: 7px; border-radius: 999px; background: var(--border, rgba(255,255,255,0.1)); overflow: hidden; }
-	.cg-barfill { display: block; height: 100%; border-radius: 999px; }
-	.cg-rhint { grid-column: 1 / -1; font-size: 0.72rem; color: var(--text-muted); }
+	.cg-score {
+		font-family: var(--font-display, sans-serif);
+		font-size: 2rem;
+		font-weight: 800;
+	}
+	.cg-tier {
+		font-size: 0.8rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+	.cg-delta {
+		font-size: 0.72rem;
+		font-weight: 700;
+	}
+	.cg-delta.pos {
+		color: #34d399;
+	}
+	.cg-delta.neg {
+		color: #fb7185;
+	}
+	.cg-breakdown {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-top: 10px;
+	}
+	.cg-row {
+		display: grid;
+		grid-template-columns: 84px 1fr;
+		grid-template-rows: auto auto;
+		gap: 2px 8px;
+		align-items: center;
+	}
+	.cg-rlabel {
+		font-size: 0.78rem;
+		font-weight: 700;
+		color: var(--text);
+	}
+	.cg-bar {
+		height: 7px;
+		border-radius: 999px;
+		background: var(--border, rgba(255, 255, 255, 0.1));
+		overflow: hidden;
+	}
+	.cg-barfill {
+		display: block;
+		height: 100%;
+		border-radius: 999px;
+	}
+	.cg-rhint {
+		grid-column: 1 / -1;
+		font-size: 0.72rem;
+		color: var(--text-muted);
+	}
 </style>
 ```
 
 - [ ] **Step 2: Gate the build**
 
 Run:
+
 ```bash
 npx prettier --write src/lib/components/CreditGauge.svelte
 npm run check
 npm run build
 ```
+
 Expected: prettier clean; svelte-check `0 errors`; build OK.
 
 - [ ] **Step 3: Commit**
@@ -590,29 +728,37 @@ git commit -m "Credit score: CreditGauge component (dial + breakdown)"
 ## Task 6: Mount on My Account + verify end-to-end
 
 **Files:**
+
 - Modify: `src/routes/bank/+page.svelte`
 
 **Interfaces:**
+
 - Consumes: `getCreditDetail()`, the `credit_score`/`credit_tier`/`credit_delta` fields already on the `getBank` result (`b`), `CreditGauge.svelte`.
 
 - [ ] **Step 1: Import + load the detail**
 
 In `src/routes/bank/+page.svelte` `<script>`, add the imports and a `cd` (credit detail) load alongside the existing `getProfileDetail`/`getBank`:
+
 ```js
 import CreditGauge from '$lib/components/CreditGauge.svelte';
 import { getBank, getProfileDetail, getCreditDetail } from '$lib/stores/statsStore.js';
 ```
+
 Add state `let cd = null;` and load it in `onMount` — extend the existing `Promise.all`:
+
 ```js
-[prof, cd] = await Promise.all([getProfileDetail(), getCreditDetail(), load()]).then(
-	(r) => [r[0], r[1]]
-);
+[prof, cd] = await Promise.all([getProfileDetail(), getCreditDetail(), load()]).then((r) => [
+	r[0],
+	r[1]
+]);
 ```
+
 (Keep `load()` setting `b`; the `.then` just picks `prof` and `cd`.)
 
 - [ ] **Step 2: Render the gauge under the account card**
 
 Directly after the `.ac-hero` block (the `<AccountCard …/>` wrapper) and before `<LoanPanel …>`, add:
+
 ```svelte
 <!-- 💳 Credit score -->
 {#if b}
@@ -627,10 +773,17 @@ Directly after the `.ac-hero` block (the `<AccountCard …/>` wrapper) and befor
 	</section>
 {/if}
 ```
+
 Add to `<style>`:
+
 ```css
-	.credit-sec { margin: 4px 0 16px; }
-	.credit-sec .hist-title { text-align: center; margin-bottom: 8px; }
+.credit-sec {
+	margin: 4px 0 16px;
+}
+.credit-sec .hist-title {
+	text-align: center;
+	margin-bottom: 8px;
+}
 ```
 
 - [ ] **Step 3: Gate**
@@ -641,6 +794,7 @@ npm run check
 npm run lint
 npm run build
 ```
+
 Expected: all clean; build OK.
 
 - [ ] **Step 4: Preview screenshot verification**
@@ -650,6 +804,7 @@ pkill -f "vite preview" 2>/dev/null
 nohup npm run preview -- --port 4173 > /tmp/wb-preview.log 2>&1 &
 sleep 4
 ```
+
 Then a Playwright script (CJS default import per `wordbank-qa-harness`) that logs in as the test user, navigates to `/bank`, waits, and screenshots. Assert in the script: `document.querySelector('.cg-score')` text is a 3-digit number and `.cg-tier` is non-empty. Read the screenshot to confirm the dial renders under the card and the tap-breakdown opens.
 
 Expected: gauge visible with a score + tier; tapping shows the 5-row breakdown.
@@ -662,6 +817,7 @@ git commit -m "Credit score: mount CreditGauge on My Account"
 git push -u origin <branch>
 gh pr create --title "Credit score Phase 1: score model + read-only gauge" --body "…"
 ```
+
 Then squash-merge and sync master (standard flow). Phase 1 ships with **no loan effects** — verify on prod that `/bank` shows a gauge and `/loans` behavior is unchanged.
 
 ---
@@ -669,6 +825,6 @@ Then squash-merge and sync master (standard flow). Phase 1 ships with **no loan 
 ## Self-review notes
 
 - **Spec coverage (§3 model, §3.1 components, §3.2 movement, §6 data model, §7 functions, §8 My Account gauge):** Tasks 1–6 cover storage (T1), the weighted target + ease + grace + derog (T2), lazy recompute + payload + detail RPC (T3), store access (T4), the gauge (T5), and the My Account surface (T6). Spec §4 loan effects, §8 Loans/Leaderboard/Badges are **explicitly deferred** (Phase 2–4) per the plan goal.
-- **Phase-1 simplifications flagged:** Utilization uses the *instantaneous* loan/cap (spec's rolling-average anti-abuse matters only once effects exist in Phase 2); Consistency falls back to a ledger-day proxy if `streak` is 0. Both are noted and safe for a read-only display.
+- **Phase-1 simplifications flagged:** Utilization uses the _instantaneous_ loan/cap (spec's rolling-average anti-abuse matters only once effects exist in Phase 2); Consistency falls back to a ledger-day proxy if `streak` is 0. Both are noted and safe for a read-only display.
 - **Type consistency:** `_recompute_credit(uuid,text,int)`, `_credit_tier(int)`, `get_credit_detail()` shape (`score/target/tier/delta/components{value,label,hint}/history`), and `CreditGauge` props (`score/tier/delta/detail`) are used identically across Tasks 2–6.
 - **No placeholders:** every DB and Svelte step includes the actual code; PR body text in T6 Step 5 is the one intentional fill-in at ship time.

--- a/docs/superpowers/plans/2026-07-08-credit-score-phase1.md
+++ b/docs/superpowers/plans/2026-07-08-credit-score-phase1.md
@@ -1,0 +1,674 @@
+# Credit Score — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a read-only credit score (300–850) — server-computed from financial-discipline signals, stored on the profile, lazily recomputed in `get_bank`, and shown as a `CreditGauge` with a breakdown on the My Account (`/bank`) screen. **No loan effects yet** (that's Phase 2).
+
+**Architecture:** All scoring math lives in one `SECURITY DEFINER` Postgres function `_recompute_credit(uid, event, event_delta)` that derives five components from a 14-day `bank_ledger` window + current profile state, eases the stored score toward a computed target (bounded per day), and appends a `credit_history` row. `get_bank` calls it lazily (at most once/calendar-day on read) and adds `credit_score`/`credit_tier`/`credit_delta` to its JSON. A new `get_credit_detail()` RPC returns the full component breakdown + a sparkline. The frontend adds a `getCreditDetail()` store getter and a `CreditGauge.svelte` component mounted on `/bank`.
+
+**Tech Stack:** SvelteKit 2.16 (Svelte 4 mode in the pages we touch), Supabase Postgres (plpgsql, `SECURITY DEFINER`), Playwright preview screenshots, psql for DB verification.
+
+## Global Constraints
+
+- **Score range:** integer `[300, 850]`; new-account default `650`. — verbatim from spec §3.
+- **Component weights:** Utilization 35% · Solvency 25% · Repayment 20% · Restraint 10% · Consistency 10% (sum = 100%). — spec §3.1.
+- **Target formula:** `T = round(300 + 550 × (0.35·U + 0.25·S + 0.20·R + 0.10·B + 0.10·C))`. — spec §3.1.
+- **Movement caps:** `DROP_CAP = 120`/day, `RISE_CAP = 40`/day. — spec §3.2.
+- **New-player grace:** first **7 days** after `profiles.created_at` (or until first loan) → score pinned at `650`, treated as **Good**. — spec §3.
+- **Derogatory mark:** default event = `−100` + `credit_derog_until = now() + 30 days`; while active, Repayment component `R` is capped at `0.3`. — spec §3.2, §10.
+- **Bands:** Excellent 780–850 · Good 670–779 · Fair 580–669 · Poor 400–579 · Bad 300–399. — spec §4.
+- **Phase 1 is read-only:** do **not** modify `_loan_cap`, `_loan_daily_rate_bp`, or `take_loan`. Those are Phase 2.
+- **DB workflow:** log the UTC timestamp (PITR point) before every apply; apply against `SUPABASE_DB_URL`; each migration is a new `supabase-credit-*.sql` file kept in-repo. — memory `wordbank-db-management`.
+- **All new RPCs:** `SECURITY DEFINER`, key on `auth.uid()`, `GRANT EXECUTE … TO authenticated`.
+- **Gates before every commit that touches `src/`:** `npx prettier --write` → `npm run check` → `npm run lint` → `npm run build`. — memory `wordbank-qa-harness`.
+- **Verify UI in a preview build**, not dev HMR (dev drops scoped styles). Preview: `npm run preview -- --port 4173`.
+
+---
+
+## File map
+
+- Create `supabase-credit-score-schema.sql` — columns on `profiles`, `credit_history` table, `_credit_tier(int)` helper.
+- Create `supabase-credit-score-recompute.sql` — `_recompute_credit(uuid, text, int)`.
+- Create `supabase-credit-score-getbank.sql` — patch `get_bank(p_limit)` for lazy recompute + payload; add `get_credit_detail()`.
+- Modify `src/lib/stores/statsStore.js` — add `getCreditDetail()`; extend the `getBank` JSDoc return type.
+- Create `src/lib/components/CreditGauge.svelte` — the dial + tier + delta, tap → breakdown.
+- Modify `src/routes/bank/+page.svelte` — mount `<CreditGauge>` under the account card; load `getCreditDetail()`.
+
+Helper for all DB steps — open a psql session with:
+```bash
+set -a; . ./.env; set +a
+psql "$SUPABASE_DB_URL"
+```
+Simulate a user inside psql with:
+```sql
+SELECT set_config('request.jwt.claims', json_build_object('sub', '<UID>')::text, true);
+```
+
+---
+
+## Task 1: DB schema + tier helper
+
+**Files:**
+- Create: `supabase-credit-score-schema.sql`
+
+**Interfaces:**
+- Produces: `profiles.credit_score int`, `profiles.credit_updated_at timestamptz`, `profiles.credit_derog_until timestamptz`; table `public.credit_history(user_id, at, score, target, tier, components)`; function `public._credit_tier(int) → text` returning one of `Excellent|Good|Fair|Poor|Bad`.
+
+- [ ] **Step 1: Write the migration file**
+
+Create `supabase-credit-score-schema.sql`:
+```sql
+-- Credit Score Phase 1 — storage + tier helper. Read-only; no loan effects yet.
+-- PITR point logged before apply (see below).
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS credit_score       INT         NOT NULL DEFAULT 650,
+  ADD COLUMN IF NOT EXISTS credit_updated_at  TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS credit_derog_until TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS public.credit_history (
+  id         BIGSERIAL PRIMARY KEY,
+  user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  score      INT  NOT NULL,
+  target     INT  NOT NULL,
+  tier       TEXT NOT NULL,
+  components JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_credit_history_user_time
+  ON public.credit_history(user_id, at DESC);
+
+CREATE OR REPLACE FUNCTION public._credit_tier(p_score INT)
+  RETURNS TEXT LANGUAGE sql IMMUTABLE AS $fn$
+  SELECT CASE
+    WHEN p_score >= 780 THEN 'Excellent'
+    WHEN p_score >= 670 THEN 'Good'
+    WHEN p_score >= 580 THEN 'Fair'
+    WHEN p_score >= 400 THEN 'Poor'
+    ELSE 'Bad'
+  END;
+$fn$;
+
+COMMIT;
+```
+
+- [ ] **Step 2: Log the PITR point (verify-it-fails analogue)**
+
+Run in psql — capture the current time so we can roll back if needed, and prove the columns do NOT yet exist:
+```sql
+SELECT now() AT TIME ZONE 'utc' AS pitr_point;
+SELECT column_name FROM information_schema.columns
+ WHERE table_name='profiles' AND column_name LIKE 'credit%';
+```
+Expected: `pitr_point` prints; the second query returns **0 rows**.
+
+- [ ] **Step 3: Apply the migration**
+
+```bash
+set -a; . ./.env; set +a
+psql "$SUPABASE_DB_URL" -f supabase-credit-score-schema.sql
+```
+Expected: `BEGIN … COMMIT`, no errors.
+
+- [ ] **Step 4: Verify schema + tier boundaries**
+
+Run in psql:
+```sql
+SELECT column_name FROM information_schema.columns
+ WHERE table_name='profiles' AND column_name LIKE 'credit%' ORDER BY 1;
+SELECT public._credit_tier(850) AS s850, public._credit_tier(780) AS s780,
+       public._credit_tier(779) AS s779, public._credit_tier(670) AS s670,
+       public._credit_tier(580) AS s580, public._credit_tier(400) AS s400,
+       public._credit_tier(399) AS s399;
+```
+Expected: 3 credit columns listed; tiers = `Excellent, Excellent, Good, Good, Fair, Poor, Bad`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase-credit-score-schema.sql
+git commit -m "Credit score: profiles columns + credit_history + _credit_tier"
+```
+
+---
+
+## Task 2: `_recompute_credit` function
+
+**Files:**
+- Create: `supabase-credit-score-recompute.sql`
+
+**Interfaces:**
+- Consumes: `_credit_tier(int)`, `_loan_cap(uuid)`, `_ensure_bank(uuid)`, `bank_ledger`, `profiles(credit_score, credit_updated_at, credit_derog_until, created_at, bank, loan, streak)`.
+- Produces: `public._recompute_credit(p_uid UUID, p_event TEXT DEFAULT NULL, p_event_delta INT DEFAULT 0) → INT` (new score). Writes `profiles.credit_score`/`credit_updated_at`, appends `credit_history`. Applies grace, per-day ease clamp, and multi-day catch-up (≤7 eases).
+
+- [ ] **Step 1: Write the function file**
+
+Create `supabase-credit-score-recompute.sql`:
+```sql
+-- Credit Score Phase 1 — core recompute. Derives 5 discipline components from a
+-- 14-day bank_ledger window, eases the stored score toward a target (bounded per
+-- day), applies new-player grace + derogatory cap + event jolts, logs history.
+-- PITR point logged before apply.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._recompute_credit(
+  p_uid UUID,
+  p_event TEXT DEFAULT NULL,
+  p_event_delta INT DEFAULT 0
+) RETURNS INT LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  DROP_CAP CONSTANT INT := 120;
+  RISE_CAP CONSTANT INT := 40;
+  v_bank BIGINT; v_loan BIGINT; v_created TIMESTAMPTZ;
+  v_prev INT; v_updated TIMESTAMPTZ; v_derog TIMESTAMPTZ; v_streak INT;
+  v_cap BIGINT;
+  u NUMERIC; s NUMERIC; r NUMERIC; b NUMERIC; c NUMERIC;
+  v_neg_days INT; v_repay INT; v_skim INT; v_take INT; v_active_days INT;
+  v_target INT; v_new INT; v_days_elapsed INT; i INT;
+  v_had_loan BOOLEAN;
+BEGIN
+  PERFORM public._ensure_bank(p_uid);
+  SELECT bank, loan, created_at, credit_score, credit_updated_at, credit_derog_until,
+         COALESCE(streak, 0)
+    INTO v_bank, v_loan, v_created, v_prev, v_updated, v_derog, v_streak
+    FROM public.profiles WHERE id = p_uid;
+  v_prev := COALESCE(v_prev, 650);
+
+  -- Has this user ever taken a loan? (ends grace early)
+  SELECT (v_loan > 0) OR EXISTS(
+    SELECT 1 FROM public.bank_ledger WHERE user_id = p_uid AND reason = 'loan_take'
+  ) INTO v_had_loan;
+
+  -- New-player grace: first 7 days and no loan yet → pin 650 / Good.
+  IF v_created IS NOT NULL AND v_created > now() - INTERVAL '7 days' AND NOT v_had_loan THEN
+    UPDATE public.profiles
+       SET credit_score = 650, credit_updated_at = now() WHERE id = p_uid;
+    INSERT INTO public.credit_history(user_id, score, target, tier, components)
+      VALUES (p_uid, 650, 650, 'Good', jsonb_build_object('grace', true));
+    RETURN 650;
+  END IF;
+
+  v_cap := GREATEST(public._loan_cap(p_uid), 1);
+
+  -- Utilization (35%): 1 - current loan/cap.
+  u := 1 - LEAST(v_loan::numeric / v_cap, 1);
+
+  -- Solvency (25%): 1 - (distinct days in last 14 with a negative balance)/14.
+  SELECT COUNT(DISTINCT date(created_at)) INTO v_neg_days
+    FROM public.bank_ledger
+   WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days'
+     AND balance_after < 0;
+  s := 1 - LEAST(v_neg_days::numeric / 14, 1);
+  IF (v_bank - v_loan) < 0 THEN s := LEAST(s, 0.5); END IF; -- currently in the red
+
+  -- Repayment (20%): repays / (repays + skims) over 14 days; 1 if no loans closed.
+  SELECT COUNT(*) FILTER (WHERE reason = 'loan_repay'),
+         COUNT(*) FILTER (WHERE reason = 'loan_skim'),
+         COUNT(*) FILTER (WHERE reason = 'loan_take')
+    INTO v_repay, v_skim, v_take
+    FROM public.bank_ledger
+   WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days';
+  r := CASE WHEN (v_repay + v_skim) = 0 THEN 1
+            ELSE v_repay::numeric / (v_repay + v_skim) END;
+  IF v_derog IS NOT NULL AND v_derog > now() THEN r := LEAST(r, 0.3); END IF;
+
+  -- Restraint (10%): 1 - min(takes/6, 1).
+  b := 1 - LEAST(v_take::numeric / 6, 1);
+
+  -- Consistency (10%): min(streak/14, 1), falling back to distinct active days.
+  IF v_streak > 0 THEN
+    c := LEAST(v_streak::numeric / 14, 1);
+  ELSE
+    SELECT COUNT(DISTINCT date(created_at)) INTO v_active_days
+      FROM public.bank_ledger
+     WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days';
+    c := LEAST(v_active_days::numeric / 14, 1);
+  END IF;
+
+  v_target := round(300 + 550 * (0.35*u + 0.25*s + 0.20*r + 0.10*b + 0.10*c));
+  v_target := GREATEST(300, LEAST(850, v_target));
+
+  -- Multi-day catch-up: one ease per elapsed calendar day, capped at 7.
+  v_days_elapsed := GREATEST(1, LEAST(7,
+    COALESCE(date_part('day', now() - v_updated)::int, 1)));
+  v_new := v_prev;
+  FOR i IN 1..v_days_elapsed LOOP
+    v_new := v_new + GREATEST(LEAST(v_target - v_new, RISE_CAP), -DROP_CAP);
+  END LOOP;
+
+  v_new := GREATEST(300, LEAST(850, v_new + COALESCE(p_event_delta, 0)));
+
+  UPDATE public.profiles
+     SET credit_score = v_new, credit_updated_at = now() WHERE id = p_uid;
+  INSERT INTO public.credit_history(user_id, score, target, tier, components)
+    VALUES (p_uid, v_new, v_target, public._credit_tier(v_new),
+      jsonb_build_object('U',round(u,3),'S',round(s,3),'R',round(r,3),
+                         'B',round(b,3),'C',round(c,3),'event',p_event));
+  RETURN v_new;
+END; $fn$;
+
+GRANT EXECUTE ON FUNCTION public._recompute_credit(UUID, TEXT, INT) TO authenticated;
+COMMIT;
+```
+
+- [ ] **Step 2: Log PITR + prove it fails**
+
+In psql:
+```sql
+SELECT now() AT TIME ZONE 'utc' AS pitr_point;
+SELECT public._recompute_credit('00000000-0000-0000-0000-000000000000');
+```
+Expected: `pitr_point` prints; the call ERRORs with `function public._recompute_credit(...) does not exist`.
+
+- [ ] **Step 3: Apply**
+
+```bash
+psql "$SUPABASE_DB_URL" -f supabase-credit-score-recompute.sql
+```
+Expected: `BEGIN … COMMIT`.
+
+- [ ] **Step 4: Verify with a real user (grace + normal paths)**
+
+Pick a real UID (`SELECT id, created_at FROM public.profiles LIMIT 1;`). Then:
+```sql
+-- Force out of grace so we exercise the real math: backdate created_at in a tx we roll back.
+BEGIN;
+UPDATE public.profiles SET created_at = now() - INTERVAL '30 days',
+       credit_updated_at = now() - INTERVAL '1 day', credit_score = 650
+ WHERE id = '<UID>';
+SELECT public._recompute_credit('<UID>') AS new_score;
+SELECT score, target, tier, components FROM public.credit_history
+ WHERE user_id = '<UID>' ORDER BY at DESC LIMIT 1;
+ROLLBACK;
+```
+Expected: `new_score` in [300,850]; a `credit_history` row with `components` containing `U/S/R/B/C`; `tier` matching the score band. (ROLLBACK restores `created_at`.)
+
+- [ ] **Step 5: Verify the daily-drop cap**
+
+```sql
+BEGIN;
+UPDATE public.profiles SET created_at = now() - INTERVAL '30 days',
+       credit_updated_at = now() - INTERVAL '1 day', credit_score = 820,
+       loan = public._loan_cap('<UID>')  -- max utilization → low target
+ WHERE id = '<UID>';
+SELECT public._recompute_credit('<UID>') AS after_one_day;  -- expect ~820-120=700, not a full crash
+ROLLBACK;
+```
+Expected: `after_one_day` ≈ `700` (drop clamped to 120), **not** near 300.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase-credit-score-recompute.sql
+git commit -m "Credit score: _recompute_credit (components, ease, grace, derog)"
+```
+
+---
+
+## Task 3: Lazy recompute in `get_bank` + `get_credit_detail()`
+
+**Files:**
+- Create: `supabase-credit-score-getbank.sql`
+
+**Interfaces:**
+- Consumes: `_recompute_credit`, `_credit_tier`, existing `get_bank(p_limit)`.
+- Produces: `get_bank` JSON gains `credit_score INT`, `credit_tier TEXT`, `credit_delta INT` (vs the prior `credit_history` row). New RPC `public.get_credit_detail() → JSONB` = `{ score, target, tier, delta, components:{utilization,solvency,repayment,restraint,consistency}, history:[{at,score}] }` where each component is `{ value:0..1, label, hint }`.
+
+- [ ] **Step 1: Copy the current `get_bank` body to edit from**
+
+Run: `psql "$SUPABASE_DB_URL" -c "\sf public.get_bank"` (note: there is a `p_limit` overload from `supabase-getbank-limit.sql` — target that signature). Confirm the exact current signature before editing so the new file `CREATE OR REPLACE`s the same one.
+
+- [ ] **Step 2: Write the patch file**
+
+Create `supabase-credit-score-getbank.sql` (adjust the `get_bank` signature/body to match Step 1's output; the credit additions are the point):
+```sql
+-- Credit Score Phase 1 — surface credit in get_bank (lazy daily recompute) and add
+-- get_credit_detail() for the gauge breakdown. PITR point logged before apply.
+BEGIN;
+
+-- Recompute at most once per calendar day on read; return current score+tier+delta.
+CREATE OR REPLACE FUNCTION public._credit_read(p_uid UUID)
+  RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_score INT; v_upd TIMESTAMPTZ; v_prev INT;
+BEGIN
+  SELECT credit_score, credit_updated_at INTO v_score, v_upd
+    FROM public.profiles WHERE id = p_uid;
+  IF v_upd IS NULL OR v_upd::date < current_date THEN
+    -- previous score for delta (last history row before this recompute)
+    SELECT score INTO v_prev FROM public.credit_history
+      WHERE user_id = p_uid ORDER BY at DESC LIMIT 1;
+    v_score := public._recompute_credit(p_uid);
+    RETURN jsonb_build_object('credit_score', v_score,
+      'credit_tier', public._credit_tier(v_score),
+      'credit_delta', v_score - COALESCE(v_prev, v_score));
+  END IF;
+  RETURN jsonb_build_object('credit_score', COALESCE(v_score,650),
+    'credit_tier', public._credit_tier(COALESCE(v_score,650)),
+    'credit_delta', 0);
+END; $fn$;
+
+-- get_bank: merge the credit fields into the existing payload.
+CREATE OR REPLACE FUNCTION public.get_bank(p_limit INT DEFAULT 12)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_bank BIGINT; v_loan BIGINT; v_led JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT bank, loan INTO v_bank, v_loan FROM public.profiles WHERE id = v_uid;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('delta',delta,'reason',reason,
+           'balance_after',balance_after,'at',created_at) ORDER BY created_at DESC),'[]'::jsonb)
+    INTO v_led FROM (SELECT * FROM public.bank_ledger WHERE user_id = v_uid
+                      ORDER BY created_at DESC LIMIT p_limit) t;
+  RETURN jsonb_build_object('bank', COALESCE(v_bank,0), 'loan', COALESCE(v_loan,0),
+           'net_worth', COALESCE(v_bank,0) - COALESCE(v_loan,0), 'ledger', v_led)
+         || public._credit_read(v_uid);
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_bank(INT) TO authenticated;
+
+-- Full breakdown for the gauge detail view.
+CREATE OR REPLACE FUNCTION public.get_credit_detail()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_score INT; v_target INT; v_comp JSONB; v_hist JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._credit_read(v_uid); -- ensure fresh
+  SELECT score, target, components INTO v_score, v_target, v_comp
+    FROM public.credit_history WHERE user_id = v_uid ORDER BY at DESC LIMIT 1;
+  v_score := COALESCE(v_score, 650);
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('at', at, 'score', score) ORDER BY at), '[]')
+    INTO v_hist FROM (SELECT at, score FROM public.credit_history
+                       WHERE user_id = v_uid ORDER BY at DESC LIMIT 30) h;
+  RETURN jsonb_build_object(
+    'score', v_score, 'target', COALESCE(v_target, v_score),
+    'tier', public._credit_tier(v_score), 'history', v_hist,
+    'components', jsonb_build_object(
+      'utilization', jsonb_build_object('value', COALESCE((v_comp->>'U')::numeric,1),
+        'label','Utilization','hint','Repay loans and keep debt low.'),
+      'solvency', jsonb_build_object('value', COALESCE((v_comp->>'S')::numeric,1),
+        'label','Solvency','hint','Stay out of the red.'),
+      'repayment', jsonb_build_object('value', COALESCE((v_comp->>'R')::numeric,1),
+        'label','Repayment','hint','Repay loans yourself before they auto-collect.'),
+      'restraint', jsonb_build_object('value', COALESCE((v_comp->>'B')::numeric,1),
+        'label','Restraint','hint','Avoid frequent borrowing.'),
+      'consistency', jsonb_build_object('value', COALESCE((v_comp->>'C')::numeric,1),
+        'label','Consistency','hint','Play daily to build history.')));
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_credit_detail() TO authenticated;
+COMMIT;
+```
+
+- [ ] **Step 3: Log PITR + apply**
+
+```bash
+psql "$SUPABASE_DB_URL" -c "SELECT now() AT TIME ZONE 'utc';"
+psql "$SUPABASE_DB_URL" -f supabase-credit-score-getbank.sql
+```
+Expected: `BEGIN … COMMIT`.
+
+- [ ] **Step 4: Verify payload + detail as a real user**
+
+In psql:
+```sql
+SELECT set_config('request.jwt.claims', json_build_object('sub','<UID>')::text, true);
+SELECT public.get_bank(5) -> 'credit_score' AS score,
+       public.get_bank(5) -> 'credit_tier'  AS tier;
+SELECT public.get_credit_detail() -> 'components' -> 'utilization';
+```
+Expected: `score` is a number 300–850; `tier` a band string; the component object has `value/label/hint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase-credit-score-getbank.sql
+git commit -m "Credit score: lazy recompute in get_bank + get_credit_detail RPC"
+```
+
+---
+
+## Task 4: Store getter + types
+
+**Files:**
+- Modify: `src/lib/stores/statsStore.js`
+
+**Interfaces:**
+- Consumes: `get_bank` (now returns credit fields), `get_credit_detail`.
+- Produces: `getCreditDetail()` → the detail object (or `null`); `getBank`'s JSDoc return type documents `credit_score`, `credit_tier`, `credit_delta`.
+
+- [ ] **Step 1: Add the getter next to `getBank`**
+
+In `src/lib/stores/statsStore.js`, immediately after the `getBank` function, add:
+```js
+/** Full credit-score breakdown for the gauge detail view. Returns null if signed out. */
+export async function getCreditDetail() {
+	const { data, error } = await supabase.rpc('get_credit_detail');
+	if (error) {
+		console.error('getCreditDetail', error);
+		return null;
+	}
+	return data;
+}
+```
+
+- [ ] **Step 2: Extend the `getBank` JSDoc**
+
+Find the JSDoc `@returns` (or the type comment) on `getBank` and append the three fields so consumers see them, e.g. add to the documented shape: `credit_score:number, credit_tier:string, credit_delta:number`. (If `getBank` has no typed return, add a one-line `/** … credit_score/credit_tier/credit_delta included … */` above it.)
+
+- [ ] **Step 3: Gate**
+
+Run:
+```bash
+npx prettier --write src/lib/stores/statsStore.js
+npm run check
+```
+Expected: prettier reformats/clean; svelte-check `0 errors`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/stores/statsStore.js
+git commit -m "Credit score: getCreditDetail() store getter"
+```
+
+---
+
+## Task 5: `CreditGauge.svelte` component
+
+**Files:**
+- Create: `src/lib/components/CreditGauge.svelte`
+
+**Interfaces:**
+- Consumes (props): `score:number`, `tier:string`, `delta:number = 0`, and `detail` (the `getCreditDetail()` object, or `null` while loading).
+- Produces: a self-contained gauge; tapping it toggles an inline breakdown panel built from `detail.components`. No external calls (parent passes data in).
+
+- [ ] **Step 1: Write the component**
+
+Create `src/lib/components/CreditGauge.svelte`:
+```svelte
+<script>
+	// 💳 Credit score gauge — 300–850 arc dial + tier + delta, tap for breakdown.
+	export let score = 650;
+	export let tier = 'Good';
+	export let delta = 0;
+	/** @type {any} */ export let detail = null;
+
+	let open = false;
+	const MIN = 300, MAX = 850;
+	// Arc: 300° sweep from 120° (bottom-left) clockwise. Map score → angle → dash.
+	$: pct = Math.max(0, Math.min(1, (score - MIN) / (MAX - MIN)));
+	const R = 80, C = 2 * Math.PI * R, SWEEP = 0.75; // 3/4 circle
+	$: dash = pct * C * SWEEP;
+	$: tierColor =
+		tier === 'Excellent' ? '#34d399'
+		: tier === 'Good' ? '#fbbf24'
+		: tier === 'Fair' ? '#f59e0b'
+		: tier === 'Poor' ? '#fb7185'
+		: '#ef4444';
+	$: comps = detail?.components
+		? [detail.components.utilization, detail.components.solvency, detail.components.repayment,
+		   detail.components.restraint, detail.components.consistency].filter(Boolean)
+		: [];
+</script>
+
+<div class="cg">
+	<button class="cg-face" on:click={() => (open = !open)} aria-expanded={open}>
+		<svg viewBox="0 0 200 200" class="cg-svg">
+			<circle class="cg-track" cx="100" cy="100" r="80"
+				stroke-dasharray="{C * 0.75} {C}" transform="rotate(135 100 100)" />
+			<circle class="cg-fill" cx="100" cy="100" r="80" stroke={tierColor}
+				stroke-dasharray="{dash} {C}" transform="rotate(135 100 100)" />
+		</svg>
+		<div class="cg-center">
+			<span class="cg-score">{score}</span>
+			<span class="cg-tier" style="color:{tierColor}">{tier}</span>
+			{#if delta !== 0}
+				<span class="cg-delta" class:pos={delta > 0} class:neg={delta < 0}
+					>{delta > 0 ? '▲' : '▼'} {Math.abs(delta)}</span>
+			{/if}
+		</div>
+	</button>
+	{#if open && comps.length}
+		<div class="cg-breakdown">
+			{#each comps as c}
+				<div class="cg-row">
+					<span class="cg-rlabel">{c.label}</span>
+					<span class="cg-bar"><span class="cg-barfill"
+						style="width:{Math.round((c.value ?? 0) * 100)}%; background:{tierColor}"></span></span>
+					<span class="cg-rhint">{c.hint}</span>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.cg { width: 100%; }
+	.cg-face {
+		position: relative; width: 200px; max-width: 60%; margin: 0 auto; display: block;
+		background: none; border: none; cursor: pointer; padding: 0;
+	}
+	.cg-svg { width: 100%; height: auto; display: block; }
+	.cg-track { fill: none; stroke: var(--border, rgba(255,255,255,0.1)); stroke-width: 14; stroke-linecap: round; }
+	.cg-fill { fill: none; stroke-width: 14; stroke-linecap: round; transition: stroke-dasharray 0.6s var(--ease-spring, ease); }
+	.cg-center {
+		position: absolute; inset: 0; display: flex; flex-direction: column;
+		align-items: center; justify-content: center; gap: 2px;
+	}
+	.cg-score { font-family: var(--font-display, sans-serif); font-size: 2rem; font-weight: 800; }
+	.cg-tier { font-size: 0.8rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+	.cg-delta { font-size: 0.72rem; font-weight: 700; }
+	.cg-delta.pos { color: #34d399; } .cg-delta.neg { color: #fb7185; }
+	.cg-breakdown { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; }
+	.cg-row { display: grid; grid-template-columns: 84px 1fr; grid-template-rows: auto auto;
+		gap: 2px 8px; align-items: center; }
+	.cg-rlabel { font-size: 0.78rem; font-weight: 700; color: var(--text); }
+	.cg-bar { height: 7px; border-radius: 999px; background: var(--border, rgba(255,255,255,0.1)); overflow: hidden; }
+	.cg-barfill { display: block; height: 100%; border-radius: 999px; }
+	.cg-rhint { grid-column: 1 / -1; font-size: 0.72rem; color: var(--text-muted); }
+</style>
+```
+
+- [ ] **Step 2: Gate the build**
+
+Run:
+```bash
+npx prettier --write src/lib/components/CreditGauge.svelte
+npm run check
+npm run build
+```
+Expected: prettier clean; svelte-check `0 errors`; build OK.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/components/CreditGauge.svelte
+git commit -m "Credit score: CreditGauge component (dial + breakdown)"
+```
+
+---
+
+## Task 6: Mount on My Account + verify end-to-end
+
+**Files:**
+- Modify: `src/routes/bank/+page.svelte`
+
+**Interfaces:**
+- Consumes: `getCreditDetail()`, the `credit_score`/`credit_tier`/`credit_delta` fields already on the `getBank` result (`b`), `CreditGauge.svelte`.
+
+- [ ] **Step 1: Import + load the detail**
+
+In `src/routes/bank/+page.svelte` `<script>`, add the imports and a `cd` (credit detail) load alongside the existing `getProfileDetail`/`getBank`:
+```js
+import CreditGauge from '$lib/components/CreditGauge.svelte';
+import { getBank, getProfileDetail, getCreditDetail } from '$lib/stores/statsStore.js';
+```
+Add state `let cd = null;` and load it in `onMount` — extend the existing `Promise.all`:
+```js
+[prof, cd] = await Promise.all([getProfileDetail(), getCreditDetail(), load()]).then(
+	(r) => [r[0], r[1]]
+);
+```
+(Keep `load()` setting `b`; the `.then` just picks `prof` and `cd`.)
+
+- [ ] **Step 2: Render the gauge under the account card**
+
+Directly after the `.ac-hero` block (the `<AccountCard …/>` wrapper) and before `<LoanPanel …>`, add:
+```svelte
+<!-- 💳 Credit score -->
+{#if b}
+	<section class="credit-sec">
+		<h2 class="hist-title">Credit Score</h2>
+		<CreditGauge
+			score={b.credit_score ?? 650}
+			tier={b.credit_tier ?? 'Good'}
+			delta={b.credit_delta ?? 0}
+			detail={cd}
+		/>
+	</section>
+{/if}
+```
+Add to `<style>`:
+```css
+	.credit-sec { margin: 4px 0 16px; }
+	.credit-sec .hist-title { text-align: center; margin-bottom: 8px; }
+```
+
+- [ ] **Step 3: Gate**
+
+```bash
+npx prettier --write src/routes/bank/+page.svelte
+npm run check
+npm run lint
+npm run build
+```
+Expected: all clean; build OK.
+
+- [ ] **Step 4: Preview screenshot verification**
+
+```bash
+pkill -f "vite preview" 2>/dev/null
+nohup npm run preview -- --port 4173 > /tmp/wb-preview.log 2>&1 &
+sleep 4
+```
+Then a Playwright script (CJS default import per `wordbank-qa-harness`) that logs in as the test user, navigates to `/bank`, waits, and screenshots. Assert in the script: `document.querySelector('.cg-score')` text is a 3-digit number and `.cg-tier` is non-empty. Read the screenshot to confirm the dial renders under the card and the tap-breakdown opens.
+
+Expected: gauge visible with a score + tier; tapping shows the 5-row breakdown.
+
+- [ ] **Step 5: Commit + PR**
+
+```bash
+git add src/routes/bank/+page.svelte
+git commit -m "Credit score: mount CreditGauge on My Account"
+git push -u origin <branch>
+gh pr create --title "Credit score Phase 1: score model + read-only gauge" --body "…"
+```
+Then squash-merge and sync master (standard flow). Phase 1 ships with **no loan effects** — verify on prod that `/bank` shows a gauge and `/loans` behavior is unchanged.
+
+---
+
+## Self-review notes
+
+- **Spec coverage (§3 model, §3.1 components, §3.2 movement, §6 data model, §7 functions, §8 My Account gauge):** Tasks 1–6 cover storage (T1), the weighted target + ease + grace + derog (T2), lazy recompute + payload + detail RPC (T3), store access (T4), the gauge (T5), and the My Account surface (T6). Spec §4 loan effects, §8 Loans/Leaderboard/Badges are **explicitly deferred** (Phase 2–4) per the plan goal.
+- **Phase-1 simplifications flagged:** Utilization uses the *instantaneous* loan/cap (spec's rolling-average anti-abuse matters only once effects exist in Phase 2); Consistency falls back to a ledger-day proxy if `streak` is 0. Both are noted and safe for a read-only display.
+- **Type consistency:** `_recompute_credit(uuid,text,int)`, `_credit_tier(int)`, `get_credit_detail()` shape (`score/target/tier/delta/components{value,label,hint}/history`), and `CreditGauge` props (`score/tier/delta/detail`) are used identically across Tasks 2–6.
+- **No placeholders:** every DB and Svelte step includes the actual code; PR body text in T6 Step 5 is the one intentional fill-in at ship time.

--- a/docs/superpowers/specs/2026-07-08-credit-score-design.md
+++ b/docs/superpowers/specs/2026-07-08-credit-score-design.md
@@ -1,0 +1,200 @@
+# Credit Score — Design Spec
+
+**Date:** 2026-07-08
+**Status:** Approved shape, pending spec review
+**Decisions locked:** Hardcore teeth · rewards financial discipline
+
+## 1. Overview
+
+Add a **credit score** to WordBank — a 300–850 reputation number that reflects how
+responsibly a player manages their money, and that **hard-gates the loan system** (cap +
+interest rate + lockouts) and becomes a **leaderboard stat + badge tier**.
+
+It introduces a second status axis orthogonal to net worth: today the only flex is *how
+much Cash you have*; credit score rewards *how disciplined you are*. A careful player who
+never gets rich can top the credit leaderboard; a reckless whale can tank their score.
+
+**Why hardcore is safe here:** loans are a *booster*, not a necessity — the core loop
+(solve puzzles → earn Cash in Daily / Cash Game) never requires credit. So a low score
+that locks borrowing removes a tool, it doesn't brick the account. And because the score
+rewards discipline, the recovery path is simply *play clean and stay solvent* — which a
+broke player can always do, without needing the thing that's locked.
+
+## 2. Goals / non-goals
+
+**Goals**
+- A legible 300–850 score driven mainly by financial discipline (utilization, solvency,
+  restraint), computed server-side from data we already have.
+- Hardcore effects: score bands set loan cap, interest rate, and lockouts.
+- Big, recoverable swings — brutal slope, no permanent cliff from a single day.
+- Surfaced as a gauge on My Account, on the Loans page, as a leaderboard column, and as
+  badge tiers.
+
+**Non-goals (v1)**
+- Real-money anything (score is virtual, like all WordBank Cash — see
+  `wordbank-virtual-currency`).
+- Gating non-loan systems (Daily, Cash Game stakes, Store) on score. Loans only, for now.
+- A separate "loan shark character"/animation (tracked separately on `/loans`).
+
+## 3. The score model (300–850)
+
+Everyone starts at a neutral **650**. Range **[300, 850]**. Recent behavior is weighted
+heavily so the score is volatile *and* recoverable.
+
+### 3.1 Components (each normalized to 0..1, higher = better)
+
+Discipline-weighted:
+
+| Component | Weight | Signal | Source |
+|---|---|---|---|
+| **Utilization** `U` | 35% | `1 − avg(loan/cap)` over the last 14 days. No debt → 1. Sitting maxed → 0. | daily util from `profiles.loan` / `_loan_cap`, or ledger-derived |
+| **Solvency** `S` | 25% | fraction of last 14 days **not in the red** (net_worth ≥ 0). | red-day counter / net_worth checks |
+| **Repayment** `R` | 20% | self-repaid vs defaulted loans in window; defaults drag hard. | `bank_ledger` reasons `loan_repay` vs `loan_skim` |
+| **Restraint** `B` | 10% | penalize serial borrowing (many `loan_take` in window) + always grabbing near-max loans. | `bank_ledger` `loan_take` count + sizes |
+| **Consistency** `C` | 10% | play streak / attendance over window. | existing streak fields |
+
+**Behavioral target:**
+```
+T = 300 + 550 × (0.35·U + 0.25·S + 0.20·R + 0.10·B + 0.10·C)
+```
+All-perfect → 850, all-zero → 300.
+
+### 3.2 Movement (ease-to-target + event jolts)
+
+The stored score **eases toward `T`** rather than snapping, giving controllable volatility
+and a per-day floor:
+
+```
+Δ_daily = clamp(T − score, −DROP_CAP, +RISE_CAP)
+score  += Δ_daily
+```
+- `DROP_CAP = 120` / day — brutal but not a cliff.
+- `RISE_CAP = 40` / day — climbing is a grind (hardcore); ~8 clean days to climb a full tier.
+
+**Catastrophic events** apply an *immediate* extra penalty on top of the eased drop (this
+is the intended "cliff" the daily cap otherwise smooths):
+- **Default** (`loan_skim` forced / loan auto-collected while unpaid): **−100** and set a
+  **derogatory mark** that decays over 30 days (repo-man style) — while active it caps the
+  Repayment component and prevents reaching Good+.
+- **Bankruptcy** (`supabase-bankruptcy.sql`): **−150**, floor the score into the Poor band.
+
+Per-event penalties are bounded; the worst realistic single day ≈ eased −120 plus one
+capped event penalty. Constants above are **tunable** and finalized during implementation.
+
+### 3.3 Recompute strategy — lazy, no cron dependency
+
+Store `credit_updated_at`. Recompute is triggered:
+- **On loan lifecycle events** — `take_loan`, `repay_loan`, `_accrue_loan` (default path),
+  bankruptcy → recompute + apply any event jolt.
+- **Lazily on read** — `get_bank()` (and login) checks elapsed days since
+  `credit_updated_at`; if ≥ 1 day, applies up to N daily eases toward `T` (catch-up) and
+  decays the derogatory mark. This avoids needing a scheduled cron job.
+
+All computation lives in a single `SECURITY DEFINER` function
+`_recompute_credit(p_uid, p_event text default null, p_event_delta int default 0)`.
+
+## 4. Bands & hardcore effects
+
+| Tier | Range | Loan cap | Interest rate | Notes |
+|---|---|---|---|---|
+| **Excellent** | 780–850 | `_loan_cap × 1.25` | base − 300bp (softened) | unlocks black card skin (Phase 4) |
+| **Good** | 670–779 | `_loan_cap × 1.0` | base | the neutral baseline |
+| **Fair** | 580–669 | `_loan_cap × 0.5` | base + 300bp | reduced access |
+| **Poor** | 400–579 | floor $250 only | max rate (1500bp) | "the shark barely trusts you" |
+| **Bad** | 300–399 | **borrowing LOCKED** | — | `take_loan` returns `credit_locked` |
+
+Integration:
+- `_loan_cap(uid)` result is multiplied by `_credit_cap_factor(score)` → new effective cap
+  surfaced in `get_bank` as `loan_cap`.
+- `_loan_daily_rate_bp(amount, cap)` gets `+ _credit_rate_adjust(score)` added to the base
+  curve (existing loans keep their locked rate; only new loans use it).
+- `take_loan` checks the band up front: Bad → reject `credit_locked`; Poor → clamp to floor
+  cap + max rate.
+
+## 5. Anti-abuse
+
+- **Utilization uses a rolling average**, not the instantaneous value, so "borrow → repay
+  right before the calc" doesn't farm a clean utilization reading.
+- **Restraint penalizes serial borrowing** so many tiny take/repay cycles hurt rather than
+  help.
+- Rewards are QoL + cosmetic-leaning (cap/rate/status), consistent with
+  `wordbank-prize-direction` — not worth botting.
+- `RISE_CAP` throttles how fast a score can be pumped.
+
+## 6. Data model
+
+**`profiles`** (new columns):
+- `credit_score INT NOT NULL DEFAULT 650`
+- `credit_updated_at TIMESTAMPTZ`
+- `credit_derog_until TIMESTAMPTZ` (derogatory-mark expiry; null = clean)
+- `credit_red_days INT DEFAULT 0` / rolling solvency counter (or derive)
+
+**`credit_history`** (new table, for the gauge trend + audit):
+`(user_id uuid, at timestamptz, score int, target int, tier text, components jsonb)` —
+one row per recompute; the gauge shows the last ~30 for a sparkline.
+
+Components that need a daily signal (utilization, solvency) are derived from a rolling
+window over `bank_ledger` + a lightweight per-day solvency check; **no new heavy snapshot
+table required for v1** (revisit if derivation proves too coarse).
+
+## 7. Server functions (SQL)
+
+- `_credit_tier(score int) → text` — band name.
+- `_credit_cap_factor(score int) → numeric` — 1.25 / 1.0 / 0.5 / (250 floor) / 0.
+- `_credit_rate_adjust(score int) → int` — bp added to base curve.
+- `_recompute_credit(p_uid, p_event, p_event_delta)` — the core: compute components →
+  target → ease → clamp → write `profiles.credit_score`, `credit_updated_at`, append
+  `credit_history`.
+- Modify: `_loan_cap` (apply cap factor), `_loan_daily_rate_bp` (apply rate adjust),
+  `take_loan` (band gate), `_accrue_loan` (default jolt), `get_bank` (lazy recompute + add
+  `credit_score`, `credit_tier`, `credit_delta` to payload).
+- `get_credit_detail()` → full breakdown (each component's 0..1 + human status + pts hint +
+  the recent `credit_history` sparkline). Powers the detail view.
+- `get_credit_leaderboard(p_limit)` → ranked by `credit_score` (mirrors existing board
+  RPCs, e.g. `get_daily_board`).
+
+All `SECURITY DEFINER`, keyed on `auth.uid()`; PITR point logged before each apply per the
+DB workflow (`wordbank-db-management`).
+
+## 8. UI surfaces
+
+- **My Account (`/bank`)** — a new `<CreditGauge>`: SVG arc dial 300–850, needle/fill to
+  score, tier label (color-coded), ▲/▼ delta since last recompute. Tap → detail view with
+  the Credit-Karma-style breakdown ("Utilization: High — repay your loan to regain ~40
+  pts") + a sparkline of recent history. Legibility is non-negotiable in a hardcore system.
+- **Loans (`/loans`)** — show current tier → your cap + rate right now; if Fair/Poor/Bad,
+  show *why* and the concrete way to recover.
+- **Leaderboard** — add a **Credit** sortable column / mode via `get_credit_leaderboard`.
+- **Badges** — 700 / 800 / 850 "club" milestones + an Excellent-tier badge.
+
+## 9. Phasing
+
+1. **Score + visibility (read-only):** columns, `_recompute_credit`, lazy recompute in
+   `get_bank`, `<CreditGauge>` + detail on My Account. **No effects yet** — let players
+   learn what moves it before it bites.
+2. **Loan effects:** cap factor, rate adjust, band lockouts, Loans-page tie-in.
+3. **Leaderboard stat + badge tiers.**
+4. **Tier card-skin cosmetics** (black card for Excellent).
+
+Each phase is its own PR(s) with the standard gates + QA smoke.
+
+## 10. Risks & open questions
+
+- **Death spiral** — mitigated by: loans are optional, recovery = play clean, `DROP_CAP`
+  floor, recent-weighting. Watch new-player experience; may need a grace window (first N
+  days pinned at 650) so newcomers aren't punished before they understand it.
+- **Derogatory-mark decay** — the user liked a repo-man style permanent-ish mark; spec'd as
+  a 30-day decay. Confirm duration.
+- **Constants** (weights, caps, band cutoffs, jolt sizes) are first-draft; will be tuned
+  against real ledgers during Phase 1–2.
+- **Utilization derivation** — if a rolling ledger derivation is too coarse, add a daily
+  `credit_snapshots` table.
+
+## 11. Testing
+
+- Simulate users via `set_config('request.jwt.claims', …)`; feed fixture `bank_ledger`
+  rows and assert `_recompute_credit` produces expected target/score.
+- Assert band → cap/rate/lockout mapping; assert `DROP_CAP`/`RISE_CAP` bound movement;
+  assert lazy catch-up over multiple elapsed days; assert default jolt + derog decay.
+- Preview-build screenshot the gauge across tiers; run `scripts/qa-e2e.mjs` before shipping
+  each phase (`wordbank-qa-harness`).

--- a/docs/superpowers/specs/2026-07-08-credit-score-design.md
+++ b/docs/superpowers/specs/2026-07-08-credit-score-design.md
@@ -10,19 +10,20 @@ Add a **credit score** to WordBank — a 300–850 reputation number that reflec
 responsibly a player manages their money, and that **hard-gates the loan system** (cap +
 interest rate + lockouts) and becomes a **leaderboard stat + badge tier**.
 
-It introduces a second status axis orthogonal to net worth: today the only flex is *how
-much Cash you have*; credit score rewards *how disciplined you are*. A careful player who
+It introduces a second status axis orthogonal to net worth: today the only flex is _how
+much Cash you have_; credit score rewards _how disciplined you are_. A careful player who
 never gets rich can top the credit leaderboard; a reckless whale can tank their score.
 
-**Why hardcore is safe here:** loans are a *booster*, not a necessity — the core loop
+**Why hardcore is safe here:** loans are a _booster_, not a necessity — the core loop
 (solve puzzles → earn Cash in Daily / Cash Game) never requires credit. So a low score
 that locks borrowing removes a tool, it doesn't brick the account. And because the score
-rewards discipline, the recovery path is simply *play clean and stay solvent* — which a
+rewards discipline, the recovery path is simply _play clean and stay solvent_ — which a
 broke player can always do, without needing the thing that's locked.
 
 ## 2. Goals / non-goals
 
 **Goals**
+
 - A legible 300–850 score driven mainly by financial discipline (utilization, solvency,
   restraint), computed server-side from data we already have.
 - Hardcore effects: score bands set loan cap, interest rate, and lockouts.
@@ -31,6 +32,7 @@ broke player can always do, without needing the thing that's locked.
   badge tiers.
 
 **Non-goals (v1)**
+
 - Real-money anything (score is virtual, like all WordBank Cash — see
   `wordbank-virtual-currency`).
 - Gating non-loan systems (Daily, Cash Game stakes, Store) on score. Loans only, for now.
@@ -39,7 +41,7 @@ broke player can always do, without needing the thing that's locked.
 ## 3. The score model (300–850)
 
 Everyone starts at a neutral **650**. Range **[300, 850]**. Recent behavior is weighted
-heavily so the score is volatile *and* recoverable.
+heavily so the score is volatile _and_ recoverable.
 
 **New-player grace (locked):** for the first **7 days** after account creation (or until
 the player's first loan, whichever comes first) the score is **pinned at 650** and the
@@ -50,18 +52,20 @@ chance to learn the system. After grace, normal recompute takes over.
 
 Discipline-weighted:
 
-| Component | Weight | Signal | Source |
-|---|---|---|---|
-| **Utilization** `U` | 35% | `1 − avg(loan/cap)` over the last 14 days. No debt → 1. Sitting maxed → 0. | daily util from `profiles.loan` / `_loan_cap`, or ledger-derived |
-| **Solvency** `S` | 25% | fraction of last 14 days **not in the red** (net_worth ≥ 0). | red-day counter / net_worth checks |
-| **Repayment** `R` | 20% | self-repaid vs defaulted loans in window; defaults drag hard. | `bank_ledger` reasons `loan_repay` vs `loan_skim` |
-| **Restraint** `B` | 10% | penalize serial borrowing (many `loan_take` in window) + always grabbing near-max loans. | `bank_ledger` `loan_take` count + sizes |
-| **Consistency** `C` | 10% | play streak / attendance over window. | existing streak fields |
+| Component           | Weight | Signal                                                                                   | Source                                                           |
+| ------------------- | ------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **Utilization** `U` | 35%    | `1 − avg(loan/cap)` over the last 14 days. No debt → 1. Sitting maxed → 0.               | daily util from `profiles.loan` / `_loan_cap`, or ledger-derived |
+| **Solvency** `S`    | 25%    | fraction of last 14 days **not in the red** (net_worth ≥ 0).                             | red-day counter / net_worth checks                               |
+| **Repayment** `R`   | 20%    | self-repaid vs defaulted loans in window; defaults drag hard.                            | `bank_ledger` reasons `loan_repay` vs `loan_skim`                |
+| **Restraint** `B`   | 10%    | penalize serial borrowing (many `loan_take` in window) + always grabbing near-max loans. | `bank_ledger` `loan_take` count + sizes                          |
+| **Consistency** `C` | 10%    | play streak / attendance over window.                                                    | existing streak fields                                           |
 
 **Behavioral target:**
+
 ```
 T = 300 + 550 × (0.35·U + 0.25·S + 0.20·R + 0.10·B + 0.10·C)
 ```
+
 All-perfect → 850, all-zero → 300.
 
 ### 3.2 Movement (ease-to-target + event jolts)
@@ -73,11 +77,13 @@ and a per-day floor:
 Δ_daily = clamp(T − score, −DROP_CAP, +RISE_CAP)
 score  += Δ_daily
 ```
+
 - `DROP_CAP = 120` / day — brutal but not a cliff.
 - `RISE_CAP = 40` / day — climbing is a grind (hardcore); ~8 clean days to climb a full tier.
 
-**Catastrophic events** apply an *immediate* extra penalty on top of the eased drop (this
+**Catastrophic events** apply an _immediate_ extra penalty on top of the eased drop (this
 is the intended "cliff" the daily cap otherwise smooths):
+
 - **Default** (`loan_skim` forced / loan auto-collected while unpaid): **−100** and set a
   **derogatory mark** that decays over 30 days (repo-man style) — while active it caps the
   Repayment component and prevents reaching Good+.
@@ -89,6 +95,7 @@ capped event penalty. Constants above are **tunable** and finalized during imple
 ### 3.3 Recompute strategy — lazy, no cron dependency
 
 Store `credit_updated_at`. Recompute is triggered:
+
 - **On loan lifecycle events** — `take_loan`, `repay_loan`, `_accrue_loan` (default path),
   bankruptcy → recompute + apply any event jolt.
 - **Lazily on read** — `get_bank()` (and login) checks elapsed days since
@@ -100,15 +107,16 @@ All computation lives in a single `SECURITY DEFINER` function
 
 ## 4. Bands & hardcore effects
 
-| Tier | Range | Loan cap | Interest rate | Notes |
-|---|---|---|---|---|
-| **Excellent** | 780–850 | `_loan_cap × 1.25` | base − 300bp (softened) | unlocks black card skin (Phase 4) |
-| **Good** | 670–779 | `_loan_cap × 1.0` | base | the neutral baseline |
-| **Fair** | 580–669 | `_loan_cap × 0.5` | base + 300bp | reduced access |
-| **Poor** | 400–579 | floor $250 only | max rate (1500bp) | "the shark barely trusts you" |
-| **Bad** | 300–399 | **borrowing LOCKED** | — | `take_loan` returns `credit_locked` |
+| Tier          | Range   | Loan cap             | Interest rate           | Notes                               |
+| ------------- | ------- | -------------------- | ----------------------- | ----------------------------------- |
+| **Excellent** | 780–850 | `_loan_cap × 1.25`   | base − 300bp (softened) | unlocks black card skin (Phase 4)   |
+| **Good**      | 670–779 | `_loan_cap × 1.0`    | base                    | the neutral baseline                |
+| **Fair**      | 580–669 | `_loan_cap × 0.5`    | base + 300bp            | reduced access                      |
+| **Poor**      | 400–579 | floor $250 only      | max rate (1500bp)       | "the shark barely trusts you"       |
+| **Bad**       | 300–399 | **borrowing LOCKED** | —                       | `take_loan` returns `credit_locked` |
 
 Integration:
+
 - `_loan_cap(uid)` result is multiplied by `_credit_cap_factor(score)` → new effective cap
   surfaced in `get_bank` as `loan_cap`.
 - `_loan_daily_rate_bp(amount, cap)` gets `+ _credit_rate_adjust(score)` added to the base
@@ -129,6 +137,7 @@ Integration:
 ## 6. Data model
 
 **`profiles`** (new columns):
+
 - `credit_score INT NOT NULL DEFAULT 650`
 - `credit_updated_at TIMESTAMPTZ`
 - `credit_derog_until TIMESTAMPTZ` (derogatory-mark expiry; null = clean)
@@ -168,7 +177,7 @@ DB workflow (`wordbank-db-management`).
   the Credit-Karma-style breakdown ("Utilization: High — repay your loan to regain ~40
   pts") + a sparkline of recent history. Legibility is non-negotiable in a hardcore system.
 - **Loans (`/loans`)** — show current tier → your cap + rate right now; if Fair/Poor/Bad,
-  show *why* and the concrete way to recover.
+  show _why_ and the concrete way to recover.
 - **Leaderboard** — add a **Credit** sortable column / mode via `get_credit_leaderboard`.
 - **Badges** — 700 / 800 / 850 "club" milestones + an Excellent-tier badge.
 

--- a/docs/superpowers/specs/2026-07-08-credit-score-design.md
+++ b/docs/superpowers/specs/2026-07-08-credit-score-design.md
@@ -41,6 +41,11 @@ broke player can always do, without needing the thing that's locked.
 Everyone starts at a neutral **650**. Range **[300, 850]**. Recent behavior is weighted
 heavily so the score is volatile *and* recoverable.
 
+**New-player grace (locked):** for the first **7 days** after account creation (or until
+the player's first loan, whichever comes first) the score is **pinned at 650** and the
+player is treated as the **Good** band — so newcomers aren't punished before they've had a
+chance to learn the system. After grace, normal recompute takes over.
+
 ### 3.1 Components (each normalized to 0..1, higher = better)
 
 Discipline-weighted:
@@ -181,10 +186,9 @@ Each phase is its own PR(s) with the standard gates + QA smoke.
 ## 10. Risks & open questions
 
 - **Death spiral** — mitigated by: loans are optional, recovery = play clean, `DROP_CAP`
-  floor, recent-weighting. Watch new-player experience; may need a grace window (first N
-  days pinned at 650) so newcomers aren't punished before they understand it.
-- **Derogatory-mark decay** — the user liked a repo-man style permanent-ish mark; spec'd as
-  a 30-day decay. Confirm duration.
+  floor, recent-weighting, and the **7-day new-player grace** (locked, §3).
+- **Derogatory-mark decay** — **locked at 30 days** (repo-man style): a default caps the
+  Repayment component and blocks Good+ until it decays.
 - **Constants** (weights, caps, band cutoffs, jolt sizes) are first-draft; will be tuned
   against real ledgers during Phase 1–2.
 - **Utilization derivation** — if a rolling ledger derivation is too coarse, add a daily

--- a/src/lib/components/CreditGauge.svelte
+++ b/src/lib/components/CreditGauge.svelte
@@ -1,0 +1,182 @@
+<script>
+	// 💳 Credit score gauge — 300–850 arc dial + tier + delta, tap for breakdown.
+	export let score = 650;
+	export let tier = 'Good';
+	export let delta = 0;
+	/** @type {any} */ export let detail = null;
+
+	let open = false;
+	const MIN = 300,
+		MAX = 850;
+	const R = 80,
+		C = 2 * Math.PI * R,
+		SWEEP = 0.75; // 3/4 circle
+	$: pct = Math.max(0, Math.min(1, (score - MIN) / (MAX - MIN)));
+	$: dash = pct * C * SWEEP;
+	$: tierColor =
+		tier === 'Excellent'
+			? '#34d399'
+			: tier === 'Good'
+				? '#fbbf24'
+				: tier === 'Fair'
+					? '#f59e0b'
+					: tier === 'Poor'
+						? '#fb7185'
+						: '#ef4444';
+	$: comps = detail?.components
+		? [
+				detail.components.utilization,
+				detail.components.solvency,
+				detail.components.repayment,
+				detail.components.restraint,
+				detail.components.consistency
+			].filter(Boolean)
+		: [];
+</script>
+
+<div class="cg">
+	<button class="cg-face" on:click={() => (open = !open)} aria-expanded={open}>
+		<svg viewBox="0 0 200 200" class="cg-svg">
+			<circle
+				class="cg-track"
+				cx="100"
+				cy="100"
+				r="80"
+				stroke-dasharray="{C * 0.75} {C}"
+				transform="rotate(135 100 100)"
+			/>
+			<circle
+				class="cg-fill"
+				cx="100"
+				cy="100"
+				r="80"
+				stroke={tierColor}
+				stroke-dasharray="{dash} {C}"
+				transform="rotate(135 100 100)"
+			/>
+		</svg>
+		<div class="cg-center">
+			<span class="cg-score">{score}</span>
+			<span class="cg-tier" style="color:{tierColor}">{tier}</span>
+			{#if delta !== 0}
+				<span class="cg-delta" class:pos={delta > 0} class:neg={delta < 0}
+					>{delta > 0 ? '▲' : '▼'} {Math.abs(delta)}</span
+				>
+			{/if}
+		</div>
+	</button>
+	{#if open && comps.length}
+		<div class="cg-breakdown">
+			{#each comps as c}
+				<div class="cg-row">
+					<span class="cg-rlabel">{c.label}</span>
+					<span class="cg-bar"
+						><span
+							class="cg-barfill"
+							style="width:{Math.round((c.value ?? 0) * 100)}%; background:{tierColor}"
+						></span></span
+					>
+					<span class="cg-rhint">{c.hint}</span>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.cg {
+		width: 100%;
+	}
+	.cg-face {
+		position: relative;
+		width: 200px;
+		max-width: 60%;
+		margin: 0 auto;
+		display: block;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+	}
+	.cg-svg {
+		width: 100%;
+		height: auto;
+		display: block;
+	}
+	.cg-track {
+		fill: none;
+		stroke: var(--border, rgba(255, 255, 255, 0.1));
+		stroke-width: 14;
+		stroke-linecap: round;
+	}
+	.cg-fill {
+		fill: none;
+		stroke-width: 14;
+		stroke-linecap: round;
+		transition: stroke-dasharray 0.6s var(--ease-spring, ease);
+	}
+	.cg-center {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 2px;
+	}
+	.cg-score {
+		font-family: var(--font-display, sans-serif);
+		font-size: 2rem;
+		font-weight: 800;
+	}
+	.cg-tier {
+		font-size: 0.8rem;
+		font-weight: 700;
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+	.cg-delta {
+		font-size: 0.72rem;
+		font-weight: 700;
+	}
+	.cg-delta.pos {
+		color: #34d399;
+	}
+	.cg-delta.neg {
+		color: #fb7185;
+	}
+	.cg-breakdown {
+		display: flex;
+		flex-direction: column;
+		gap: 8px;
+		margin-top: 10px;
+	}
+	.cg-row {
+		display: grid;
+		grid-template-columns: 84px 1fr;
+		grid-template-rows: auto auto;
+		gap: 2px 8px;
+		align-items: center;
+	}
+	.cg-rlabel {
+		font-size: 0.78rem;
+		font-weight: 700;
+		color: var(--text);
+	}
+	.cg-bar {
+		height: 7px;
+		border-radius: 999px;
+		background: var(--border, rgba(255, 255, 255, 0.1));
+		overflow: hidden;
+	}
+	.cg-barfill {
+		display: block;
+		height: 100%;
+		border-radius: 999px;
+	}
+	.cg-rhint {
+		grid-column: 1 / -1;
+		font-size: 0.72rem;
+		color: var(--text-muted);
+	}
+</style>

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -70,14 +70,24 @@ export async function getDailyStatus(userId) {
 	};
 }
 
-/** My Cash: balance (= Net Worth) and recent ledger. (v3: loans removed.)
- * @returns {Promise<{ bank:number, net_worth:number, ledger:any[] }>} */
-/** @param {number} [limit] ledger rows to return (default 12; pass a big number for full history) */
+/** My Cash: balance (= Net Worth), recent ledger, and credit summary.
+ * Credit fields (credit_score/credit_tier/credit_delta) ride along from get_bank.
+ * @param {number} [limit] ledger rows to return (default 12; pass a big number for full history) */
 export async function getBank(limit) {
 	const { data, error } = await supabase.rpc('get_bank', limit ? { p_limit: limit } : {});
 	if (error || !data) {
 		if (error) console.error('❌ get_bank:', error);
-		return { bank: 0, net_worth: 0, loan: 0, loan_cap: 0, in_the_red: false, ledger: [] };
+		return {
+			bank: 0,
+			net_worth: 0,
+			loan: 0,
+			loan_cap: 0,
+			in_the_red: false,
+			ledger: [],
+			credit_score: 650,
+			credit_tier: 'Good',
+			credit_delta: 0
+		};
 	}
 	return {
 		bank: data.bank ?? 0,
@@ -85,8 +95,22 @@ export async function getBank(limit) {
 		loan: data.loan ?? 0,
 		loan_cap: data.loan_cap ?? 0,
 		in_the_red: !!data.in_the_red,
-		ledger: Array.isArray(data.ledger) ? data.ledger : []
+		ledger: Array.isArray(data.ledger) ? data.ledger : [],
+		credit_score: data.credit_score ?? 650,
+		credit_tier: data.credit_tier ?? 'Good',
+		credit_delta: data.credit_delta ?? 0
 	};
+}
+
+/** Full credit-score breakdown for the gauge detail view. Returns null if signed out.
+ * @returns {Promise<null|{ score:number, target:number, tier:string, history:any[], components:Record<string,{value:number,label:string,hint:string}> }>} */
+export async function getCreditDetail() {
+	const { data, error } = await supabase.rpc('get_credit_detail');
+	if (error) {
+		console.error('❌ get_credit_detail:', error);
+		return null;
+	}
+	return data;
 }
 
 /** Borrow from the Loan Shark (25% fee, one at a time, ≤ credit limit). @param {number} amount */

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -1,15 +1,18 @@
 <script>
 	import { onMount } from 'svelte';
 	import PageNav from '$lib/components/PageNav.svelte';
-	import { getBank, getProfileDetail } from '$lib/stores/statsStore.js';
+	import { getBank, getProfileDetail, getCreditDetail } from '$lib/stores/statsStore.js';
 	import AccountCard from '$lib/components/AccountCard.svelte';
+	import CreditGauge from '$lib/components/CreditGauge.svelte';
 	import LoanPanel from '$lib/components/LoanPanel.svelte';
 	import { track } from '$lib/analytics.js';
 
-	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
+	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[], credit_score:number, credit_tier:string, credit_delta:number }|null} */
 	let b = null;
 	/** @type {any} */
 	let prof = null;
+	/** @type {any} */
+	let cd = null;
 	let loading = true;
 
 	async function load() {
@@ -18,7 +21,9 @@
 	onMount(async () => {
 		track('bank_view');
 		try {
-			[prof] = await Promise.all([getProfileDetail(), load()]);
+			const [p, c] = await Promise.all([getProfileDetail(), getCreditDetail(), load()]);
+			prof = p;
+			cd = c;
 		} finally {
 			loading = false;
 		}
@@ -102,6 +107,17 @@
 				balance={b.bank}
 			/>
 		</div>
+
+		<!-- 💳 Credit score -->
+		<section class="credit-sec">
+			<h2 class="hist-title">Credit Score</h2>
+			<CreditGauge
+				score={b.credit_score ?? 650}
+				tier={b.credit_tier ?? 'Good'}
+				delta={b.credit_delta ?? 0}
+				detail={cd}
+			/>
+		</section>
 
 		<!-- 💸 Loan Shark -->
 		<LoanPanel bank={b} on:changed={load} />
@@ -201,6 +217,13 @@
 
 	.ac-hero {
 		margin-bottom: 14px;
+	}
+	.credit-sec {
+		margin: 4px 0 16px;
+	}
+	.credit-sec .hist-title {
+		text-align: center;
+		margin-bottom: 8px;
 	}
 
 	.led-head {

--- a/supabase-credit-score-getbank.sql
+++ b/supabase-credit-score-getbank.sql
@@ -1,0 +1,69 @@
+-- Credit Score Phase 1 — surface credit in get_bank (lazy daily recompute) and add
+-- get_credit_detail() for the gauge breakdown. PITR point logged before apply.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._credit_read(p_uid UUID)
+  RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE v_score INT; v_upd TIMESTAMPTZ; v_prev INT;
+BEGIN
+  SELECT credit_score, credit_updated_at INTO v_score, v_upd
+    FROM public.profiles WHERE id = p_uid;
+  IF v_upd IS NULL OR v_upd::date < current_date THEN
+    SELECT score INTO v_prev FROM public.credit_history
+      WHERE user_id = p_uid ORDER BY at DESC LIMIT 1;
+    v_score := public._recompute_credit(p_uid);
+    RETURN jsonb_build_object('credit_score', v_score,
+      'credit_tier', public._credit_tier(v_score),
+      'credit_delta', v_score - COALESCE(v_prev, v_score));
+  END IF;
+  RETURN jsonb_build_object('credit_score', COALESCE(v_score,650),
+    'credit_tier', public._credit_tier(COALESCE(v_score,650)),
+    'credit_delta', 0);
+END; $fn$;
+
+CREATE OR REPLACE FUNCTION public.get_bank(p_limit INT DEFAULT 12)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_bank BIGINT; v_loan BIGINT; v_led JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT bank, loan INTO v_bank, v_loan FROM public.profiles WHERE id = v_uid;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('delta',delta,'reason',reason,
+           'balance_after',balance_after,'at',created_at) ORDER BY created_at DESC),'[]'::jsonb)
+    INTO v_led FROM (SELECT * FROM public.bank_ledger WHERE user_id = v_uid
+                      ORDER BY created_at DESC LIMIT p_limit) t;
+  RETURN jsonb_build_object('bank', COALESCE(v_bank,0), 'loan', COALESCE(v_loan,0),
+           'net_worth', COALESCE(v_bank,0) - COALESCE(v_loan,0), 'ledger', v_led)
+         || public._credit_read(v_uid);
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_bank(INT) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_credit_detail()
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE v_uid UUID := auth.uid(); v_score INT; v_target INT; v_comp JSONB; v_hist JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._credit_read(v_uid);
+  SELECT score, target, components INTO v_score, v_target, v_comp
+    FROM public.credit_history WHERE user_id = v_uid ORDER BY at DESC LIMIT 1;
+  v_score := COALESCE(v_score, 650);
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('at', at, 'score', score) ORDER BY at), '[]')
+    INTO v_hist FROM (SELECT at, score FROM public.credit_history
+                       WHERE user_id = v_uid ORDER BY at DESC LIMIT 30) h;
+  RETURN jsonb_build_object(
+    'score', v_score, 'target', COALESCE(v_target, v_score),
+    'tier', public._credit_tier(v_score), 'history', v_hist,
+    'components', jsonb_build_object(
+      'utilization', jsonb_build_object('value', COALESCE((v_comp->>'U')::numeric,1),
+        'label','Utilization','hint','Repay loans and keep debt low.'),
+      'solvency', jsonb_build_object('value', COALESCE((v_comp->>'S')::numeric,1),
+        'label','Solvency','hint','Stay out of the red.'),
+      'repayment', jsonb_build_object('value', COALESCE((v_comp->>'R')::numeric,1),
+        'label','Repayment','hint','Repay loans yourself before they auto-collect.'),
+      'restraint', jsonb_build_object('value', COALESCE((v_comp->>'B')::numeric,1),
+        'label','Restraint','hint','Avoid frequent borrowing.'),
+      'consistency', jsonb_build_object('value', COALESCE((v_comp->>'C')::numeric,1),
+        'label','Consistency','hint','Play daily to build history.')));
+END; $$;
+GRANT EXECUTE ON FUNCTION public.get_credit_detail() TO authenticated;
+COMMIT;

--- a/supabase-credit-score-recompute.sql
+++ b/supabase-credit-score-recompute.sql
@@ -93,5 +93,10 @@ BEGIN
   RETURN v_new;
 END; $fn$;
 
-GRANT EXECUTE ON FUNCTION public._recompute_credit(UUID, TEXT, INT) TO authenticated;
+-- SECURITY: internal-only. Clients must NOT call this directly — it accepts an
+-- arbitrary p_uid and p_event_delta, so a GRANT to authenticated would allow score
+-- tampering/IDOR. It is invoked solely by SECURITY DEFINER wrappers (get_bank,
+-- get_credit_detail, and — in later phases — loan lifecycle functions) which run as
+-- the owner and derive the uid from auth.uid(). Revoke from all client roles.
+REVOKE ALL ON FUNCTION public._recompute_credit(UUID, TEXT, INT) FROM PUBLIC, anon, authenticated;
 COMMIT;

--- a/supabase-credit-score-recompute.sql
+++ b/supabase-credit-score-recompute.sql
@@ -1,0 +1,97 @@
+-- Credit Score Phase 1 — core recompute. Derives 5 discipline components from a
+-- 14-day bank_ledger window, eases the stored score toward a target (bounded per
+-- day), applies new-player grace + derogatory cap + event jolts, logs history.
+-- PITR point logged before apply.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._recompute_credit(
+  p_uid UUID,
+  p_event TEXT DEFAULT NULL,
+  p_event_delta INT DEFAULT 0
+) RETURNS INT LANGUAGE plpgsql SECURITY DEFINER AS $fn$
+DECLARE
+  DROP_CAP CONSTANT INT := 120;
+  RISE_CAP CONSTANT INT := 40;
+  v_bank BIGINT; v_loan BIGINT; v_created TIMESTAMPTZ;
+  v_prev INT; v_updated TIMESTAMPTZ; v_derog TIMESTAMPTZ; v_streak INT;
+  v_cap BIGINT;
+  u NUMERIC; s NUMERIC; r NUMERIC; b NUMERIC; c NUMERIC;
+  v_neg_days INT; v_repay INT; v_skim INT; v_take INT; v_active_days INT;
+  v_target INT; v_new INT; v_days_elapsed INT; i INT;
+  v_had_loan BOOLEAN;
+BEGIN
+  PERFORM public._ensure_bank(p_uid);
+  SELECT p.bank, p.loan, p.credit_score, p.credit_updated_at, p.credit_derog_until,
+         COALESCE(p.current_daily_play_streak, 0)
+    INTO v_bank, v_loan, v_prev, v_updated, v_derog, v_streak
+    FROM public.profiles p WHERE p.id = p_uid;
+  SELECT u.created_at INTO v_created FROM auth.users u WHERE u.id = p_uid;
+  v_prev := COALESCE(v_prev, 650);
+
+  SELECT (v_loan > 0) OR EXISTS(
+    SELECT 1 FROM public.bank_ledger WHERE user_id = p_uid AND reason = 'loan_take'
+  ) INTO v_had_loan;
+
+  IF v_created IS NOT NULL AND v_created > now() - INTERVAL '7 days' AND NOT v_had_loan THEN
+    UPDATE public.profiles
+       SET credit_score = 650, credit_updated_at = now() WHERE id = p_uid;
+    INSERT INTO public.credit_history(user_id, score, target, tier, components)
+      VALUES (p_uid, 650, 650, 'Good', jsonb_build_object('grace', true));
+    RETURN 650;
+  END IF;
+
+  v_cap := GREATEST(public._loan_cap(p_uid), 1);
+
+  u := 1 - LEAST(v_loan::numeric / v_cap, 1);
+
+  SELECT COUNT(DISTINCT date(created_at)) INTO v_neg_days
+    FROM public.bank_ledger
+   WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days'
+     AND balance_after < 0;
+  s := 1 - LEAST(v_neg_days::numeric / 14, 1);
+  IF (v_bank - v_loan) < 0 THEN s := LEAST(s, 0.5); END IF;
+
+  SELECT COUNT(*) FILTER (WHERE reason = 'loan_repay'),
+         COUNT(*) FILTER (WHERE reason = 'loan_skim'),
+         COUNT(*) FILTER (WHERE reason = 'loan_take')
+    INTO v_repay, v_skim, v_take
+    FROM public.bank_ledger
+   WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days';
+  r := CASE WHEN (v_repay + v_skim) = 0 THEN 1
+            ELSE v_repay::numeric / (v_repay + v_skim) END;
+  IF v_derog IS NOT NULL AND v_derog > now() THEN r := LEAST(r, 0.3); END IF;
+
+  b := 1 - LEAST(v_take::numeric / 6, 1);
+
+  IF v_streak > 0 THEN
+    c := LEAST(v_streak::numeric / 14, 1);
+  ELSE
+    SELECT COUNT(DISTINCT date(created_at)) INTO v_active_days
+      FROM public.bank_ledger
+     WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days';
+    c := LEAST(v_active_days::numeric / 14, 1);
+  END IF;
+
+  v_target := round(300 + 550 * (0.35*u + 0.25*s + 0.20*r + 0.10*b + 0.10*c));
+  v_target := GREATEST(300, LEAST(850, v_target));
+
+  v_days_elapsed := GREATEST(1, LEAST(7,
+    COALESCE(date_part('day', now() - v_updated)::int, 1)));
+  v_new := v_prev;
+  FOR i IN 1..v_days_elapsed LOOP
+    v_new := v_new + GREATEST(LEAST(v_target - v_new, RISE_CAP), -DROP_CAP);
+  END LOOP;
+
+  v_new := GREATEST(300, LEAST(850, v_new + COALESCE(p_event_delta, 0)));
+
+  UPDATE public.profiles
+     SET credit_score = v_new, credit_updated_at = now() WHERE id = p_uid;
+  INSERT INTO public.credit_history(user_id, score, target, tier, components)
+    VALUES (p_uid, v_new, v_target, public._credit_tier(v_new),
+      jsonb_build_object('U',round(u,3),'S',round(s,3),'R',round(r,3),
+                         'B',round(b,3),'C',round(c,3),'event',p_event));
+  RETURN v_new;
+END; $fn$;
+
+GRANT EXECUTE ON FUNCTION public._recompute_credit(UUID, TEXT, INT) TO authenticated;
+COMMIT;

--- a/supabase-credit-score-schema.sql
+++ b/supabase-credit-score-schema.sql
@@ -1,0 +1,33 @@
+-- Credit Score Phase 1 — storage + tier helper. Read-only; no loan effects yet.
+-- PITR point logged before apply.
+BEGIN;
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS credit_score       INT         NOT NULL DEFAULT 650,
+  ADD COLUMN IF NOT EXISTS credit_updated_at  TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS credit_derog_until TIMESTAMPTZ;
+
+CREATE TABLE IF NOT EXISTS public.credit_history (
+  id         BIGSERIAL PRIMARY KEY,
+  user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  score      INT  NOT NULL,
+  target     INT  NOT NULL,
+  tier       TEXT NOT NULL,
+  components JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_credit_history_user_time
+  ON public.credit_history(user_id, at DESC);
+
+CREATE OR REPLACE FUNCTION public._credit_tier(p_score INT)
+  RETURNS TEXT LANGUAGE sql IMMUTABLE AS $fn$
+  SELECT CASE
+    WHEN p_score >= 780 THEN 'Excellent'
+    WHEN p_score >= 670 THEN 'Good'
+    WHEN p_score >= 580 THEN 'Fair'
+    WHEN p_score >= 400 THEN 'Poor'
+    ELSE 'Bad'
+  END;
+$fn$;
+
+COMMIT;


### PR DESCRIPTION
Ships Phase 1 of the credit score (per `docs/superpowers/specs/2026-07-08-credit-score-design.md` + `plans/2026-07-08-credit-score-phase1.md`). **Read-only — no loan effects yet** (Phase 2).

**DB** (`supabase-credit-score-*.sql`, applied to prod, PITR points logged):
- `profiles.credit_score/credit_updated_at/credit_derog_until` + `credit_history` table + `_credit_tier`.
- `_recompute_credit(uid,event,delta)` — 5 discipline components (Utilization 35 / Solvency 25 / Repayment 20 / Restraint 10 / Consistency 10) over a 14-day `bank_ledger` window → target `300+550×Σ` → ease with **−120/day drop cap, +40/day rise**, 7-day new-player grace, 30-day derogatory cap, event jolts. **Internal-only** (revoked from clients — it takes an arbitrary uid + delta, so a client grant would be an IDOR / score-pump vector; invoked only by `SECURITY DEFINER` wrappers that derive the uid from `auth.uid()`).
- `get_bank` lazily recomputes at most once/calendar-day and adds `credit_score/credit_tier/credit_delta`; new `get_credit_detail()` returns the breakdown + 30-point history.

**Frontend:**
- `getBank` passes the credit fields through; `getCreditDetail()` getter.
- `CreditGauge.svelte` — 300–850 arc dial + tier + delta, tap for the component breakdown.
- Mounted on `/bank` (My Account) under the account card.

**Verified:** DB math (normal 650→603, drop-cap 820→700, default→480), the security revoke (authenticated blocked, wrappers still work), gates (svelte-check 0 · lint · build), and a preview screenshot of the dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)