### PR TITLE
Cash Game peek: "bounty" → "payout"

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4820,7 +4820,7 @@
 								<span class="cg-peek-val"
 									><CategoryIcon category={climb.next_category} size={15} />{categoryLabel(
 										climb.next_category
-									)} · <b>${(climb.next_bounty ?? 0).toLocaleString()}</b> bounty</span
+									)} · <b>${(climb.next_bounty ?? 0).toLocaleString()}</b> payout</span
 								>
 							</div>
 						{/if}


### PR DESCRIPTION
Renames the next-puzzle peek from "$X bounty" to "$X payout" — clearer for the push-or-bank decision.

Note: the number is technically the puzzle's spend budget (Cash Advance); the real payout is that × your Yield, so "payout" reads well but slightly undersells a clean solve. Fine for a quick peek.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)