### PR TITLE
Hide Blitz for launch (reversible flag)

### DIFF
--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -1,0 +1,8 @@
+// Feature flags — flip to re-enable a hidden feature (code + DB stay intact).
+
+// ⚡ Blitz (timed, money-staked mode) is HIDDEN for the first App Store submission.
+// Timed money modes are the hardest to anti-cheat, so per the launch plan Blitz is a
+// planned fast-follow. `false` hides the Play-menu Blitz tile AND the Standard/Blitz
+// toggle in the challenge builder (all challenges default to Standard). In-flight Blitz
+// matches still resolve. Set to `true` to restore it.
+export const BLITZ_ENABLED = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -81,6 +81,7 @@
 	} from '$lib/stores/notificationStore.js';
 	import { track } from '$lib/analytics.js';
 	import { reasonLabel } from '$lib/bankReasons.js';
+	import { BLITZ_ENABLED } from '$lib/features.js';
 	import { modifierInfo } from '$lib/powerups.js';
 	import {
 		saveGameToLocalStorage,
@@ -1953,6 +1954,7 @@
 		if (!get(user)?.id) return;
 		mbMsg = '';
 		mbStep = 1;
+		if (!BLITZ_ENABLED) mbMode = 'standard'; // Blitz hidden → force Standard challenges
 		mbSearch = '';
 		mbResults = [];
 		showChallenges = true;
@@ -3325,9 +3327,11 @@
 						<span class="mc-title">Cash Game</span>
 						{#if climbInProgress}<span class="daily-chip prog">▶ Resume</span>{/if}
 					</button>
-					<button class="menu-card" style="--i: 2" on:click={handleMenuBlitz}>
-						<span class="mc-title">⚡ Blitz</span><span class="mc-stat">Beat the clock</span>
-					</button>
+					{#if BLITZ_ENABLED}
+						<button class="menu-card" style="--i: 2" on:click={handleMenuBlitz}>
+							<span class="mc-title">⚡ Blitz</span><span class="mc-stat">Beat the clock</span>
+						</button>
+					{/if}
 				</div>
 			{:else if menuView === 'community'}
 				<div class="sub-head">
@@ -3622,21 +3626,24 @@
 						{:else if mbStep === 2}
 							<!-- Step 2 · Match -->
 							<div class="ch-step-title">The match</div>
-							<div class="ch-modes">
-								<button
-									type="button"
-									class="ch-mode"
-									class:active={mbMode === 'standard'}
-									on:click={() => (mbMode = 'standard')}
-									>🧠 Standard<small>spend less</small></button
-								>
-								<button
-									type="button"
-									class="ch-mode"
-									class:active={mbMode === 'blitz'}
-									on:click={() => (mbMode = 'blitz')}>⚡ Blitz<small>timed · combos</small></button
-								>
-							</div>
+							{#if BLITZ_ENABLED}
+								<div class="ch-modes">
+									<button
+										type="button"
+										class="ch-mode"
+										class:active={mbMode === 'standard'}
+										on:click={() => (mbMode = 'standard')}
+										>🧠 Standard<small>spend less</small></button
+									>
+									<button
+										type="button"
+										class="ch-mode"
+										class:active={mbMode === 'blitz'}
+										on:click={() => (mbMode = 'blitz')}
+										>⚡ Blitz<small>timed · combos</small></button
+									>
+								</div>
+							{/if}
 
 							<div class="ch-field">
 								<span>Categories <em class="ch-opt">(optional)</em></span>


### PR DESCRIPTION
Per the launch decision — hide Blitz for the first App Store submission (it's a timed money mode, the hardest to anti-cheat, and the launch plan already positions it as a fast-follow).

- New `BLITZ_ENABLED` flag (`src/lib/features.js`, `false`).
- Hides the **Blitz tile** in the Play Now menu → just Daily + Cash Game.
- Hides the **Standard/Blitz toggle** in the challenge builder → every challenge is Standard.
- Code + DB untouched; in-flight Blitz matches still resolve. Re-enable = flip the flag to `true`.

Verified: Play menu shows only Daily + Cash Game; gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)