### PR TITLE
Cash Game: earned interest (efficiency + credit) + working Heat Shield

### DIFF
--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -20,6 +20,7 @@
 		free_vowel: { icon: '🅰️', desc: 'Reveal one vowel free' },
 		half_off: { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
 		vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
+		heat_shield: { icon: '🛡️', desc: 'Escape one bust — keep your Payout & Interest' },
 		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
 		extra_hint: { icon: '💡', desc: 'First letter of each word' },
 		last_letters: { icon: '🔚', desc: 'Last letter of each word' },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2838,11 +2838,12 @@
 			<button class="modal-x" on:click={() => (climbInfo = null)} aria-label="Close">✕</button>
 			{#if climbInfo === 'heat'}
 				<div class="info-big">🔥 +{Math.round((climb?.heat ?? 100) - 100)}%</div>
-				<h3 class="info-title">Interest — your bounty boost</h3>
+				<h3 class="info-title">Interest — grows your payouts</h3>
 				<p class="info-sub">Every new bounty lands in your Payout boosted by your Interest.</p>
 				<div class="info-rows">
-					<div class="info-row"><span>Base</span><b>+0%</b></div>
-					<div class="info-row"><span>Each solve in a row</span><b class="pos">+10%</b></div>
+					<div class="info-row"><span>Each solve</span><b class="pos">+5%</b></div>
+					<div class="info-row"><span>⚡ Solved cheaply</span><b class="pos">up to +10%</b></div>
+					<div class="info-row"><span>💳 Credit standing</span><b class="pos">up to +4%</b></div>
 					<div class="info-row">
 						<span>Maxes out at</span><b>+{Math.round((climb?.heat_cap ?? 200) - 100)}%</b>
 					</div>
@@ -2851,10 +2852,11 @@
 					</div>
 				</div>
 				<p class="info-note">
-					Interest climbs with your <button
+					Interest grows every <button
 						class="info-inline"
-						on:click|stopPropagation={() => (climbInfo = 'streak')}>solve streak</button
-					> and resets to +0% on a bust.
+						on:click|stopPropagation={() => (climbInfo = 'streak')}>solve</button
+					> — more when you solve cheaply and keep good credit. It resets to +0% on a bust, unless a
+					🛡️ Heat Shield saves you.
 				</p>
 			{:else if climbInfo === 'streak'}
 				<div class="info-big">🔥 {climbStreak}</div>

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -32,6 +32,10 @@
 		free_vowel: { icon: '🅰️', desc: 'Reveal one vowel free' },
 		half_off: { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
 		vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
+		heat_shield: {
+			icon: '🛡️',
+			desc: 'Escape one bust — keep your Payout & Interest and jump to a fresh puzzle'
+		},
 		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
 		extra_hint: { icon: '💡', desc: 'Reveal the first letter of each word' },
 		last_letters: { icon: '🔚', desc: 'Reveal the last letter of each word' },

--- a/supabase-cashgame-interest-rework.sql
+++ b/supabase-cashgame-interest-rework.sql
@@ -1,0 +1,133 @@
+-- ============================================================================
+-- Cash Game interest rework: the per-solve interest (heat) gain is now EARNED,
+-- not a flat +10%. Plus: the Heat Shield power-up finally does something.
+-- ============================================================================
+-- gain per solve = 5 (base) + efficiency (0-10) + credit (0-4), capped by tier:
+--   • efficiency = how cheaply you solved (kept / bounty), rounded ×10  → +0..+10
+--   • credit     = your credit tier: Excellent +4, Good +2, Fair +1, else +0
+-- So a cheap solve with great credit ≈ +19%; a sloppy one ≈ +5%. Tier still caps
+-- the ceiling (Micro +100% → Gold +200%).
+--
+-- Heat Shield (was dead in Cash Game): if OWNED, it auto-saves you from a bust —
+-- when a wrong guess would end the run, it's consumed instead and you jump to a
+-- fresh puzzle keeping your Payout AND your interest. The one thing that wipes
+-- your interest is a bust, so this is the true "protect your interest" power-up.
+-- ============================================================================
+BEGIN;
+
+-- ── Dynamic interest gain on solve ─────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public._climb_resolve(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_phrase TEXT; v_won BOOLEAN; v_tier JSONB; v_k NUMERIC; v_stake INT; v_cap INT;
+  v_bounty INT; v_keep INT; v_cat TEXT; v_time INT; v_next UUID;
+  v_eff NUMERIC; v_ctier TEXT; v_cbonus INT; v_gain INT;
+BEGIN
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(p_uid); END IF;
+  v_tier := public._cg_tier(cs.tier); v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_cap := COALESCE((v_tier->>'heat_cap')::int, 250); v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions)));
+  IF v_won THEN
+    -- Heat is baked into the bounty; keep = what carries into the Balance. No 2nd ×heat.
+    v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+    v_keep := GREATEST(0, v_bounty - cs.spent);
+    -- Earned interest gain: base + efficiency (how cheaply you solved) + credit standing.
+    v_eff := CASE WHEN v_bounty > 0 THEN LEAST(1.0, v_keep::numeric / v_bounty) ELSE 0 END;
+    v_ctier := public._credit_tier((SELECT COALESCE(credit_score, 650) FROM public.profiles WHERE id = p_uid));
+    v_cbonus := CASE v_ctier WHEN 'Excellent' THEN 4 WHEN 'Good' THEN 2 WHEN 'Fair' THEN 1 ELSE 0 END;
+    v_gain := 5 + round(10 * v_eff)::int + v_cbonus;
+    v_time := LEAST(GREATEST(EXTRACT(epoch FROM (now() - COALESCE(cs.puzzle_started_at, cs.updated_at))) * 1000, 0), 1800000)::int;
+    v_next := public._pick_casual(p_uid, null, cs.puzzle_id, 0);
+    UPDATE public.climb_state SET state = 'solved', last_gain = v_keep,
+      bankroll = cs.bankroll + v_keep,
+      heat_x100 = LEAST(v_cap, cs.heat_x100 + v_gain),
+      run_solves = cs.run_solves + 1, next_puzzle_id = v_next, updated_at = now() WHERE user_id = p_uid;
+    PERFORM public._record_category_solve(p_uid, v_cat);
+    PERFORM public._log_game_result(p_uid,'climb','won', cs.puzzle_id, v_cat, 1, 1, cs.spent::int, v_keep, v_time);
+  ELSE
+    UPDATE public.climb_state SET state = 'active', updated_at = now() WHERE user_id = p_uid;
+  END IF;
+  RETURN public._climb_board(p_uid);
+END; $function$;
+
+-- ── Heat Shield: auto-save from a bust (keep Payout + interest, jump to a fresh puzzle) ──
+CREATE OR REPLACE FUNCTION public._cg_try_shield(p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cs public.climb_state; v_qty INT; v_pid UUID;
+BEGIN
+  SELECT qty INTO v_qty FROM public.user_powerups_v2
+    WHERE user_id = p_uid AND powerup_id = 'heat_shield' AND pool = 'cash';
+  IF COALESCE(v_qty, 0) <= 0 THEN RETURN NULL; END IF;                 -- no shield owned → let it bust
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = p_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state <> 'active' THEN RETURN NULL; END IF;
+  v_pid := public._pick_casual(p_uid, null, cs.puzzle_id, 0);
+  IF v_pid IS NULL THEN RETURN NULL; END IF;                           -- nowhere to advance → bust
+  UPDATE public.user_powerups_v2 SET qty = qty - 1
+    WHERE user_id = p_uid AND powerup_id = 'heat_shield' AND pool = 'cash';
+  -- Escape: fresh puzzle, per-puzzle fields reset, but bankroll (Payout) + heat_x100 (interest) kept.
+  UPDATE public.climb_state SET position = cs.position + 1, puzzle_id = v_pid, revealed_positions = '{}',
+    incorrect_letters = '{}', spent = 0, last_gain = 0, active_powerups = '{}', next_puzzle_id = NULL,
+    pups_locked = false, state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = p_uid;
+  PERFORM public._mark_seen(p_uid, v_pid);
+  RETURN public._climb_board(p_uid) || jsonb_build_object('shielded', true);
+END; $function$;
+
+-- ── Wire the shield into the bust wall ─────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.climb_submit_guess(p_guess jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}';
+  v_all BOOLEAN := true; pos INT; v_ch TEXT;
+  v_tier JSONB; v_k NUMERIC; v_stake INT; v_bounty INT; v_budget_left INT; v_cheapest INT; v_pen INT; v_shield JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_submit_guess: not authenticated'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_submit_guess: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(cs.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._climb_board(v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_correct) ORDER BY 1);
+    UPDATE public.climb_state SET revealed_positions = cs.revealed_positions, updated_at = now() WHERE user_id = v_uid;
+    RETURN public._climb_resolve(v_uid);
+  END IF;
+
+  -- ── Wrong guess ──────────────────────────────────────────────────────────
+  v_tier := public._cg_tier(cs.tier);
+  v_k := COALESCE((v_tier->>'k')::numeric, 0.85);
+  v_stake := COALESCE((v_tier->>'stake')::int, 1);
+  v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+  v_budget_left := GREATEST(0, v_bounty - cs.spent);
+  v_cheapest := public._cg_cheapest(cs);
+  IF v_cheapest IS NULL OR v_budget_left < v_cheapest THEN
+    -- Out of budget: this was your last guess → bust — unless a Heat Shield saves you.
+    v_shield := public._cg_try_shield(v_uid);
+    IF v_shield IS NOT NULL THEN RETURN v_shield; END IF;
+    RETURN public._cg_bust(v_uid);
+  END IF;
+  -- Still have budget: drain a penalty (≥ one letter, or 20% of what's left) and keep playing.
+  v_pen := LEAST(v_budget_left, GREATEST(v_cheapest, (round(0.2 * v_budget_left / 10.0) * 10)::int));
+  UPDATE public.climb_state SET spent = cs.spent + v_pen, pups_locked = true, updated_at = now()
+    WHERE user_id = v_uid;
+  RETURN public._climb_board(v_uid);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
## What

Cash Game interest (heat) was a single flat lever — **+10% per solve**. Now it's **earned**, per the approved design (efficiency + credit + power-up, "balanced" tuning).

**Per-solve interest gain = 5% base + efficiency (0–10%) + credit (0–4%)**, still capped by your buy-in tier.
- **⚡ Efficiency** = `kept / bounty` (how cheaply you solved), rounded ×10 → +0…+10
- **💳 Credit** = `_credit_tier(score)`: Excellent +4 / Good +2 / Fair +1 / else 0
- **Tier** = the cap (Micro +100% → Gold +200%), unchanged

So a cheap solve with great credit ≈ **+19%**, a sloppy one ≈ **+5%**. Verified: (1.0, Excellent)=19, (0.5, Good)=12, (0.0, Bad)=5.

## Heat Shield — the premise correction
While wiring the "power-up lever," I found the assumption behind it was wrong: **a skip doesn't reset heat** (nothing does except starting a new run), and **both `heat_shield` AND `insurance` are dead in Cash Game** — they're in the store but do nothing. The *only* thing that destroys your interest is a **bust** (which wipes the whole run).

So the faithful "protect your interest" mechanic is a **bust-save**: if you own a Heat Shield, a would-be bust consumes it instead and you jump to a fresh puzzle **keeping your Payout and your interest**. (`_cg_try_shield`, wired into the bust wall in `climb_submit_guess`.) Verified in a rollback — shield consumed, payout + heat kept, run advanced.

## Files
- **Server** `supabase-cashgame-interest-rework.sql` (applied to prod + verified): `_climb_resolve` dynamic gain, `_cg_try_shield`, `climb_submit_guess` shield hook.
- **Client**: interest HUD modal now breaks down base / efficiency / credit and notes the Heat Shield save; Heat Shield gets a real description in the Store + inventory.

## ⚠️ Heads-up
`insurance` (and possibly other Cash Game power-ups like `double_down` / `extra_attempt`) also appear **unwired** — sold but non-functional. Flagged for a follow-up.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
