### PR TITLE
HUD balance strip: lighten gray text

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8880,7 +8880,7 @@
 		font-family: 'Courier New', 'Courier', ui-monospace, monospace;
 		font-size: 0.74rem;
 		letter-spacing: 0.12em;
-		color: var(--text-faint);
+		color: #aab4c4;
 	}
 	.as-div {
 		width: 1px;
@@ -8898,7 +8898,7 @@
 		font-weight: 700;
 		letter-spacing: 0.08em;
 		text-transform: uppercase;
-		color: var(--text-faint);
+		color: #d6dbe4;
 	}
 	.as-amt {
 		font-family: var(--font-display, sans-serif);


### PR DESCRIPTION
Account number and `AVAILABLE BALANCE` label were on `--text-faint` (#5d6b80) — too dark to read. Lightened to #aab4c4 (account no.) and #d6dbe4 (label). Client-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)