### PR TITLE
CreditGauge: white score number

### DIFF
--- a/src/lib/components/CreditGauge.svelte
+++ b/src/lib/components/CreditGauge.svelte
@@ -128,6 +128,7 @@
 		font-family: var(--font-display, sans-serif);
 		font-size: 2rem;
 		font-weight: 800;
+		color: #fff;
 	}
 	.cg-tier {
 		font-size: 0.8rem;


### PR DESCRIPTION
The credit score number rendered dark (inherited text color) and was hard to read on the dark gauge. Set it to white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)