### PR TITLE
HUD Phase 1: rebuild the -$X spend floater (all modes)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-single-focus-hud.md
+++ b/docs/superpowers/plans/2026-07-11-single-focus-hud.md
@@ -1,0 +1,67 @@
+# Single-Focus HUD — Implementation Plan
+
+**Date:** 2026-07-11
+**Goal:** Every mode's in-game HUD shows **one unlabeled number** (the bounty you spend down), taught live by a prominent **−$X spend floater**. The account balance is demoted from the prime top slot to a small ambient **bankroll chip** in the corner. Daily loses the pure/leveler complexity; Challenge shows a **fresh per-puzzle bounty** with **Score** promoted to the top slot.
+
+## The vision
+
+| Mode          | Corner chip | Top (prominent)      | Center — the one number (no label) |
+| ------------- | ----------- | -------------------- | ---------------------------------- |
+| **Daily**     | 🪙 bankroll | _(mode pill only)_   | bounty → your day's score          |
+| **Cash Game** | 🪙 bankroll | _(mode pill only)_   | bounty → cumulative, cash out      |
+| **Challenge** | 🪙 bankroll | **Score** + Pot/Beat | fresh per-puzzle bounty            |
+
+**Why this works:** the center number is the same everywhere (bounty − spent), it moves _down_ as you buy letters, and the **−$X floater** makes that subtractive behavior legible on every purchase — which is what lets us drop the label entirely. The account is static during play in all modes, so it becomes ambient status, not a competing number.
+
+## ⚠️ Open decision (blocks Phase 5 only)
+
+**Daily win-streak Interest — keep or drop?** Recommendation: **DROP from the score.** Score = `bounty − spent`, deposited flat, so the daily leaderboard is a fair skill comparison (not streak-inflated). Streak rewards still exist via the **attendance** milestones. If kept, Phase 5 removal is smaller but the score stays streak-dependent.
+
+---
+
+## Phases (each = its own PR: prettier → check → lint → build → ship)
+
+### Phase 1 — Rebuild the −$X spend floater _(foundational, decision-independent — start here)_
+
+**Current state (`+page.svelte`):** `trackSpend` (~925) watches `$gameStore.bankroll`, fires `spendFloaters` only for `daily/makeup/climb`, caps at `$300`, renders `.spend-float` (~4540) in the panel's **top-right corner** in **Orbitron**.
+**Bugs it has now:** watches the wrong value for Cash Game (`bankroll` = secured pile, unchanged on a letter-buy → **floats nothing in Cash Game**); **excludes Challenge**; `$300` cap hides high-tier ($20× stake) spends.
+**Change:**
+
+- Trigger off the **displayed center value** (`soloHero.net`) decreasing, guarded against `introBuilding` and non-spend jumps → fires correctly in all three modes.
+- Remove the `$300` cap.
+- Render the floater **at the center number** so it flies up-and-off it (not the corner).
+- Restyle: `var(--font-display)`, larger, a scale-pop so it reads as a satisfying "that cost me" beat.
+- Optional: a positive lock-in flash on the number at solve.
+  **Files:** `src/routes/+page.svelte` (trackSpend, render slot, `.spend-float` CSS).
+
+### Phase 2 — Corner bankroll chip; remove in-game "My Account" strip
+
+- Remove the `.acct-strip` (My Account) from the in-game top bar (~4264).
+- Add a small, muted **bankroll chip** (coin glyph + amount, tappable → `/bank`) in a corner, consistent across all modes. Reads as ambient status, not a game number.
+  **Files:** `src/routes/+page.svelte` (top-bar block + CSS).
+
+### Phase 3 — Strip the center labels
+
+- Remove the `bp-label` text (currently "Payout" / "Score" / "Balance Remaining"). Center = the number + its badge only.
+  **Files:** `src/routes/+page.svelte` (~4439).
+
+### Phase 4 — Challenge: fresh per-puzzle bounty + Score up top
+
+- `soloHero` match branch: `matchEarnings` (accumulated) → `matchLeft` (this puzzle's leftover) so the center **resets each puzzle**.
+- Promote **Score** (`total_score`, already tracked server-side) to the prominent top slot; keep the **Pot** + **Beat $X** + standing chips as the scoreboard.
+- Between-puzzle beat: **"Kept +$X → Score $Y → next fresh bounty."**
+  **Files:** `src/routes/+page.svelte` (soloHero ~626, match HUD ~4366, between-puzzle transition). No server change (score already accumulates).
+
+### Phase 5 — Daily: remove pure/leveler, Twist always-on, apply Interest decision
+
+- **Remove the pure/×1.5 leveler** everywhere: the Use/Pure UI + `twist_used` flag + the ×1.5 bonus. The daily **Twist/modifier applies to everyone, always**.
+- **Server:** strip pure/leveler from `daily_start` / `_finalize_daily` / `_daily_resolve_and_return`; drop `twist_used` if fully unused. **If dropping Interest:** `winnings = kept` (no `×mult`); remove the streak-multiplier logic.
+- **Client:** remove Use/Pure UI + leveler; **if dropping Interest:** remove the Daily Interest badge, the receipt Interest line, the `mult` info modal, and `dlMult`/`bountyMult` plumbing.
+  **Files:** `supabase-*.sql` (daily fns) + `+page.svelte` + `statsStore.js`/`GameStore.js`.
+  **Verify:** `BEGIN…ROLLBACK` money-conservation + `qa-e2e.mjs` (Daily is the biggest, most SQL-heavy phase).
+
+---
+
+## Sequencing & rationale
+
+**1 → 2 → 3 → 4 → 5.** Floater first (feel-first, and it fixes real Cash Game/Challenge bugs regardless of the rest). Labels come off only after the floater proves it carries the meaning. Daily last — it's the largest surface and the only one touching prod SQL.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -918,23 +918,28 @@
 	$: dlWrong = $gameStore.wrongGuesses ?? 0;
 	$: dlPenalty = Math.min(0.2 * dlWrong, Math.max(0, dlMult - 1)); // shown penalty, can't push below ×1.0 floor
 	$: dlBoost = Math.max(0, Math.round((dlMult - 1 - dlStreakBonus + dlPenalty) * 10) / 10);
-	let _prevBank = /** @type {number|null} */ (null);
+	let _prevNet = /** @type {number|null} */ (null);
 	let _floatId = 0;
 	/** @type {{id:number,text:string}[]} */
 	let spendFloaters = [];
-	$: trackSpend($gameStore.bankroll, $gameStore.gameMode, showMainMenu);
-	/** @param {number|null|undefined} b @param {string} mode @param {boolean} onMenu */
-	function trackSpend(b, mode, onMenu) {
+	// Float a −$X off the hero number whenever it drops from a letter buy — in ANY mode.
+	// Watches the actual displayed value (soloHero.net) so it fires identically for Daily,
+	// Cash Game and Challenge. Guards: only while the game is active (so a bust → $0 doesn't
+	// float) and not during the opening reveal count-up (introBuilding) or on the menu.
+	$: trackSpend(soloHero?.net, gameActive, showMainMenu, introBuilding);
+	/** @param {number|null|undefined} v @param {boolean} active @param {boolean} onMenu @param {boolean} building */
+	function trackSpend(v, active, onMenu, building) {
 		if (
 			browser &&
+			active &&
 			!onMenu &&
-			_prevBank != null &&
-			b != null &&
-			b < _prevBank &&
-			['daily', 'makeup', 'climb'].includes(mode)
+			!building &&
+			_prevNet != null &&
+			v != null &&
+			v < _prevNet
 		) {
-			const amt = _prevBank - b;
-			if (amt > 0 && amt <= 300) {
+			const amt = _prevNet - v;
+			if (amt > 0) {
 				const id = ++_floatId;
 				spendFloaters = [...spendFloaters, { id, text: '−$' + amt.toLocaleString() }];
 				setTimeout(() => {
@@ -942,7 +947,7 @@
 				}, 1100);
 			}
 		}
-		_prevBank = b ?? null;
+		_prevNet = v ?? null;
 	}
 
 	// 💥 Dramatic bank pop on a big swing (win payout / big change).
@@ -8769,31 +8774,34 @@
 			transform: scale(1);
 		}
 	}
-	/* floating -$X spend feedback by the green number */
+	/* 💸 −$X spend feedback — pops at the hero number and flies up-and-off it, so the
+	   letter's cost is visibly what just came off the number. Clean font, punchy. */
 	.spend-float {
 		position: absolute;
-		right: 16px;
-		top: 8px;
+		left: 50%;
+		top: 46%;
 		pointer-events: none;
-		font-family: 'Orbitron', var(--font-display);
+		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
-		font-size: 1.05rem;
+		font-size: 1.55rem;
 		color: #fb7185;
-		text-shadow: 0 0 8px rgba(248, 113, 133, 0.55);
-		animation: spendFloat 1.1s ease-out forwards;
+		text-shadow: 0 0 12px rgba(248, 113, 133, 0.65);
+		font-variant-numeric: tabular-nums;
+		white-space: nowrap;
+		animation: spendFloat 1.05s cubic-bezier(0.2, 0.75, 0.3, 1) forwards;
 	}
 	@keyframes spendFloat {
 		0% {
 			opacity: 0;
-			transform: translateY(8px) scale(0.9);
+			transform: translate(-50%, 6px) scale(0.8);
 		}
-		16% {
+		20% {
 			opacity: 1;
-			transform: translateY(0) scale(1.06);
+			transform: translate(-50%, -6px) scale(1.15);
 		}
 		100% {
 			opacity: 0;
-			transform: translateY(-28px) scale(1);
+			transform: translate(-50%, -46px) scale(1);
 		}
 	}
 	/* 💰 Top bankroll bar (very top, all modes) */


### PR DESCRIPTION
First phase of the single-focus HUD plan (`docs/superpowers/plans/2026-07-11-single-focus-hud.md`). The idea: teach the subtractive hero number *live* — every letter buy pops a **−$X** at the number and flies it up-and-off, so "buying a letter took this off my number" is obvious. That's what makes dropping the label (Phase 3) safe.

**It also fixes real bugs in the old floater:**
- It watched `$gameStore.bankroll` (the *secured pile*), which doesn't change on a Cash Game letter-buy — so Cash Game floated **nothing**. Now it watches the displayed hero value, so it fires identically in **Daily, Cash Game, and Challenge**.
- Dropped the **$300 cap** that silently hid high-tier (20× stake) letter spends.
- Moved it from the panel corner to **fly off the number itself**, Space Grotesk, bigger, with a scale-pop.

Guards: only fires while the game is active (so a bust → $0 doesn't float a giant −$X) and not during the opening reveal count-up.

Client-only, gates green. Feel-check this one before we pull the labels in Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
