### PR TITLE
Cash Game win screen: fix Deposit modal, rename Push → Play On

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2824,7 +2824,7 @@
 <!-- ℹ️ Challenge "Left to Spend" explainer -->
 {#if showDepositConfirm}
 	<div
-		class="modal-overlay info-overlay"
+		class="modal-overlay info-overlay dep-confirm-overlay"
 		role="button"
 		tabindex="0"
 		aria-label="Close"
@@ -4812,7 +4812,7 @@
 									>${Math.round(menuBank ?? 0).toLocaleString()}</span
 								>
 							</div>
-							<div class="rcpt-foot">Bank it now, or push on and risk it all.</div>
+							<div class="rcpt-foot">Bank it now, or play on and risk it all.</div>
 						</div>
 						{#if climb?.next_category}
 							<div class="cg-peek">
@@ -4846,7 +4846,7 @@
 									showResultModal = false;
 									hasTriggeredModal = false;
 									climbAdvance().then(() => tick().then(playDailyIntroIfArmed));
-								}}>Push →</button
+								}}>Play On →</button
 							>
 						</div>
 					{:else if isClimb}
@@ -8165,6 +8165,11 @@
 	.info-overlay {
 		border: none;
 		cursor: pointer;
+	}
+	/* Deposit confirm is opened FROM the win receipt (also a .modal-overlay), so it
+	   must sit above it — otherwise it renders behind and the tap looks like a no-op. */
+	.dep-confirm-overlay {
+		z-index: 10000;
 	}
 	.info-card {
 		position: relative;


### PR DESCRIPTION
Fixes the between-puzzle win screen.

**Deposit button "acting weird":** clicking Deposit opens the deposit-confirm modal, but that modal is declared *earlier* in the DOM than the win receipt — and both are `.modal-overlay` at z-index 9999, so the confirm rendered **behind** the receipt and the tap looked like a no-op. Gave the confirm overlay `z-index: 10000` so it sits on top and explains the deposit as intended. Tapping **Keep Playing** returns to the receipt (no soft-lock — the result modal is triggered by a reveal-complete callback, not a reactive, so nothing loops).

**"Push" → "Play On":** renamed the risk-it button to **"Play On →"** (pairs with "Deposit"), and updated the receipt line to "Bank it now, or play on and risk it all." (The Push/Play-On flow itself was already correct — it closes the receipt and advances via `climbAdvance` → the pre-picked next puzzle.)

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)