### PR TITLE
Credit score Phase 4: tier card skins

### DIFF
--- a/src/lib/components/AccountCard.svelte
+++ b/src/lib/components/AccountCard.svelte
@@ -5,15 +5,26 @@
 	/** @type {any} */ export let account = '';
 	/** @type {any} */ export let member = null;
 	/** @type {any} */ export let balance = 0;
+	/** Credit tier — skins the card (Excellent = black card; Poor/Bad = distressed). */
+	/** @type {string} */ export let tier = 'Good';
 
+	$: tierClass =
+		tier === 'Excellent'
+			? 'ac-excellent'
+			: tier === 'Poor'
+				? 'ac-poor'
+				: tier === 'Bad'
+					? 'ac-bad'
+					: '';
 	$: last4 = (account ?? '').toString().slice(-4) || '••••';
 	$: holderName = (holder ? String(holder) : 'Wordbanker').toUpperCase();
 	$: memberLabel = member != null ? '#' + String(member).padStart(4, '0') : '—';
 	$: amount = Math.round(Number(balance) || 0).toLocaleString();
 </script>
 
-<div class="acct-card">
+<div class="acct-card {tierClass}">
 	<div class="ac-sheen"></div>
+	{#if tier === 'Excellent'}<span class="ac-tier-mark" aria-hidden="true">◆ ELITE</span>{/if}
 	<div class="ac-inner">
 		<div class="ac-top">
 			<span class="ac-brand">
@@ -62,6 +73,37 @@
 		box-shadow:
 			0 18px 44px rgba(0, 0, 0, 0.55),
 			inset 0 1px 0 rgba(255, 255, 255, 0.08);
+	}
+	/* 💳 Excellent — matte "black card" with a brighter gold edge. */
+	.acct-card.ac-excellent {
+		background: linear-gradient(135deg, #08080b 0%, #1a1a20 45%, #0c0c10 100%);
+		border-color: rgba(251, 191, 36, 0.6);
+		box-shadow:
+			0 18px 44px rgba(0, 0, 0, 0.7),
+			inset 0 1px 0 rgba(255, 255, 255, 0.12),
+			0 0 0 1px rgba(251, 191, 36, 0.18);
+	}
+	/* Poor / Bad — distressed, red-tinted. */
+	.acct-card.ac-poor {
+		background: linear-gradient(135deg, #241c1c 0%, #2a2226 45%, #1c1616 100%);
+		border-color: rgba(248, 113, 113, 0.42);
+	}
+	.acct-card.ac-bad {
+		background: linear-gradient(135deg, #251818 0%, #2a1b1b 45%, #190f0f 100%);
+		border-color: rgba(248, 113, 113, 0.62);
+		filter: saturate(0.92);
+	}
+	.ac-tier-mark {
+		position: absolute;
+		top: 14px;
+		left: 50%;
+		transform: translateX(-50%);
+		font-family: var(--font-display, sans-serif);
+		font-size: 0.52rem;
+		font-weight: 800;
+		letter-spacing: 0.32em;
+		color: rgba(251, 191, 36, 0.75);
+		z-index: 2;
 	}
 	.ac-sheen {
 		position: absolute;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -209,12 +209,14 @@
 	/** Spendable Bank balance (never negative) — what the top chip shows. */
 	let menuBank = /** @type {number|null} */ (null);
 	let menuLoan = 0; // outstanding loan → drives the menu debt banner + chip badge
+	let menuCreditTier = /** @type {string} */ ('Good'); // skins the menu account card
 	async function refreshBank() {
 		try {
 			const gb = await getBank();
 			netWorth = gb.net_worth;
 			menuBank = gb.bank ?? 0;
 			menuLoan = gb.loan ?? 0;
+			menuCreditTier = gb.credit_tier ?? 'Good';
 		} catch {
 			/* non-fatal */
 		}
@@ -656,7 +658,7 @@
 
 	// 💰 Bank Account hub: a modal (not a route) so closing it returns to where you were.
 	let showBank = false;
-	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[] }|null} */
+	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[], credit_tier?:string }|null} */
 	let bankData = null;
 	async function openBankModal() {
 		fx('tap');
@@ -2546,6 +2548,7 @@
 					account={$userProfile?.account_number ?? ''}
 					member={$userProfile?.member_no ?? null}
 					balance={bankData?.bank ?? menuBank ?? netWorth ?? 0}
+					tier={bankData?.credit_tier ?? menuCreditTier ?? 'Good'}
 				/>
 			</div>
 			<!-- 🦈 Borrow / Repay, inline -->
@@ -3138,6 +3141,7 @@
 						account={$userProfile?.account_number ?? ''}
 						member={$userProfile?.member_no ?? null}
 						balance={menuBank ?? $userProfile?.bank ?? 0}
+						tier={menuCreditTier ?? 'Good'}
 					/>
 					{#if menuLoan > 0}
 						<span class="mcw-debt" title="You owe the Loan Shark"

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -105,6 +105,7 @@
 				account={prof?.account_number ?? ''}
 				member={prof?.member_no ?? null}
 				balance={b.bank}
+				tier={b.credit_tier ?? 'Good'}
 			/>
 		</div>
 


### PR DESCRIPTION
The visual reward tier (spec Phase 4). `AccountCard` now takes a credit tier and skins itself:

- **Excellent** → matte **black card** with a brighter gold edge + a "◆ ELITE" mark.
- **Poor / Bad** → distressed, red-tinted.
- **Good / Fair** → the default purple-gold.

Tier is passed at all three render sites — My Account (`/bank`), the home-menu card, and the in-game bank modal — from `get_bank.credit_tier`.

Verified by rendering all five tiers side-by-side in a preview build (screenshot). Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)