### PR TITLE
Daily: multiplier vocab → "Interest" (+%), fix stale streak copy

### DIFF
--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -1,6 +1,6 @@
 <script>
 	// 🎒 My Bag — everything you currently own that you bought/earned, grouped by type:
-	// Power-ups (incl. Bounty Boosts), Sabotage, and Extras (titles + name colors).
+	// Power-ups (incl. Interest Boosts), Sabotage, and Extras (titles + name colors).
 	// Power-ups are spent in-game; cosmetics are equipped from the Store/Profile.
 	import { onMount } from 'svelte';
 	import { getPowerups, getShop } from '$lib/stores/statsStore.js';
@@ -14,8 +14,8 @@
 
 	/** @type {Record<string,{icon:string,desc:string}>} */
 	const META = {
-		bounty_boost: { icon: '💥', desc: 'Adds +50% to your Daily bounty' },
-		jackpot_boost: { icon: '💎', desc: 'Adds +100% to your Daily bounty' },
+		bounty_boost: { icon: '💥', desc: 'Adds +50% Interest to your Daily deposit' },
+		jackpot_boost: { icon: '💎', desc: 'Adds +100% Interest to your Daily deposit' },
 		free_reveal: { icon: '🔍', desc: 'Reveal the most useful letter' },
 		free_vowel: { icon: '🅰️', desc: 'Reveal one vowel free' },
 		half_off: { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },

--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -8,14 +8,14 @@
 	const dispatch = createEventDispatcher();
 
 	let page = 0; // 0 = how to win, 1 = power-ups (daily only)
-	// Power-ups a player can use in the Daily: the weekday Twists + the Bounty Boosts.
+	// Power-ups a player can use in the Daily: the weekday Twists + the Interest Boosts.
 	const DAILY_PUPS = [
 		{ group: 'Daily Twist — one free helper each weekday', items: Object.values(MODIFIERS) },
 		{
-			group: 'Bounty Boosts — buy in the Store, stack your multiplier',
+			group: 'Interest Boosts — buy in the Store, stack your rate',
 			items: [
-				{ emoji: '💥', name: 'Bounty Boost', blurb: 'Adds ×0.5 to your bounty multiplier' },
-				{ emoji: '💎', name: 'Jackpot', blurb: 'Adds ×1.0 to your bounty multiplier' }
+				{ emoji: '💥', name: 'Interest Boost', blurb: 'Adds +50% Interest to your deposit' },
+				{ emoji: '💎', name: 'Jackpot', blurb: 'Adds +100% Interest to your deposit' }
 			]
 		}
 	];
@@ -34,7 +34,7 @@
 					title: "Today's Daily",
 					goal: 'Solve the hidden phrase.',
 					win: 'Spend as little as you can — your leftover Deposits to your account.',
-					bar: 'A win streak pays Interest on every solve.'
+					bar: 'Boosts from the Store add Interest to your deposit.'
 				};
 			case 'climb':
 				return {

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -1275,7 +1275,7 @@ export async function useDailyTwist() {
 	}
 }
 
-/** Spend an owned Bounty Boost on today's Daily (bumps the bounty multiplier). */
+/** Spend an owned Interest Boost on today's Daily (bumps the deposit multiplier). */
 /** @param {string} id */
 export async function useDailyBoost(id) {
 	try {

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -601,7 +601,7 @@ export async function dailyUseTwist() {
 	return data;
 }
 
-/** Spend an owned Bounty Boost on today's Daily (adds to the bounty multiplier). @param {string} id */
+/** Spend an owned Interest Boost on today's Daily (adds to the deposit multiplier). @param {string} id */
 export async function dailyUseBoost(id) {
 	const { data, error } = await supabase.rpc('daily_use_boost', { p_id: id });
 	if (error) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -722,8 +722,8 @@
 	let vaultMsg = '';
 	/** @type {ReturnType<typeof setTimeout>|undefined} */ let _vaultMsgTimer;
 	const BOOST_META = /** @type {Record<string,{emoji:string,blurb:string}>} */ ({
-		bounty_boost: { emoji: '💥', blurb: 'Adds +50% to your bounty' },
-		jackpot_boost: { emoji: '💎', blurb: 'Adds +100% to your bounty' }
+		bounty_boost: { emoji: '💥', blurb: 'Adds +50% Interest to your deposit' },
+		jackpot_boost: { emoji: '💎', blurb: 'Adds +100% Interest to your deposit' }
 	});
 	async function loadVault() {
 		try {
@@ -2705,20 +2705,20 @@
 			<button class="modal-x" on:click={() => (dailyInfo = null)} aria-label="Close">✕</button>
 			{#if dailyInfo === 'mult'}
 				<div class="info-big">+{Math.round((dlMult - 1) * 100)}%</div>
-				<h3 class="info-title">Boost</h3>
-				<p class="info-sub">A power-up boost on everything you Deposit from this puzzle.</p>
+				<h3 class="info-title">Interest</h3>
+				<p class="info-sub">Extra Interest on everything you Deposit from this puzzle.</p>
 				<div class="info-rows">
 					<div class="info-row"><span>Base</span><b>+0%</b></div>
 					{#if dlBoost > 0}<div class="info-row">
 							<span>💥 Boosts</span><b class="pos">+{Math.round(dlBoost * 100)}%</b>
 						</div>{/if}
 					<div class="info-row total">
-						<span>Your Boost</span><b>+{Math.round((dlMult - 1) * 100)}%</b>
+						<span>Your Interest</span><b>+{Math.round((dlMult - 1) * 100)}%</b>
 					</div>
 				</div>
 				<p class="info-note">
-					Stock up on 💥/💎 boosts in the Store and tap one in before you solve — the Daily itself
-					has no streak multiplier, so your score is just what you keep of the bounty.
+					Stock up on 💥/💎 Interest Boosts in the Store and tap one in before you solve — the Daily
+					itself has no streak multiplier, so your score is just what you keep of the bounty.
 				</p>
 			{:else if dailyInfo === 'twist'}
 				<div class="info-big">{dailyMod?.emoji ?? '🎁'}</div>
@@ -2748,7 +2748,7 @@
 						<span>Balance Remaining</span><b class="pos">${dlRemaining.toLocaleString()}</b>
 					</div>
 					{#if dlMult > 1}<div class="info-row">
-							<span>Boost</span><b class="pos">+{Math.round((dlMult - 1) * 100)}%</b>
+							<span>Interest</span><b class="pos">+{Math.round((dlMult - 1) * 100)}%</b>
 						</div>{/if}
 					<div class="info-row total">
 						<span>You deposit</span><b class="green">${dlWinnings.toLocaleString()}</b>
@@ -2757,7 +2757,7 @@
 				<p class="info-note">
 					Deduce letters instead of buying them — keep more of your balance. Grows your <button
 						class="info-inline"
-						on:click|stopPropagation={() => (dailyInfo = 'mult')}>multiplier</button
+						on:click|stopPropagation={() => (dailyInfo = 'mult')}>Interest</button
 					> too.
 				</p>
 			{/if}
@@ -4402,7 +4402,7 @@
 							<!-- Daily badge only appears when a 💥/💎 boost is active (no streak interest). -->
 							<button
 								class="bp-mult-badge"
-								title="Boost — a power-up multiplier on your deposit"
+								title="Interest — a power-up multiplier on your deposit"
 								on:click={() => {
 									fx('tap');
 									dailyInfo = 'mult';

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -40,8 +40,8 @@
 		sabotage_toll: { icon: '🚧', desc: "An opponent's next letter costs 3×" },
 		sabotage_vowel_block: { icon: '🚫', desc: "An opponent's vowels cost 3×" },
 		sabotage_lock: { icon: '🔒', desc: 'Wipe a letter an opponent revealed' },
-		bounty_boost: { icon: '💥', desc: 'Adds +50% to your Daily bounty' },
-		jackpot_boost: { icon: '💎', desc: 'Adds +100% to your Daily bounty' }
+		bounty_boost: { icon: '💥', desc: 'Adds +50% Interest to your Daily deposit' },
+		jackpot_boost: { icon: '💎', desc: 'Adds +100% Interest to your Daily deposit' }
 	});
 
 	/** @type {any[]} */
@@ -165,10 +165,10 @@
 		{/key}
 
 		{#if dboost.length}
-			<h2 class="section">💥 Bounty Boosts</h2>
+			<h2 class="section">💥 Interest Boosts</h2>
 			<p class="section-note">
-				Stock up, then tap them in the Daily to multiply your bounty — they stack on your win-streak
-				multiplier (carry up to 5 of each).
+				Stock up, then tap one in before you solve the Daily to add Interest to your deposit — they
+				stack (carry up to 5 of each).
 			</p>
 			<div class="grid">
 				{#each dboost as item}

--- a/supabase-rename-interest-boost.sql
+++ b/supabase-rename-interest-boost.sql
@@ -1,0 +1,12 @@
+-- ============================================================================
+-- Rename the daily 💥 boost power-up: "Bounty Boost" → "Interest Boost".
+-- The Daily deposit multiplier is now spoken of as "Interest" (+%) everywhere
+-- (the win-streak interest was dropped in PR #517; only these Store-bought boosts
+-- multiply the deposit). The id stays `bounty_boost` — display name only.
+-- Jackpot keeps its name. get_powerups()/get_shop() surface `name` to the client.
+-- ============================================================================
+BEGIN;
+
+UPDATE public.powerups SET name = 'Interest Boost' WHERE id = 'bounty_boost';
+
+COMMIT;


### PR DESCRIPTION
## Answers to the three questions

**1. "How to win" card accuracy** — one line was wrong. `ObjectiveCard` still said *"A win streak pays Interest on every solve"*, but win-streak interest was dropped in #517 (streak is bragging-rights only now). Fixed → *"Boosts from the Store add Interest to your deposit."*

**2. Daily leaderboard** — no change needed (per decision). It already shows both: **Earnings** = your actual deposit (includes 💥/💎 boosts) and **Efficiency** = pure spend-less skill (`kept ÷ base × 100`, same base for everyone, no boosts/streak). So *with* interest and *without* are both displayed.

**3. "Bounty" → "Interest"** — scoped to the **multiplier only** (per decision). The per-puzzle spend budget stays "bounty" (it's the prize pool, not a rate). Unifies the multiplier vocab, which was already half-"Interest".

## Changes
- **DB** (`supabase-rename-interest-boost.sql`, applied to prod + verified): powerup display name `Bounty Boost` → `Interest Boost` (id unchanged; Jackpot unchanged).
- **Store**: `💥 Bounty Boosts` → `💥 Interest Boosts`; note no longer references the removed win-streak multiplier; descriptions → "+50%/+100% Interest to your Daily deposit".
- **ObjectiveCard**: fixed the false streak line; power-up group/names/blurbs → Interest.
- **Daily HUD**: `'mult'` modal title Boost → Interest ("Your Interest"); deposit-modal row Boost → Interest; badge tooltip → Interest; inventory descriptions → Interest.

Cash Game's heat/"Interest" modal untouched (already correct; its "bounty" = budget).

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
