### PR TITLE
Line icons for all 12 categories + Cash Game coin

### DIFF
--- a/src/lib/categories.js
+++ b/src/lib/categories.js
@@ -1,17 +1,38 @@
 // The 12 puzzle categories. `value` is the exact string stored on
 // daily_puzzles.category (emoji included); used by the Challenge builder's picker.
-/** @type {{ value: string, label: string, emoji: string }[]} */
+// `icon` keys into CategoryIcon.svelte for the line-icon (non-emoji) rendering.
+/** @type {{ value: string, label: string, emoji: string, icon: string }[]} */
 export const CATEGORIES = [
-	{ value: 'Movies & TV 🎬', label: 'Movies & TV', emoji: '🎬' },
-	{ value: 'Music 🎵', label: 'Music', emoji: '🎵' },
-	{ value: 'Famous People 🌟', label: 'Famous People', emoji: '🌟' },
-	{ value: 'Food & Drink 🍔', label: 'Food & Drink', emoji: '🍔' },
-	{ value: 'Places & Travel ✈️', label: 'Places & Travel', emoji: '✈️' },
-	{ value: 'Sports 🏆', label: 'Sports', emoji: '🏆' },
-	{ value: 'Phrases & Sayings 🗣️', label: 'Phrases & Sayings', emoji: '🗣️' },
-	{ value: 'Science & Nature 🔬', label: 'Science & Nature', emoji: '🔬' },
-	{ value: 'Books & Characters 📚', label: 'Books & Characters', emoji: '📚' },
-	{ value: 'Video Games 🎮', label: 'Video Games', emoji: '🎮' },
-	{ value: 'Brands & Logos 🏷️', label: 'Brands & Logos', emoji: '🏷️' },
-	{ value: 'Tech & Internet 💻', label: 'Tech & Internet', emoji: '💻' }
+	{ value: 'Movies & TV 🎬', label: 'Movies & TV', emoji: '🎬', icon: 'movies' },
+	{ value: 'Music 🎵', label: 'Music', emoji: '🎵', icon: 'music' },
+	{ value: 'Famous People 🌟', label: 'Famous People', emoji: '🌟', icon: 'famous' },
+	{ value: 'Food & Drink 🍔', label: 'Food & Drink', emoji: '🍔', icon: 'food' },
+	{ value: 'Places & Travel ✈️', label: 'Places & Travel', emoji: '✈️', icon: 'travel' },
+	{ value: 'Sports 🏆', label: 'Sports', emoji: '🏆', icon: 'sports' },
+	{ value: 'Phrases & Sayings 🗣️', label: 'Phrases & Sayings', emoji: '🗣️', icon: 'phrases' },
+	{ value: 'Science & Nature 🔬', label: 'Science & Nature', emoji: '🔬', icon: 'science' },
+	{ value: 'Books & Characters 📚', label: 'Books & Characters', emoji: '📚', icon: 'books' },
+	{ value: 'Video Games 🎮', label: 'Video Games', emoji: '🎮', icon: 'games' },
+	{ value: 'Brands & Logos 🏷️', label: 'Brands & Logos', emoji: '🏷️', icon: 'brands' },
+	{ value: 'Tech & Internet 💻', label: 'Tech & Internet', emoji: '💻', icon: 'tech' }
 ];
+
+/** Category value/label (emoji may be baked in) → its entry, or null. */
+export function categoryMeta(/** @type {string} */ value) {
+	const raw = String(value ?? '');
+	return (
+		CATEGORIES.find((c) => c.value === raw || c.label === raw) ||
+		CATEGORIES.find((c) => c.label === raw.replace(/[^\x20-\x7E]+/g, '').trim()) ||
+		null
+	);
+}
+
+/** Clean display label with no emoji (falls back to stripping non-ASCII). */
+export function categoryLabel(/** @type {string} */ value) {
+	const m = categoryMeta(value);
+	return m
+		? m.label
+		: String(value ?? '')
+				.replace(/[^\x20-\x7E]+/g, '')
+				.trim();
+}

--- a/src/lib/components/BadgesPanel.svelte
+++ b/src/lib/components/BadgesPanel.svelte
@@ -2,6 +2,7 @@
 	import { onMount, tick } from 'svelte';
 	import { getCategoryStats, getUserBadges } from '$lib/stores/statsStore.js';
 	import { CATEGORIES } from '$lib/categories.js';
+	import CategoryIcon from '$lib/components/CategoryIcon.svelte';
 	import {
 		categoryProgress,
 		CATEGORY_TIERS,
@@ -253,7 +254,7 @@
 								style="stroke-dasharray:{CIRC};stroke-dashoffset:{CIRC * (1 - r.progress)}"
 							/>
 						</svg>
-						<span class="ring-emoji">{r.emoji}</span>
+						<span class="ring-emoji"><CategoryIcon category={r.value} size={24} /></span>
 						{#if r.current}<span class="ring-medal">{r.current.medal}</span>{/if}
 					</div>
 					<div class="cat-name">{r.label}</div>
@@ -331,7 +332,7 @@
 		<button class="cd-backdrop" aria-label="Close" onclick={() => (detail = null)}></button>
 		<div class="cd-card" role="dialog" aria-modal="true">
 			<button class="cd-x" onclick={() => (detail = null)} aria-label="Close">✕</button>
-			<div class="cd-emoji">{detail.emoji}</div>
+			<div class="cd-emoji"><CategoryIcon category={detail.value} size={42} /></div>
 			<h3 class="cd-name">{detail.label}</h3>
 			<p class="cd-solves">
 				{detail.solves}

--- a/src/lib/components/CategoryIcon.svelte
+++ b/src/lib/components/CategoryIcon.svelte
@@ -1,0 +1,47 @@
+<script>
+	import { categoryMeta } from '$lib/categories.js';
+
+	/** Category value (emoji may be baked in) or label. */
+	export let category = '';
+	/** Pixel size (square). */
+	export let size = 18;
+
+	// Shared line-icon attrs; stroke inherits via currentColor so callers set color.
+	const A =
+		'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" ' +
+		'stroke-linecap="round" stroke-linejoin="round" style="width:100%;height:100%" aria-hidden="true"';
+
+	/** @type {Record<string,string>} */
+	const SVG = {
+		movies: `<svg ${A}><path d="M3 9h18"/><path d="M3.4 9 21 9 19.2 4.6 4.6 4.6Z"/><path d="M8.2 4.7 6.3 9M13 4.7 11.1 9M17.8 4.7 15.9 9"/><rect x="3" y="9" width="18" height="11" rx="1.6"/></svg>`,
+		music: `<svg ${A}><path d="M9 17.5V6l9-1.8V15.5"/><circle cx="6.6" cy="17.6" r="2.4"/><circle cx="15.6" cy="15.6" r="2.4"/></svg>`,
+		famous: `<svg ${A}><path d="M12 3.6l2.5 5.1 5.6.8-4 3.9.95 5.6L12 16.3 6.9 19l.95-5.6-4-3.9 5.6-.8z"/></svg>`,
+		food: `<svg ${A}><path d="M6 3v4a2 2 0 0 0 2 2 2 2 0 0 0 2-2V3"/><path d="M8 9v12"/><path d="M17 21V3c-2.2 1-3.3 4.2-3.3 7.2 0 2 1.2 3.3 3.3 3.3z"/></svg>`,
+		travel: `<svg ${A}><path d="M21 3 3 10.5l6 2.4 2.4 6z"/><path d="M21 3 9.4 13"/></svg>`,
+		sports: `<svg ${A}><path d="M7 4.2h10v4.8a5 5 0 0 1-10 0z"/><path d="M7 6.2H4.2v.8a3 3 0 0 0 2.8 3M17 6.2h2.8v.8a3 3 0 0 1-2.8 3"/><path d="M12 13.8v2.8M9 20.4h6M10.3 20.4c0-1.9.5-3.8 1.7-3.8s1.7 1.9 1.7 3.8"/></svg>`,
+		phrases: `<svg ${A}><path d="M4 5h16a1.2 1.2 0 0 1 1.2 1.2v8.6a1.2 1.2 0 0 1-1.2 1.2H9.5L5.5 20v-3.8H4a1.2 1.2 0 0 1-1.2-1.2V6.2A1.2 1.2 0 0 1 4 5z"/><path d="M8 9.4c0 1-.7 1.7-1.6 1.9M13.4 9.4c0 1-.7 1.7-1.6 1.9"/></svg>`,
+		science: `<svg ${A}><path d="M9 3h6"/><path d="M10 3.2v6L5.3 17a1.5 1.5 0 0 0 1.3 2.3h10.8a1.5 1.5 0 0 0 1.3-2.3L14 9.2v-6"/><path d="M7.4 14.2h9.2"/></svg>`,
+		books: `<svg ${A}><path d="M12 6.2C10 4.7 6.6 4.7 4 5.4v12.8c2.6-.7 6-.7 8 .8 2-1.5 5.4-1.5 8-.8V5.4c-2.6-.7-6-.7-8 .8z"/><path d="M12 6.2V19"/></svg>`,
+		games: `<svg ${A}><rect x="2.5" y="8" width="19" height="9" rx="4.5"/><path d="M6.8 11v3M5.3 12.5h3"/><circle cx="15.8" cy="11.6" r="1"/><circle cx="18.3" cy="13.6" r="1"/></svg>`,
+		brands: `<svg ${A}><path d="M11 3.5H4.5A1 1 0 0 0 3.5 4.5V11l8.8 8.8a1.2 1.2 0 0 0 1.7 0l5.8-5.8a1.2 1.2 0 0 0 0-1.7z"/><circle cx="8" cy="8" r="1.3"/></svg>`,
+		tech: `<svg ${A}><rect x="5" y="4.8" width="14" height="9.6" rx="1.6"/><path d="M2.5 19h19M3.6 19 5 17h14l1.4 2"/></svg>`
+	};
+
+	$: html = SVG[categoryMeta(category)?.icon ?? ''] ?? '';
+</script>
+
+{#if html}
+	<!-- SVG strings are hard-coded constants (see SVG map above), never user input. -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	<span class="cat-ic" style="width:{size}px;height:{size}px">{@html html}</span>
+{/if}
+
+<style>
+	.cat-ic {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: none;
+		line-height: 0;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -43,7 +43,8 @@
 		getMatchOpponents,
 		declineMatch
 	} from '$lib/stores/statsStore.js';
-	import { CATEGORIES } from '$lib/categories.js';
+	import { CATEGORIES, categoryLabel } from '$lib/categories.js';
+	import CategoryIcon from '$lib/components/CategoryIcon.svelte';
 	import {
 		user,
 		userProfile,
@@ -3684,7 +3685,7 @@
 											class:on={mbCategories.includes(c.value)}
 											on:click={() => toggleCategory(c.value)}
 										>
-											<span class="ch-catemoji">{c.emoji}</span>
+											<span class="ch-catemoji"><CategoryIcon category={c.value} size={19} /></span>
 											<span class="ch-catname">{c.label}</span>
 											<span class="ch-catcheck">{mbCategories.includes(c.value) ? '✓' : ''}</span>
 										</button>
@@ -4112,7 +4113,13 @@
 					showObjectiveFor($gameStore.gameMode, true);
 				}}
 			>
-				{#if modeLabel.emoji}<span class="mp-emoji">{modeLabel.emoji}</span
+				{#if isClimb}<span class="mp-emoji"
+						><svg class="mp-cash-ic" viewBox="0 0 24 24" fill="none" aria-hidden="true"
+							><circle cx="12" cy="12" r="8.6" /><path d="M12 7v10" /><path
+								d="M14.6 9.2c-.6-.8-1.6-1.2-2.7-1.2-1.7 0-2.9 1-2.9 2.3s1.3 1.9 2.9 2.2 2.9 1 2.9 2.3-1.3 2.3-2.9 2.3c-1.1 0-2.2-.5-2.8-1.3"
+							/></svg
+						></span
+					>{:else if modeLabel.emoji}<span class="mp-emoji">{modeLabel.emoji}</span
 					>{/if}{modeLabel.name}{#if isClimb && climb?.buy_in}<span class="mp-sub"
 						>· {(climb.tier ?? '').charAt(0).toUpperCase() + (climb.tier ?? '').slice(1)} · ${Math.round(
 							climb.buy_in ?? 0
@@ -4282,7 +4289,11 @@
 
 		<!-- 🌍 Category + today's auto-applied Twist chip + witty clue -->
 		<div class="puzzle-meta">
-			{#if $gameStore.category}<span class="category-chip">{$gameStore.category}</span>{/if}
+			{#if $gameStore.category}<span class="category-chip"
+					><CategoryIcon category={$gameStore.category} size={14} />{categoryLabel(
+						$gameStore.category
+					)}</span
+				>{/if}
 			{#if $gameStore.gameMode === 'daily' && dailyMod}
 				<button
 					class="twist-chip"
@@ -5564,6 +5575,9 @@
 		margin: 0 0 12px;
 	}
 	.category-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
 		font-family: var(--font-display);
 		font-weight: 600;
 		font-size: 0.8rem;
@@ -7355,7 +7369,10 @@
 		background: rgba(251, 191, 36, 0.1);
 	}
 	.ch-catemoji {
-		font-size: 1.05rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
 	}
 	.ch-catname {
 		flex: 1;
@@ -8737,6 +8754,18 @@
 	.mp-emoji {
 		font-size: 0.9rem;
 		letter-spacing: 0;
+		display: inline-flex;
+		align-items: center;
+	}
+	/* 🪙 Cash Game money glyph (replaces the slot-machine emoji) */
+	.mp-cash-ic {
+		width: 1.05em;
+		height: 1.05em;
+		fill: none;
+		stroke: #fcd34d;
+		stroke-width: 1.7;
+		stroke-linecap: round;
+		stroke-linejoin: round;
 	}
 	.mp-info {
 		font-size: 0.72rem;


### PR DESCRIPTION
Replaces category **emojis** with the single-color **line-icon set** approved in the design preview, and swaps the Cash Game 🎰 for a **coin** money glyph.

**New:** `src/lib/components/CategoryIcon.svelte` — renders the 12 icons, resolving from a category value/label (works whether or not the emoji is baked in). `categories.js` gains an `icon` key per category plus `categoryMeta` / `categoryLabel` helpers.

**Wired in everywhere categories show:**
- In-game **category chip** → icon + clean label (no emoji)
- **Challenge-builder** category picker
- Per-category **badge rings** + category **detail modal**

**Cash Game:** mode pill now shows a gold coin instead of the slot-machine emoji.

Resume tiles and the History filter keep their emojis for now (one row mixing an SVG with 📅/⚔️ would look worse than all-emoji) — quick follow-up if we want to iconify all modes.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)