### PR TITLE
HUD top: simple balance strip (not a mini-card)

### DIFF
--- a/src/lib/components/AccountCard.svelte
+++ b/src/lib/components/AccountCard.svelte
@@ -8,8 +8,6 @@
 	import { cardName } from '$lib/creditTiers.js';
 	/** Credit tier — skins the card (Excellent = black card; Poor/Bad = distressed). */
 	/** @type {string} */ export let tier = 'Good';
-	/** Compact = a mini card for the in-game HUD top bar (drops holder/member footer). */
-	export let compact = false;
 
 	$: cardTitle = cardName(tier);
 	$: tierClass =
@@ -26,7 +24,7 @@
 	$: amount = Math.round(Number(balance) || 0).toLocaleString();
 </script>
 
-<div class="acct-card {tierClass}" class:compact>
+<div class="acct-card {tierClass}">
 	<div class="ac-sheen"></div>
 	<div class="ac-inner">
 		<div class="ac-top">
@@ -41,7 +39,7 @@
 			<div class="ac-cap">Available Balance</div>
 			<div class="ac-amt">${amount}</div>
 		</div>
-		<div class="ac-num">{compact ? `···· ${last4}` : `•••• •••• •••• ${last4}`}</div>
+		<div class="ac-num">•••• •••• •••• {last4}</div>
 		<div class="ac-foot">
 			<div>
 				<div class="ac-cap sm">Account Holder</div>
@@ -200,52 +198,5 @@
 		font-size: 0.9rem;
 		color: #fbbf24;
 		font-variant-numeric: tabular-nums;
-	}
-	/* 💳 Compact — the mini card that lives in the in-game HUD top bar. */
-	.acct-card.compact {
-		min-height: 0;
-		max-width: 228px;
-		padding: 10px 14px 11px;
-		border-radius: 13px;
-		box-shadow:
-			0 6px 18px rgba(0, 0, 0, 0.5),
-			inset 0 1px 0 rgba(255, 255, 255, 0.08);
-	}
-	.acct-card.compact .ac-inner {
-		gap: 3px;
-	}
-	.acct-card.compact .ac-foot,
-	.acct-card.compact .ac-cardname {
-		display: none;
-	}
-	.acct-card.compact .ac-coin {
-		width: 17px;
-		height: 17px;
-	}
-	.acct-card.compact .ac-brand {
-		font-size: 0.64rem;
-		letter-spacing: 0.11em;
-		gap: 5px;
-	}
-	.acct-card.compact .ac-chip {
-		width: 25px;
-		height: 19px;
-		border-radius: 4px;
-	}
-	.acct-card.compact .ac-bal {
-		margin-top: 3px;
-	}
-	.acct-card.compact .ac-cap {
-		font-size: 0.53rem;
-		letter-spacing: 0.14em;
-	}
-	.acct-card.compact .ac-amt {
-		font-size: 1.45rem;
-	}
-	.acct-card.compact .ac-num {
-		font-size: 0.82rem;
-		letter-spacing: 0.14em;
-		color: #b8ac97;
-		margin-top: 2px;
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4264,19 +4264,19 @@
 			{:else if !matchBlitz}
 				{@const isDailyLike = $gameStore.gameMode === 'daily' || isMakeup}
 				{#if isDailyLike || isClimb}
-					<!-- 💳 Mini account card — your real, safe money; the hero number below is the
+					<!-- 🏦 Account balance strip — your real, safe money; the hero number below is the
                  at-risk game money that banks into this account. -->
 					<button
-						class="mini-card-btn"
+						class="acct-strip"
 						title="Available Balance — your account; solving deposits into it"
 						on:click={openBankModal}
 					>
-						<AccountCard
-							compact
-							account={acctNo}
-							balance={menuBank ?? netWorth ?? 0}
-							tier={bankData?.credit_tier ?? menuCreditTier ?? 'Good'}
-						/>
+						<span class="as-acct">···· {acctNo}</span>
+						<span class="as-div"></span>
+						<span class="as-right">
+							<span class="as-cap">Available Balance</span>
+							<span class="as-amt">${Math.round(menuBank ?? netWorth ?? 0).toLocaleString()}</span>
+						</span>
 					</button>
 				{:else}
 					<button
@@ -8859,19 +8859,53 @@
 	.top-bank.solo:active {
 		transform: scale(0.97);
 	}
-	/* 💳 Mini account-card wrapper (Daily + Cash Game top bar) — a bare tappable button. */
-	.mini-card-btn {
-		display: block;
+	/* 🏦 Account balance strip (Daily + Cash Game top bar) — account no. + Available Balance. */
+	.acct-strip {
+		display: inline-flex;
+		align-items: center;
+		gap: 12px;
 		width: fit-content;
 		margin: 0 auto 12px;
-		padding: 0;
-		border: 0;
-		background: none;
+		padding: 6px 16px;
+		border-radius: 12px;
+		border: 1px solid rgba(253, 224, 71, 0.28);
+		background: linear-gradient(135deg, rgba(251, 191, 36, 0.1), rgba(251, 191, 36, 0.03));
 		cursor: pointer;
 		transition: transform 0.12s ease;
 	}
-	.mini-card-btn:active {
+	.acct-strip:active {
 		transform: scale(0.98);
+	}
+	.as-acct {
+		font-family: 'Courier New', 'Courier', ui-monospace, monospace;
+		font-size: 0.74rem;
+		letter-spacing: 0.12em;
+		color: var(--text-faint);
+	}
+	.as-div {
+		width: 1px;
+		height: 22px;
+		background: rgba(253, 224, 71, 0.25);
+	}
+	.as-right {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		line-height: 1.05;
+	}
+	.as-cap {
+		font-size: 0.54rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--text-faint);
+	}
+	.as-amt {
+		font-family: var(--font-display, sans-serif);
+		font-weight: 800;
+		font-size: 1.3rem;
+		color: #fcd34d;
+		font-variant-numeric: tabular-nums;
 	}
 	/* 🔥 Cash Game tagline under the title in the tier picker. */
 	.cg-tagline {


### PR DESCRIPTION
Follow-up to #496 — the mini credit-card was too much for the top bar. Replaced it with a plain **balance strip**:

```
[ ···· 4821  │  AVAILABLE BALANCE  $200 ]
```

Account number + Available Balance label + amount, tappable to open the bank. Reverted the `AccountCard` `compact` mode (the full card is still used on the menu/bank hub). Daily + Cash Game only; Challenge keeps its Score chip. Client-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)