### PR TITLE
Decision #8: live "Beat $X" target-to-beat in Challenge

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4283,6 +4283,9 @@
 			{:else}
 				<div class="match-meta">
 					{#if matchPot > 0}<span class="pot-chip">Pot ${matchPot.toLocaleString()}</span>{/if}
+					{#if matchInfo.target != null}<span class="beat-chip"
+							>Beat ${Number(matchInfo.target).toLocaleString()}</span
+						>{/if}
 					{#if matchInfo.pack_size > 1}<span class="match-pos"
 							>Puzzle {matchInfo.position}/{matchInfo.pack_size}</span
 						>{/if}
@@ -5224,6 +5227,18 @@
 		color: #fcd34d;
 		background: rgba(252, 211, 77, 0.12);
 		border: 1px solid rgba(252, 211, 77, 0.3);
+		padding: 3px 11px;
+		border-radius: 999px;
+		font-variant-numeric: tabular-nums;
+	}
+	/* 🎯 The score to beat (opponent has played) — the async duel's live target */
+	.beat-chip {
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.8rem;
+		color: #fb7185;
+		background: rgba(251, 113, 133, 0.12);
+		border: 1px solid rgba(251, 113, 133, 0.35);
 		padding: 3px 11px;
 		border-radius: 999px;
 		font-variant-numeric: tabular-nums;

--- a/supabase-challenge-target-to-beat.sql
+++ b/supabase-challenge-target-to-beat.sql
@@ -1,0 +1,70 @@
+-- Decision #8: expose the score-to-beat (best finished opponent) to a live player.
+-- Efficiency-duel plays the whole pack, so a shown target can't be gamed by stopping.
+-- PITR logged.
+BEGIN;
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager, 'target', (SELECT max(o.total_score) FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done'),
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')),
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id)) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF m.mode = 'blitz' THEN
+    v_minfo := v_minfo || jsonb_build_object('started_at', cp.started_at, 'clock_seconds', m.pack_size * 30, 'combo', cp.combo_x100);
+  END IF;
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' AND m.mode <> 'blitz' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN 'fog' = ANY(COALESCE(cp.debuffs,'{}')) THEN NULL ELSE v_clue END);
+END; $function$
+
+;
+COMMIT;


### PR DESCRIPTION
Warms up the cold async duel — once your opponent has played, you see the exact **Score to beat**.

- **Server** (`supabase-challenge-target-to-beat.sql`, applied to prod): `_match_board` now exposes `target` = the best **finished** opponent's `total_score` (null until someone finishes). This is safe to reveal here — the efficiency-duel plays the whole pack, so a known target **can't be gamed by stopping early** (that exploit only exists in a press-your-luck bank-or-push, which is deliberately Cash-Game-only per §5b). Verified in a rolled-back tx: opponent finishes → the still-active player's `board.target` = the opponent's final Score.
- **Client**: a red **"Beat $X"** chip beside the **Pot** chip in the match HUD.

This is the core of the async-warming (Decision #8). The H2H settle reveal already lives in the Match Detail modal; a "your opponent just played — you're up" push is a small remaining follow-up.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)