### PR TITLE
Credit score Phase 3: leaderboard column + badge tiers

### DIFF
--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -42,7 +42,10 @@ export const BADGES = {
 	hustler: { emoji: '🤝', name: 'Hustler', desc: 'Won 10 challenges' },
 
 	// 💸 Economy
-	paid_in_full: { emoji: '🧾', name: 'Paid in Full', desc: 'Cleared a loan from the Shark' }
+	paid_in_full: { emoji: '🧾', name: 'Paid in Full', desc: 'Cleared a loan from the Shark' },
+	credit_700: { emoji: '💳', name: '700 Club', desc: 'Reached a 700 credit score' },
+	credit_800: { emoji: '🏦', name: '800 Club', desc: 'Reached an 800 credit score' },
+	credit_850: { emoji: '💎', name: 'Perfect 850', desc: 'Hit a perfect 850 credit score' }
 };
 
 /** @param {string} id */

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -16,7 +16,7 @@
 
 	// Sortable columns (client-side). Default: by place, best → worst. Tap # again to
 	// flip and bring LAST place to the top.
-	/** @typedef {'place'|'name'|'net_worth'|'score'|'efficiency'|'play_streak'|'win_streak'} SortKey */
+	/** @typedef {'place'|'name'|'net_worth'|'credit'|'score'|'efficiency'|'play_streak'|'win_streak'} SortKey */
 	let sortKey = $state(/** @type {SortKey} */ ('place'));
 	let sortDir = $state(/** @type {'asc'|'desc'} */ ('asc'));
 	/** @param {SortKey} k */
@@ -129,6 +129,15 @@
 						></th
 					>
 					<th class="num"
+						><button
+							class="sort"
+							class:on={sortKey === 'credit'}
+							onclick={() => setSort('credit')}
+							title="Credit score — reputation from responsible money management (300–850)"
+							>💳 Credit{arrow('credit')}</button
+						></th
+					>
+					<th class="num"
 						><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}
 							>Bounty Earned{arrow('score')}</button
 						></th
@@ -179,6 +188,7 @@
 							{#if r.title}<span class="title">{r.title}</span>{/if}
 						</td>
 						<td class="metric">{fmt(r.net_worth)}</td>
+						<td class="metric">{r.credit ?? 650}</td>
 						<td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
 						<td class="metric eff">{r.efficiency != null ? r.efficiency + '%' : '—'}</td>
 						<td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>

--- a/supabase-credit-leaderboard.sql
+++ b/supabase-credit-leaderboard.sql
@@ -1,0 +1,49 @@
+-- Credit Score Phase 3 — expose credit_score on the daily leaderboard so the Ranks
+-- table gets a sortable Credit column. Only adds the credit field; ranking unchanged.
+-- PITR point logged before apply.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_daily_board(p_scope text DEFAULT 'everyone'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB; v_base int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  v_base := public._daily_reward(public._todays_puzzle_id());
+  WITH circle AS (
+    SELECT v_uid AS id
+    UNION SELECT friend_id FROM public.friendships WHERE user_id = v_uid AND p_scope = 'friends'
+    UNION SELECT user_id FROM public.group_members WHERE group_id = p_group AND p_scope = 'group'
+    UNION SELECT id FROM public.profiles WHERE p_scope IN ('global','everyone')
+  ),
+  d AS (
+    SELECT c.id,
+      (COALESCE(pr.bank, 0) - COALESCE(pr.loan, 0))::bigint AS net_worth,
+      COALESCE(pr.credit_score, 650) AS credit,
+      (CASE WHEN pr.last_daily_play_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_play_streak,0) ELSE 0 END) AS play_streak,
+      (CASE WHEN pr.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_solve_streak,0) ELSE 0 END) AS win_streak,
+      g.score AS score,
+      (CASE WHEN g.won AND v_base > 0 THEN GREATEST(0, LEAST(100, round(COALESCE(g.kept,0)::numeric / v_base * 100)::int)) ELSE NULL END) AS efficiency,
+      pr.equipped_title, pr.equipped_color
+    FROM circle c
+    JOIN public.profiles pr ON pr.id = c.id
+    LEFT JOIN LATERAL (
+      SELECT gr.score, gr.kept, gr.won FROM public.game_results gr
+      WHERE gr.user_id = c.id AND gr.game_mode = 'daily' AND gr.played_at::date = CURRENT_DATE
+      ORDER BY gr.played_at DESC LIMIT 1
+    ) g ON true
+    WHERE c.id IS NOT NULL
+  ),
+  ranked AS (
+    SELECT *, row_number() OVER (ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC) AS rank
+    FROM d ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC LIMIT 100
+  )
+  SELECT jsonb_agg(jsonb_build_object(
+    'rank', rank, 'name', public._display_name(id), 'net_worth', net_worth, 'score', score,
+    'efficiency', efficiency, 'credit', credit,
+    'play_streak', play_streak, 'win_streak', win_streak, 'played', score IS NOT NULL,
+    'is_me', id = v_uid, 'title', equipped_title, 'color', equipped_color) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+COMMIT;

--- a/supabase-credit-score-recompute.sql
+++ b/supabase-credit-score-recompute.sql
@@ -90,6 +90,10 @@ BEGIN
     VALUES (p_uid, v_new, v_target, public._credit_tier(v_new),
       jsonb_build_object('U',round(u,3),'S',round(s,3),'R',round(r,3),
                          'B',round(b,3),'C',round(c,3),'event',p_event));
+  -- Credit-tier badge milestones (700 / 800 / perfect 850).
+  IF v_new >= 700 THEN PERFORM public._award_badge(p_uid, 'credit_700'); END IF;
+  IF v_new >= 800 THEN PERFORM public._award_badge(p_uid, 'credit_800'); END IF;
+  IF v_new >= 850 THEN PERFORM public._award_badge(p_uid, 'credit_850'); END IF;
   RETURN v_new;
 END; $fn$;
 


### PR DESCRIPTION
Makes the credit score a visible status stat (spec Phase 3).

**Leaderboard** — `get_daily_board` now returns `credit` per row, and the Ranks table gets a sortable **💳 Credit** column (next to Cash). Tap to rank the world by credit score.

**Badges** — `_recompute_credit` awards `credit_700` / `credit_800` / `credit_850` when the score crosses those thresholds; catalog entries added (💳 700 Club · 🏦 800 Club · 💎 Perfect 850).

**Verified (SQL sim, rolled back):** daily-board rows carry `credit`; a disciplined user crossing 700 earns `credit_700`. Gates green; `/loans` + leaderboard render with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)