### PR TITLE
Friend profile: credit-card hero, drop emojis

### DIFF
--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -5,6 +5,8 @@
 	import { page } from '$app/stores';
 	import { getPublicProfile, addFriend, requestJoinGroup } from '$lib/stores/statsStore.js';
 	import Avatar from '$lib/components/Avatar.svelte';
+	import AccountCard from '$lib/components/AccountCard.svelte';
+	import ModeIcon from '$lib/components/ModeIcon.svelte';
 	import { track } from '$lib/analytics.js';
 	/** @type {Record<string,string>} */ let busyFriend = $state({});
 	/** @type {Record<string,string>} */ let groupState = $state({});
@@ -18,7 +20,6 @@
 
 	const username = $derived($page.params.username);
 
-	const money = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
 	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '—');
 	const winPct = (/** @type {any} */ a) =>
 		a?.games_played ? Math.round((a.games_won / a.games_played) * 100) + '%' : '—';
@@ -88,8 +89,13 @@
 			{/if}
 			<h1>@{p.username}</h1>
 			{#if p.title}<span class="u-title">{p.title}</span>{/if}
-			<div class="u-net" class:neg={Number(p.net_worth) < 0}>{money(p.net_worth)}</div>
-			<span class="u-net-lbl">Net Worth</span>
+			<div class="u-card">
+				<AccountCard
+					holder={p.name || p.username}
+					balance={p.net_worth}
+					tier={p.credit_tier ?? 'Good'}
+				/>
+			</div>
 		</header>
 
 		{#if !p.is_self}
@@ -126,7 +132,7 @@
 					<button class="pill" disabled={addBusy} onclick={add}>+ Add friend</button>
 				{/if}
 				<button class="pill gold" onclick={() => goto('/?challenge=' + p.username)}
-					>⚔️ Challenge</button
+					><ModeIcon mode="challenge" size={16} /> Challenge</button
 				>
 			</div>
 			{#if addMsg}<p class="add-msg">{addMsg}</p>{/if}
@@ -138,7 +144,7 @@
 
 		<section class="grid">
 			<div class="stat">
-				<span class="s-n">🔥 {p.current_streak}</span><span class="s-l">Streak</span>
+				<span class="s-n">{p.current_streak}</span><span class="s-l">Streak</span>
 			</div>
 			<div class="stat">
 				<span class="s-n">{p.longest_streak}</span><span class="s-l">Best streak</span>
@@ -168,7 +174,7 @@
 				<div class="b-h">Badges · {p.badges.length}</div>
 				<div class="b-wrap">
 					{#each p.badges as b}<span class="badge"
-							>🏅 {(b || '')
+							>{(b || '')
 								.replace(/_/g, ' ')
 								.replace(/\b\w/g, (/** @type {string} */ c) => c.toUpperCase())}</span
 						>{/each}
@@ -209,7 +215,7 @@
 				<div class="b-h">Groups · {p.groups.length}</div>
 				{#each p.groups as g}
 					<div class="soc-row">
-						<span class="soc-main static">👥 {g.name}</span>
+						<span class="soc-main static">{g.name}</span>
 						{#if g.my_status === 'member'}
 							<span class="soc-tag">✓ Member</span>
 						{:else if groupState[g.id] === 'requested' || g.my_status === 'requested'}
@@ -275,23 +281,9 @@
 		font-size: 0.78rem;
 		color: var(--gold);
 	}
-	.u-net {
-		font-family: 'Orbitron', var(--font-display);
-		font-weight: 800;
-		font-size: 2rem;
-		color: #fde047;
-		margin-top: 12px;
-		text-shadow: 0 0 18px rgba(251, 191, 36, 0.5);
-	}
-	.u-net.neg {
-		color: #fb7185;
-		text-shadow: none;
-	}
-	.u-net-lbl {
-		font-size: 0.72rem;
-		color: var(--text-faint);
-		text-transform: uppercase;
-		letter-spacing: 0.1em;
+	.u-card {
+		max-width: 340px;
+		margin: 16px auto 0;
 	}
 
 	.h2h {
@@ -377,6 +369,10 @@
 		flex-wrap: wrap;
 	}
 	.pill {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		gap: 5px;
 		padding: 9px 18px;
 		border-radius: var(--r-pill);
 		border: 1px solid var(--border-strong);

--- a/supabase-public-profile-credit.sql
+++ b/supabase-public-profile-credit.sql
@@ -1,0 +1,49 @@
+-- Add friend's credit (score + tier) to the public profile for the credit-card hero.
+BEGIN;
+CREATE OR REPLACE FUNCTION public.get_public_profile(p_username text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid(); v_tid uuid; p public.profiles;
+  v_climb int; v_cwins int; v_badges jsonb; v_avg int; v_best int; v_solved int; v_dplayed int; v_dwon int;
+  v_is_friend boolean; v_req_out boolean; v_req_in boolean; v_h2h jsonb;
+BEGIN
+  SELECT id INTO v_tid FROM public.profiles WHERE lower(username) = lower(p_username);
+  IF v_tid IS NULL THEN RETURN NULL; END IF;
+  SELECT * INTO p FROM public.profiles WHERE id = v_tid;
+  SELECT position INTO v_climb FROM public.climb_state WHERE user_id = v_tid;
+  SELECT count(*) INTO v_cwins FROM public.challenge_matches m
+    JOIN public.challenge_participants cp ON cp.match_id = m.id AND cp.user_id = v_tid
+    WHERE m.status = 'settled'
+      AND cp.total_score = (SELECT max(total_score) FROM public.challenge_participants x WHERE x.match_id = m.id);
+  SELECT COALESCE(jsonb_agg(badge), '[]'::jsonb) INTO v_badges FROM public.user_badges WHERE user_id = v_tid;
+  SELECT round(avg(multiple_x100))::int, max(multiple_x100),
+         COALESCE(sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)),0),
+         count(*) FILTER (WHERE game_mode='daily'),
+         count(*) FILTER (WHERE game_mode='daily' AND outcome='won')
+    INTO v_avg, v_best, v_solved, v_dplayed, v_dwon
+    FROM public.game_results WHERE user_id = v_tid;
+  v_is_friend := EXISTS (SELECT 1 FROM public.friendships WHERE user_id = v_uid AND friend_id = v_tid);
+  v_req_out := EXISTS (SELECT 1 FROM public.friend_requests WHERE requester = v_uid AND addressee = v_tid);
+  v_req_in  := EXISTS (SELECT 1 FROM public.friend_requests WHERE requester = v_tid AND addressee = v_uid);
+  IF v_uid IS DISTINCT FROM v_tid THEN v_h2h := public.get_head_to_head(v_tid); END IF;
+  RETURN jsonb_build_object(
+    'id', v_tid, 'username', p.username, 'avatar', p.avatar, 'name', public._display_name(v_tid),
+    'title', p.equipped_title, 'color', p.equipped_color,
+    'net_worth', COALESCE(p.bank,0), 'cash', COALESCE(p.bank,0),
+    'credit_score', COALESCE(p.credit_score, 650), 'credit_tier', public._credit_tier(COALESCE(p.credit_score,650)),
+    'current_streak', COALESCE(p.current_daily_play_streak,0), 'longest_streak', COALESCE(p.best_daily_play_streak,0),
+    'games_played', v_dplayed, 'games_won', v_dwon,
+    'puzzles_solved', v_solved, 'climb_position', COALESCE(v_climb,0),
+    'challenge_wins', COALESCE(v_cwins,0), 'avg_multiple_x100', v_avg, 'best_multiple_x100', v_best,
+    'badges', v_badges,
+    'friends', (SELECT COALESCE(jsonb_agg(jsonb_build_object('username', p2.username, 'name', public._display_name(p2.id), 'is_self', (p2.id = v_uid), 'status', CASE WHEN p2.id = v_uid THEN 'self' WHEN EXISTS(SELECT 1 FROM public.friendships fx WHERE fx.user_id = v_uid AND fx.friend_id = p2.id) THEN 'friends' WHEN EXISTS(SELECT 1 FROM public.friend_requests rq WHERE rq.requester = v_uid AND rq.addressee = p2.id) THEN 'pending_out' WHEN EXISTS(SELECT 1 FROM public.friend_requests rq WHERE rq.requester = p2.id AND rq.addressee = v_uid) THEN 'pending_in' ELSE 'none' END) ORDER BY p2.username), '[]'::jsonb) FROM public.friendships f JOIN public.profiles p2 ON p2.id = f.friend_id WHERE f.user_id = v_tid AND p2.username IS NOT NULL),
+    'groups', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', g.id, 'name', g.name, 'my_status', CASE WHEN g.owner_id = v_uid OR EXISTS(SELECT 1 FROM public.group_members gm2 WHERE gm2.group_id=g.id AND gm2.user_id=v_uid) THEN 'member' WHEN EXISTS(SELECT 1 FROM public.group_join_requests jr WHERE jr.group_id=g.id AND jr.requester_id=v_uid) THEN 'requested' ELSE 'none' END) ORDER BY g.name), '[]'::jsonb) FROM public.group_members gm JOIN public.groups g ON g.id = gm.group_id WHERE gm.user_id = v_tid), 'is_self', (v_uid IS NOT DISTINCT FROM v_tid), 'is_friend', v_is_friend,
+    'request_outgoing', v_req_out, 'request_incoming', v_req_in, 'head_to_head', v_h2h
+  );
+END; $function$
+
+;
+COMMIT;


### PR DESCRIPTION
Fixes the public profile (`/u/[username]`) per request.

- **Credit card up top instead of the net-worth LCD** — swapped the big `$X Net Worth` Orbitron number for the **`AccountCard`** (the tiered credit card), skinned to the friend's credit tier and showing their name + balance.
- **`get_public_profile` now returns `credit_score` + `credit_tier`** (server migration, applied to prod + verified) so the card can render the friend's tier.
- **Emojis removed:** ⚔️ Challenge → the swords `ModeIcon` (consistent with the rest of the app), plus 🔥 Streak, 🏅 badges, 👥 groups. Kept the ✓ status marks (universally clean).

If you'd rather the hero lead with the **credit-score gauge/dial** (like My Account) instead of the balance-forward card, that's a one-line swap — say the word.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)