### PR TITLE
Store: lock it while you owe on a loan

### DIFF
--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -414,14 +414,18 @@ export async function getNetworthLeaderboard(scope = 'friends') {
 }
 
 /* ===== Cosmetics shop (Bank spending sink; earned-Bank-only, no pay-to-win) ===== */
-/** Shop catalog + owned/equipped flags + my Bank. @returns {Promise<{bank:number, items:any[]}>} */
+/** Shop catalog + owned/equipped flags + my Bank + loan. @returns {Promise<{bank:number, loan:number, items:any[]}>} */
 export async function getShop() {
 	const { data, error } = await supabase.rpc('get_shop');
 	if (error || !data) {
 		if (error) console.error('❌ get_shop:', error);
-		return { bank: 0, items: [] };
+		return { bank: 0, loan: 0, items: [] };
 	}
-	return { bank: data.bank ?? 0, items: Array.isArray(data.items) ? data.items : [] };
+	return {
+		bank: data.bank ?? 0,
+		loan: data.loan ?? 0,
+		items: Array.isArray(data.items) ? data.items : []
+	};
 }
 /** Buy a cosmetic with Bank. @param {string} id @returns {Promise<{ok:boolean, reason?:string}>} */
 export async function buyCosmetic(id) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3282,12 +3282,12 @@
 								<path d="M18 13.5a6 6 0 0 1 3 5.5" />
 							</svg><span class="qt-l">Friends</span>
 						</button>
-						<button class="qt" on:click={() => goto('/shop')}>
+						<button class="qt" class:qt-locked={menuLoan > 0} on:click={() => goto('/shop')}>
 							<svg class="qt-svg" viewBox="0 0 24 24" aria-hidden="true">
 								<path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" />
 								<path d="M3 6h18" />
 								<path d="M16 10a4 4 0 0 1-8 0" />
-							</svg><span class="qt-l">Store</span>
+							</svg><span class="qt-l">{menuLoan > 0 ? '🔒 Store' : 'Store'}</span>
 						</button>
 						<button class="qt" on:click={() => openCommunity('leaderboard')}>
 							<svg class="qt-svg" viewBox="0 0 24 24" aria-hidden="true">
@@ -6402,6 +6402,11 @@
 	}
 	.qt:active {
 		transform: scale(0.96);
+	}
+	/* 🔒 Store tile while you owe — dimmed with a red-tinted edge (page hard-locks buys). */
+	.qt-locked {
+		opacity: 0.72;
+		border-color: rgba(248, 113, 113, 0.4);
 	}
 	.qt-svg {
 		width: 25px;

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -18,6 +18,7 @@
 	let backTo = $derived($page.url.searchParams.get('from') === 'bank' ? '/bank' : '/');
 
 	let bank = $state(0);
+	let loan = $state(0); // Store is locked while you owe — no buying anything until it's paid off.
 	/** @type {any[]} */
 	let items = $state([]);
 	/** @type {any[]} */
@@ -53,6 +54,7 @@
 	async function load() {
 		const [shop, pu] = await Promise.all([getShop(), getPowerups()]);
 		bank = shop.bank;
+		loan = shop.loan ?? 0;
 		items = shop.items;
 		pups = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'climb');
 		sabs = (pu.items || []).filter((/** @type {any} */ i) => i.kind === 'sabotage');
@@ -72,6 +74,10 @@
 			track('powerup_buy', { id: item.id });
 			await load();
 		} else {
+			if (res?.reason === 'in_debt') {
+				await load(); // loan outstanding → lock the whole Store
+				return;
+			}
 			msg =
 				res?.reason === 'insufficient'
 					? 'Not enough Cash.'
@@ -103,6 +109,8 @@
 			fx('win');
 			track('cosmetic_buy', { id: item.id });
 			await load();
+		} else if (res.reason === 'in_debt') {
+			await load(); // loan outstanding → lock the whole Store
 		} else {
 			msg = res.reason === 'insufficient' ? 'Not enough Cash.' : 'Could not buy that.';
 		}
@@ -132,6 +140,20 @@
 
 	{#if loading}
 		<p class="loading">Loading…</p>
+	{:else if loan > 0}
+		<!-- 🔒 Store locked while you owe — no buying anything until the loan is paid off. -->
+		<div class="locked">
+			<div class="locked-ic">🔒</div>
+			<h2>Store locked</h2>
+			<p class="locked-msg">
+				You owe <b>${loan.toLocaleString()}</b> on a loan. The Store stays closed until it's paid off
+				— no cosmetics, power-ups, or boosts.
+			</p>
+			<a class="pay-btn" href="/loans">🦈 Pay off loan →</a>
+			<p class="locked-sub">
+				Solve the Daily or a Cash Game to earn — half of every deposit auto-pays your loan down.
+			</p>
+		</div>
 	{:else}
 		{#if msg}<p class="msg">{msg}</p>{/if}
 
@@ -314,6 +336,56 @@
 		color: var(--text-muted);
 		padding: 2rem;
 		text-align: center;
+	}
+	.locked {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		gap: 0.5rem;
+		margin: 2rem auto 0;
+		padding: 2rem 1.4rem;
+		max-width: 340px;
+		border: 1px solid rgba(248, 113, 113, 0.32);
+		border-radius: 18px;
+		background: linear-gradient(160deg, rgba(248, 113, 113, 0.08), rgba(248, 113, 113, 0.02));
+	}
+	.locked-ic {
+		font-size: 2.4rem;
+		line-height: 1;
+	}
+	.locked h2 {
+		font-family: var(--font-display);
+		font-size: 1.35rem;
+		margin: 0.2rem 0 0;
+	}
+	.locked-msg {
+		color: var(--text-muted);
+		font-size: 0.92rem;
+		line-height: 1.45;
+		margin: 0;
+	}
+	.locked-msg b {
+		color: #fca5a5;
+		font-family: var(--font-display);
+	}
+	.pay-btn {
+		display: inline-block;
+		margin: 0.7rem 0 0.2rem;
+		padding: 0.7rem 1.4rem;
+		border-radius: 12px;
+		font-family: var(--font-display);
+		font-weight: 800;
+		font-size: 0.98rem;
+		text-decoration: none;
+		color: #3a2a00;
+		background: var(--brand-grad, linear-gradient(135deg, #fbbf24, #fde047));
+	}
+	.locked-sub {
+		color: var(--text-faint);
+		font-size: 0.78rem;
+		line-height: 1.4;
+		margin: 0.4rem 0 0;
 	}
 	.msg {
 		text-align: center;

--- a/supabase-shop-loan-gate.sql
+++ b/supabase-shop-loan-gate.sql
@@ -1,0 +1,30 @@
+-- ============================================================================
+-- get_shop: also return `loan` so the Store can lock itself while you owe.
+-- ============================================================================
+-- buy_cosmetic / buy_powerup already reject with reason 'in_debt' when loan>0;
+-- this just lets the client gate the UI instead of failing on click.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_shop()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_bank BIGINT; v_loan BIGINT; v_items JSONB; v_t TEXT; v_c TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('bank',0,'loan',0,'items','[]'::jsonb); END IF;
+  PERFORM public._ensure_bank(v_uid);
+  PERFORM public._accrue_loan(v_uid);   -- keep the owed figure current
+  SELECT bank, COALESCE(loan,0), equipped_title, equipped_color INTO v_bank, v_loan, v_t, v_c
+    FROM public.profiles WHERE id = v_uid;
+  SELECT jsonb_agg(jsonb_build_object(
+    'id', c.id, 'kind', c.kind, 'label', c.label, 'value', c.value, 'price', c.price,
+    'owned', EXISTS (SELECT 1 FROM public.user_cosmetics uc WHERE uc.user_id = v_uid AND uc.cosmetic_id = c.id),
+    'equipped', (c.id = v_t OR c.id = v_c)
+  ) ORDER BY c.sort) INTO v_items FROM public.cosmetics c WHERE NOT COALESCE(c.earned, false);
+  RETURN jsonb_build_object('bank', COALESCE(v_bank,0), 'loan', COALESCE(v_loan,0),
+    'items', COALESCE(v_items,'[]'::jsonb));
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
The server already blocked `buy_cosmetic`/`buy_powerup` with reason `in_debt` when `loan>0` — but the Store UI still rendered everything as buyable and only showed a generic 'Could not buy that' on click. Now it's a real lock:

- **`get_shop` returns `loan`** (accrued fresh), so the Store page renders a **'Store locked'** state — the owed amount + a **'🦈 Pay off loan →'** CTA — instead of any items. No cosmetics, power-ups, or boosts while owing.
- Buy handlers treat a stray `in_debt` by re-locking the page.
- The menu **Store quick-tile shows 🔒 and dims** while owing (on top of the existing debt banner).

Scope note: in-game letter buys (Cash Game / Daily / Challenge) are gameplay budget spends, not real-Cash store purchases, so they're intentionally unaffected — you can still play to earn and pay the loan down.

Client + `supabase-shop-loan-gate.sql` (applied to prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)