### PR TITLE
Cash Game receipt: faint "Available balance" reference

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4954,6 +4954,13 @@
 							<div class="rcpt-line">
 								<span>Interest · Solves</span><span>+{runInt}% · {solves}</span>
 							</div>
+							<div class="rcpt-rule"></div>
+							<!-- Ambient reference: your account (untouched until you Deposit the run). -->
+							<div class="rcpt-line rcpt-faint">
+								<span>Available balance</span><span
+									>${Math.round(menuBank ?? 0).toLocaleString()}</span
+								>
+							</div>
 						</div>
 						{#if climb?.next_category}
 							<div class="cg-peek">
@@ -9448,6 +9455,11 @@
 	.rcpt-line.balance {
 		font-weight: 800;
 		letter-spacing: 0.02em;
+	}
+	/* Ambient account reference on a run slip — de-emphasized so it doesn't read as run math. */
+	.rcpt-line.rcpt-faint {
+		font-size: 0.72rem;
+		color: #8a8172;
 	}
 	.rcpt-rule {
 		border-top: 1px dashed #b3a88f;


### PR DESCRIPTION
Sneaks your actual account balance back onto the per-puzzle slip — but as an **ambient reference**, not a bold total. It's a small, gray line at the very bottom below its own divider, visually separate from the bold run math, so it reads as *"your run pile deposits into here when you cash out"* rather than a number the run just moved.

```
YOUR RUN
RUNNING PAYOUT          $380
Interest · Solves     +21% · 2
─────────────
Available balance      $1,050   ← faint / small
```

New `.rcpt-faint` style. Verified layout in the render harness. Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
