### PR TITLE
Credit score hotfix: NULL-loan deflation + grace band

### DIFF
--- a/docs/superpowers/specs/2026-07-08-credit-score-design.md
+++ b/docs/superpowers/specs/2026-07-08-credit-score-design.md
@@ -110,10 +110,12 @@ All computation lives in a single `SECURITY DEFINER` function
 | Tier          | Range   | Loan cap             | Interest rate           | Notes                               |
 | ------------- | ------- | -------------------- | ----------------------- | ----------------------------------- |
 | **Excellent** | 780–850 | `_loan_cap × 1.25`   | base − 300bp (softened) | unlocks black card skin (Phase 4)   |
-| **Good**      | 670–779 | `_loan_cap × 1.0`    | base                    | the neutral baseline                |
-| **Fair**      | 580–669 | `_loan_cap × 0.5`    | base + 300bp            | reduced access                      |
-| **Poor**      | 400–579 | floor $250 only      | max rate (1500bp)       | "the shark barely trusts you"       |
+| **Good**      | 650–779 | `_loan_cap × 1.0`    | base                    | neutral start 650 lands here        |
+| **Fair**      | 560–649 | `_loan_cap × 0.5`    | base + 300bp            | reduced access                      |
+| **Poor**      | 400–559 | floor $250 only      | max rate (1500bp)       | "the shark barely trusts you"       |
 | **Bad**       | 300–399 | **borrowing LOCKED** | —                       | `take_loan` returns `credit_locked` |
+
+_(Good's floor is 650 — the neutral start — so a grace newcomer is Good, not Fair.)_
 
 Integration:
 

--- a/supabase-credit-score-recompute.sql
+++ b/supabase-credit-score-recompute.sql
@@ -21,8 +21,11 @@ DECLARE
   v_had_loan BOOLEAN;
 BEGIN
   PERFORM public._ensure_bank(p_uid);
-  SELECT p.bank, p.loan, p.credit_score, p.credit_updated_at, p.credit_derog_until,
-         COALESCE(p.current_daily_play_streak, 0)
+  -- COALESCE loan/bank to 0: a player who never borrowed has loan = NULL, and NULL
+  -- would (a) make `v_loan > 0` NULL so grace is skipped and (b) make LEAST(NULL/cap,1)
+  -- collapse to 1 → utilization 0, wrongly deflating a debt-free newcomer.
+  SELECT COALESCE(p.bank, 0), COALESCE(p.loan, 0), p.credit_score, p.credit_updated_at,
+         p.credit_derog_until, COALESCE(p.current_daily_play_streak, 0)
     INTO v_bank, v_loan, v_prev, v_updated, v_derog, v_streak
     FROM public.profiles p WHERE p.id = p_uid;
   SELECT u.created_at INTO v_created FROM auth.users u WHERE u.id = p_uid;

--- a/supabase-credit-score-reset.sql
+++ b/supabase-credit-score-reset.sql
@@ -1,0 +1,10 @@
+-- One-time reset: the initial credit launch had a NULL-loan bug that deflated scores
+-- (LEAST(NULL/cap,1)=1 → utilization 0) and skipped new-player grace. Now fixed. The
+-- feature is <1 day old, so wipe the buggy stored scores back to the neutral 650 baseline
+-- and let the corrected lazy recompute rebuild them. PITR point logged before apply.
+BEGIN;
+UPDATE public.profiles
+   SET credit_score = 650, credit_updated_at = NULL, credit_derog_until = NULL;
+-- Clear any credit badges auto-awarded off buggy scores; they re-award correctly on recompute.
+DELETE FROM public.user_badges WHERE badge IN ('credit_700','credit_800','credit_850');
+COMMIT;

--- a/supabase-credit-score-schema.sql
+++ b/supabase-credit-score-schema.sql
@@ -23,8 +23,8 @@ CREATE OR REPLACE FUNCTION public._credit_tier(p_score INT)
   RETURNS TEXT LANGUAGE sql IMMUTABLE AS $fn$
   SELECT CASE
     WHEN p_score >= 780 THEN 'Excellent'
-    WHEN p_score >= 670 THEN 'Good'
-    WHEN p_score >= 580 THEN 'Fair'
+    WHEN p_score >= 650 THEN 'Good'      -- neutral start (650) lands in Good, not Fair
+    WHEN p_score >= 560 THEN 'Fair'
     WHEN p_score >= 400 THEN 'Poor'
     ELSE 'Bad'
   END;


### PR DESCRIPTION
Running the full `qa-e2e.mjs` sweep (a real authenticated signup) after shipping Phases 1–4 caught two bugs that DB sims + unauthenticated previews had missed.

**1. NULL-loan deflated everyone debt-free.** Players who never borrowed have `loan = NULL` (not 0). `LEAST(NULL/cap, 1)` collapses to `1`, so utilization came out `0` — dragging every no-debt user toward Fair. `NULL > 0` also made the grace check NULL, so new-player grace was skipped. Fixed with `COALESCE(loan/bank, 0)`.

**2. Neutral start (650) was Fair, not Good.** Good was `670+`, so a grace newcomer pinned to 650 rendered as Fair/\$500 instead of Good/\$1,000. Lowered Good floor to **650** (Fair 560–649, Poor 400–559).

**Cleanup:** one-time reset of all 99 profiles to the 650 baseline (`supabase-credit-score-reset.sql`) so they recompute fresh under the corrected logic; cleared credit badges (re-award on recompute).

**Verified:** fresh signup `get_bank` → **650 / Good / \$1,000**; debt-free `utilization = 1.000`; `_credit_tier(650)=Good`, `(649)=Fair`. Full E2E sweep: 0 console errors, all pages load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)