### PR TITLE
Loans: upfront origination (day-1 interest + 10% floor)

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -40,11 +40,10 @@
 		200,
 		Math.min(2500, rateBpFor(borrowAmt, loanCap) + creditAdjBp(creditTier))
 	);
-	$: ratePct = rateBp / 100; // 2 / 4 / 6 / 8 (%/day)
-	$: proj7 = Math.min(
-		Math.round(borrowAmt * Math.pow(1 + rateBp / 10000, 7)),
-		Math.round(borrowAmt * 2.5)
-	);
+	$: ratePct = rateBp / 100; // %/day
+	// Upfront charge at borrow (mirrors take_loan): GREATEST(one day's interest, 10% floor).
+	$: upfront = Math.max(Math.round((borrowAmt * rateBp) / 10000), Math.round(borrowAmt * 0.1));
+	$: owedNow = borrowAmt + upfront;
 	$: activeRatePct = (bank?.loan_rate_bp ?? 0) / 100;
 	$: owedTomorrow = bank?.loan_owed_tomorrow ?? owed;
 	$: loanDays = bank?.loan_days ?? 0;
@@ -79,8 +78,8 @@
 		try {
 			await requirePin(`Borrow $${borrowAmt.toLocaleString()}`, [
 				{ label: 'You receive', value: '$' + borrowAmt.toLocaleString() },
-				{ label: 'Interest', value: ratePct + '%/day, compounding' },
-				{ label: '~Owe in a week', value: '$' + proj7.toLocaleString() }
+				{ label: 'You owe', value: '$' + owedNow.toLocaleString() },
+				{ label: 'Then', value: ratePct + '%/day, compounding' }
 			]);
 		} catch {
 			return;
@@ -225,7 +224,7 @@
 			>
 			<div class="loan-amt">
 				<span class="loan-usd">{fmt(borrowAmt)}</span><span class="loan-sub"
-					>{ratePct}%/day · ~{fmt(proj7)} in a week</span
+					>owe {fmt(owedNow)} · {ratePct}%/day</span
 				>
 			</div>
 			<button
@@ -280,7 +279,8 @@
 					{fmt(applyResult?.borrowed ?? borrowAmt)} deposited to your account.
 				</div>
 				<div class="la-terms">
-					{(applyResult?.rate_bp ?? rateBp) / 100}%/day · repay anytime
+					You owe {fmt(applyResult?.owed ?? owedNow)} · {(applyResult?.rate_bp ?? rateBp) /
+						100}%/day
 				</div>
 				<button class="loan-btn borrow la-btn" on:click={closeApply}>Done</button>
 			{:else}

--- a/supabase-loan-origination.sql
+++ b/supabase-loan-origination.sql
@@ -1,0 +1,37 @@
+-- Loans: charge an upfront origination the moment you borrow so a same-day take+repay
+-- is never free. You owe principal + GREATEST(one day's interest, 10% of principal).
+-- The bank still receives the full principal. PITR point logged before apply.
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.take_loan(p_amount bigint)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_loan bigint; v_cap bigint; v_rate int; v_score int;
+        v_upfront bigint; v_owed bigint;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  IF p_amount IS NULL OR p_amount < 50 THEN RETURN jsonb_build_object('ok',false,'reason','bad_amount'); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT COALESCE(loan,0), COALESCE(credit_score,650) INTO v_loan, v_score
+    FROM public.profiles WHERE id = v_uid FOR UPDATE;
+  IF v_loan > 0 THEN RETURN jsonb_build_object('ok',false,'reason','active_loan'); END IF;
+  v_cap := public._credit_effective_cap(v_uid);
+  IF v_cap <= 0 THEN RETURN jsonb_build_object('ok',false,'reason','credit_locked'); END IF;
+  IF p_amount > v_cap THEN RETURN jsonb_build_object('ok',false,'reason','over_cap','cap',v_cap); END IF;
+  v_rate := GREATEST(200, LEAST(2500,
+    public._loan_daily_rate_bp(p_amount, v_cap) + public._credit_rate_adjust(v_score)));
+  -- Upfront charge: the greater of one day's interest or a 10% floor. Baked into what's
+  -- owed at borrow time (bank still receives the full principal).
+  v_upfront := GREATEST(round(p_amount * v_rate / 10000.0)::bigint, round(p_amount * 0.10)::bigint);
+  v_owed := p_amount + v_upfront;
+  UPDATE public.profiles
+    SET loan = v_owed, loan_principal = p_amount, loan_rate_bp = v_rate,
+        loan_taken_at = now(), loan_accrued_at = now()
+    WHERE id = v_uid;
+  PERFORM public._bank_credit(v_uid, p_amount, 'loan_take');   -- principal to Cash (skim-exempt)
+  PERFORM public._recompute_credit(v_uid, 'take_loan', 0);     -- utilization/restraint moved
+  RETURN jsonb_build_object('ok',true,'borrowed',p_amount,'owed',v_owed,
+                            'upfront',v_upfront,'rate_bp',v_rate,'cap',v_cap);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Per the decision — penalize taking a loan so a same-day take+repay is never free.

**Server (`take_loan`):** you now owe `principal + GREATEST(one days interest, 10% of principal)` the moment you borrow (the bank still receives the full principal). So $100 @ 5%/day → **owe $110** immediately; a bigger/higher-rate loan owes its day-1 interest when that exceeds 10%.

**UI (LoanPanel):** the borrow dial shows **"owe $110 · 5%/day"**, the PIN confirm shows **You receive / You owe / Then %/day**, and the approval screen shows **"You owe $X · Y%/day"** — so its never a surprise.

**Verified (SQL sim, rolled back):** $200 @ 5%/day → owe $220 (10% floor); $1000 @ 15%/day → owe $1150 (day-1 interest wins). Gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)