### PR TITLE
Cash Game must-guess banner: new-vocab wording

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4231,16 +4231,16 @@
 					<div class="bn-head">
 						<span class="bn-app">🏦 WordBank</span><span class="bn-time">now</span>
 					</div>
-					<div class="bn-title">Cash Advance depleted</div>
+					<div class="bn-title">Balance too low</div>
 					{#if (climb.wallet ?? climb.bankroll ?? 0) > 0}
 						<div class="bn-body">
-							You have to guess now — no more letters. Solve to bank it, or a wrong guess voids your
-							whole Wallet.
+							Not enough to buy another letter — you have to guess. Solve to bank it, or a wrong
+							guess voids your whole Potential Payout.
 						</div>
 					{:else}
 						<div class="bn-body">
-							You have to guess now. Solve to credit your account; a wrong guess voids the session
-							and forfeits your Principal.
+							Not enough to buy another letter — you have to guess. Solve to bank your winnings; a
+							wrong guess ends the run and forfeits your Principal.
 						</div>
 					{/if}
 				</div>


### PR DESCRIPTION
Updates the "must guess" banner to the reworked vocabulary — it was still saying "Cash Advance depleted" and "voids your whole **Wallet**", which clashes with the "**Balance Remaining**" number right below it.

- Title: **"Balance too low"** (matches Balance Remaining; also more accurate — you usually have *some* left, just not enough to afford the cheapest letter).
- Body: "Not enough to buy another letter — you have to guess. Solve to bank it, or a wrong guess voids your whole **Potential Payout**." (Wallet → Potential Payout.)
- The no-winnings-yet variant keeps "forfeits your Principal" (still a live term).

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)