### PR TITLE
Loans: loan amount uses the clean bankroll font

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -505,11 +505,12 @@
 		gap: 1px;
 	}
 	.loan-usd {
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		color: var(--brand-2);
-		font-size: 1.6rem;
+		font-size: 1.7rem;
 		line-height: 1;
+		font-variant-numeric: tabular-nums;
 	}
 	.loan-sub {
 		font-size: 0.68rem;


### PR DESCRIPTION
Switches the borrow/repay amount from the LCD-style **Orbitron** to the same clean display font as the account-card balance (`--font-display` / Space Grotesk), with tabular figures. No more slashed-zero digital look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)