### PR TITLE
ModeIcon line-icons for every mode indicator

### DIFF
--- a/src/lib/components/HistoryList.svelte
+++ b/src/lib/components/HistoryList.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { getHistory, getMatchDetail } from '$lib/stores/statsStore.js';
 	import MatchDetailModal from '$lib/components/MatchDetailModal.svelte';
+	import ModeIcon from '$lib/components/ModeIcon.svelte';
 	import { track } from '$lib/analytics.js';
 
 	/** @type {'all'|'daily'|'climb'|'challenge'} */
@@ -25,20 +26,10 @@
 
 	const MODES = [
 		{ k: 'all', label: 'All' },
-		{ k: 'daily', label: '📅 Daily' },
-		{ k: 'climb', label: '🎰 Cash Game' },
-		{ k: 'challenge', label: '⚔️ Versus' }
+		{ k: 'daily', label: 'Daily' },
+		{ k: 'climb', label: 'Cash Game' },
+		{ k: 'challenge', label: 'Versus' }
 	];
-	const icon = (/** @type {string} */ m) =>
-		m === 'daily'
-			? '📅'
-			: m === 'makeup'
-				? '🗓️'
-				: m === 'climb'
-					? '🎰'
-					: m === 'challenge'
-						? '⚔️'
-						: '🎮';
 	const money = (/** @type {any} */ n) =>
 		(Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
 	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '');
@@ -109,7 +100,7 @@
 	<div class="chips">
 		{#each MODES as m}
 			<button class="chip" class:active={mode === m.k} onclick={() => setMode(m.k)}
-				>{m.label}</button
+				>{#if m.k !== 'all'}<ModeIcon mode={m.k} size={15} />{/if}{m.label}</button
 			>
 		{/each}
 	</div>
@@ -139,7 +130,7 @@
 			{#each rows as r (r.id)}
 				<li class="item" class:open={openRow === r.id}>
 					<button class="item-main" onclick={() => openDetail(r)}>
-						<span class="ic">{icon(r.game_mode)}</span>
+						<span class="ic"><ModeIcon mode={r.game_mode} size={20} /></span>
 						<span class="mid">
 							<span class="ttl">{title(r)}</span>
 							<span class="sub">
@@ -210,6 +201,9 @@
 		margin-bottom: 10px;
 	}
 	.chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
 		flex: 0 0 auto;
 		padding: 7px 13px;
 		border-radius: var(--r-pill);
@@ -292,7 +286,9 @@
 		text-align: left;
 	}
 	.ic {
-		font-size: 1.3rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 		flex: 0 0 auto;
 	}
 	.mid {

--- a/src/lib/components/ModeIcon.svelte
+++ b/src/lib/components/ModeIcon.svelte
@@ -1,0 +1,42 @@
+<script>
+	/** Game mode: daily | makeup | climb | match | challenge | blitz. */
+	export let mode = '';
+	/** Pixel size (square). */
+	export let size = 18;
+
+	// Shared line-icon attrs; stroke inherits via currentColor so callers set color.
+	const A =
+		'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" ' +
+		'stroke-linecap="round" stroke-linejoin="round" style="width:100%;height:100%" aria-hidden="true"';
+
+	const CAL = `<svg ${A}><rect x="3.5" y="5" width="17" height="15" rx="2"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>`;
+	const SWORDS = `<svg ${A}><polyline points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/><line x1="13" y1="19" x2="19" y2="13"/><line x1="16" y1="16" x2="20" y2="20"/><line x1="19" y1="21" x2="21" y2="19"/><polyline points="14.5 6.5 18 3 21 3 21 6 17.5 9.5"/><line x1="5" y1="14" x2="9" y2="18"/><line x1="7" y1="17" x2="4" y2="20"/><line x1="3" y1="19" x2="5" y2="21"/></svg>`;
+
+	/** @type {Record<string,string>} */
+	const SVG = {
+		daily: CAL,
+		makeup: CAL,
+		climb: `<svg ${A}><circle cx="12" cy="12" r="8.6"/><path d="M12 7v10"/><path d="M14.6 9.2c-.6-.8-1.6-1.2-2.7-1.2-1.7 0-2.9 1-2.9 2.3s1.3 1.9 2.9 2.2 2.9 1 2.9 2.3-1.3 2.3-2.9 2.3c-1.1 0-2.2-.5-2.8-1.3"/></svg>`,
+		match: SWORDS,
+		challenge: SWORDS,
+		blitz: `<svg ${A}><path d="M13 2 4.5 13.5H11l-1 8.5 8.5-11.5H12z"/></svg>`
+	};
+
+	$: html = SVG[mode] ?? '';
+</script>
+
+{#if html}
+	<!-- SVG strings are hard-coded constants above, never user input. -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	<span class="mode-ic" style="width:{size}px;height:{size}px">{@html html}</span>
+{/if}
+
+<style>
+	.mode-ic {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: none;
+		line-height: 0;
+	}
+</style>

--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -4,6 +4,7 @@
 	// once — per-mode for solo modes, per-match for challenges (first entry, not resume).
 	import { createEventDispatcher } from 'svelte';
 	import { MODIFIERS } from '$lib/powerups.js';
+	import ModeIcon from '$lib/components/ModeIcon.svelte';
 	const dispatch = createEventDispatcher();
 
 	let page = 0; // 0 = how to win, 1 = power-ups (daily only)
@@ -80,6 +81,11 @@
 	}
 
 	$: c = content(mode, ctx);
+	// Use the mode line-icon for every mode except a group challenge (keeps its 👥)
+	// and the unknown-mode fallback (keeps 🎯).
+	$: useModeIcon =
+		['daily', 'makeup', 'climb', 'challenge', 'blitz'].includes(mode) ||
+		(mode === 'match' && (ctx.fieldSize ?? 2) <= 2);
 	function go() {
 		dispatch('close');
 	}
@@ -90,7 +96,9 @@
 		<button class="obj-x" on:click={go} aria-label="Close">✕</button>
 		{#if page === 0}
 			<span class="obj-pill">🎯 How to win</span>
-			<div class="obj-icon">{c.icon}</div>
+			<div class="obj-icon">
+				{#if useModeIcon}<ModeIcon {mode} size={44} />{:else}{c.icon}{/if}
+			</div>
 			<h2 class="obj-title">{c.title}</h2>
 
 			<p class="obj-goal">{c.goal}</p>
@@ -205,6 +213,9 @@
 		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
 	}
 	.obj-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		font-size: 2.8rem;
 		line-height: 1;
 		margin: 2px 0 10px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -45,6 +45,7 @@
 	} from '$lib/stores/statsStore.js';
 	import { CATEGORIES, categoryLabel } from '$lib/categories.js';
 	import CategoryIcon from '$lib/components/CategoryIcon.svelte';
+	import ModeIcon from '$lib/components/ModeIcon.svelte';
 	import {
 		user,
 		userProfile,
@@ -186,7 +187,7 @@
 		...openGames.map((/** @type {any} */ g) => ({
 			key: 'solo-' + g.mode,
 			label: RESUME_LABEL[g.mode] ?? 'Game',
-			icon: /** @type {Record<string,string>} */ ({ daily: '📅', climb: '🎰' })[g.mode] ?? '▶',
+			modeKey: g.mode,
 			go: () => resumeSolo(g.mode)
 		})),
 		...(myMatches ?? [])
@@ -194,7 +195,7 @@
 			.map((/** @type {any} */ m) => ({
 				key: 'match-' + m.id,
 				label: m.group_name || (m.opponent ? '@' + m.opponent : 'Challenge'),
-				icon: '⚔️',
+				modeKey: 'match',
 				go: () => respondToMatch(m)
 			}))
 	];
@@ -2972,9 +2973,9 @@
 							r.go();
 						}}
 					>
-						<span class="rm-ic">{r.icon}</span><span class="rm-label">{r.label}</span><span
-							class="rm-arrow">▶</span
-						>
+						<span class="rm-ic"><ModeIcon mode={r.modeKey} size={20} /></span><span class="rm-label"
+							>{r.label}</span
+						><span class="rm-arrow">▶</span>
 					</button>
 				{/each}
 			</div>
@@ -4113,14 +4114,8 @@
 					showObjectiveFor($gameStore.gameMode, true);
 				}}
 			>
-				{#if isClimb}<span class="mp-emoji"
-						><svg class="mp-cash-ic" viewBox="0 0 24 24" fill="none" aria-hidden="true"
-							><circle cx="12" cy="12" r="8.6" /><path d="M12 7v10" /><path
-								d="M14.6 9.2c-.6-.8-1.6-1.2-2.7-1.2-1.7 0-2.9 1-2.9 2.3s1.3 1.9 2.9 2.2 2.9 1 2.9 2.3-1.3 2.3-2.9 2.3c-1.1 0-2.2-.5-2.8-1.3"
-							/></svg
-						></span
-					>{:else if modeLabel.emoji}<span class="mp-emoji">{modeLabel.emoji}</span
-					>{/if}{modeLabel.name}{#if isClimb && climb?.buy_in}<span class="mp-sub"
+				<span class="mp-emoji"><ModeIcon mode={$gameStore.gameMode} size={15} /></span
+				>{modeLabel.name}{#if isClimb && climb?.buy_in}<span class="mp-sub"
 						>· {(climb.tier ?? '').charAt(0).toUpperCase() + (climb.tier ?? '').slice(1)} · ${Math.round(
 							climb.buy_in ?? 0
 						).toLocaleString()}</span
@@ -6608,7 +6603,9 @@
 		transform: scale(0.98);
 	}
 	.rm-ic {
-		font-size: 1.2rem;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
 	}
 	.rm-label {
 		flex: 1;
@@ -8756,16 +8753,6 @@
 		letter-spacing: 0;
 		display: inline-flex;
 		align-items: center;
-	}
-	/* 🪙 Cash Game money glyph (replaces the slot-machine emoji) */
-	.mp-cash-ic {
-		width: 1.05em;
-		height: 1.05em;
-		fill: none;
-		stroke: #fcd34d;
-		stroke-width: 1.7;
-		stroke-linecap: round;
-		stroke-linejoin: round;
 	}
 	.mp-info {
 		font-size: 0.72rem;


### PR DESCRIPTION
New `src/lib/components/ModeIcon.svelte` — a single-color line-icon family for game modes (**calendar** = Daily/Make-up, **coin** = Cash Game, **crossed swords** = Challenge/Versus, **lightning** = Blitz) — replacing the 📅/🎰/⚔️/⚡ emojis everywhere a mode is shown as an icon:

- In-game **mode pill** (now all modes, not just Cash Game's coin)
- **Resume-a-game** tiles
- **History** filter chips + per-row mode icons
- **ObjectiveCard** "how to win" explainer (group challenge keeps 👥, unknown-mode fallback keeps 🎯)

Matches the CategoryIcon set from #471. Removed the now-unused inline coin SVG + emoji fallbacks.

**Left as-is (decorative / mixed-emoji, not mode-indicator lists):** the activity feed, menu section headers (e.g. "⚔️ New Challenge"), and win-screen medals. Happy to sweep those too if you want them iconified.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)