### PR TITLE
Credit score Phase 2: loan cap/rate/lockout effects (+ get_bank regression fix)

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -7,7 +7,8 @@
 
 	/** The get_bank payload (loan detail added in loans-v3)
 	 * @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean,
-	 *   loan_principal?:number, loan_rate_bp?:number, loan_days?:number, loan_owed_tomorrow?:number }|null} */
+	 *   loan_principal?:number, loan_rate_bp?:number, loan_days?:number, loan_owed_tomorrow?:number,
+	 *   credit_score?:number, credit_tier?:string, credit_delta?:number }|null} */
 	export let bank = null;
 	/** Open the borrow panel by default (used on the dedicated /loans page). */
 	export let expanded = false;
@@ -22,13 +23,23 @@
 	let loanMsg = '';
 	$: loanCap = bank?.loan_cap ?? 0;
 	$: owed = bank?.loan ?? 0;
+	// 💳 Credit tier sets your cap + a rate adjustment (mirrors _credit_effective_cap / _credit_rate_adjust).
+	$: creditTier = bank?.credit_tier ?? 'Good';
+	$: creditScore = bank?.credit_score ?? 650;
+	/** @param {string} tier */
+	function creditAdjBp(tier) {
+		return tier === 'Excellent' ? -300 : tier === 'Fair' ? 300 : tier === 'Poor' ? 600 : 0;
+	}
 	/** @param {number} amt @param {number} cap */
 	function rateBpFor(amt, cap) {
 		if (cap <= 0) return 1500;
 		const p = amt / cap;
 		return p <= 0.25 ? 500 : p <= 0.5 ? 800 : p <= 0.75 ? 1200 : 1500;
 	}
-	$: rateBp = rateBpFor(borrowAmt, loanCap);
+	$: rateBp = Math.max(
+		200,
+		Math.min(2500, rateBpFor(borrowAmt, loanCap) + creditAdjBp(creditTier))
+	);
 	$: ratePct = rateBp / 100; // 2 / 4 / 6 / 8 (%/day)
 	$: proj7 = Math.min(
 		Math.round(borrowAmt * Math.pow(1 + rateBp / 10000, 7)),
@@ -71,9 +82,11 @@
 			loanMsg =
 				res?.reason === 'active_loan'
 					? 'Pay off your current loan first.'
-					: res?.reason === 'over_cap'
-						? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.`
-						: 'Could not borrow right now.';
+					: res?.reason === 'credit_locked'
+						? 'Borrowing is locked — raise your credit score to borrow again.'
+						: res?.reason === 'over_cap'
+							? `Over your $${(res.cap ?? loanCap).toLocaleString()} limit.`
+							: 'Could not borrow right now.';
 		}
 	}
 
@@ -178,6 +191,10 @@
 			Interest compounds daily — the more you take, the higher the rate. One loan at a time; while
 			you owe, the Store locks and half of every payout auto-pays it down.
 		</p>
+		<p class="loan-tier">
+			Credit <b>{creditTier}</b> ({creditScore}) — sets your ${loanCap.toLocaleString()} limit{#if creditAdjBp(creditTier) !== 0}
+				and a {creditAdjBp(creditTier) > 0 ? '+' : ''}{creditAdjBp(creditTier) / 100}%/day rate{/if}.
+		</p>
 		<div class="loan-dial">
 			<button
 				class="loan-step"
@@ -212,6 +229,16 @@
 		>
 		{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
 	</details>
+{:else}
+	<!-- Bad tier: borrowing locked -->
+	<div class="loan-card locked">
+		<div class="loan-locked-h">🦈 Borrowing locked</div>
+		<p class="loan-note" style="margin:0">
+			Your credit is <b class="neg">{creditTier}</b> ({creditScore}). The Shark won't lend to you
+			right now — repay on time, stay out of the red, and keep utilization low to climb back to
+			<b>Poor</b> (400+) and unlock loans again.
+		</p>
+	</div>
 {/if}
 
 <style>
@@ -225,6 +252,24 @@
 	.loan-card.debt {
 		border-color: rgba(248, 113, 113, 0.5);
 		background: linear-gradient(135deg, rgba(248, 113, 113, 0.12), rgba(248, 113, 113, 0.03));
+	}
+	.loan-card.locked {
+		border-color: rgba(248, 113, 113, 0.45);
+		background: linear-gradient(135deg, rgba(248, 113, 113, 0.1), rgba(248, 113, 113, 0.02));
+	}
+	.loan-locked-h {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 1rem;
+		margin-bottom: 6px;
+	}
+	.loan-tier {
+		margin: 0 0 10px;
+		font-size: 0.76rem;
+		color: var(--text-muted);
+	}
+	.loan-tier b {
+		color: var(--brand-2, #fde047);
 	}
 	.loan-head {
 		display: flex;

--- a/supabase-credit-loan-effects.sql
+++ b/supabase-credit-loan-effects.sql
@@ -1,0 +1,66 @@
+-- Credit Score Phase 2a — loan effects on READ + restore the rich get_bank that
+-- Phase 1 accidentally slimmed (it had dropped _accrue_loan + loan detail fields).
+-- Adds credit-tier cap factor + rate-adjust helpers and merges credit into get_bank.
+-- PITR point logged before apply.
+BEGIN;
+
+-- Effective loan cap = base (Cash-Game-tier) cap scaled by credit tier.
+--   Excellent ×1.25 · Good ×1.0 · Fair ×0.5 · Poor floor $250 · Bad locked (0).
+CREATE OR REPLACE FUNCTION public._credit_effective_cap(p_uid uuid)
+  RETURNS bigint LANGUAGE plpgsql STABLE SECURITY DEFINER AS $fn$
+DECLARE v_base bigint; v_score int;
+BEGIN
+  v_base := public._loan_cap(p_uid);
+  SELECT COALESCE(credit_score, 650) INTO v_score FROM public.profiles WHERE id = p_uid;
+  RETURN CASE public._credit_tier(v_score)
+    WHEN 'Excellent' THEN round(v_base * 1.25)::bigint
+    WHEN 'Good'      THEN v_base
+    WHEN 'Fair'      THEN round(v_base * 0.5)::bigint
+    WHEN 'Poor'      THEN LEAST(v_base, 250)
+    ELSE 0
+  END;
+END; $fn$;
+
+-- Daily-rate adjustment (basis points) added to the base curve at borrow time.
+CREATE OR REPLACE FUNCTION public._credit_rate_adjust(p_score int)
+  RETURNS int LANGUAGE sql IMMUTABLE AS $fn$
+  SELECT CASE public._credit_tier(p_score)
+    WHEN 'Excellent' THEN -300
+    WHEN 'Good'      THEN 0
+    WHEN 'Fair'      THEN 300
+    WHEN 'Poor'      THEN 600
+    ELSE 0
+  END;
+$fn$;
+
+-- get_bank: rich loan detail (accrue + principal/rate/days/projected) + credit fields,
+-- with loan_cap now the credit-effective cap.
+CREATE OR REPLACE FUNCTION public.get_bank(p_limit integer DEFAULT 12)
+  RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); p public.profiles; v_led jsonb; v_rate numeric;
+        v_tomorrow bigint; v_days int; v_credit jsonb;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  PERFORM public._accrue_loan(v_uid);
+  v_credit := public._credit_read(v_uid);         -- recompute (≤1/day) BEFORE effective cap
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('delta',delta,'reason',reason,'balance_after',balance_after,'at',created_at) ORDER BY created_at DESC), '[]'::jsonb)
+    INTO v_led FROM (SELECT * FROM public.bank_ledger WHERE user_id = v_uid ORDER BY created_at DESC LIMIT GREATEST(p_limit, 1)) t;
+  v_rate := COALESCE(p.loan_rate_bp,0) / 10000.0;
+  v_tomorrow := CASE WHEN COALESCE(p.loan,0) > 0
+    THEN LEAST(round(p.loan * (1 + v_rate))::bigint, round(COALESCE(p.loan_principal, p.loan) * 2.5)::bigint)
+    ELSE 0 END;
+  v_days := CASE WHEN p.loan_taken_at IS NOT NULL THEN floor(extract(epoch FROM now() - p.loan_taken_at)/86400)::int ELSE 0 END;
+  RETURN jsonb_build_object(
+    'bank', COALESCE(p.bank,0), 'net_worth', COALESCE(p.bank,0) - COALESCE(p.loan,0),
+    'loan', COALESCE(p.loan,0), 'auto_repay', COALESCE(p.loan,0) > 0, 'in_the_red', COALESCE(p.loan,0) > 0,
+    'loan_cap', public._credit_effective_cap(v_uid), 'ledger', v_led,
+    'loan_principal', COALESCE(p.loan_principal,0), 'loan_rate_bp', COALESCE(p.loan_rate_bp,0),
+    'loan_taken_at', p.loan_taken_at, 'loan_days', v_days, 'loan_owed_tomorrow', v_tomorrow)
+    || v_credit;
+END; $function$;
+GRANT EXECUTE ON FUNCTION public.get_bank(integer) TO authenticated;
+
+COMMIT;

--- a/supabase-credit-loan-gate.sql
+++ b/supabase-credit-loan-gate.sql
@@ -1,0 +1,55 @@
+-- Credit Score Phase 2b — take_loan honors the credit-effective cap + rate + Bad
+-- lockout, and both take/repay recompute the score. PITR point logged before apply.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.take_loan(p_amount bigint)
+  RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_loan bigint; v_cap bigint; v_rate int; v_score int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  IF p_amount IS NULL OR p_amount < 50 THEN RETURN jsonb_build_object('ok',false,'reason','bad_amount'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT COALESCE(loan,0), COALESCE(credit_score,650) INTO v_loan, v_score
+    FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan > 0 THEN RETURN jsonb_build_object('ok',false,'reason','active_loan'); END IF;
+  v_cap := public._credit_effective_cap(v_uid);
+  IF v_cap <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','credit_locked'); END IF;
+  IF p_amount > v_cap THEN RETURN jsonb_build_object('ok',false,'reason','over_cap','cap',v_cap); END IF;
+  v_rate := GREATEST(200, LEAST(2500,
+    public._loan_daily_rate_bp(p_amount, v_cap) + public._credit_rate_adjust(v_score)));
+  UPDATE public.profiles
+    SET loan = p_amount, loan_principal = p_amount, loan_rate_bp = v_rate,
+        loan_taken_at = now(), loan_accrued_at = now()
+    WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, p_amount, 'loan_take');   -- principal to Cash (skim-exempt)
+  PERFORM public._recompute_credit(v_uid, 'take_loan', 0);     -- utilization/restraint moved
+  RETURN jsonb_build_object('ok',true,'borrowed',p_amount,'owed',p_amount,'rate_bp',v_rate,'cap',v_cap);
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public.repay_loan(p_amount bigint DEFAULT NULL::bigint)
+  RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_loan bigint; v_bank bigint; v_pay bigint;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  PERFORM public._accrue_loan(v_uid);
+  SELECT COALESCE(loan,0), COALESCE(bank,0) INTO v_loan, v_bank FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','no_loan'); END IF;
+  v_pay := LEAST(COALESCE(p_amount, v_loan), v_loan, v_bank);
+  IF v_pay <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+  UPDATE public.profiles
+    SET loan = v_loan - v_pay,
+        loan_accrued_at  = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_accrued_at END,
+        loan_principal   = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_principal  END,
+        loan_rate_bp     = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_rate_bp    END,
+        loan_taken_at    = CASE WHEN v_loan - v_pay <= 0 THEN NULL ELSE loan_taken_at   END
+    WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, -v_pay, 'loan_repay');
+  IF v_loan - v_pay <= 0 THEN PERFORM public._award_badge(v_uid, 'paid_in_full'); END IF;
+  PERFORM public._recompute_credit(v_uid, 'repay_loan', 0);    -- utilization/repayment moved
+  RETURN jsonb_build_object('ok',true,'paid',v_pay,'remaining',v_loan - v_pay,'cleared',(v_loan - v_pay) <= 0);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Gives the credit score its teeth (spec Phase 2), and **fixes a live regression**: Phase 1's `get_bank` rewrite had dropped `_accrue_loan` + the loan-detail fields, so on prod loans stopped accruing daily interest and the cap read \$0. This restores the rich payload and layers credit on top.

**DB** (`supabase-credit-loan-effects.sql`, `supabase-credit-loan-gate.sql`, applied to prod, PITR logged):
- `_credit_effective_cap(uid)` = base (Cash-Game-tier) cap × credit tier: Excellent ×1.25 · Good ×1.0 · Fair ×0.5 · Poor floor \$250 · **Bad locked (0)**.
- `_credit_rate_adjust(score)` bp added at borrow: Excellent −300 · Fair +300 · Poor +600.
- `get_bank`: restored `_accrue_loan` + `loan_principal/rate_bp/days/owed_tomorrow/...`; `loan_cap` is now the effective cap; merges `credit_score/tier/delta`.
- `take_loan`: effective-cap gate, **Bad → `credit_locked`**, rate + adjust (clamped 200–2500), recompute after. `repay_loan`: recompute after.

**Frontend (LoanPanel):**
- Client rate estimate now includes the credit adjust (matches the server).
- `credit_locked` message + a Bad-tier locked panel with the recovery path.
- A tier line: “Credit Good (740) — sets your \$1,000 limit …”.

**Verified (SQL sim, rolled back):** Bad→locked · Good→ok(500bp) · Fair→+300bp(1100) · Poor→\$250 cap+2100bp · score moves on borrow (700→740) · all 15 `get_bank` keys restored · `/loans` renders with no console errors.

Note: no bankruptcy hook — `supabase-bankruptcy.sql` defines no live function, so the −150/derog jolt in `_recompute_credit` has no trigger yet (wires up when bankruptcy ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)