### PR TITLE
Daily Twist modal: simplify (drop boilerplate lines)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2723,9 +2723,7 @@
 			{:else if dailyInfo === 'twist'}
 				<div class="info-big">{dailyMod?.emoji ?? '🎁'}</div>
 				<h3 class="info-title">{dailyMod?.name ?? "Today's Twist"}</h3>
-				<p class="info-sub">Today's special — applied automatically. ✓</p>
 				<p class="info-twist-do">{dailyMod?.blurb ?? ''}</p>
-				<p class="info-note">A different special each weekday — same for everyone.</p>
 			{:else if dailyInfo === 'streak'}
 				<div class="info-big">🏆 {dlWinStreak}</div>
 				<h3 class="info-title">Deposit Streak</h3>


### PR DESCRIPTION
Removes the two generic chrome lines from the Twist info modal, per request:
- "Today's special — applied automatically. ✓"
- "A different special each weekday — same for everyone."

Keeps just the icon, the Twist name, and its effect line (e.g. "Your first wrong letter is free").

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
