### PR TITLE
Statement: consistent ledger line-item names

### DIFF
--- a/src/lib/bankReasons.js
+++ b/src/lib/bankReasons.js
@@ -1,0 +1,61 @@
+// Single source of truth for statement / ledger line-item names. Used by the /bank
+// Statement and the in-game bank modal so they never drift apart.
+//
+// Naming convention (Title Case throughout):
+//   • buy-ins / stakes  → "<Mode> Entry"
+//   • winnings          → "<Mode> Payout"  (or Bounty for per-solve credit)
+//   • given, not won    → "<X> Reward"
+//   • store spend       → "<X> Purchase"
+//   • loans             → "Loan <X>"
+
+/** @type {Record<string, string>} */
+const LABELS = {
+	// 🗓️ Daily
+	daily_win: 'Daily Reward',
+	daily_reward: 'Daily Reward',
+	attendance: 'Attendance Reward',
+	makeup_reward: 'Make-Up Reward',
+	quest_reward: 'Quest Reward',
+
+	// 🎰 Cash Game
+	cashgame_buyin: 'Cash Game Entry',
+	cashgame_cashout: 'Cash Game Payout',
+	climb_bounty: 'Cash Game Bounty',
+	climb_letter: 'Cash Game Letter',
+
+	// ⚡ Blitz
+	blitz_buyin: 'Blitz Entry',
+	blitz_payout: 'Blitz Payout',
+
+	// ⚔️ Challenges (wager_* are the challenge staking system)
+	challenge_payout: 'Challenge Payout',
+	wager_stake: 'Challenge Entry',
+	wager_win: 'Challenge Payout',
+	wager_refund: 'Challenge Refund',
+
+	// 🛍️ Store
+	cosmetic_buy: 'Store Purchase',
+	powerup_buy: 'Power-Up Purchase',
+
+	// 🦈 Loans
+	loan_take: 'Loan Received',
+	loan_repay: 'Loan Repayment',
+	loan_skim: 'Loan Auto-Payment',
+
+	// 💱 Credits / legacy
+	buy_credits: 'Credits Purchase',
+	arcade_cashout: 'Arcade Payout',
+	freeplay_reward: 'Free Play Reward',
+	freeplay_cashout: 'Credits Exchange'
+};
+
+/** Friendly, uniform label for a bank_ledger reason. Unknown reasons Title-Case the raw key.
+ * @param {string} reason @returns {string} */
+export function reasonLabel(reason) {
+	return (
+		LABELS[reason] ||
+		String(reason || '')
+			.replace(/_/g, ' ')
+			.replace(/\b\w/g, (c) => c.toUpperCase())
+	);
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,6 +79,7 @@
 		markChallengeNotifRead
 	} from '$lib/stores/notificationStore.js';
 	import { track } from '$lib/analytics.js';
+	import { reasonLabel } from '$lib/bankReasons.js';
 	import { modifierInfo } from '$lib/powerups.js';
 	import {
 		saveGameToLocalStorage,
@@ -680,28 +681,7 @@
 	}
 	const fmtCash = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
 	/** @param {string} reason */
-	const bankReason = (reason) =>
-		/** @type {Record<string,string>} */ ({
-			daily_win: 'Daily reward',
-			daily_reward: 'Daily reward',
-			attendance: 'Daily attendance reward',
-			makeup_reward: 'Make-up Daily',
-			cashgame_buyin: 'Cash Game invest',
-			cashgame_cashout: 'Cash Game deposit',
-			climb_bounty: 'Cash Game credit',
-			climb_letter: 'Cash Game letter',
-			blitz_buyin: 'Blitz entry',
-			blitz_payout: 'Blitz payout',
-			challenge_payout: 'Challenge payout',
-			cosmetic_buy: 'Store purchase',
-			powerup_buy: 'Power-up purchase',
-			loan_take: 'Loan received',
-			loan_repay: 'Loan repayment',
-			loan_skim: 'Loan auto-payment',
-			wager_win: 'Won a wager',
-			wager_stake: 'Wager staked',
-			wager_refund: 'Wager refunded'
-		})[reason] || reason;
+	const bankReason = reasonLabel;
 
 	// 🔐 My Vault — owned inventory; use power-ups in-game (mode-eligible only).
 	let showBag = false;

--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -5,6 +5,7 @@
 	import AccountCard from '$lib/components/AccountCard.svelte';
 	import CreditGauge from '$lib/components/CreditGauge.svelte';
 	import LoanPanel from '$lib/components/LoanPanel.svelte';
+	import { reasonLabel } from '$lib/bankReasons.js';
 	import { track } from '$lib/analytics.js';
 
 	/** @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean, ledger:any[], credit_score:number, credit_tier:string, credit_delta:number }|null} */
@@ -55,38 +56,6 @@
 			if (sortBy === 'smallest') return Math.abs(x.delta) - Math.abs(y.delta);
 			return new Date(y.at).getTime() - new Date(x.at).getTime();
 		});
-
-	/** @param {string} reason */
-	function reasonLabel(reason) {
-		return (
-			{
-				daily_win: 'Daily reward',
-				daily_reward: 'Daily reward',
-				attendance: 'Attendance reward',
-				makeup_reward: 'Make-up Daily',
-				cashgame_buyin: 'Cash Game invest',
-				cashgame_cashout: 'Cash Game deposit',
-				climb_bounty: 'Cash Game credit',
-				climb_letter: 'Cash Game letter',
-				blitz_buyin: 'Blitz entry',
-				blitz_payout: 'Blitz payout',
-				challenge_payout: 'Challenge payout',
-				wager_win: 'Won a wager',
-				wager_stake: 'Wager staked',
-				wager_refund: 'Wager refunded',
-				cosmetic_buy: 'Store purchase',
-				powerup_buy: 'Power-up purchase',
-				loan_take: 'Loan received',
-				loan_repay: 'Loan repayment',
-				loan_skim: 'Loan auto-payment',
-				quest_reward: 'Quest reward',
-				buy_credits: 'Bought credits',
-				arcade_cashout: 'Arcade cash-out',
-				freeplay_reward: 'Free Play reward',
-				freeplay_cashout: 'Exchanged credits'
-			}[reason] || reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
-		);
-	}
 </script>
 
 <svelte:head><title>WordBank — My Account</title></svelte:head>


### PR DESCRIPTION
The `/bank` Statement and the in-game bank modal had two separate reason→label maps that had already drifted (attendance and wager labels differed; the modal was missing several reasons and had a worse fallback).

Consolidated into one source of truth (`src/lib/bankReasons.js`), used by the Statement, its type-filter dropdown, and the in-game modal.

Uniform Title-Case naming:
- **Entry** for buy-ins/stakes — **Cash Game Entry** (was "Cash Game invest"), **Blitz Entry**, **Challenge Entry**.
- **Payout** for winnings — Cash Game / Blitz / Challenge Payout.
- **Reward** for gifts (Daily / Attendance / Quest), **Purchase** for store (Store / Power-Up), **Loan …** for the loan family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)