### PR TITLE
Cash Game: "Give up" when stuck (forfeit + confirmation)

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -36,6 +36,7 @@ import {
 	climbSubmitGuess,
 	climbNext,
 	climbLeave,
+	climbForfeit,
 	climbSkip,
 	climbDoubleOrNothing,
 	climbUsePowerup,
@@ -671,6 +672,14 @@ export async function climbAdvance() {
 	} finally {
 		dailyInFlight = false;
 	}
+}
+
+/** Voluntarily give up the current Cash Game run — a clean bust (same as a wrong
+ *  guess: wipes the pot, reveals the answer). Shows the VOID receipt. */
+export async function climbForfeitRun() {
+	const board = await climbForfeit();
+	if (board) reconcileClimbBoard(board);
+	return board;
 }
 
 /** Leave the Cash Game (clears heat; position + Cash persist). */

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -790,6 +790,16 @@ export async function climbLeave() {
 	}
 	return data;
 }
+/** Voluntarily give up the current Cash Game run — a clean bust (wipes the pot,
+ *  reveals the answer). @returns {Promise<any>} */
+export async function climbForfeit() {
+	const { data, error } = await supabase.rpc('climb_forfeit');
+	if (error) {
+		console.error('❌ climb_forfeit:', error);
+		return null;
+	}
+	return data;
+}
 /** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). @returns {Promise<any>} */
 export async function climbSkip() {
 	const { data, error } = await supabase.rpc('climb_skip');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 		startCashGame,
 		cashOutClimb,
 		climbAdvance,
+		climbForfeitRun,
 		climbLeaveGame,
 		climbSkipPuzzle,
 		climbArmDoubleOrNothing,
@@ -1818,6 +1819,23 @@
 			refreshBank();
 		}
 	}
+	// 🏳️ Give up: when you're stuck (can't afford letters, don't know it), forfeit
+	// the run instead of typing wrong guesses. Same outcome as a bust — a forced-choice
+	// confirm makes the loss deliberate.
+	let showForfeitConfirm = false;
+	let forfeitAmount = 0;
+	function askForfeit() {
+		if (cgBusy) return;
+		forfeitAmount = Math.round(climb?.bankroll ?? 0);
+		showForfeitConfirm = true;
+	}
+	async function confirmForfeit() {
+		if (cgBusy) return;
+		showForfeitConfirm = false;
+		cgBusy = true;
+		await climbForfeitRun();
+		cgBusy = false;
+	}
 
 	// ===== ⚡ Blitz — tier select + timed run =====
 	let showBlitzTier = false;
@@ -2836,6 +2854,24 @@
 				<button class="dep-go" disabled={cgBusy} on:click={confirmDeposit}
 					>Deposit ${depositPend.toLocaleString()}</button
 				>
+			</div>
+		</div>
+	</div>
+{/if}
+
+{#if showForfeitConfirm}
+	<!-- Forced choice — Keep Playing or Give Up. -->
+	<div class="modal-overlay info-overlay dep-confirm-overlay">
+		<div class="info-card" role="dialog" aria-modal="true">
+			<div class="info-big neg">−${forfeitAmount.toLocaleString()}</div>
+			<h3 class="info-title">Give up this puzzle?</h3>
+			<p class="info-sub">
+				You'll <b class="neg">lose your ${forfeitAmount.toLocaleString()} Potential Payout</b> and see
+				the answer. This can't be undone.
+			</p>
+			<div class="dep-actions">
+				<button class="dep-keep" on:click={() => (showForfeitConfirm = false)}>Keep Playing</button>
+				<button class="dep-go forfeit" disabled={cgBusy} on:click={confirmForfeit}>Give Up</button>
 			</div>
 		</div>
 	</div>
@@ -4243,6 +4279,7 @@
 							wrong guess ends the run and forfeits your Principal.
 						</div>
 					{/if}
+					<button class="bn-forfeit" on:click={askForfeit}>Don't know it? Give up →</button>
 				</div>
 			{/if}
 		{/if}
@@ -5376,6 +5413,20 @@
 		font-size: 0.78rem;
 		line-height: 1.35;
 		color: #d8cccc;
+	}
+	/* 🏳️ give-up link inside the must-guess banner */
+	.bn-forfeit {
+		margin-top: 8px;
+		background: none;
+		border: none;
+		padding: 2px 0;
+		font-family: var(--font-ui);
+		font-weight: 700;
+		font-size: 0.76rem;
+		color: #fb7185;
+		cursor: pointer;
+		text-decoration: underline;
+		text-underline-offset: 2px;
 	}
 
 	.dep-ic {
@@ -8425,6 +8476,12 @@
 		color: #4ade80;
 		text-shadow: 0 0 22px rgba(74, 222, 128, 0.45);
 	}
+	.info-big.neg {
+		font-family: var(--font-display, sans-serif);
+		font-variant-numeric: tabular-nums;
+		color: #fb7185;
+		text-shadow: 0 0 22px rgba(251, 113, 133, 0.4);
+	}
 	.info-title {
 		font-family: var(--font-display);
 		font-size: 1.15rem;
@@ -8471,6 +8528,11 @@
 	.dep-go:disabled {
 		opacity: 0.6;
 		cursor: default;
+	}
+	/* destructive variant — Give Up (forfeit) */
+	.dep-go.forfeit {
+		background: linear-gradient(135deg, #fb7185, #e11d48);
+		color: #fff;
 	}
 	.info-rows {
 		display: flex;

--- a/supabase-climb-forfeit.sql
+++ b/supabase-climb-forfeit.sql
@@ -1,0 +1,14 @@
+-- Voluntary give-up for Cash Game: a clean bust so a stuck player doesn't have to
+-- type wrong guesses. Same outcome as a wrong guess (_cg_bust: wipes the pot,
+-- reveals the answer, ends the run). Gated on an active run. PITR logged.
+BEGIN;
+CREATE OR REPLACE FUNCTION public.climb_forfeit()
+ RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER AS $function$
+DECLARE v_uid uuid := auth.uid(); cs public.climb_state;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_forfeit: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  RETURN public._cg_bust(v_uid);
+END; $function$;
+COMMIT;


### PR DESCRIPTION
When Cash Game forces you to guess (Balance too low) and you don't know the answer, you had to type random wrong guesses just to bust. Now there's a clean **Give up** option.

- **Server:** `climb_forfeit()` — a public voluntary bust (wraps `_cg_bust`: wipes the pot, reveals the answer, ends the run), gated on an active run. Applied to prod + verified in a rolled-back tx (forfeit → `state='busted'`, run row deleted).
- **Client:** a **"Don't know it? Give up →"** link on the "Balance too low" banner opens a **forced-choice confirmation** (no ✕): *"You'll lose your $X Potential Payout and see the answer. This can't be undone."* → forfeits and shows the VOID receipt. Same outcome as a wrong guess — just deliberate and less tedious.

Design note: giving up = busting (you committed to the puzzle; solve-or-bust), so it loses the accumulated Potential Payout — hence the confirmation. It's scoped to the must-guess banner (the clear "stuck" state) for now.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)