### PR TITLE
Cash Game power-ups: activate Heat Shield + audit result

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -555,6 +555,10 @@ function reconcileClimbBoard(board, wrong = false) {
 	if (busted) fx('bust');
 	else if (solved) {
 		fx('win');
+	} else if (board.shielded) {
+		// 🛡️ Heat Shield turned a would-be bust into a fresh puzzle (Payout + interest kept).
+		fx('multiplier');
+		flashTwistCue('🛡️ Heat Shield · saved your run!');
 	} else playMoveCue(prev, board);
 }
 
@@ -669,6 +673,11 @@ async function submitGuessClimb(state) {
 			const wrong = stillPlaying && (c.spent ?? 0) > prevSpent;
 			reconcileClimbBoard(board, wrong);
 			if (wrong) fx('wrong');
+			// 🛡️ Heat Shield jumped you to a fresh puzzle — arm its reveal + pull the new clue.
+			if (board.shielded) {
+				maybeArmClimbIntro();
+				await refreshClimbClue();
+			}
 		}
 	} finally {
 		dailyInFlight = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -773,6 +773,9 @@
 								reason: avail ? '' : 'Bought after you started — usable on your next puzzle.'
 							});
 						} else if (it.kind === 'climb') {
+							// Heat Shield is a PASSIVE safety net (auto-saves you from a bust while owned) —
+							// it's not tap-to-use, so keep it out of the usable tray.
+							if (it.id === 'heat_shield') continue;
 							// Self-buffs work in BOTH the Cash Game and Challenges.
 							const climbUsed = (climb?.equipped ?? []).includes(it.id);
 							const matchUsed = (matchInfo?.used_powerups ?? []).includes(it.id);

--- a/supabase-heat-shield-activate.sql
+++ b/supabase-heat-shield-activate.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- Activate the (now-working) Heat Shield power-up so it's actually purchasable.
+-- Heat Shield is PASSIVE: owning one auto-saves you from a bust (see _cg_try_shield
+-- in supabase-cashgame-interest-rework.sql). So tapping it in the power-up tray must
+-- NOT consume it — climb_use_powerup becomes a no-op for heat_shield.
+--
+-- The other dead Cash Game power-ups (double_down, extra_attempt, insurance) are left
+-- inactive on purpose: they're redundant/meaningless (DoN already has its own button;
+-- Cash Game guesses are free/unlimited; a bust-save is now Heat Shield's job).
+-- ============================================================================
+BEGIN;
+
+UPDATE public.powerups SET active = true WHERE id = 'heat_shield';
+
+CREATE OR REPLACE FUNCTION public.climb_use_powerup(p_id text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_eff TEXT; v_qty INT; v_phrase TEXT; v_positions INT[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_use_powerup: not authenticated'; END IF;
+  SELECT effect_key INTO v_eff FROM public.powerups WHERE id = p_id AND kind = 'climb' AND active;
+  IF v_eff IS NULL THEN RAISE EXCEPTION 'climb_use_powerup: invalid power-up'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  -- Heat Shield is a passive safety net (auto-consumed on a bust). Tapping it does nothing
+  -- and must never burn the charge.
+  IF v_eff = 'heat_shield' THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._climb_board(v_uid); END IF;
+  IF v_eff = ANY(cs.active_powerups) THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+  UPDATE public.climb_state SET active_powerups = array_append(active_powerups, v_eff) WHERE user_id = v_uid;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_positions := public._powerup_reveal(v_phrase, v_eff, cs.revealed_positions);
+  IF v_positions IS NOT NULL THEN
+    UPDATE public.climb_state SET revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_positions) ORDER BY 1) WHERE user_id = v_uid;
+  END IF;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
## Audit result (all 11 Cash Game power-ups)

Good news — **the store is actually clean.** Every power-up currently *sold* works:

| Working & active (7) | How |
|---|---|
| free_reveal, free_vowel, vowel_vision, extra_hint, last_letters, reveal_word | reveal positions via `_powerup_reveal` |
| half_off | `climb_buy_letter` reads `active_powerups` → letters 50% off |

The 3 truly-dead ones — **`double_down`, `extra_attempt`, `insurance`** — were **already `active=false` with 0 owned**, so nothing was ever sold-but-broken (my earlier flag was too alarmist). Left inactive on purpose: Double-or-Nothing already has its own button, Cash Game guesses are free/unlimited (so "extra attempt" is meaningless), and a bust-save is now Heat Shield's job.

## The one real fix: activate Heat Shield

`heat_shield` was made functional in #532 but was still `active=false` — unbuyable, so the fix was dormant. This activates it.

- **Server** (`supabase-heat-shield-activate.sql`, applied to prod): `active=true` for heat_shield; `climb_use_powerup` **no-ops** for heat_shield — it's a **passive** that auto-saves from inventory, so tapping it must never burn the charge.
- **Client**: excluded from the tap-to-use tray (passive, not usable); when a shielded board arrives (a bust turned into a fresh puzzle), it flashes **"🛡️ Heat Shield · saved your run!"**, arms the new puzzle's reveal, and refreshes its clue.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
