### PR TITLE
Challenge: podium-aware "Beat $X" target

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4284,7 +4284,10 @@
 				<div class="match-meta">
 					{#if matchPot > 0}<span class="pot-chip">Pot ${matchPot.toLocaleString()}</span>{/if}
 					{#if matchInfo.target != null}<span class="beat-chip"
-							>Beat ${Number(matchInfo.target).toLocaleString()}</span
+							>Beat ${Number(
+								matchInfo.target
+							).toLocaleString()}{#if matchInfo.target_kind === 'place'}
+								to place{/if}</span
 						>{/if}
 					{#if matchInfo.pack_size > 1}<span class="match-pos"
 							>Puzzle {matchInfo.position}/{matchInfo.pack_size}</span

--- a/supabase-challenge-podium-target.sql
+++ b/supabase-challenge-podium-target.sql
@@ -1,0 +1,95 @@
+-- ============================================================================
+-- Podium-aware "Beat $X" target. Previously target = the #1 score. For a podium
+-- group the useful bar is "beat this to get IN THE MONEY" (a paying place), not
+-- just to win. Server now returns `target` + `target_kind` ('win' | 'place'):
+--   * pay places K = 1 (duel/winner-take-all) · 2 (3-player podium) · 3 (4+ podium)
+--   * if >= K opponents finished → target = the K-th highest finished Score (the
+--     podium cutoff); kind = 'win' when K=1 else 'place'.
+--   * if 0 < finished < K → you're in the money so far → target = top Score, 'win'.
+--   * if none finished → null (first mover, no bar yet).
+-- PITR logged.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')),
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id)) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF m.mode = 'blitz' THEN
+    v_minfo := v_minfo || jsonb_build_object('started_at', cp.started_at, 'clock_seconds', m.pack_size * 30, 'combo', cp.combo_x100);
+  END IF;
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' AND m.mode <> 'blitz' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN 'fog' = ANY(COALESCE(cp.debuffs,'{}')) THEN NULL ELSE v_clue END);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
The one visible group-challenge gap from the status check: the "Beat $X" target used to always show the **#1** score, but in a podium group the actionable bar is "beat this to get **in the money**."

`_match_board` now returns `target` + `target_kind`:
- Pay places **K** = 1 (duel/winner-take-all) · 2 (3-player podium) · 3 (4+ podium).
- If **≥ K** opponents finished → `target` = the **K-th highest** finished Score (the podium cutoff); `target_kind` = `'win'` when K=1 else `'place'`.
- If **0 < finished < K** → you're in the money so far → `target` = top Score, kind `'win'`.
- If none finished → `null` (no bar yet).

Client: the chip reads **"Beat $X to place"** for podium placement, **"Beat $X"** for a win.

**Verified** in a rolled-back tx across all three cases: 3-player podium with 2 finished → `1580 / place`; with 1 finished → `1780 / win`; duel → `1780 / win`. Applied to prod.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)