### PR TITLE
Credit: reweight toward Consistency (earned, not default)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-credit-score-design.md
+++ b/docs/superpowers/specs/2026-07-08-credit-score-design.md
@@ -54,16 +54,16 @@ Discipline-weighted:
 
 | Component           | Weight | Signal                                                                                   | Source                                                           |
 | ------------------- | ------ | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| **Utilization** `U` | 35%    | `1 − avg(loan/cap)` over the last 14 days. No debt → 1. Sitting maxed → 0.               | daily util from `profiles.loan` / `_loan_cap`, or ledger-derived |
-| **Solvency** `S`    | 25%    | fraction of last 14 days **not in the red** (net_worth ≥ 0).                             | red-day counter / net_worth checks                               |
-| **Repayment** `R`   | 20%    | self-repaid vs defaulted loans in window; defaults drag hard.                            | `bank_ledger` reasons `loan_repay` vs `loan_skim`                |
+| **Utilization** `U` | 25%    | `1 − avg(loan/cap)` over the last 14 days. No debt → 1. Sitting maxed → 0.               | daily util from `profiles.loan` / `_loan_cap`, or ledger-derived |
+| **Solvency** `S`    | 20%    | fraction of last 14 days **not in the red** (net_worth ≥ 0).                             | red-day counter / net_worth checks                               |
+| **Repayment** `R`   | 15%    | self-repaid vs defaulted loans in window; defaults drag hard.                            | `bank_ledger` reasons `loan_repay` vs `loan_skim`                |
 | **Restraint** `B`   | 10%    | penalize serial borrowing (many `loan_take` in window) + always grabbing near-max loans. | `bank_ledger` `loan_take` count + sizes                          |
-| **Consistency** `C` | 10%    | play streak / attendance over window.                                                    | existing streak fields                                           |
+| **Consistency** `C` | 30%    | play streak / attendance over window.                                                    | existing streak fields                                           |
 
 **Behavioral target:**
 
 ```
-T = 300 + 550 × (0.35·U + 0.25·S + 0.20·R + 0.10·B + 0.10·C)
+T = 300 + 550 × (0.25·U + 0.20·S + 0.15·R + 0.10·B + 0.30·C)
 ```
 
 All-perfect → 850, all-zero → 300.

--- a/supabase-credit-score-recompute.sql
+++ b/supabase-credit-score-recompute.sql
@@ -67,15 +67,18 @@ BEGIN
   b := 1 - LEAST(v_take::numeric / 6, 1);
 
   IF v_streak > 0 THEN
-    c := LEAST(v_streak::numeric / 14, 1);
+    c := LEAST(v_streak::numeric / 21, 1); -- ~3-week daily streak to max Consistency
   ELSE
     SELECT COUNT(DISTINCT date(created_at)) INTO v_active_days
       FROM public.bank_ledger
-     WHERE user_id = p_uid AND created_at > now() - INTERVAL '14 days';
-    c := LEAST(v_active_days::numeric / 14, 1);
+     WHERE user_id = p_uid AND created_at > now() - INTERVAL '21 days';
+    c := LEAST(v_active_days::numeric / 21, 1);
   END IF;
 
-  v_target := round(300 + 550 * (0.35*u + 0.25*s + 0.20*r + 0.10*b + 0.10*c));
+  -- Reweighted so credit is EARNED, not default: pulled weight off the auto-perfect
+  -- factors (util/solvency/repayment default to 1.0 for non-borrowers) onto Consistency,
+  -- so reaching Excellent needs sustained daily play, not just "never messed up".
+  v_target := round(300 + 550 * (0.25*u + 0.20*s + 0.15*r + 0.10*b + 0.30*c));
   v_target := GREATEST(300, LEAST(850, v_target));
 
   v_days_elapsed := GREATEST(1, LEAST(7,


### PR DESCRIPTION
Credit was too easy to build — Utilization/Solvency/Repayment all default to 1.0 for anyone who never borrows or goes in the red, so ~80% of the score was auto-perfect and a do-nothing player targeted ~795 (**Excellent**) just by existing.

**Rebalanced** (`_recompute_credit`): weights **U 25 · S 20 · R 15 · B 10 · C 30** (was 35/25/20/10/10), and Consistency now maxes at a **21-day** streak (was 14).

**Result:**

| Play streak | Target | Tier |
|---|---|---|
| 0 (do-nothing) | 685 | Good |
| 7 | 740 | Good |
| 13 | 787 | **Excellent** |
| 21 | 850 | max |

So a do-nothing non-borrower is now **Good (685)**, and **Excellent requires ~a 13-day daily streak** + clean finances — sustained engagement, not just "never messed up." Buildable without loans (per the decision). Existing Excellent users ease down to Good until they rebuild a streak. Verified target math in SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)