### PR TITLE
Loans: merge Repay/Pay off into one button + owed font

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -180,20 +180,14 @@
 				bind:value={repayAmt}
 			/>
 			<div class="loan-actions">
+				<!-- One slider-driven action: reads "Pay off" when the slider clears the whole
+             balance, "Repay $X" for a partial payment. -->
 				<button
-					class="loan-btn ghost"
+					class="loan-btn pay"
 					disabled={!!loanBusy || repayAmt <= 0}
-					on:click={() => repay(repayAmt)}>Repay {fmt(repayAmt)}</button
+					on:click={() => repay(repayAmt)}
+					>{repayAmt >= owed ? `Pay off (${fmt(repayAmt)})` : `Repay ${fmt(repayAmt)}`}</button
 				>
-				{#if canClear}
-					<button class="loan-btn pay" disabled={!!loanBusy} on:click={() => repay(owed)}
-						>Pay off ({fmt(owed)})</button
-					>
-				{:else}
-					<button class="loan-btn pay" disabled={!!loanBusy} on:click={() => repay(maxRepay)}
-						>Repay all ({fmt(maxRepay)})</button
-					>
-				{/if}
 			</div>
 			{#if !canClear}
 				<p class="loan-note" style="margin-bottom:0">
@@ -425,9 +419,10 @@
 		font-size: 1rem;
 	}
 	.loan-owed {
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		font-size: 1.5rem;
+		font-variant-numeric: tabular-nums;
 		color: #fb7185;
 	}
 	.loan-summary {


### PR DESCRIPTION
Two loans-panel tweaks from feedback.

**Repay vs Pay off — merged.** They only differed by the slider: Repay = the slider amount (partial), Pay off = the full balance. Since the slider defaults to the max, the two buttons were identical in the default state (the screenshot showed "Repay $615" next to "Pay off ($615)"). Now it's **one slider-driven button** that reads:
- **"Pay off ($615)"** when the slider clears the whole balance
- **"Repay $200"** for a partial payment

The "you don't have enough to clear it" note (when you can't afford the full balance) is unchanged — the button just says "Repay $X" there since it can't pay off.

**Owed value font.** The top-right "You owe" number was on Orbitron — the odd one out. Switched to the app's money font (Space Grotesk / var(--font-display)) with tabular-nums, matching everything else.

Client-only, gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
