### PR TITLE
HUD: bank-preview badges match the amount font

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8042,7 +8042,7 @@
 	}
 	.bp-mult-badge {
 		justify-self: start;
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		font-size: 0.9rem;
 		line-height: 1;
@@ -8064,7 +8064,7 @@
 	.bp-winstreak {
 		justify-self: end;
 		cursor: pointer;
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		font-size: 0.9rem;
 		line-height: 1;


### PR DESCRIPTION
The two side badges on the bank-preview panel (the `+30%` multiplier and the `🏆 3` win-streak) were still LCD-style Orbitron; switched `.bp-mult-badge` + `.bp-winstreak` to `--font-display` (Space Grotesk) to match the amount above them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)