### PR TITLE
Daily: bring back Interest as an earned rate (streak + credit tier)

### DIFF
--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -34,7 +34,7 @@
 					title: "Today's Daily",
 					goal: 'Solve the hidden phrase.',
 					win: 'Spend as little as you can — your leftover Deposits to your account.',
-					bar: 'Boosts from the Store add Interest to your deposit.'
+					bar: 'Earn Interest on every Deposit — from your streak, credit & boosts.'
 				};
 			case 'climb':
 				return {

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -631,6 +631,17 @@ export async function getDailyAvailBoosts() {
 	return data ?? {};
 }
 
+/** Breakdown of today's Daily Interest rate (earned + boosts) for the HUD modal.
+ * @returns {Promise<{win_streak:number,tier:string,streak:number,credit:number,boost:number,total:number}|null>} */
+export async function getDailyInterest() {
+	const { data, error } = await supabase.rpc('get_daily_interest');
+	if (error) {
+		console.error('❌ get_daily_interest:', error);
+		return null;
+	}
+	return data ?? null;
+}
+
 /* ===== Make-up daily (play a past missed day in the current month) =====
    No streak repair, no Bank deposit — fills the calendar + earns week/month badges.
    Each returns a daily board with an extra { makeup: { date } } marker. */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,7 @@
 	import {
 		getPowerups,
 		getDailyAvailBoosts,
+		getDailyInterest,
 		getMyMatches,
 		getMyGroups,
 		getMatchDetail,
@@ -906,13 +907,20 @@
 	// ℹ️ Daily explainers: ×N badge, Solve-to-Earn, 🏆 streak, or today's Twist.
 	/** @type {'mult'|'bounty'|'streak'|'twist'|null} */
 	let dailyInfo = null;
+	/** @type {{win_streak:number,tier:string,streak:number,credit:number,boost:number,total:number}|null} */
+	let dailyInterest = null;
+	// Open the Interest breakdown modal and pull the fresh streak/credit/boost split.
+	async function openDailyMult() {
+		fx('tap');
+		dailyInfo = 'mult';
+		dailyInterest = await getDailyInterest();
+	}
 	$: dlMult = Number($gameStore.dailyLive?.mult ?? $gameStore.bountyMult ?? 1);
 	$: dlRemaining = $gameStore.dailyLive?.remaining ?? 0; // Prize budget left
 	$: dlWinnings = $gameStore.dailyLive?.winnings ?? Math.round(dlRemaining * dlMult); // banked if you solve now
 	$: dlWinStreak = dailyStatus?.win_streak ?? 0;
-	// Daily multiplier is now boost-only — the win-streak "interest" was dropped, so score =
-	// bounty − spent for normal play. Any multiplier comes purely from 💥/💎 boost power-ups.
-	$: dlBoost = Math.max(0, Math.round((dlMult - 1) * 10) / 10);
+	// Daily Interest = earned (win streak + credit tier) + any 💥/💎 Interest Boosts you tap in.
+	// Total lands in dlMult; the breakdown comes from getDailyInterest() (dailyInterest).
 	let _prevNet = /** @type {number|null} */ (null);
 	let _floatId = 0;
 	let _prevWrongTick = 0;
@@ -2708,17 +2716,30 @@
 				<h3 class="info-title">Interest</h3>
 				<p class="info-sub">Extra Interest on everything you Deposit from this puzzle.</p>
 				<div class="info-rows">
-					<div class="info-row"><span>Base</span><b>+0%</b></div>
-					{#if dlBoost > 0}<div class="info-row">
-							<span>💥 Boosts</span><b class="pos">+{Math.round(dlBoost * 100)}%</b>
+					<div class="info-row">
+						<span>🏆 Win streak{dailyInterest ? ` (${dailyInterest.win_streak})` : ''}</span><b
+							class:pos={(dailyInterest?.streak ?? 0) > 0}
+							>+{Math.round((dailyInterest?.streak ?? 0) * 100)}%</b
+						>
+					</div>
+					<div class="info-row">
+						<span>💳 Credit{dailyInterest ? ` (${dailyInterest.tier})` : ''}</span><b
+							class:pos={(dailyInterest?.credit ?? 0) > 0}
+							>+{Math.round((dailyInterest?.credit ?? 0) * 100)}%</b
+						>
+					</div>
+					{#if (dailyInterest?.boost ?? 0) > 0}<div class="info-row">
+							<span>💥 Boosts</span><b class="pos"
+								>+{Math.round((dailyInterest?.boost ?? 0) * 100)}%</b
+							>
 						</div>{/if}
 					<div class="info-row total">
 						<span>Your Interest</span><b>+{Math.round((dlMult - 1) * 100)}%</b>
 					</div>
 				</div>
 				<p class="info-note">
-					Stock up on 💥/💎 Interest Boosts in the Store and tap one in before you solve — the Daily
-					itself has no streak multiplier, so your score is just what you keep of the bounty.
+					Interest is earned — solve day after day to grow your 🏆 streak (up to +15%) and keep good
+					💳 credit (up to +10%). Tap in 💥/💎 Interest Boosts from the Store for more on top.
 				</p>
 			{:else if dailyInfo === 'twist'}
 				<div class="info-big">{dailyMod?.emoji ?? '🎁'}</div>
@@ -2753,7 +2774,7 @@
 				<p class="info-note">
 					Deduce letters instead of buying them — keep more of your balance. Grows your <button
 						class="info-inline"
-						on:click|stopPropagation={() => (dailyInfo = 'mult')}>Interest</button
+						on:click|stopPropagation={openDailyMult}>Interest</button
 					> too.
 				</p>
 			{/if}
@@ -4400,11 +4421,9 @@
 							<!-- Daily badge only appears when a 💥/💎 boost is active (no streak interest). -->
 							<button
 								class="bp-mult-badge"
-								title="Interest — a power-up multiplier on your deposit"
-								on:click={() => {
-									fx('tap');
-									dailyInfo = 'mult';
-								}}>+{Math.round((Number($gameStore.bountyMult ?? 1) - 1) * 100)}%</button
+								title="Interest — earned from your streak + credit, plus boosts"
+								on:click={openDailyMult}
+								>+{Math.round((Number($gameStore.bountyMult ?? 1) - 1) * 100)}%</button
 							>
 						{:else if isClimb}
 							<button

--- a/supabase-daily-earned-interest.sql
+++ b/supabase-daily-earned-interest.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Daily: bring back "Interest" as an EARNED loyalty/creditworthiness rate.
+-- ============================================================================
+-- The Daily deposit multiplier is now:  mult = 1 + interest, where
+--   interest = streak + credit + boosts   (clamped so mult stays in [1.0, 3.0])
+--     • streak  = +2% per consecutive Daily solve, capped +15% (current_daily_solve_streak)
+--     • credit  = tier bonus: Excellent +10%, Good +5%, Fair +2%, Poor/Bad +0%
+--     • boosts  = the 💥/💎 Interest Boost power-ups you buy + tap in (daily_sessions.bounty_boost)
+-- "Interest" is one unified concept with three sources; the 💥/💎 boosts literally
+-- boost your interest. Earned interest (streak+credit) caps at +25%; boosts stack on top.
+-- Single source of truth = _daily_interest_parts(uid); _daily_bounty_mult sums its 'total'.
+-- get_daily_interest() exposes the breakdown for the HUD 'Interest' modal.
+-- ============================================================================
+BEGIN;
+
+-- Component breakdown (fractions, e.g. 0.10 = +10%). Single source of truth.
+CREATE OR REPLACE FUNCTION public._daily_interest_parts(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  WITH p AS (
+    SELECT
+      COALESCE(pr.current_daily_solve_streak, 0) AS ws,
+      public._credit_tier(COALESCE(pr.credit_score, 650)) AS tier
+    FROM public.profiles pr WHERE pr.id = p_uid
+  ),
+  parts AS (
+    SELECT
+      p.ws,
+      p.tier,
+      LEAST(0.15, 0.02 * p.ws) AS streak,
+      CASE p.tier
+        WHEN 'Excellent' THEN 0.10
+        WHEN 'Good'      THEN 0.05
+        WHEN 'Fair'      THEN 0.02
+        ELSE 0.0
+      END AS credit,
+      COALESCE((SELECT bounty_boost FROM public.daily_sessions
+                WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE), 0)::numeric AS boost
+    FROM p
+  )
+  SELECT jsonb_build_object(
+    'win_streak', parts.ws,
+    'tier',       parts.tier,
+    'streak',     parts.streak,
+    'credit',     parts.credit,
+    'boost',      parts.boost,
+    'total',      parts.streak + parts.credit + parts.boost
+  ) FROM parts;
+$function$;
+
+-- Deposit multiplier = 1 + total interest, clamped to [1.0, 3.0].
+CREATE OR REPLACE FUNCTION public._daily_bounty_mult(p_uid uuid)
+ RETURNS numeric
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT GREATEST(1.0, LEAST(3.0,
+    1.0 + COALESCE((public._daily_interest_parts(p_uid)->>'total')::numeric, 0)
+  ));
+$function$;
+
+-- Thin RPC for the HUD 'Interest' modal breakdown.
+CREATE OR REPLACE FUNCTION public.get_daily_interest()
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+AS $function$
+  SELECT public._daily_interest_parts(auth.uid());
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_daily_interest() TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## What

Reintroduces **Interest** on the Daily deposit — but as an **earned** loyalty/creditworthiness rate, not the old streak multiplier we dropped for fairness. Approved design.

`deposit = round((bounty − spent) × (1 + interest))`, `interest = streak + credit + boosts`, clamped so `mult ∈ [1.0, 3.0]`.

| Source | Rule | Max |
|---|---|---|
| 🏆 Win streak | +2% per consecutive solve | +15% |
| 💳 Credit tier | Excellent +10 · Good +5 · Fair +2 · Poor/Bad +0 | +10% |
| 💥/💎 Interest Boosts | bought + tapped in (unchanged) | stacks on top |

"Interest" is now **one unified concept** — the 💥/💎 boosts literally boost your interest, so no rename needed. Earned interest caps at **+25%**; boosts add more.

## Why this shape
- Reuses the existing **credit-score** system — gives it another reason to matter, and keeps the banking metaphor honest (interest is *earned* through loyalty + good standing, with an optional bought bonus).
- **Leaderboard unchanged:** Earnings = your real deposit (now rewards loyalty), Efficiency = pure skill for the fair competitive board.

## Server (`supabase-daily-earned-interest.sql`, applied to prod + verified)
- `_daily_interest_parts(uid)` — single source of truth; returns `{win_streak, tier, streak, credit, boost, total}`.
- `_daily_bounty_mult(uid)` — now `1 + parts.total`, clamped.
- `get_daily_interest()` — thin RPC for the HUD modal.

Verified against real profiles: streak 6 + Good → +17%; streak 2 + Fair → +6%; +15% cap holds.

## Client
- The Interest chip reappears on the HUD whenever interest > 0.
- The Interest modal shows the earned breakdown (🏆 streak / 💳 credit / 💥 boosts / total), fetched on open via `getDailyInterest()`.
- Objective "How to win" bar updated.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
