### PR TITLE
Cash Game receipt: "Solved for" → "Puzzle value"

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4937,7 +4937,7 @@
 							<div class="rcpt-rule"></div>
 							<div class="rcpt-cap">This solve</div>
 							<div class="rcpt-line">
-								<span>Solved for</span><span>${advance.toLocaleString()}</span>
+								<span>Puzzle value</span><span>${advance.toLocaleString()}</span>
 							</div>
 							<div class="rcpt-line">
 								<span>Letters (debit)</span><span class="neg">−${letters.toLocaleString()}</span>


### PR DESCRIPTION
"Solved for $780" implied your take-home, but that line is the **gross** — you actually net it *minus* what you spent on letters (the +$90 kept). **"Puzzle value"** is the honest label for the pre-spend value, and it matches the prose that already says "puzzle value" / "a puzzle's value" everywhere.

```
THIS SOLVE
Puzzle value            $780
Letters (debit)        −$690
════
Kept this solve         +$90
```

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
