### PR TITLE
Cash Game: wrong guess drains budget instead of instant bust

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -105,7 +105,8 @@ import { track } from '$lib/analytics.js';
  *   dailyLive?: { remaining:number, mult:number, winnings:number } | null,
  *   dailyIntro?: number,
  *   dailyIntroGo?: number,
- *   dailyIntroPlayed?: number
+ *   dailyIntroPlayed?: number,
+ *   wrongTick?: number
  * }} GameState
  */
 
@@ -178,7 +179,8 @@ export const gameStore = writable(
 		dailyLive: null, // { remaining, mult, winnings } — live Daily V2 HUD (Prize left → what you'd bank)
 		dailyIntro: 0, // bumps on a FRESH daily open → ARMS the opening reveal (pending)
 		dailyIntroGo: 0, // bumps once the board is actually visible → PLAYS the opening reveal
-		dailyIntroPlayed: 0 // the dailyIntro token that has already played (persists across remounts)
+		dailyIntroPlayed: 0, // the dailyIntro token that has already played (persists across remounts)
+		wrongTick: 0 // bumps on a non-busting wrong whole-phrase guess → UI flashes a distinct "✗ Wrong" cue
 	})
 );
 
@@ -526,8 +528,8 @@ async function refreshClimbClue() {
 	}
 }
 
-/** @param {any} board */
-function reconcileClimbBoard(board) {
+/** @param {any} board @param {boolean} [wrong] a wrong-but-still-playing guess (bump the "✗ Wrong" cue) */
+function reconcileClimbBoard(board, wrong = false) {
 	if (!board) return;
 	const prev = get(gameStore);
 	const climb = board.climb || {};
@@ -541,7 +543,9 @@ function reconcileClimbBoard(board) {
 			gameMode: 'climb',
 			gameState: busted ? 'lost' : solved ? 'won' : 'default',
 			modifier: null,
-			climbInfo: climb
+			climbInfo: climb,
+			// Bump in the SAME update as the budget drop so the floater is labeled correctly.
+			wrongTick: wrong ? (prev.wrongTick || 0) + 1 : (prev.wrongTick ?? 0)
 		})
 	);
 	// No confetti — the slot-machine reveal (box-by-box win pop) is the celebration, like Daily.
@@ -651,8 +655,18 @@ async function submitGuessClimb(state) {
 	if (Object.keys(guess).length === 0) return;
 	dailyInFlight = true;
 	try {
+		const prevSpent = get(gameStore).climbInfo?.spent ?? 0;
 		const board = await climbSubmitGuess(guess);
-		if (board) reconcileClimbBoard(board);
+		if (board) {
+			// A wrong guess that DOESN'T bust now drains budget and keeps the run alive
+			// (server: cashgame wrong-guess penalty). Detect it so the UI shows a distinct
+			// "✗ Wrong" cue instead of a silent letter-buy-style −$X drop.
+			const c = board.climb || {};
+			const stillPlaying = c.state !== 'solved' && c.state !== 'busted' && c.busted !== true;
+			const wrong = stillPlaying && (c.spent ?? 0) > prevSpent;
+			reconcileClimbBoard(board, wrong);
+			if (wrong) fx('wrong');
+		}
 	} finally {
 		dailyInFlight = false;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -915,15 +915,20 @@
 	$: dlBoost = Math.max(0, Math.round((dlMult - 1) * 10) / 10);
 	let _prevNet = /** @type {number|null} */ (null);
 	let _floatId = 0;
-	/** @type {{id:number,text:string}[]} */
+	let _prevWrongTick = 0;
+	/** @type {{id:number,text:string,wrong?:boolean}[]} */
 	let spendFloaters = [];
 	// Float a −$X off the hero number whenever it drops from a letter buy — in ANY mode.
 	// Watches the actual displayed value (soloHero.net) so it fires identically for Daily,
 	// Cash Game and Challenge. Guards: only while the game is active (so a bust → $0 doesn't
 	// float) and not during the opening reveal count-up (introBuilding) or on the menu.
-	$: trackSpend(soloHero?.net, gameActive, showMainMenu, introBuilding);
-	/** @param {number|null|undefined} v @param {boolean} active @param {boolean} onMenu @param {boolean} building */
-	function trackSpend(v, active, onMenu, building) {
+	$: trackSpend(soloHero?.net, gameActive, showMainMenu, introBuilding, $gameStore.wrongTick);
+	/** @param {number|null|undefined} v @param {boolean} active @param {boolean} onMenu @param {boolean} building @param {number|undefined} wtick */
+	function trackSpend(v, active, onMenu, building, wtick) {
+		// A Cash Game wrong guess bumps wrongTick in the SAME update as the budget drop, so this
+		// reactive sees both together — label that one floater "✗ Wrong" instead of a plain −$X buy.
+		const isWrong = wtick != null && wtick > _prevWrongTick;
+		_prevWrongTick = wtick ?? _prevWrongTick;
 		if (
 			browser &&
 			active &&
@@ -936,7 +941,8 @@
 			const amt = _prevNet - v;
 			if (amt > 0) {
 				const id = ++_floatId;
-				spendFloaters = [...spendFloaters, { id, text: '−$' + amt.toLocaleString() }];
+				const text = (isWrong ? '✗ Wrong  −$' : '−$') + amt.toLocaleString();
+				spendFloaters = [...spendFloaters, { id, text, wrong: isWrong }];
 				setTimeout(() => {
 					spendFloaters = spendFloaters.filter((f) => f.id !== id);
 				}, 1100);
@@ -4488,7 +4494,9 @@
 							<span class="bp-badge-spacer"></span>
 						{/if}
 					</div>
-					{#each spendFloaters as f (f.id)}<span class="spend-float">{f.text}</span>{/each}
+					{#each spendFloaters as f (f.id)}<span class="spend-float" class:wrong={f.wrong}
+							>{f.text}</span
+						>{/each}
 				</div>
 				{#if isMatch && matchLive}
 					<div class="ante-bar">
@@ -8747,6 +8755,34 @@
 		font-variant-numeric: tabular-nums;
 		white-space: nowrap;
 		animation: spendFloat 1.05s cubic-bezier(0.2, 0.75, 0.3, 1) forwards;
+	}
+	/* A wrong whole-phrase guess (Cash Game): same red, but bigger + a hard shake so it
+	   reads as a penalty, not a routine letter buy. */
+	.spend-float.wrong {
+		font-size: 1.85rem;
+		letter-spacing: 0.02em;
+		text-shadow: 0 0 16px rgba(248, 113, 133, 0.85);
+		animation:
+			spendFloat 1.15s cubic-bezier(0.2, 0.75, 0.3, 1) forwards,
+			wrongShake 0.42s ease-in-out;
+	}
+	@keyframes wrongShake {
+		0%,
+		100% {
+			margin-left: 0;
+		}
+		20% {
+			margin-left: -7px;
+		}
+		40% {
+			margin-left: 6px;
+		}
+		60% {
+			margin-left: -4px;
+		}
+		80% {
+			margin-left: 3px;
+		}
 	}
 	@keyframes spendFloat {
 		0% {

--- a/supabase-cashgame-wrong-guess-penalty.sql
+++ b/supabase-cashgame-wrong-guess-penalty.sql
@@ -1,0 +1,56 @@
+-- ============================================================================
+-- Cash Game: a wrong guess no longer busts the whole run while you can still
+-- afford letters. Mirrors Daily: a wrong guess DRAINS budget (a penalty) and
+-- you keep playing; you BUST only when you're out of budget (can't afford the
+-- cheapest letter) and guess wrong — the "one last guess or you lose" wall.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.climb_submit_guess(p_guess jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}';
+  v_all BOOLEAN := true; pos INT; v_ch TEXT;
+  v_tier JSONB; v_k NUMERIC; v_stake INT; v_bounty INT; v_budget_left INT; v_cheapest INT; v_pen INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_submit_guess: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_submit_guess: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._climb_board(v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_correct) ORDER BY 1);
+    UPDATE public.climb_state SET revealed_positions = cs.revealed_positions, updated_at = now() WHERE user_id = v_uid;
+    RETURN public._climb_resolve(v_uid);
+  END IF;
+
+  -- ── Wrong guess ──────────────────────────────────────────────────────────
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+  v_budget_left := GREATEST(0, v_bounty - cs.spent);
+  v_cheapest := public._cg_cheapest(cs);
+  IF v_cheapest IS NULL OR v_budget_left < v_cheapest THEN
+    -- Out of budget: this was your last guess → bust the run.
+    RETURN public._cg_bust(v_uid);
+  END IF;
+  -- Still have budget: drain a penalty (≥ one letter, or 20% of what's left) and keep playing.
+  v_pen := LEAST(v_budget_left, GREATEST(v_cheapest, (round(0.2 * v_budget_left / 10.0) * 10)::int));
+  UPDATE public.climb_state SET spent = cs.spent + v_pen, pups_locked = true, updated_at = now()
+    WHERE user_id = v_uid;
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
## What

Fixes Cash Game busting on **any** wrong guess even with money left.

A wrong whole-phrase guess now **drains budget** (a penalty, mirroring Daily) and you keep playing. You **bust** only when you're out of budget — can't afford the cheapest letter — and guess wrong: the "one last guess or you lose" wall.

## Server
`supabase-cashgame-wrong-guess-penalty.sql` (already applied to prod, PITR-verified via BEGIN/ROLLBACK) rewrites the wrong-guess branch of `climb_submit_guess`:
- `budget_left < cheapest` → `_cg_bust` (final-guess wall)
- else drain `LEAST(budget_left, GREATEST(cheapest, round(0.2 × budget_left)))` and keep the run alive.

## Client
A non-busting wrong guess previously looked identical to a letter buy — a silent `−$X` floater. Now:
- `GameStore.submitGuessClimb` detects a wrong-but-still-playing guess (state active + `spent` grew), bumps a `wrongTick` in the **same** store update as the budget drop, and plays `fx('wrong')`.
- `+page` folds `wrongTick` into the existing `trackSpend` reactive so the single floater is labeled **"✗ Wrong  −$X"** with a larger red shake variant — distinct from a routine letter buy.

## Gates
`prettier` · `check` (0 errors, 1 pre-existing a11y warning) · `lint` · `build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
