### PR TITLE
Cash Game tier select: buy-in amounts → clean money font

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5537,10 +5537,11 @@
 		font-size: 1.05rem;
 	}
 	.tt-buyin {
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		color: var(--brand-2);
 		font-size: 1.1rem;
+		font-variant-numeric: tabular-nums;
 	}
 	.tt-buyin small {
 		font-family: var(--font-ui);


### PR DESCRIPTION
The tier buy-in amounts ($250 / $1,000 / …) were still in the LCD/Orbitron face. Switched them to `--font-display` (Space Grotesk) with tabular-nums, consistent with the rest of the money vocabulary/font sweep.

Gates: prettier ✓ · svelte-check 0 err / 1 baseline warning ✓ · lint ✓ · build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)