### PR TITLE
Cash Game: simplify the out-of-money banner

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4384,8 +4384,8 @@
 					<div class="bn-head">
 						<span class="bn-app">🏦 WordBank</span><span class="bn-time">now</span>
 					</div>
-					<div class="bn-title">Out of budget for this word!</div>
-					<div class="bn-body">Solve it now — or bust and lose your Payout.</div>
+					<div class="bn-title">You're out of money</div>
+					<div class="bn-body">One guess left — guess wrong and you lose your run.</div>
 					<button class="bn-forfeit" on:click={askForfeit}>Don't know it? Give up →</button>
 				</div>
 			{/if}


### PR DESCRIPTION
Makes the "you're stuck" banner plain and simple, per request:

- Title: "Out of budget for this word!" → **"You're out of money"**
- Body: "Solve it now — or bust and lose your Payout." → **"One guess left — guess wrong and you lose your run."**

Out of money, one guess, wrong = you lose. Keeps the "Don't know it? Give up →" escape.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
