### PR TITLE
Loans: remove shark imagery + trim wordiness

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -77,7 +77,7 @@
 	async function borrow() {
 		if (loanBusy || borrowAmt < MIN_BORROW) return;
 		try {
-			await requirePin(`Borrow $${borrowAmt.toLocaleString()} from the Shark`, [
+			await requirePin(`Borrow $${borrowAmt.toLocaleString()}`, [
 				{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
 				{ label: 'Interest', value: ratePct + '%/day, compounding' },
 				{ label: '~Owe in a week', value: '$' + proj7.toLocaleString() }
@@ -140,7 +140,7 @@
 	<!-- In debt: repay panel + the teeth -->
 	<div class="loan-card debt">
 		<div class="loan-head">
-			<span class="loan-title">🦈 You owe the Shark</span>
+			<span class="loan-title">You owe</span>
 			<span class="loan-owed">{fmt(owed)}</span>
 		</div>
 		<div class="loan-facts">
@@ -149,8 +149,8 @@
 			<span>→ {fmt(owedTomorrow)} tomorrow</span>
 		</div>
 		<p class="loan-note">
-			Interest compounds daily. The Store is locked and half of every payout auto-pays your debt
-			until it's clear. Your net worth is <b class="neg">{fmt(bank.net_worth)}</b>.
+			The Store is locked and half of every payout auto-repays this. Net worth
+			<b class="neg">{fmt(bank.net_worth)}</b>.
 		</p>
 		{#if maxRepay > 0}
 			<div class="loan-dial">
@@ -213,8 +213,7 @@
 	<details class="loan-card" open={expanded}>
 		<summary class="loan-summary">Apply for a Loan <span class="loan-cv">▾</span></summary>
 		<p class="loan-note">
-			Interest compounds daily — the more you take, the higher the rate. One loan at a time; while
-			you owe, the Store locks and half of every payout auto-pays it down.
+			One loan at a time. While you owe, the Store locks and half of every payout auto-repays it.
 		</p>
 		<p class="loan-tier">
 			Credit <b>{creditTier}</b> ({creditScore}) — sets your ${loanCap.toLocaleString()} limit{#if creditAdjBp(creditTier) !== 0}
@@ -250,18 +249,18 @@
 		<button
 			class="loan-btn borrow"
 			disabled={!!loanBusy || borrowAmt < MIN_BORROW}
-			on:click={borrow}>🦈 Borrow {fmt(borrowAmt)}</button
+			on:click={borrow}>Borrow {fmt(borrowAmt)}</button
 		>
 		{#if loanMsg}<p class="msg">{loanMsg}</p>{/if}
 	</details>
 {:else}
 	<!-- Bad tier: borrowing locked -->
 	<div class="loan-card locked">
-		<div class="loan-locked-h">🦈 Borrowing locked</div>
+		<div class="loan-locked-h">Borrowing locked</div>
 		<p class="loan-note" style="margin:0">
-			Your credit is <b class="neg">{creditTier}</b> ({creditScore}). The Shark won't lend to you
-			right now — repay on time, stay out of the red, and keep utilization low to climb back to
-			<b>Poor</b> (400+) and unlock loans again.
+			Your credit is <b class="neg">{creditTier}</b> ({creditScore}). You can't borrow right now —
+			repay on time, stay out of the red, and keep utilization low to climb back to <b>Poor</b>
+			(400+) and unlock loans.
 		</p>
 	</div>
 {/if}

--- a/src/routes/loans/+page.svelte
+++ b/src/routes/loans/+page.svelte
@@ -29,16 +29,13 @@
 <main class="loans-page">
 	<PageNav back="/" />
 
-	<!-- 🦈 Shark hero — placeholder art now; animation pass lands here later -->
-	<div class="shark-hero" class:owe={inDebt}>
-		<div class="shark-art" aria-hidden="true">🦈</div>
-		<h1 class="shark-title">Loan Shark</h1>
-		<p class="shark-sub">
+	<div class="loan-hero">
+		<h1 class="loan-title">Loans</h1>
+		<p class="loan-sub">
 			{#if inDebt}
-				The Shark's circling. Interest compounds every day it's out — pay it down before it bites.
+				Interest grows every day it's out — pay it down soon.
 			{:else}
-				Need Cash fast? Borrow on the spot. Interest compounds daily and the more you take, the
-				steeper the rate — so borrow smart and pay it back quick.
+				Borrow Cash instantly. Daily interest scales with how much you take.
 			{/if}
 		</p>
 	</div>
@@ -48,19 +45,15 @@
 	{:else if b}
 		<LoanPanel bank={b} expanded on:changed={load} />
 
-		<!-- How the Shark charges -->
 		<div class="rate-card">
-			<div class="rc-head">Daily interest — the more you borrow, the higher the rate</div>
+			<div class="rc-head">Daily interest by amount</div>
 			<div class="rc-rows">
 				<div class="rc-row"><span>Up to 25% of your limit</span><b>5% / day</b></div>
 				<div class="rc-row"><span>Up to 50%</span><b>8% / day</b></div>
 				<div class="rc-row"><span>Up to 75%</span><b class="hot">12% / day</b></div>
 				<div class="rc-row"><span>Above 75%</span><b class="hot">15% / day</b></div>
 			</div>
-			<p class="rc-note">
-				Compounds daily · never grows past <b>2.5×</b> what you borrowed · half of every payout auto-pays
-				it down.
-			</p>
+			<p class="rc-note">Caps at <b>2.5×</b> what you borrow · half of each payout auto-repays.</p>
 		</div>
 	{/if}
 </main>
@@ -71,43 +64,20 @@
 		margin: 0 auto;
 		padding: 12px 16px 40px;
 	}
-	.shark-hero {
+	.loan-hero {
 		text-align: center;
-		padding: 8px 6px 18px;
+		padding: 6px 6px 16px;
 	}
-	.shark-art {
-		font-size: 4.6rem;
-		line-height: 1;
-		filter: drop-shadow(0 8px 22px rgba(56, 189, 248, 0.4));
-		animation: sharkBob 3.4s ease-in-out infinite;
-	}
-	.shark-hero.owe .shark-art {
-		filter: drop-shadow(0 8px 22px rgba(248, 113, 113, 0.5));
-	}
-	@keyframes sharkBob {
-		0%,
-		100% {
-			transform: translateY(0) rotate(-2deg);
-		}
-		50% {
-			transform: translateY(-8px) rotate(2deg);
-		}
-	}
-	@media (prefers-reduced-motion: reduce) {
-		.shark-art {
-			animation: none;
-		}
-	}
-	.shark-title {
+	.loan-title {
 		font-family: var(--font-display);
 		font-weight: 800;
 		font-size: 1.7rem;
-		margin: 8px 0 4px;
+		margin: 0 0 4px;
 		color: var(--text, #f4f6fb);
 	}
-	.shark-sub {
+	.loan-sub {
 		font-size: 0.9rem;
-		line-height: 1.5;
+		line-height: 1.45;
 		color: var(--text-muted, #aeb8c6);
 		max-width: 340px;
 		margin: 0 auto;


### PR DESCRIPTION
Per feedback — the /loans page was much too wordy and I removed the shark theming.

**No more sharks:** dropped the 🦈 hero art, renamed **"Loan Shark" → "Loans"**, and stripped every 🦈 / "Shark" reference from LoanPanel (Borrow button, the debt title → "You owe", the locked header + copy, and the PIN prompt).

**Much less wordy:** the page said "interest compounds daily / the more you take the higher the rate" **three times**. Now:
- Hero subtitle → one short line.
- Panel note → just the non-obvious mechanics ("One loan at a time. While you owe, the Store locks and half of every payout auto-repays it.").
- Rate-card head → "Daily interest by amount"; footer trimmed to "Caps at 2.5× what you borrow · half of each payout auto-repays."
- Debt-state note tightened.

Verified authenticated: no 🦈, no "Shark", title "Loans". Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)