### PR TITLE
Loans: PIN-confirm loan repayment

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -120,6 +120,15 @@
 		if (loanBusy) return;
 		const pay = amt ?? maxRepay;
 		if (pay <= 0) return;
+		// 🔐 Money-out → PIN confirm (same gate as store/avatar buys).
+		try {
+			await requirePin(pay >= owed ? `Pay off ${fmt(pay)}` : `Repay ${fmt(pay)}`, [
+				{ label: 'Repay', value: fmt(pay) },
+				{ label: 'Owed after', value: fmt(Math.max(0, owed - pay)) }
+			]);
+		} catch {
+			return; // cancelled at the pad
+		}
 		loanBusy = 'repay';
 		loanMsg = '';
 		const res = await repayLoan(amt);


### PR DESCRIPTION
Repaying a loan moves Cash out of your account, so it should be gated like every other money-out action. Added the same PIN pad used for store and avatar purchases.

- The repay button now opens the PIN confirm first, showing the **amount** and **balance owed after**.
- Cancelling at the pad aborts (no repay).
- The confirm title reads **"Pay off $X"** when it clears the whole balance, **"Repay $X"** for a partial payment.

Client-only, gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
