### PR TITLE
Menu: widen CTAs to match the card + tiles

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6180,7 +6180,7 @@
 		flex-direction: column;
 		gap: 0.85rem;
 		width: 100%;
-		max-width: 264px;
+		max-width: 360px;
 		margin: 0 auto;
 	}
 	/* ── Gold bullion bars ─────────────────────────────────────────────── */


### PR DESCRIPTION
Brings the three main-menu buttons (Resume / Play Now / Challenge Friends) back to **360px** so they line up with the account card and the swipe tiles — everything is now one consistent centered 360px column (card, tiles, and buttons all span l:30 → r:390).

🤖 Generated with [Claude Code](https://claude.com/claude-code)