### PR TITLE
Cash Game: one-balance overhaul (top=account, Heat on bounty)

### DIFF
--- a/docs/superpowers/specs/2026-07-09-economy-rework-cashgame-challenge.md
+++ b/docs/superpowers/specs/2026-07-09-economy-rework-cashgame-challenge.md
@@ -172,3 +172,41 @@ If we ever want the flavor in Challenge: do a **blind** head-to-head press-your-
 - **Phase 6 — Cleanup + docs.** Kill dead challenge SQL + legacy gameMode, prune dead reasons, QA harness, Notion.
 
 **Sequencing note:** Challenge first (Phases 1–2) — it's the bigger conceptual change and it validates the shared bounty-efficiency engine that Cash Game already uses. Cash Game (3–4) is then a smaller, self-contained flow change.
+
+---
+
+## 7. Phase 7 — Cash Game "One Balance" overhaul (2026-07-09)
+
+**Goal:** Kill the two-number HUD (top "Potential Payout" = accumulated `bankroll`; center "Balance Remaining" = `budget_left × heat`). Replace with **one running Balance**, top bar shows your **real account balance** (like Daily), and move **Heat onto the bounty injection** so it stays a single number.
+
+### 7.1 The model (locked)
+
+- **One number = `balance` = `bankroll` (secured pile) + `budget_left` (this puzzle's spendable).** Buying a letter drops it; solving _secures_ it (folds `budget_left` into `bankroll`); busting zeroes it.
+- **Heat multiplies the bounty as it's injected**, not the payout: `bounty_eff = round(_climb_bounty(pid,k) × stake × heat/100)`. At heat ×1.0 puzzle 1 starts _at the bounty_ (matches the user's "starts as the bounty"). Heat still `+10`/solve, capped at `heat_cap`.
+- **Letters spend from the current puzzle's `bounty_eff` only** (`budget_left = bounty_eff − spent`; `must_guess` when `budget_left < cheapest`). The secured pile is **safe from letter-spend**, at risk only from a wrong final guess → this preserves the bust mechanic (a flush pile can't buy its way out of a hard word). Copy at `must_guess`: framed as "out of budget for _this word_."
+- **Solving no longer makes the number jump** — the Balance already shows your at-risk total. Solve = "secured, carried"; the next bounty (× the new heat) is added when you hit **Play On**. Cash out (between puzzles) = take the Balance; net = `balance − buy_in`. Bust = `$0`, down the buy-in.
+- **Buy-in unchanged** — still the entry fee / sink / risk floor, deducted at `cashgame_start`. Tiers still gate bounty size.
+- **DON is a dead stub** (`climb_double_or_nothing` returns the board) → untouched.
+
+### 7.2 Server (`supabase-cashgame-v5-onebalance.sql`)
+
+Three functions change; `cashgame_start` / `climb_next` / `cashgame_cashout` / `_cg_bust` keep their logic (they already operate on `bankroll` = secured pile, which conserves).
+
+- **`_climb_board`**: compute `v_bounty := round(_climb_bounty(pid,k) × stake × heat/100)`; `v_budget_left := max(0, v_bounty − spent)`; add **`'balance' = bankroll + v_budget_left`**; `solve_reward := v_budget_left` (back-compat); `next_bounty := round(_climb_bounty(next,k) × stake × min(cap, heat+10)/100)` (peek uses the heat you'll have). `must_guess` unchanged (uses new `v_budget_left`).
+- **`_climb_resolve`**: `v_bounty_eff := round(_climb_bounty(pid,k) × stake × heat/100)`; `v_keep := max(0, v_bounty_eff − spent)`; `bankroll += v_keep` (**no** second `× heat`); `heat += 10` (cap); `last_gain := v_keep`; log `net := v_keep`.
+- **`climb_buy_letter`**: `v_bounty := round(_climb_bounty(pid,k) × stake × heat/100)`; rest identical (affordability check uses the heat-boosted budget).
+
+**Conservation:** letters stay off-ledger; only `buy_in` (sink) and `cashout(bankroll)` (source) touch `_bank_credit`. `bankroll` only ever grows by `max(0, bounty_eff − spent)` per solve → `net = bankroll − buy_in`. Verify in a `BEGIN…ROLLBACK` run: buy-in debits bank, multi-solve accumulates, cashout credits exactly `bankroll`, bust credits nothing. No `econ_v` gate needed — runs are single-session and the change is display + heat-target (no in-flight leak).
+
+**Balance note:** heat-on-bounty means a hot streak has _more_ working capital (can afford more letters) — intended "hot = flush." `k<1` on higher tiers already decays base bounties deeper in, counterbalancing heat growth; bust probability rises with harder deep puzzles. Watch avg cash-out multiples after ship; tune `heat` increment / `heat_cap` if inflationary.
+
+### 7.3 Client (`src/routes/+page.svelte`)
+
+- **Top bar (isClimb)**: cap "Potential Payout" → **"Available Balance"**, value `$tweenBank` → real account (`menuBank ?? netWorth ?? 0`), static during play — same treatment just shipped for Daily (#494).
+- **Center hero (isClimb)**: `climbLive.net` (= `solve_reward`) → **`climb.balance`**; label stays "Balance". Heat badge `+{climbYield}%` → **`×{heat/100}`** to match Daily's Interest badge grammar.
+- **Between-puzzle screen**: show **carried `bankroll`** + **next bounty (`next_bounty`, heat-boosted)** → **new Balance**; Cash Out banks the carried, Play On injects the next bounty.
+- **`must_guess` banner / info modals / win-secure / cashout / bust** copy: reframe from "payout" to "Balance" — solving _secures_, busting _zeroes_.
+
+### 7.4 Verification
+
+PITR stamp → apply via MCP/psql → `BEGIN…ROLLBACK` conservation test (impersonate a user, run buy-in→buys→solve→next→solve→cashout, assert ledger net = `bankroll − buy_in`; separate bust path asserts no credit) → prettier/check/lint/build → `qa-e2e.mjs` → ship.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -608,7 +608,8 @@
 			? {
 					spent: climb.spent ?? 0,
 					payout: climb.solve_reward ?? 0,
-					net: climb.solve_reward ?? 0
+					// One-number model: the hero shows the running Balance (secured pile + this puzzle's spend).
+					net: climb.balance ?? (climb.bankroll ?? 0) + (climb.solve_reward ?? 0)
 				}
 			: null;
 	// Challenge live: Spent of your ante budget — lowest spend wins (standard only).
@@ -1120,8 +1121,6 @@
 		matchExpiredFired = true;
 		await matchTimeoutCheck();
 	}
-	// Cash Game "Yield" = heat expressed as a % gain (heat ×1.3 → +30%).
-	$: climbYield = Math.round((climb?.heat ?? 100) - 100);
 	// Heat IS the Cash Game win streak: each solve +0.1× (cap ×2.0), reset to ×1.0 when stuck.
 	$: climbStreak = Math.max(0, Math.round(((climb?.heat ?? 100) - 100) / 10));
 	// 🔥 The run: solves + cumulative profit since heat last reset (run_profit can be negative early).
@@ -1774,6 +1773,7 @@
 		const res = await startCashGame(tier);
 		cgBusy = false;
 		if (res?.ok) {
+			refreshBank(); // buy-in was just debited server-side → keep the top-bar Available Balance fresh
 			await enterClimbGame();
 		} else if (res?.reason === 'insufficient') {
 			await borrowToBuyIn(tier, res.buy_in ?? 0, res.bank ?? 0);
@@ -1822,6 +1822,7 @@
 		cgBusy = false;
 		if (retry?.ok) {
 			fx('win');
+			refreshBank(); // borrowed + bought in → refresh the top-bar Available Balance
 			await enterClimbGame();
 		} else {
 			fx('wrong');
@@ -2812,60 +2813,65 @@
 		<div class="info-card" on:click|stopPropagation role="dialog" aria-modal="true">
 			<button class="modal-x" on:click={() => (climbInfo = null)} aria-label="Close">✕</button>
 			{#if climbInfo === 'heat'}
-				<div class="info-big">📈 +{climbYield}%</div>
-				<h3 class="info-title">Yield — your return rate</h3>
-				<p class="info-sub">Everything you earn from a puzzle is boosted by your Yield rate.</p>
+				<div class="info-big">🔥 ×{((climb?.heat ?? 100) / 100).toFixed(1)}</div>
+				<h3 class="info-title">Heat — your bounty multiplier</h3>
+				<p class="info-sub">Every new bounty lands in your Balance boosted by your Heat.</p>
 				<div class="info-rows">
-					<div class="info-row"><span>Base</span><b>+0%</b></div>
-					<div class="info-row"><span>Each solve in a row</span><b class="pos">+10%</b></div>
+					<div class="info-row"><span>Base</span><b>×1.0</b></div>
+					<div class="info-row"><span>Each solve in a row</span><b class="pos">+0.1×</b></div>
 					<div class="info-row">
-						<span>Maxes out at</span><b>+{(climb?.heat_cap ?? 200) - 100}%</b>
+						<span>Maxes out at</span><b>×{((climb?.heat_cap ?? 200) / 100).toFixed(1)}</b>
 					</div>
-					<div class="info-row total"><span>Your Yield</span><b>+{climbYield}%</b></div>
+					<div class="info-row total">
+						<span>Your Heat</span><b>×{((climb?.heat ?? 100) / 100).toFixed(1)}</b>
+					</div>
 				</div>
 				<p class="info-note">
-					Yield climbs with your <button
+					Heat climbs with your <button
 						class="info-inline"
-						on:click|stopPropagation={() => (climbInfo = 'streak')}>deposit streak</button
-					> and resets to +0% on a VOID.
+						on:click|stopPropagation={() => (climbInfo = 'streak')}>solve streak</button
+					> and resets to ×1.0 on a bust.
 				</p>
 			{:else if climbInfo === 'streak'}
-				<div class="info-big">🏆 {climbStreak}</div>
-				<h3 class="info-title">Deposit Streak</h3>
+				<div class="info-big">🔥 {climbStreak}</div>
+				<h3 class="info-title">Solve Streak</h3>
 				<p class="info-sub">Cash Game puzzles you've solved in a row.</p>
 				<div class="info-rows">
 					<div class="info-row"><span>Solve a puzzle</span><b class="pos">+1</b></div>
-					<div class="info-row"><span>VOID</span><b class="neg">back to 0</b></div>
+					<div class="info-row"><span>Bust</span><b class="neg">back to 0</b></div>
 				</div>
 				<p class="info-note">
 					Powers your <button
 						class="info-inline"
-						on:click|stopPropagation={() => (climbInfo = 'heat')}>Yield</button
+						on:click|stopPropagation={() => (climbInfo = 'heat')}>Heat</button
 					>
-					— <b>+10%</b> per solve.
+					— <b>+0.1×</b> per solve.
 				</p>
 			{:else}
 				<div class="info-big green">${Math.max(0, climbLive?.net ?? 0).toLocaleString()}</div>
-				<h3 class="info-title">Balance Remaining</h3>
-				<p class="info-sub">What lands in your Potential Payout if you solve right now.</p>
+				<h3 class="info-title">Balance</h3>
+				<p class="info-sub">
+					Your running cash this run — solve to keep it, one wrong guess loses it all.
+				</p>
 				<div class="info-rows">
 					<div class="info-row">
-						<span>Cash Advance left <small>(spend on letters)</small></span><b
+						<span>Secured so far</span><b>${Math.round(climb?.bankroll ?? 0).toLocaleString()}</b>
+					</div>
+					<div class="info-row">
+						<span>This puzzle's budget <small>(spend on letters)</small></span><b
 							>${Math.round(climb?.budget_left ?? 0).toLocaleString()}</b
 						>
 					</div>
-					<div class="info-row">
-						<span>📈 Yield</span><b class="pos">+{climbYield}%</b>
-					</div>
 					<div class="info-row total">
-						<span>Credit</span><b class="green">${(climbLive?.net ?? 0).toLocaleString()}</b>
+						<span>Balance</span><b class="green">${(climbLive?.net ?? 0).toLocaleString()}</b>
 					</div>
 				</div>
 				<p class="info-note">
-					Each puzzle's <b>Cash Advance</b> shrinks as you buy letters — solve to keep what's left ×
+					Each puzzle's <b>budget</b> shrinks as you buy letters — solve to lock it into your
+					Balance. Reveal less, keep more; the next bounty lands ×
 					<button class="info-inline" on:click|stopPropagation={() => (climbInfo = 'heat')}
-						>Yield</button
-					>. Reveal less, keep more.
+						>Heat</button
+					>.
 				</p>
 			{/if}
 			<button class="info-close" on:click={() => (climbInfo = null)}>Got it</button>
@@ -2900,8 +2906,8 @@
 			<div class="info-big neg">−${forfeitAmount.toLocaleString()}</div>
 			<h3 class="info-title">Give up this puzzle?</h3>
 			<p class="info-sub">
-				You'll <b class="neg">lose your ${forfeitAmount.toLocaleString()} Potential Payout</b> and see
-				the answer. This can't be undone.
+				You'll <b class="neg">lose your ${forfeitAmount.toLocaleString()} Balance</b> and see the answer.
+				This can't be undone.
 			</p>
 			<div class="dep-actions">
 				<button class="dep-keep" on:click={() => (showForfeitConfirm = false)}>Keep Playing</button>
@@ -3561,8 +3567,8 @@
 					<button class="close-btn" on:click={() => (showTierSelect = false)}>❌</button>
 					<h2>Cash Game</h2>
 					<p class="cat-sub">
-						Invest your Principal, grow it, Deposit — or VOID. Higher tiers put more on the table
-						for a bigger Yield.
+						Spend each bounty, keep what's left, and grow one Balance across puzzles. Cash out
+						anytime — but one wrong guess busts it. Higher tiers, bigger bounties.
 					</p>
 					<div class="tier-balance">
 						Your Cash <b class:neg={cgBroke}>${(cgMeta?.bank ?? 0).toLocaleString()}</b>
@@ -4263,18 +4269,22 @@
 					title={isDailyLike
 						? 'Available Balance — your account; today’s puzzle deposits into it'
 						: isClimb
-							? 'Potential Payout — deposit it before a wrong guess'
+							? 'Available Balance — your account; cash out your run into it'
 							: isMatch
 								? 'Your Score — cash kept, banks up with each solve'
 								: 'Available Balance'}
 					on:click={openBankModal}
 				>
-					{#if isMatch}<span class="tb-wallet-cap">Score</span>{:else if isDailyLike}<span
-							class="tb-wallet-cap">Available Balance</span
-						>{:else if isClimb}<span class="tb-wallet-cap">Potential Payout</span>{/if}
+					{#if isMatch}<span class="tb-wallet-cap">Score</span
+						>{:else if isDailyLike || isClimb}<span class="tb-wallet-cap">Available Balance</span
+						>{/if}
 					<span class="tb-solo"
 						>${Math.round(
-							isMatch ? $tweenScore : isDailyLike ? (menuBank ?? netWorth ?? 0) : $tweenBank
+							isMatch
+								? $tweenScore
+								: isDailyLike || isClimb
+									? (menuBank ?? netWorth ?? 0)
+									: $tweenBank
 						).toLocaleString()}</span
 					>
 				</button>
@@ -4320,16 +4330,16 @@
 			</div>
 		{/if}
 
-		<!-- 🎰 Cash Game (Climb) HUD — number-free so it feels random. Heat lives in the
-         Solve-to-Earn box; power-ups live in the vault beside Solve. -->
+		<!-- 🎰 Cash Game (Climb) HUD — one running Balance up top; Heat badge + Balance in the
+         hero. Must-guess banner shows when this puzzle's budget is spent. -->
 		{#if isClimb && climb}
 			{#if mgBannerVisible && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				<div class="bank-notif">
 					<div class="bn-head">
 						<span class="bn-app">🏦 WordBank</span><span class="bn-time">now</span>
 					</div>
-					<div class="bn-title">You're out of money!</div>
-					<div class="bn-body">Solve now, or forfeit your payout!</div>
+					<div class="bn-title">Out of budget for this word!</div>
+					<div class="bn-body">Solve it now — or bust and lose your Balance.</div>
 					<button class="bn-forfeit" on:click={askForfeit}>Don't know it? Give up →</button>
 				</div>
 			{/if}
@@ -4447,9 +4457,11 @@
 								: 'Nothing left'
 							: $gameStore.gameMode === 'daily'
 								? 'Balance Remaining'
-								: soloHero.net >= 0
-									? 'Balance Remaining'
-									: '⚠️ You’re losing money'}</span
+								: isClimb
+									? 'Balance'
+									: soloHero.net >= 0
+										? 'Balance Remaining'
+										: '⚠️ You’re losing money'}</span
 					>
 					<div class="bp-row">
 						{#if $gameStore.gameMode === 'daily'}
@@ -4464,11 +4476,11 @@
 						{:else if isClimb}
 							<button
 								class="bp-mult-badge"
-								title="Yield — your return rate, climbs with each solve"
+								title="Heat — boosts each new bounty as it lands in your Balance"
 								on:click={() => {
 									fx('tap');
 									climbInfo = 'heat';
-								}}>+{climbYield}%</button
+								}}>×{((climb?.heat ?? 100) / 100).toFixed(1)}</button
 							>
 						{:else}
 							<span class="bp-badge-spacer"></span>
@@ -4621,7 +4633,7 @@
 
 		<!-- 🏆 Game Outcome Banner (win celebration handled by the slot-machine reveal) -->
 		{#if $gameStore.gameState === 'lost'}
-			<div class="banner lose">{isClimb ? '⚠ VOID' : 'No luck'}</div>
+			<div class="banner lose">{isClimb ? '⚠ BUST' : 'No luck'}</div>
 		{/if}
 
 		<!-- 🎯 Result Modal -->
@@ -4722,7 +4734,7 @@
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
 							</div>
-							<div class="rcpt-title void">⚠ VOID</div>
+							<div class="rcpt-title void">⚠ BUST</div>
 							<div class="rcpt-acct">WORDBANK CHECKING</div>
 							<div class="rcpt-sub">
 								ACCT ·········{acctNo}{#if myUsername}
@@ -4778,10 +4790,10 @@
 							</div>
 							<div class="rcpt-rule"></div>
 							<div class="rcpt-line">
-								<span>Earnings</span><span>${(co.banked ?? 0).toLocaleString()}</span>
+								<span>Balance banked</span><span>${(co.banked ?? 0).toLocaleString()}</span>
 							</div>
 							<div class="rcpt-line">
-								<span>Principal</span><span class="neg">−${(co.buy_in ?? 0).toLocaleString()}</span>
+								<span>Buy-in</span><span class="neg">−${(co.buy_in ?? 0).toLocaleString()}</span>
 							</div>
 							<div class="rcpt-rule double"></div>
 							<div class="rcpt-line total" class:profit={prof >= 0}>
@@ -4790,9 +4802,9 @@
 								>
 							</div>
 							<div class="rcpt-note">
-								{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× principal · peak yield +{Math.round(
-									(co.heat ?? 100) - 100
-								)}%
+								{((co.multiple_x100 ?? 0) / 100).toFixed(1)}× buy-in · peak heat ×{(
+									(co.heat ?? 100) / 100
+								).toFixed(1)}
 							</div>
 							{#if co.phrase}
 								<div class="rcpt-rule"></div>
@@ -4828,12 +4840,10 @@
 						</div>
 					{:else if isClimb && resultWon}
 						<!-- 🧾 Per-puzzle TRANSACTION slip -->
+						{@const heatMult = ((climb?.heat ?? 100) / 100).toFixed(1)}
 						{@const advance = Math.round(climb?.bounty ?? 0)}
 						{@const letters = Math.round(climb?.spent ?? 0)}
-						{@const subtotal = Math.max(0, advance - letters)}
 						{@const payout = Math.round(climb?.last_gain ?? 0)}
-						{@const yieldBonus = Math.max(0, payout - subtotal)}
-						{@const yieldPct = Math.round((climb?.heat ?? 100) - 100)}
 						{@const pendAfter = Math.round(climb?.bankroll ?? 0)}
 						{@const pendBefore = pendAfter - payout}
 						<div class="receipt">
@@ -4859,26 +4869,19 @@
 							</div>
 							<div class="rcpt-rule"></div>
 							<div class="rcpt-line">
-								<span>Cash Advance</span><span>${advance.toLocaleString()}</span>
+								<span>Bounty <small>(×{heatMult} Heat)</small></span><span
+									>${advance.toLocaleString()}</span
+								>
 							</div>
 							<div class="rcpt-line">
 								<span>Letters (debit)</span><span class="neg">−${letters.toLocaleString()}</span>
 							</div>
-							<div class="rcpt-rule"></div>
-							<div class="rcpt-line">
-								<span>Subtotal</span><span>${subtotal.toLocaleString()}</span>
-							</div>
-							<div class="rcpt-line">
-								<span>Yield +{yieldPct}%</span><span class="pos"
-									>+${yieldBonus.toLocaleString()}</span
-								>
-							</div>
 							<div class="rcpt-rule double"></div>
 							<div class="rcpt-line total profit">
-								<span>CREDIT</span><span>+${payout.toLocaleString()}</span>
+								<span>SECURED</span><span>+${payout.toLocaleString()}</span>
 							</div>
 							<div class="rcpt-line">
-								<span>Earnings</span><span
+								<span>Balance</span><span
 									>${pendBefore.toLocaleString()} ▸ ${pendAfter.toLocaleString()}</span
 								>
 							</div>
@@ -4896,7 +4899,7 @@
 								<span class="cg-peek-val"
 									><CategoryIcon category={climb.next_category} size={15} />{categoryLabel(
 										climb.next_category
-									)} · <b>${(climb.next_bounty ?? 0).toLocaleString()}</b> payout</span
+									)} · <b>+${(climb.next_bounty ?? 0).toLocaleString()}</b> bounty</span
 								>
 							</div>
 						{/if}
@@ -4934,7 +4937,7 @@
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
 							</div>
-							<div class="rcpt-title void">⚠ VOID</div>
+							<div class="rcpt-title void">⚠ BUST</div>
 							<div class="rcpt-acct">WORDBANK CHECKING</div>
 							<div class="rcpt-sub">
 								ACCT ·········{acctNo}{#if myUsername}
@@ -4953,16 +4956,16 @@
 							<div class="rcpt-rule"></div>
 							{#if wiped > 0}
 								<div class="rcpt-line">
-									<span>Earnings</span><span>${wiped.toLocaleString()}</span>
+									<span>Balance</span><span>${wiped.toLocaleString()}</span>
 								</div>
 								<div class="rcpt-line">
 									<span>Wrong guess</span><span class="neg">−${wiped.toLocaleString()}</span>
 								</div>
 								<div class="rcpt-rule double"></div>
-								<div class="rcpt-line total"><span>DEPOSIT VOIDED</span><span>$0</span></div>
+								<div class="rcpt-line total"><span>BALANCE LOST</span><span>$0</span></div>
 							{/if}
 							<div class="rcpt-line">
-								<span>Principal lost</span><span class="neg">−${ante.toLocaleString()}</span>
+								<span>Buy-in lost</span><span class="neg">−${ante.toLocaleString()}</span>
 							</div>
 							<div class="rcpt-rule"></div>
 							<div class="rcpt-line answer">
@@ -8606,7 +8609,7 @@
 		margin: 0 0 14px;
 	}
 	/* 🏦 Deposit confirm — amount uses the clean money font (not Orbitron) and the
-	   same gold as its source (the Potential Payout number in the HUD). */
+	   same gold as its source (the Balance number in the HUD). */
 	.info-big.dep-amt {
 		font-family: var(--font-display, sans-serif);
 		font-variant-numeric: tabular-nums;

--- a/supabase-cashgame-v5-onebalance.sql
+++ b/supabase-cashgame-v5-onebalance.sql
@@ -1,0 +1,132 @@
+-- ============================================================================
+-- Cash Game v5 — "One Balance" overhaul
+-- ============================================================================
+-- Collapses the two-number HUD into a single running Balance and moves Heat
+-- onto the bounty *injection* instead of the payout, so it stays one number.
+--
+--   balance      = bankroll (secured pile) + budget_left (this puzzle's spend)
+--   bounty_eff   = round(_climb_bounty(pid,k) * stake * heat/100)   -- heat here
+--   budget_left  = max(0, bounty_eff - spent)                        -- letters spend this
+--   solve        = bankroll += (bounty_eff - spent); heat += 10      -- secures, no 2nd ×heat
+--   bust         = bankroll -> 0                                     -- unchanged
+--   cashout      = credit bankroll to bank                           -- unchanged
+--
+-- Only _climb_board / _climb_resolve / climb_buy_letter change. cashgame_start,
+-- climb_next, cashgame_cashout, _cg_bust already operate on `bankroll` (the
+-- secured pile) which conserves — left as-is. No econ_v gate: runs are
+-- single-session and the change is display + heat-target (no in-flight leak).
+-- ============================================================================
+
+BEGIN;
+
+-- ── Board: expose the single `balance`; heat-boost the bounty + next-peek ────
+CREATE OR REPLACE FUNCTION public._climb_board(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_state TEXT; v_board JSONB; v_tier JSONB;
+  v_k NUMERIC; v_stake INT; v_cap INT; v_bounty INT; v_budget_left INT; v_cheapest INT; v_balance INT;
+  v_solve_reward INT; v_next_cat TEXT; v_next_bounty INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  v_cap := COALESCE((v_tier->>'heat_cap')::int, 250);
+  SELECT upper(phrase), category, COALESCE(subcategory,'') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_state := CASE cs.state WHEN 'solved' THEN 'won' WHEN 'busted' THEN 'lost' ELSE 'active' END;
+  -- Heat now multiplies the bounty as it's injected (one-number model).
+  v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+  -- Only an ACTIVE puzzle has a spendable budget; once solved it's folded into bankroll
+  -- (its budget must NOT be re-counted into the Balance, else it double-counts at the bumped heat).
+  v_budget_left := CASE WHEN cs.state = 'active' THEN GREATEST(0, v_bounty - cs.spent) ELSE 0 END;
+  v_cheapest := public._cg_cheapest(cs);
+  v_balance := cs.bankroll + v_budget_left;             -- the ONE number the HUD shows
+  v_solve_reward := v_budget_left;                      -- back-compat: what solving secures
+  -- Between-round peek: next puzzle's bounty at the heat you'll have (heat+10), + its category.
+  IF cs.state = 'solved' AND cs.next_puzzle_id IS NOT NULL THEN
+    SELECT category INTO v_next_cat FROM public.daily_puzzles WHERE id = cs.next_puzzle_id;
+    v_next_bounty := round(public._climb_bounty(cs.next_puzzle_id, v_k) * v_stake * LEAST(v_cap, cs.heat_x100 + 10) / 100.0)::int;
+  END IF;
+  v_board := public._daily_board(v_phrase, v_state, cs.bankroll::int, 99, cs.revealed_positions, cs.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('climb', jsonb_build_object(
+    'wallet', cs.bankroll, 'bankroll', cs.bankroll, 'balance', v_balance,
+    'bounty', v_bounty, 'budget_left', v_budget_left, 'solve_reward', v_solve_reward, 'spent', cs.spent,
+    'heat', cs.heat_x100, 'heat_cap', v_cap, 'tier', cs.tier, 'buy_in', cs.buy_in,
+    'tier_label', v_tier->>'label', 'stake', v_stake, 'cheapest', v_cheapest,
+    'must_guess', (cs.state = 'active' AND (v_cheapest IS NULL OR v_budget_left < v_cheapest)),
+    'position', cs.position, 'last_gain', cs.last_gain, 'state', cs.state,
+    'pups_locked', cs.pups_locked, 'equipped', to_jsonb(cs.active_powerups),
+    'run_solves', cs.run_solves, 'run_profit', cs.bankroll - cs.buy_in,
+    'next_bounty', v_next_bounty, 'next_category', v_next_cat));
+END; $function$;
+
+-- ── Resolve: secure (bounty_eff − spent) into bankroll; heat already applied ──
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_tier JSONB; v_k NUMERIC; v_stake INT; v_cap INT;
+  v_bounty INT; v_keep INT; v_cat TEXT; v_time INT; v_next UUID;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(p_uid); END IF;
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_cap := COALESCE((v_tier->>'heat_cap')::int, 250); v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    -- Heat is baked into the bounty; keep = what carries into the Balance. No 2nd ×heat.
+    v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+    v_keep := GREATEST(0, v_bounty - cs.spent);
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    v_next := public._pick_casual(p_uid, null, cs.puzzle_id, 0);
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_keep,
+      bankroll = cs.bankroll + v_keep,
+      heat_x100 = LEAST(v_cap, cs.heat_x100 + 10),
+      run_solves = cs.run_solves + 1, next_puzzle_id = v_next, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._record_category_solve(p_uid, v_cat);
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_keep, v_time);
+  ELSE
+    UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- ── Buy letter: affordability check uses the heat-boosted per-puzzle budget ───
+CREATE OR REPLACE FUNCTION public.climb_buy_letter(p_letter text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_letter TEXT; v_cost INT; v_stake INT;
+  v_k NUMERIC; v_bounty INT; v_budget_left INT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter);
+  IF public.letter_cost(v_letter) IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_buy_letter: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  v_k := COALESCE((public._cg_tier(cs.tier)->>'k')::numeric, 0.85);
+  v_stake := COALESCE((public._cg_tier(cs.tier)->>'stake')::int, 1);
+  v_cost := public.letter_cost(v_letter) * v_stake;
+  IF 'half_off' = ANY(cs.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+  v_budget_left := v_bounty - cs.spent;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  IF v_letter = ANY(cs.incorrect_letters) OR v_budget_left < v_cost THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cs.revealed_positions THEN RETURN public._climb_board(v_uid); END IF;
+  IF v_positions IS NULL THEN cs.incorrect_letters := array_append(cs.incorrect_letters, v_letter);
+  ELSE cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.climb_state SET revealed_positions = cs.revealed_positions,
+    incorrect_letters = cs.incorrect_letters, spent = cs.spent + v_cost, pups_locked = true, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Collapses Cash Game's two-number HUD into a **single running Balance** — the last mode still speaking a different language now matches Daily/Challenge.

## The model
- **One number = Balance** = secured pile + this puzzle's spendable budget. Buying a letter drops it; solving *secures* it; a wrong guess zeroes it.
- **Heat moved onto the bounty injection** (`bounty_eff = bounty × stake × heat/100`) instead of the payout — so it stays one number and the `×N` badge matches Daily's Interest badge.
- **Top bar → Available Balance** (your real account, like Daily; refreshed after the buy-in debits).
- Buy-in, tiers, cashout-between-puzzles, bust = unchanged.

## Server — `supabase-cashgame-v5-onebalance.sql` (applied to prod)
Only `_climb_board` / `_climb_resolve` / `climb_buy_letter` change; `cashgame_start`/`climb_next`/`cashout`/`_cg_bust` operate on the secured `bankroll` (conserves) and are untouched.

**Verified in a `BEGIN…ROLLBACK` play-through:** buy-in → buy letters → guess-solve → Play On → clean solve → cashout **conserves money** (bank delta = `bankroll − buy_in`); bust path credits nothing beyond the lost buy-in. Caught + fixed a double-count bug (solved puzzle's budget re-added at bumped heat) during verification.

## Client
Top bar + center hero, heat badge (`+N%`→`×N`), per-puzzle receipt (Bounty ×Heat / SECURED / Balance), cashout + bust slips, info modals (Heat / Solve Streak / Balance), must-guess banner (now "out of budget for this word"), tier intro. VOID→BUST.

Spec: §7 of the economy-rework doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)