### PR TITLE
LoanPanel: "Apply for a Loan" CTA

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -184,9 +184,7 @@
 {:else if loanCap > 0}
 	<!-- No debt: borrow panel -->
 	<details class="loan-card" open={expanded}>
-		<summary class="loan-summary"
-			>🦈 Need Cash? Borrow up to {fmt(loanCap)} <span class="loan-cv">▾</span></summary
-		>
+		<summary class="loan-summary">🦈 Apply for a Loan <span class="loan-cv">▾</span></summary>
 		<p class="loan-note">
 			Interest compounds daily — the more you take, the higher the rate. One loan at a time; while
 			you owe, the Store locks and half of every payout auto-pays it down.


### PR DESCRIPTION
Renames the borrow summary from "🦈 Need Cash? Borrow up to \$X" to "🦈 Apply for a Loan" — cleaner, bank-app phrasing. The cap is still shown in the credit-tier line inside the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)