### PR TITLE
HUD: money amounts use the clean display font

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7972,7 +7972,7 @@
 		color: #fb7185;
 	}
 	.bp-amount {
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		font-size: 2.3rem;
 		line-height: 1.05;
@@ -8610,7 +8610,7 @@
 		}
 	}
 	.tb-solo {
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		font-size: 1.55rem;
 		color: #fcd34d;


### PR DESCRIPTION
The in-game **Pending Deposit** (top-bank) and **You'll Bank** (bank preview) amounts were still in LCD-style Orbitron (slashed zeros). Switched `.tb-solo` and `.bp-amount` to `--font-display` (Space Grotesk) to match the account-card balance and loan amounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)