### PR TITLE
Cash Game: give up available anytime (top-right button)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2414,9 +2414,14 @@
 		}}>{$soundEnabled || $musicEnabled ? '🔊' : '🔇'}</button
 	>
 {/if}
-<!-- 🏳️ Give up (top-right) — Daily / Challenges -->
-{#if loggedIn && hasInitialized && !showMainMenu && foldMode && gameActive}
-	<button class="giveup-btn" title="Give up" aria-label="Give up" on:click={confirmFold}>↪</button>
+<!-- 🏳️ Give up (top-right) — Daily / Challenges / Cash Game (forfeit) -->
+{#if loggedIn && hasInitialized && !showMainMenu && gameActive && (foldMode || (isClimb && climb?.state === 'active'))}
+	<button
+		class="giveup-btn"
+		title="Give up"
+		aria-label="Give up"
+		on:click={isClimb ? askForfeit : confirmFold}>↪</button
+	>
 {/if}
 <!-- Skip retired in Cash Game V4 — Cash Out is the graceful bail. -->
 


### PR DESCRIPTION
Makes the Cash Game **Give up** available any time during a puzzle, not just from the "Balance too low" banner.

The app already has a top-right give-up arrow (`↪`), but it was gated to `foldMode` (Daily + Challenges only) and Cash Game's old path was a now-dead "Skip". This surfaces that button for Cash Game during an **active** puzzle and routes it to the new forfeit flow (`askForfeit` → forced-choice confirm → `climb_forfeit`).

Now there are two entry points, both opening the same confirmation:
- the top-right **↪** (always available mid-puzzle), and
- the contextual **"Don't know it? Give up →"** link on the must-guess banner.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)