### PR TITLE
Daily: explain each Twist the moment it happens

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -2,6 +2,7 @@
 
 import { writable, get } from 'svelte/store';
 import { fx } from '$lib/sound.js';
+import { MODIFIERS } from '$lib/powerups.js';
 import {
 	dailyStart,
 	dailyUseTwist,
@@ -106,7 +107,8 @@ import { track } from '$lib/analytics.js';
  *   dailyIntro?: number,
  *   dailyIntroGo?: number,
  *   dailyIntroPlayed?: number,
- *   wrongTick?: number
+ *   wrongTick?: number,
+ *   twistCue?: { id:number, text:string } | null
  * }} GameState
  */
 
@@ -180,7 +182,8 @@ export const gameStore = writable(
 		dailyIntro: 0, // bumps on a FRESH daily open → ARMS the opening reveal (pending)
 		dailyIntroGo: 0, // bumps once the board is actually visible → PLAYS the opening reveal
 		dailyIntroPlayed: 0, // the dailyIntro token that has already played (persists across remounts)
-		wrongTick: 0 // bumps on a non-busting wrong whole-phrase guess → UI flashes a distinct "✗ Wrong" cue
+		wrongTick: 0, // bumps on a non-busting wrong whole-phrase guess → UI flashes a distinct "✗ Wrong" cue
+		twistCue: null // { id, text } — transient "the Twist just did X" toast (Daily), cleared by the UI
 	})
 );
 
@@ -985,6 +988,38 @@ async function submitGuessMatch(state) {
 	}
 }
 
+let _twistCueId = 0;
+/** Flash a transient "the Twist just did X" toast (Daily). @param {string} text */
+function flashTwistCue(text) {
+	if (!text) return;
+	gameStore.update((s) => ({ ...s, twistCue: { id: ++_twistCueId, text } }));
+}
+
+/**
+ * Explain a Daily Twist the moment it affects a letter buy: the Insured free wrong
+ * letter, or a pricing Twist's saving (discount/flat/vowel-vision/consonant-sale).
+ * @param {string} letter @param {number} prevBankroll @param {number} prevWrong @param {string|null|undefined} mod
+ */
+function detectDailyBuyCue(letter, prevBankroll, prevWrong, mod) {
+	if (!mod) return;
+	const info = MODIFIERS[mod];
+	if (!info) return;
+	const s = get(gameStore);
+	const charged = Math.max(0, prevBankroll - (s.bankroll ?? 0));
+	const wasWrong = (s.incorrectLetters || []).length > prevWrong;
+	const base = LETTER_COSTS[letter] || 0;
+	// Insured: the first wrong letter is free.
+	if (mod === 'insured' && wasWrong && charged === 0) {
+		flashTwistCue(`${info.emoji} ${info.name} · first wrong letter free`);
+		return;
+	}
+	// Pricing Twists: only when the Twist actually made this letter cheaper.
+	const pricing = ['discount', 'flat_rate', 'vowel_vision', 'consonant_sale'];
+	if (pricing.includes(mod) && charged > 0 && base > charged) {
+		flashTwistCue(`${info.emoji} ${info.name} · saved $${(base - charged).toLocaleString()}`);
+	}
+}
+
 /**
  * confirmPurchaseDaily
  * Commit a pending letter/hint/extra-guess purchase via the server.
@@ -993,6 +1028,10 @@ async function submitGuessMatch(state) {
 async function confirmPurchaseDaily(state) {
 	const purchase = state.selectedPurchase;
 	if (!purchase || dailyInFlight) return;
+	const letter = purchase.type === 'letter' ? String(purchase.value ?? '').toUpperCase() : null;
+	const prevBankroll = state.bankroll ?? 0;
+	const prevWrong = (state.incorrectLetters || []).length;
+	const mod = state.modifier;
 	dailyInFlight = true;
 	try {
 		let board = null;
@@ -1005,6 +1044,7 @@ async function confirmPurchaseDaily(state) {
 
 		if (board) {
 			reconcileDailyBoard(board);
+			if (letter) detectDailyBuyCue(letter, prevBankroll, prevWrong, mod);
 		} else {
 			gameStore.update((s) => ({ ...s, selectedPurchase: null, gameState: 'default' }));
 		}
@@ -1314,6 +1354,13 @@ export async function fetchDailyGame() {
 		// 🎰 Fresh open (first time today, board still active) → play the opening reveal.
 		if (ab.state === 'active' && ab.attendance != null && ab.attendance > 0) {
 			gameStore.update((s) => ({ ...s, dailyIntro: (s.dailyIntro || 0) + 1 }));
+			// Auto-reveal Twists (head_start / free_vowel) pre-fill letters at open — explain why.
+			// The UI holds this until the board is interactive (past the intro / How-to-win card).
+			const mod = ab.modifier;
+			if (mod === 'head_start' || mod === 'free_vowel') {
+				const info = MODIFIERS[mod];
+				if (info) flashTwistCue(`${info.emoji} ${info.name} · ${info.blurb.toLowerCase()}`);
+			}
 		}
 		try {
 			const clue = await getDailyClue();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -976,6 +976,33 @@
 	// where stalling stalls a real opponent, keep the broke clock.
 	$: brokeMode = $gameStore.gameMode === 'match';
 	$: gameActive = $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost';
+
+	// 🎁 Daily Twist "as it happens" toast. GameStore sets $gameStore.twistCue when a Twist
+	// affects a buy (Insured free / pricing saving) or pre-reveals at open (head start / free
+	// vowel). Hold it until the board is interactive (past the intro + How-to-win card), then
+	// flash it for ~2.6s.
+	let twistToast = /** @type {{ id:number, text:string }|null} */ (null);
+	let _twistSeenId = 0;
+	$: maybeTwistToast(
+		$gameStore.twistCue,
+		gameActive,
+		showMainMenu,
+		introBuilding,
+		objective,
+		$gameStore.cashToast
+	);
+	/** @param {{id:number,text:string}|null|undefined} cue @param {boolean} active @param {boolean} onMenu @param {boolean} building @param {any} obj @param {any} attendanceToast */
+	function maybeTwistToast(cue, active, onMenu, building, obj, attendanceToast) {
+		if (!browser || !cue || cue.id === _twistSeenId) return;
+		// Wait until the board is playable AND the attendance toast has cleared (no stacking).
+		if (!active || onMenu || building || obj || attendanceToast) return;
+		_twistSeenId = cue.id;
+		twistToast = cue;
+		setTimeout(() => {
+			if (twistToast?.id === cue.id) twistToast = null;
+		}, 2600);
+	}
+
 	$: isBroke = (() => {
 		// Only while actively on a game screen — never on the menu.
 		if (!brokeMode || !gameActive || showMainMenu) return false;
@@ -2565,6 +2592,11 @@
 			> ·
 		{/if}{$gameStore.cashToast.label}
 	</button>
+{/if}
+
+<!-- 🎁 Daily Twist "as it happens" explainer toast -->
+{#if twistToast}
+	<div class="twist-toast" role="status">{twistToast.text}</div>
 {/if}
 
 <!-- 🔐 Vault door-open animation (from the main menu, after the PIN) → then items -->
@@ -5147,6 +5179,47 @@
 		to {
 			transform: translate(-50%, 0);
 			opacity: 1;
+		}
+	}
+	/* 🎁 Daily Twist explainer toast — sits just below the attendance toast, distinct
+	   neon-indigo look so it reads as "your Twist did this". */
+	.twist-toast {
+		position: fixed;
+		top: 58px;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 2000;
+		max-width: min(90vw, 340px);
+		padding: 0.5rem 0.95rem;
+		border-radius: 999px;
+		text-align: center;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.82rem;
+		line-height: 1.25;
+		color: #e9f2ff;
+		background: rgba(20, 24, 40, 0.94);
+		border: 1px solid rgba(129, 140, 248, 0.6);
+		box-shadow: 0 8px 24px rgba(99, 102, 241, 0.3);
+		pointer-events: none;
+		animation:
+			twistDrop 0.35s var(--ease-spring, ease) both,
+			twistOut 0.4s ease 2.2s forwards;
+	}
+	@keyframes twistDrop {
+		from {
+			transform: translate(-50%, -40px);
+			opacity: 0;
+		}
+		to {
+			transform: translate(-50%, 0);
+			opacity: 1;
+		}
+	}
+	@keyframes twistOut {
+		to {
+			opacity: 0;
+			transform: translate(-50%, -12px);
 		}
 	}
 	main {


### PR DESCRIPTION
## What

Follows up the "free J" confusion — a wrong letter that was free (Insured) or a letter that cost less (a pricing Twist) gave **no feedback**, so it looked like a glitch. Now the Daily flashes a small **"the Twist just did X"** toast at the moment of effect, covering all 7 weekday Twists.

| Twist | When | Toast |
|---|---|---|
| **Insured** | first wrong letter | 🛡️ Insured · first wrong letter free |
| **Discount / Flat Rate / Vowel Vision / Consonant Sale** | on a buy the Twist made cheaper | 🏷️ Discount · saved $X (only when it truly saved) |
| **Head Start / Free Vowel** | at open (pre-filled letters) | 🅰️ Head Start · first letter of each word free |

## How
- `GameStore` sets a transient `twistCue {id, text}`:
  - `detectDailyBuyCue()` compares pre/post **bankroll** + **incorrect-letters** after a buy to detect the free/discount, and labels it from the shared `MODIFIERS` metadata.
  - `fetchDailyGame()` flashes the auto-reveal Twists on a fresh open.
- `+page` holds the cue until the board is actually interactive (past the intro reveal, the How-to-win card, and the attendance toast), then flashes a neon-indigo `.twist-toast` for ~2.6s.

The detection is generic (`charged < base` while a pricing Twist is active), so vowel-only / consonant-only / flat-rate-cheaper-only cases all resolve correctly, and no cue fires when a letter wasn't actually discounted.

## Verification
Live dev + Playwright on today's **Insured** day: buying a wrong `Z` fired **"🛡️ Insured · first wrong letter free"** and the balance stayed put ($199, no deduction). Screenshot confirms placement/styling. Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
