### PR TITLE
Cash Game Phases 3+4: bank between puzzles + next-puzzle peek

### DIFF
--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -41,8 +41,8 @@
 					icon: '🎰',
 					title: 'Cash Game',
 					goal: 'Invest your Principal → grow it by solving puzzles cheaply.',
-					win: 'Deposit anytime to bank it — Yield climbs with each solve.',
-					bar: 'A wrong guess VOIDs your Earnings.'
+					win: 'Bank between puzzles — once you start one, it’s solve or bust. Yield climbs with each solve.',
+					bar: 'A wrong guess VOIDs your Wallet.'
 				};
 			case 'makeup':
 				return {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4246,14 +4246,13 @@
 					<div class="bn-title">Cash Advance depleted</div>
 					{#if (climb.wallet ?? climb.bankroll ?? 0) > 0}
 						<div class="bn-body">
-							Solve to credit your account, or Deposit your ${Math.round(
-								climb.wallet ?? climb.bankroll ?? 0
-							).toLocaleString()} now to bank it. A wrong guess voids it.
+							You have to guess now — no more letters. Solve to bank it, or a wrong guess voids your
+							whole Wallet.
 						</div>
 					{:else}
 						<div class="bn-body">
-							Solve to credit your account. A wrong guess voids the session and forfeits your
-							Principal.
+							You have to guess now. Solve to credit your account; a wrong guess voids the session
+							and forfeits your Principal.
 						</div>
 					{/if}
 				</div>
@@ -4527,23 +4526,6 @@
 								<rect x="13.5" y="13.5" width="7" height="7" rx="1.5" />
 							</svg>
 							{#if usableMatchPups > 0}<span class="solve-vault-badge">{usableMatchPups}</span>{/if}
-						</button>
-					{/if}
-				</svelte:fragment>
-				<svelte:fragment slot="right">
-					{#if isClimb && climb?.state === 'active' && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
-						<button
-							class="solve-deposit"
-							on:click={cashOut}
-							disabled={cgBusy || (climb.bankroll ?? 0) <= 0}
-							title="Deposit your Earnings"
-							aria-label="Deposit your Earnings"
-						>
-							<svg class="dep-ic" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-								<path d="M12 4v10" />
-								<path d="M8 11l4 4 4-4" />
-								<path d="M5 17v2a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2" />
-							</svg>
 						</button>
 					{/if}
 				</svelte:fragment>
@@ -4824,16 +4806,25 @@
 									>${Math.round(menuBank ?? 0).toLocaleString()}</span
 								>
 							</div>
-							<div class="rcpt-foot">Earnings are at risk until you Deposit them.</div>
+							<div class="rcpt-foot">Bank it now, or push on and risk it all.</div>
 						</div>
+						{#if climb?.next_category}
+							<div class="cg-peek">
+								<span class="cg-peek-cap">Next puzzle</span>
+								<span class="cg-peek-val"
+									><CategoryIcon category={climb.next_category} size={15} />{categoryLabel(
+										climb.next_category
+									)} · <b>${(climb.next_bounty ?? 0).toLocaleString()}</b> bounty</span
+								>
+							</div>
+						{/if}
 						<div class="result-actions">
 							<button
 								class="share-btn co-inline"
 								disabled={cgBusy}
 								on:click={() => {
-									// Leave the modal up — cashOut() runs the PIN gate, then swaps this
-									// transaction slip for the cash-out slip on success. Cancelling the PIN
-									// keeps this slip so the player can retry or hit Next (no soft-lock).
+									// Between-puzzle bank: opens the deposit confirm, then swaps this slip for
+									// the cash-out slip on success. Cancelling keeps this slip (no soft-lock).
 									hasTriggeredModal = false;
 									cashOut();
 								}}
@@ -4849,7 +4840,7 @@
 									showResultModal = false;
 									hasTriggeredModal = false;
 									climbAdvance().then(() => tick().then(playDailyIntroIfArmed));
-								}}>Next →</button
+								}}>Push →</button
 							>
 						</div>
 					{:else if isClimb}
@@ -5381,35 +5372,6 @@
 		color: #d8cccc;
 	}
 
-	/* 🏦 Deposit accessory — icon-only button to the right of Solve, mirroring the
-	   power-ups vault on the left. White glyph on the same glassy surface. */
-	.solve-deposit {
-		position: absolute;
-		left: 100%;
-		margin-left: 12px;
-		top: 50%;
-		transform: translateY(-50%);
-		width: 50px;
-		height: 50px;
-		border-radius: 14px;
-		display: grid;
-		place-items: center;
-		cursor: pointer;
-		background: var(--surface-strong, rgba(20, 28, 40, 0.9));
-		border: 1px solid rgba(253, 224, 71, 0.5);
-		backdrop-filter: blur(10px);
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-		transition:
-			transform 0.16s var(--ease-spring),
-			opacity 0.2s;
-	}
-	.solve-deposit:active {
-		transform: translateY(-50%) scale(0.93);
-	}
-	.solve-deposit:disabled {
-		opacity: 0.4;
-		cursor: default;
-	}
 	.dep-ic {
 		width: 26px;
 		height: 26px;
@@ -9276,6 +9238,36 @@
 		font-size: 0.84rem;
 		text-decoration: underline;
 		cursor: pointer;
+	}
+	/* 🔮 Between-puzzle peek — what you'd be pushing into (Cash Game) */
+	.cg-peek {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 10px;
+		margin: 0 0 12px;
+		padding: 9px 13px;
+		border-radius: 12px;
+		background: rgba(255, 255, 255, 0.05);
+		border: 1px solid var(--border, rgba(255, 255, 255, 0.12));
+	}
+	.cg-peek-cap {
+		font-size: 0.68rem;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
+	.cg-peek-val {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.86rem;
+		color: var(--text);
+	}
+	.cg-peek-val b {
+		color: #fcd34d;
 	}
 	.result-actions {
 		display: flex;

--- a/supabase-cashgame-bank-between-puzzles.sql
+++ b/supabase-cashgame-bank-between-puzzles.sql
@@ -1,0 +1,137 @@
+-- ============================================================================
+-- Phase 3 — Cash Game: bank only BETWEEN puzzles + next-puzzle peek.
+-- (spec: docs/superpowers/specs/2026-07-09-economy-rework-cashgame-challenge.md)
+--
+-- Today cashgame_cashout allows state IN ('active','solved') — i.e. you can bank
+-- MID-puzzle, a free penalty-free cop-out when you don't know the answer. Fix:
+--   * cashout is allowed ONLY at the between-puzzle decision point (state='solved').
+--     Mid-puzzle ('active') your only outs are solve or bust.
+--   * On solve we PRE-PICK the next puzzle and store climb_state.next_puzzle_id, so
+--     the "Bank or Push" peek (next bounty + category) is truthful; climb_next deals
+--     that exact puzzle.
+-- No new economy math — the 'solved' between-state already exists. PITR logged.
+-- ============================================================================
+BEGIN;
+
+ALTER TABLE public.climb_state ADD COLUMN IF NOT EXISTS next_puzzle_id uuid;
+
+-- 1) On solve: bank leftover (unchanged) + PRE-PICK the next puzzle for the peek.
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_tier JSONB; v_k NUMERIC; v_stake INT; v_cap INT;
+  v_bounty INT; v_keep INT; v_payout INT; v_cat TEXT; v_time INT; v_next UUID;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(p_uid); END IF;
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_cap := COALESCE((v_tier->>'heat_cap')::int, 250); v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    v_bounty := public._climb_bounty(cs.puzzle_id, v_k) * v_stake;
+    v_keep := GREATEST(0, v_bounty - cs.spent);
+    v_payout := round(v_keep * cs.heat_x100 / 100.0)::int;
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    -- Pre-pick the next puzzle now so the between-round peek matches what you'll get.
+    v_next := public._pick_casual(p_uid, null, cs.puzzle_id, 0);
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_payout,
+      bankroll = cs.bankroll + v_payout,
+      heat_x100 = LEAST(v_cap, cs.heat_x100 + 10),
+      run_solves = cs.run_solves + 1, next_puzzle_id = v_next, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_payout, v_time);
+  ELSE
+    UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- 2) Push: deal the pre-picked next puzzle (fallback to a fresh pick), clear it.
+CREATE OR REPLACE FUNCTION public.climb_next()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_pid UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_next: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state <> 'solved' THEN RETURN public._climb_board(v_uid); END IF;
+  v_pid := COALESCE(cs.next_puzzle_id, public._pick_casual(v_uid, null, cs.puzzle_id, 0));
+  IF v_pid IS NULL THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.climb_state SET position = cs.position + 1, puzzle_id = v_pid, revealed_positions = '{}',
+    incorrect_letters = '{}', spent = 0, last_gain = 0, active_powerups = '{}', next_puzzle_id = NULL,
+    pups_locked = false, state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = v_uid;
+  PERFORM public._mark_seen(v_uid, v_pid);
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+-- 3) Board: expose the next puzzle's bounty + category as the between-round peek.
+CREATE OR REPLACE FUNCTION public._climb_board(p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_state TEXT; v_board JSONB; v_tier JSONB;
+  v_k NUMERIC; v_stake INT; v_bounty INT; v_budget_left INT; v_cheapest INT; v_solve_reward INT;
+  v_next_cat TEXT; v_next_bounty INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_state := CASE cs.state WHEN 'solved' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  v_bounty := public._climb_bounty(cs.puzzle_id, v_k) * v_stake;
+  v_budget_left := GREATEST(0, v_bounty - cs.spent);
+  v_cheapest := public._cg_cheapest(cs);
+  v_solve_reward := round(v_budget_left * cs.heat_x100 / 100.0)::int;
+  -- Between-round peek: what the next puzzle is worth + its category (no phrase/answer).
+  IF cs.state = 'solved' AND cs.next_puzzle_id IS NOT NULL THEN
+    SELECT category INTO v_next_cat FROM public.daily_puzzles WHERE id = cs.next_puzzle_id;
+    v_next_bounty := public._climb_bounty(cs.next_puzzle_id, v_k) * v_stake;
+  END IF;
+  v_board := public._daily_board(v_phrase, v_state, cs.bankroll::int, 99, cs.revealed_positions, cs.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('climb', jsonb_build_object(
+    'wallet', cs.bankroll, 'bankroll', cs.bankroll,
+    'bounty', v_bounty, 'budget_left', v_budget_left, 'solve_reward', v_solve_reward, 'spent', cs.spent,
+    'heat', cs.heat_x100, 'heat_cap', (v_tier->>'heat_cap')::int, 'tier', cs.tier, 'buy_in', cs.buy_in,
+    'tier_label', v_tier->>'label', 'stake', v_stake, 'cheapest', v_cheapest,
+    'must_guess', (cs.state = 'active' AND (v_cheapest IS NULL OR v_budget_left < v_cheapest)),
+    'position', cs.position, 'last_gain', cs.last_gain, 'state', cs.state,
+    'pups_locked', cs.pups_locked, 'equipped', to_jsonb(cs.active_powerups),
+    'run_solves', cs.run_solves, 'run_profit', cs.bankroll - cs.buy_in,
+    'next_bounty', v_next_bounty, 'next_category', v_next_cat));
+END; $function$;
+
+-- 4) Cashout: allowed ONLY between puzzles (state='solved'); mid-puzzle = solve or bust.
+CREATE OR REPLACE FUNCTION public.cashgame_cashout()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_profit BIGINT; v_mult INT; v_wins jsonb; v_streak INT; v_bestrs INT; v_phrase TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'cashgame_cashout: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok', false, 'reason', 'no_run'); END IF;
+  IF cs.state <> 'solved' THEN RETURN jsonb_build_object('ok', false, 'reason', 'in_puzzle'); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_profit := cs.bankroll - cs.buy_in;
+  v_mult := CASE WHEN cs.buy_in > 0 THEN round(cs.bankroll * 100.0 / cs.buy_in)::int ELSE 0 END;
+  IF cs.bankroll > 0 THEN PERFORM public._bank_credit(v_uid, cs.bankroll, 'cashgame_cashout'); END IF;
+  SELECT COALESCE(cg_wins,'{}'::jsonb), COALESCE(cg_run_streak,0), COALESCE(cg_best_run_streak,0)
+    INTO v_wins, v_streak, v_bestrs FROM public.profiles WHERE id = v_uid;
+  IF v_profit > 0 THEN
+    v_wins := jsonb_set(v_wins, ARRAY[cs.tier], to_jsonb(COALESCE((v_wins->>cs.tier)::int,0) + 1), true);
+    v_streak := v_streak + 1;
+  ELSE
+    v_streak := 0;
+  END IF;
+  UPDATE public.profiles SET
+    cg_wins = v_wins,
+    cg_run_streak = v_streak,
+    cg_best_run_streak = GREATEST(v_bestrs, v_streak),
+    cg_best_run = GREATEST(COALESCE(cg_best_run,0), cs.bankroll),
+    cg_best_multiple_x100 = GREATEST(COALESCE(cg_best_multiple_x100,0), v_mult),
+    cg_best_heat_x100 = GREATEST(COALESCE(cg_best_heat_x100,100), cs.heat_x100),
+    cg_lifetime_net = COALESCE(cg_lifetime_net,0) + v_profit
+    WHERE id = v_uid;
+  DELETE FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object('ok', true, 'banked', cs.bankroll, 'buy_in', cs.buy_in, 'profit', v_profit,
+    'multiple_x100', v_mult, 'solves', cs.run_solves, 'tier', cs.tier, 'heat', cs.heat_x100, 'phrase', v_phrase);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Closes the mid-puzzle deposit cop-out you flagged — in Cash Game you can now bank **only between puzzles**; once you start one it's **solve or bust**. Between puzzles you get an informed **Bank or Push** decision with a peek at the next puzzle.

**Server** (`supabase-cashgame-bank-between-puzzles.sql`, applied to prod):
- `cashgame_cashout` allowed **only** at `state='solved'` (between puzzles); mid-puzzle returns `in_puzzle`.
- On solve, `_climb_resolve` **pre-picks the next puzzle** (`climb_state.next_puzzle_id`) so the peek is truthful; `_climb_board` exposes `next_bounty` + `next_category`; `climb_next` deals that exact puzzle.
- Verified in a rolled-back tx: start → mid-puzzle cashout **blocked**, solve → `state=solved` + peek present (`next_bounty`, `next_category`), between-puzzle cashout **works**.

**Client:**
- Removed the anytime mid-puzzle Deposit button (the cop-out). Banking is now the win-screen Deposit only.
- The win screen shows a **"Next puzzle" peek** (category icon + bounty) above **Deposit** / **Push →**.
- Copy fixes: the "Cash Advance depleted" notice no longer offers a mid-puzzle deposit; ObjectiveCard climb → "bank between puzzles — solve or bust".

**Compatibility:** the between-puzzle win screen already existed, so the currently-deployed client stays functional after the migration (the old mid-puzzle button just no-ops until this deploys).

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)