### PR TITLE
Share: always link to production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ VITE_SUPABASE_URL=https://your-project-id.supabase.co
 
 # Your Supabase anon/public key
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
+
+# Optional: canonical production URL used for share links (defaults to the prod alias)
+VITE_SITE_URL=https://wordbanksvelte.vercel.app

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1299,8 +1299,9 @@
 	let shareCopied = false;
 	function buildShareText() {
 		const br = '$' + resultBankroll.toLocaleString();
-		// Link to the live origin (never a hardcoded/deleted project URL).
-		const link = typeof window !== 'undefined' ? window.location.origin : '';
+		// Always share the production URL — never localhost/preview. Override with
+		// VITE_SITE_URL if the domain ever changes; falls back to the prod alias.
+		const link = import.meta.env.VITE_SITE_URL || 'https://wordbanksvelte.vercel.app';
 		if (isDailyResult) {
 			if (resultWon && dr) {
 				return `🧠 WordBank Daily · ${todayLabel}\nProfit ${(dr.net ?? 0) >= 0 ? '+' : '−'}$${Math.abs(dr.net ?? 0).toLocaleString()} — beat that 👀\n${link}`;


### PR DESCRIPTION
The result-share feature built its link from `window.location.origin`, so sharing from a local or preview build put a `localhost`/preview URL in the message.

Now it uses the canonical production URL (`https://wordbanksvelte.vercel.app`), with an optional `VITE_SITE_URL` override (documented in `.env.example`) in case the domain ever changes. Auth redirect URLs are untouched — those correctly use the live origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)