### PR TITLE
Leaderboard: "Bounty Earned" → "Earnings" + drop redundant row emojis

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -147,7 +147,11 @@
 						></th
 					>
 					<th class="num"
-						><button class="sort" class:on={sortKey === 'score'} onclick={() => setSort('score')}
+						><button
+							class="sort"
+							class:on={sortKey === 'score'}
+							onclick={() => setSort('score')}
+							title="Earnings — what you banked from today's Daily"
 							><svg class="hcol-ic" viewBox="0 0 24 24" aria-hidden="true"
 								><circle cx="12" cy="12" r="8.5" /><circle cx="12" cy="12" r="4.5" /><circle
 									cx="12"
@@ -155,7 +159,7 @@
 									r="1.2"
 								/></svg
 							>
-							Bounty Earned{arrow('score')}</button
+							Earnings{arrow('score')}</button
 						></th
 					>
 					<th class="num"
@@ -226,8 +230,8 @@
 						<td class="metric">{r.credit ?? 650}</td>
 						<td class="metric gold">{r.played ? Number(r.score).toLocaleString() : '—'}</td>
 						<td class="metric eff">{r.efficiency != null ? r.efficiency + '%' : '—'}</td>
-						<td class="metric small">{r.play_streak > 0 ? '🔥' + r.play_streak : '—'}</td>
-						<td class="metric small">{r.win_streak > 0 ? '🏆' + r.win_streak : '—'}</td>
+						<td class="metric small">{r.play_streak > 0 ? r.play_streak : '—'}</td>
+						<td class="metric small">{r.win_streak > 0 ? r.win_streak : '—'}</td>
 					</tr>
 				{/each}
 			</tbody>


### PR DESCRIPTION
Post-economy-rework cleanup of the Daily leaderboard.

- **"Bounty Earned" → "Earnings"** (with a tooltip). "Bounty" now specifically means the *per-puzzle spend allowance* everywhere in the reworked economy, so "Bounty Earned" conflated the thing you spend with the thing you earn. The column is the daily score = what you banked, so "Earnings" (matching the Daily HUD) is the right term.
- **Dropped the `🔥`/`🏆` emoji from the streak/wins row cells** — the column *headers* already carry the flame/trophy line icons (from the icon sweep), so the rows just show the number. Fixes a header-icon-vs-row-emoji mismatch.

Left as-is on purpose: the scope dropdown emojis (🌍/👋/👥 — native `<select>` options can't hold SVG) and the 🥇🥈🥉 rank medals.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)