### PR TITLE
Cash Game: refresh "How to win" copy (drop Wallet/Yield, fix wrong-guess line)

### DIFF
--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -40,9 +40,9 @@
 				return {
 					icon: '🎰',
 					title: 'Cash Game',
-					goal: 'Invest your Principal → grow it by solving puzzles cheaply.',
-					win: 'Bank between puzzles — once you start one, it’s solve or bust. Yield climbs with each solve.',
-					bar: 'A wrong guess VOIDs your Wallet.'
+					goal: 'Invest your buy-in → grow it by solving puzzles cheaply.',
+					win: 'Bank between puzzles — once you start one, it’s solve or bust. Your Interest climbs with each solve.',
+					bar: 'A wrong guess drains your budget — run out and you bust.'
 				};
 			case 'makeup':
 				return {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -600,8 +600,8 @@
 	// The doubled target payout (matches server: bounty ×2, then × heat, rounded).
 	$: donTarget =
 		isClimb && climb ? Math.round(((climb.bounty ?? 0) * 2 * (climb.heat ?? 100)) / 100) : 0;
-	// Climb live (Accumulator): "Solve to Earn" = leftover budget × heat, banked into the
-	// Wallet on solve. Server-computed as solve_reward.
+	// Climb live (Accumulator): "Solve to Earn" = leftover budget × heat, added to the
+	// Payout on solve. Server-computed as solve_reward.
 	$: climbLive =
 		isClimb && climb && climb.state === 'active'
 			? {
@@ -3597,8 +3597,8 @@
 								on:click={() => pickTier(t.tier)}
 							>
 								<span class="tt-label">{t.label}</span>
-								<span class="tt-buyin">${t.buy_in.toLocaleString()} <small>principal</small></span>
-								<span class="tt-meta">yield to +{Math.round(t.heat_cap - 100)}%</span>
+								<span class="tt-buyin">${t.buy_in.toLocaleString()} <small>buy-in</small></span>
+								<span class="tt-meta">interest to +{Math.round(t.heat_cap - 100)}%</span>
 								{#if !t.unlocked}<span class="tt-lock"
 										>🔒 {t.tier === 'silver'
 											? '3 Bronze deposits'


### PR DESCRIPTION
Updates the Cash Game "How to win" card (and the tier picker) to current vocabulary and mechanics.

| Old | New | Why |
|---|---|---|
| "A wrong guess VOIDs your **Wallet**." | "A wrong guess **drains your budget — run out and you bust**." | "Wallet" retired; also the mechanic changed in #519 (a wrong guess drains budget, it doesn't instantly void everything) |
| "**Yield** climbs with each solve." | "Your **Interest** climbs with each solve." | Matches the HUD (heat = Interest) |
| "Invest your **Principal** →…" | "Invest your **buy-in** →…" | Matches the cash-out receipt's "Buy-in" |
| tier picker: "$X **principal**" · "**yield** to +X%" | "$X **buy-in**" · "**interest** to +X%" | Same terms, swept for consistency |

Kept "Bank between puzzles" (clear, not flagged) and the loan's real "principal". Also tidied one stale "Wallet" code comment.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
