### PR TITLE
Credit: card tier names + collapsible gauge detail

### DIFF
--- a/src/lib/components/AccountCard.svelte
+++ b/src/lib/components/AccountCard.svelte
@@ -5,9 +5,11 @@
 	/** @type {any} */ export let account = '';
 	/** @type {any} */ export let member = null;
 	/** @type {any} */ export let balance = 0;
+	import { cardName } from '$lib/creditTiers.js';
 	/** Credit tier — skins the card (Excellent = black card; Poor/Bad = distressed). */
 	/** @type {string} */ export let tier = 'Good';
 
+	$: cardTitle = cardName(tier);
 	$: tierClass =
 		tier === 'Excellent'
 			? 'ac-excellent'
@@ -24,12 +26,12 @@
 
 <div class="acct-card {tierClass}">
 	<div class="ac-sheen"></div>
-	{#if tier === 'Excellent'}<span class="ac-tier-mark" aria-hidden="true">◆ ELITE</span>{/if}
 	<div class="ac-inner">
 		<div class="ac-top">
 			<span class="ac-brand">
 				<img class="ac-coin" src="/logo-coin.png" alt="" width="22" height="22" />
 				<span><span class="ac-gold">WORD</span>BANK</span>
+				<span class="ac-cardname">{cardTitle}</span>
 			</span>
 			<span class="ac-chip" aria-hidden="true"></span>
 		</div>
@@ -93,17 +95,17 @@
 		border-color: rgba(248, 113, 113, 0.62);
 		filter: saturate(0.92);
 	}
-	.ac-tier-mark {
-		position: absolute;
-		top: 14px;
-		left: 50%;
-		transform: translateX(-50%);
+	.ac-cardname {
 		font-family: var(--font-display, sans-serif);
-		font-size: 0.52rem;
+		font-size: 0.56rem;
 		font-weight: 800;
-		letter-spacing: 0.32em;
-		color: rgba(251, 191, 36, 0.75);
-		z-index: 2;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: rgba(251, 191, 36, 0.85);
+		padding-left: 7px;
+		margin-left: 1px;
+		border-left: 1px solid rgba(251, 191, 36, 0.35);
+		align-self: center;
 	}
 	.ac-sheen {
 		position: absolute;

--- a/src/lib/components/CreditGauge.svelte
+++ b/src/lib/components/CreditGauge.svelte
@@ -1,11 +1,14 @@
 <script>
 	// 💳 Credit score gauge — 300–850 arc dial + tier + delta, tap for breakdown.
+	import { cardName, tierEffect } from '$lib/creditTiers.js';
 	export let score = 650;
 	export let tier = 'Good';
 	export let delta = 0;
 	/** @type {any} */ export let detail = null;
 
 	let open = false;
+	$: card = cardName(tier);
+	$: effect = tierEffect(tier);
 	const MIN = 300,
 		MAX = 850;
 	const R = 80,
@@ -65,6 +68,16 @@
 			{/if}
 		</div>
 	</button>
+	<button class="cg-toggle" on:click={() => (open = !open)} aria-expanded={open}>
+		{open ? 'Hide details ▴' : 'Tap for details ▾'}
+	</button>
+	{#if open}
+		<!-- 💳 Which card you have + how the tier affects your loans -->
+		<div class="cg-cardinfo" style="border-color:{tierColor}33">
+			<div class="cg-cardname">WordBank <b style="color:{tierColor}">{card}</b></div>
+			<div class="cg-cardeff">{effect}</div>
+		</div>
+	{/if}
 	{#if open && comps.length}
 		<div class="cg-breakdown">
 			{#each comps as c}
@@ -145,6 +158,40 @@
 	}
 	.cg-delta.neg {
 		color: #fb7185;
+	}
+	.cg-toggle {
+		display: block;
+		margin: 8px auto 0;
+		background: none;
+		border: none;
+		cursor: pointer;
+		font-family: var(--font-ui, sans-serif);
+		font-size: 0.74rem;
+		font-weight: 700;
+		letter-spacing: 0.04em;
+		color: var(--text-muted);
+	}
+	.cg-toggle:hover {
+		color: var(--text);
+	}
+	.cg-cardinfo {
+		margin-top: 10px;
+		padding: 10px 12px;
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		text-align: center;
+		background: rgba(255, 255, 255, 0.02);
+	}
+	.cg-cardname {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 800;
+		font-size: 0.95rem;
+		letter-spacing: 0.02em;
+	}
+	.cg-cardeff {
+		margin-top: 2px;
+		font-size: 0.76rem;
+		color: var(--text-muted);
 	}
 	.cg-breakdown {
 		display: flex;

--- a/src/lib/creditTiers.js
+++ b/src/lib/creditTiers.js
@@ -1,0 +1,35 @@
+// Credit-tier → WordBank card name + a plain-English "how it affects loans" line.
+// The card ladder (worst → best): Secured · Freedom · Plus · Preferred · Reserve.
+// Keep in sync with the server's _credit_effective_cap / _credit_rate_adjust.
+
+/** @type {Record<string, string>} */
+const CARD_NAME = {
+	Excellent: 'Reserve',
+	Good: 'Preferred',
+	Fair: 'Plus',
+	Poor: 'Freedom',
+	Bad: 'Secured'
+};
+
+/** @param {string} tier @returns {string} */
+export function cardName(tier) {
+	return CARD_NAME[tier] || 'Preferred';
+}
+
+/** How this tier changes your loan cap + interest rate. @param {string} tier @returns {string} */
+export function tierEffect(tier) {
+	switch (tier) {
+		case 'Excellent':
+			return '1.25× loan limit · −3%/day interest';
+		case 'Good':
+			return 'Standard loan limit & interest';
+		case 'Fair':
+			return '0.5× loan limit · +3%/day interest';
+		case 'Poor':
+			return '$250 loan limit · +6%/day interest';
+		case 'Bad':
+			return 'Borrowing locked';
+		default:
+			return 'Standard loan limit & interest';
+	}
+}


### PR DESCRIPTION
Four small credit-UX asks:

- **Card tier names** — a ladder by credit tier: **Secured → Freedom → Plus → Preferred → Reserve** (`src/lib/creditTiers.js`). Shown **next to WORDBANK** on the debit card (e.g. "WORDBANK | PREFERRED"), replacing the Excellent-only ELITE mark so every tier names its card.
- **Detail only on click** — the factor breakdown is collapsed by default behind a "Tap for details ▾" toggle.
- **How it affects loans** — the expanded view leads with your card + the tier’s effect ("WordBank Preferred — Standard loan limit & interest"; Excellent "1.25× limit · −3%/day", Poor "$250 limit · +6%/day", Bad "Borrowing locked").

Verified authenticated: card shows "Preferred", breakdown hidden until tapped, expanded shows card + effect + 5 bars. Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)