### PR TITLE
Cash Game: "Overdrive" power-up — a free letter when you're out of money

### DIFF
--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -21,6 +21,7 @@
 		half_off: { icon: '🏷️', desc: 'Letters cost 50% less this puzzle' },
 		vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
 		heat_shield: { icon: '🛡️', desc: 'Escape one bust — keep your Payout & Interest' },
+		overdrive: { icon: '🏧', desc: 'Out of money? Reveal one more letter, free' },
 		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
 		extra_hint: { icon: '💡', desc: 'First letter of each word' },
 		last_letters: { icon: '🔚', desc: 'Last letter of each word' },

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -1126,7 +1126,9 @@ export function selectLetter(letter) {
 			// BUDGET (not the accumulated Wallet); server matches both.
 			const isClimb = state.gameMode === 'climb';
 			const climbMult = isClimb ? Number(state.climbInfo?.stake ?? 1) || 1 : 1;
-			const cost = (LETTER_COSTS[letter] || 0) * climbMult;
+			// 🏧 Overdrive armed → the next letter is free (any letter), even with an empty budget.
+			const overdrive = isClimb && (state.climbInfo?.equipped ?? []).includes('overdrive');
+			const cost = overdrive ? 0 : (LETTER_COSTS[letter] || 0) * climbMult;
 			const affordPool = isClimb ? Number(state.climbInfo?.budget_left ?? 0) : state.bankroll;
 			if (affordPool < cost) {
 				console.log(`Insufficient funds to purchase letter ${letter}`);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -806,28 +806,37 @@
 							// Self-buffs work in BOTH the Cash Game and Challenges.
 							const climbUsed = (climb?.equipped ?? []).includes(it.id);
 							const matchUsed = (matchInfo?.used_powerups ?? []).includes(it.id);
+							// 🏧 Overdrive is a Cash-Game lifeline: only usable when you're out of money.
+							const isOverdrive = it.id === 'overdrive';
 							const climbAvail =
-								$gameStore.gameMode === 'climb' && gameActive && !climbUsed && (it.owned ?? 0) > 0;
+								$gameStore.gameMode === 'climb' &&
+								gameActive &&
+								!climbUsed &&
+								(it.owned ?? 0) > 0 &&
+								(!isOverdrive || !!climb?.must_guess);
 							const matchAvail =
 								isMatch &&
 								!!matchInfo?.items_allowed &&
 								gameActive &&
 								!matchUsed &&
-								(it.owned ?? 0) > 0;
+								(it.owned ?? 0) > 0 &&
+								!isOverdrive;
 							const avail = climbAvail || matchAvail;
 							out.push({
 								id: it.id,
 								emoji: PUP_ICON[it.id] ?? '✨',
 								name: it.name,
-								blurb: avail ? 'Tap to use now' : '',
+								blurb: avail ? (isOverdrive ? 'Then buy any letter — free' : 'Tap to use now') : '',
 								count: it.owned,
 								usable: avail,
 								reason:
 									climbUsed || matchUsed
 										? 'Already used on this puzzle.'
-										: $gameStore.gameMode === 'climb' || isMatch
-											? ''
-											: 'For the Cash Game or Challenges — not this mode.'
+										: isOverdrive && $gameStore.gameMode === 'climb' && !climb?.must_guess
+											? 'Use it when you run out of money.'
+											: $gameStore.gameMode === 'climb' || isMatch
+												? ''
+												: 'For the Cash Game or Challenges — not this mode.'
 							});
 						} else if (it.kind === 'sabotage') {
 							const sabAvail =
@@ -1198,6 +1207,7 @@
 		reveal_word: '📖',
 		free_vowel: '🅰️',
 		last_letters: '🔚',
+		overdrive: '🏧',
 		sabotage_tax: '💸',
 		sabotage_fog: '🌫️',
 		sabotage_toll: '🚧',
@@ -4379,7 +4389,16 @@
 		<!-- 🎰 Cash Game (Climb) HUD — account strip up top; Interest badge + Payout in the
          hero. Must-guess banner shows when this puzzle's budget is spent. -->
 		{#if isClimb && climb}
-			{#if mgBannerVisible && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+			{#if (climb?.equipped ?? []).includes('overdrive') && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
+				<!-- 🏧 Overdrive armed → guide the player to spend the free letter. -->
+				<div class="bank-notif overdrive-armed">
+					<div class="bn-head">
+						<span class="bn-app">🏧 Overdrive</span><span class="bn-time">now</span>
+					</div>
+					<div class="bn-title">Overdrive armed</div>
+					<div class="bn-body">Pick any letter — it's free.</div>
+				</div>
+			{:else if mgBannerVisible && $gameStore.gameState !== 'won' && $gameStore.gameState !== 'lost'}
 				<div class="bank-notif">
 					<div class="bn-head">
 						<span class="bn-app">🏦 WordBank</span><span class="bn-time">now</span>
@@ -5747,6 +5766,14 @@
 		background: linear-gradient(180deg, rgba(32, 22, 24, 0.92), rgba(24, 17, 19, 0.92));
 		box-shadow: 0 10px 26px rgba(0, 0, 0, 0.45);
 		text-align: left;
+	}
+	/* 🏧 Overdrive armed — green accent (a helpful lifeline, not the red warning). */
+	.bank-notif.overdrive-armed {
+		border-color: rgba(74, 222, 128, 0.4);
+		background: linear-gradient(180deg, rgba(20, 34, 26, 0.94), rgba(15, 26, 20, 0.94));
+	}
+	.bank-notif.overdrive-armed .bn-title {
+		color: #4ade80;
 	}
 	.bn-head {
 		display: flex;

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -36,6 +36,10 @@
 			icon: '🛡️',
 			desc: 'Escape one bust — keep your Payout & Interest and jump to a fresh puzzle'
 		},
+		overdrive: {
+			icon: '🏧',
+			desc: 'Out of money? Reveal one more letter of your choice — free'
+		},
 		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
 		extra_hint: { icon: '💡', desc: 'Reveal the first letter of each word' },
 		last_letters: { icon: '🔚', desc: 'Reveal the last letter of each word' },

--- a/supabase-overdrive-powerup.sql
+++ b/supabase-overdrive-powerup.sql
@@ -1,0 +1,98 @@
+-- ============================================================================
+-- 🏧 Overdrive — a Cash Game lifeline for the "out of money" moment.
+-- Usable ONLY when you're stuck (can't afford any letter). Arms a single FREE
+-- letter of your choice (any letter): tap Overdrive, then buy any letter for $0,
+-- even with an empty budget. Consumed when that letter is bought.
+-- ============================================================================
+BEGIN;
+
+INSERT INTO public.powerups (id, name, kind, effect_key, price, sort, active)
+VALUES ('overdrive', 'Overdrive', 'climb', 'overdrive', 120, 50, true)
+ON CONFLICT (id) DO UPDATE
+  SET name = EXCLUDED.name, kind = EXCLUDED.kind, effect_key = EXCLUDED.effect_key,
+      price = EXCLUDED.price, active = true;
+
+-- ── Use: arm the free letter (stuck-only) ──────────────────────────────────
+CREATE OR REPLACE FUNCTION public.climb_use_powerup(p_id text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_eff TEXT; v_qty INT; v_phrase TEXT; v_positions INT[];
+  v_k NUMERIC; v_stake INT; v_bounty INT; v_budget_left INT; v_cheapest INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_use_powerup: not authenticated'; END IF;
+  SELECT effect_key INTO v_eff FROM public.powerups WHERE id = p_id AND kind = 'climb' AND active;
+  IF v_eff IS NULL THEN RAISE EXCEPTION 'climb_use_powerup: invalid power-up'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  -- Heat Shield is a passive safety net (auto-consumed on a bust) — tapping it never burns it.
+  IF v_eff = 'heat_shield' THEN RETURN public._climb_board(v_uid); END IF;
+  -- 🏧 Overdrive: only usable when you're out of money; arms one free letter of your choice.
+  IF v_eff = 'overdrive' THEN
+    v_k := COALESCE((public._cg_tier(cs.tier)->>'k')::numeric, 0.85);
+    v_stake := COALESCE((public._cg_tier(cs.tier)->>'stake')::int, 1);
+    v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+    v_budget_left := GREATEST(0, v_bounty - cs.spent);
+    v_cheapest := public._cg_cheapest(cs);
+    -- Not stuck (you can still afford a letter) → can't use it. Don't consume.
+    IF v_cheapest IS NOT NULL AND v_budget_left >= v_cheapest THEN RETURN public._climb_board(v_uid); END IF;
+    SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+    IF COALESCE(v_qty,0) <= 0 OR 'overdrive' = ANY(cs.active_powerups) THEN RETURN public._climb_board(v_uid); END IF;
+    UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+    UPDATE public.climb_state SET active_powerups = array_append(active_powerups, 'overdrive') WHERE user_id = v_uid;
+    RETURN public._climb_board(v_uid);
+  END IF;
+  -- Reveal-type power-ups (free_reveal, vowel_vision, reveal_word, …).
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._climb_board(v_uid); END IF;
+  IF v_eff = ANY(cs.active_powerups) THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+  UPDATE public.climb_state SET active_powerups = array_append(active_powerups, v_eff) WHERE user_id = v_uid;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_positions := public._powerup_reveal(v_phrase, v_eff, cs.revealed_positions);
+  IF v_positions IS NOT NULL THEN
+    UPDATE public.climb_state SET revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_positions) ORDER BY 1) WHERE user_id = v_uid;
+  END IF;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- ── Buy: an armed Overdrive makes the next letter free (any letter, even broke) ──
+CREATE OR REPLACE FUNCTION public.climb_buy_letter(p_letter text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_phrase TEXT; v_letter TEXT; v_cost INT; v_stake INT;
+  v_k NUMERIC; v_bounty INT; v_budget_left INT; v_positions INT[]; v_free BOOLEAN := false;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: not authenticated'; END IF;
+  v_letter := upper(p_letter);
+  IF public.letter_cost(v_letter) IS NULL THEN RAISE EXCEPTION 'climb_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'climb_buy_letter: no run'; END IF;
+  IF cs.state <> 'active' THEN RETURN public._climb_board(v_uid); END IF;
+  v_k := COALESCE((public._cg_tier(cs.tier)->>'k')::numeric, 0.85);
+  v_stake := COALESCE((public._cg_tier(cs.tier)->>'stake')::int, 1);
+  v_cost := public.letter_cost(v_letter) * v_stake;
+  IF 'half_off' = ANY(cs.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  -- 🏧 Overdrive armed → this letter is free (any letter), even with an empty budget.
+  v_free := 'overdrive' = ANY(cs.active_powerups);
+  IF v_free THEN v_cost := 0; END IF;
+  v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+  v_budget_left := v_bounty - cs.spent;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  -- Overdrive letters bypass the budget check entirely (they're free even at $0 budget).
+  IF v_letter = ANY(cs.incorrect_letters) OR (NOT v_free AND v_budget_left < v_cost) THEN RETURN public._climb_board(v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cs.revealed_positions THEN RETURN public._climb_board(v_uid); END IF;
+  IF v_positions IS NULL THEN cs.incorrect_letters := array_append(cs.incorrect_letters, v_letter);
+  ELSE cs.revealed_positions := ARRAY(SELECT DISTINCT unnest(cs.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.climb_state SET revealed_positions = cs.revealed_positions,
+    incorrect_letters = cs.incorrect_letters, spent = cs.spent + v_cost,
+    active_powerups = CASE WHEN v_free THEN array_remove(cs.active_powerups, 'overdrive') ELSE cs.active_powerups END,
+    pups_locked = true, updated_at = now() WHERE user_id = v_uid;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
## What

A new Cash Game lifeline for the exact "out of money, do-or-die" moment.

**🏧 Overdrive** — usable **only when you're stuck** (can't afford any letter). Tap it to arm **one free letter of your choice** (any letter): buy any letter for **$0**, even with an empty budget, then keep trying to solve. Consumed when that letter is bought.

## Server (`supabase-overdrive-powerup.sql`, applied to prod + rollback-verified)
- New `overdrive` catalog item (climb-kind, $120, active).
- `climb_use_powerup` arms it **only when stuck** (`budget_left < cheapest letter`) — otherwise it's a no-op and isn't consumed — and adds `overdrive` to `active_powerups`.
- `climb_buy_letter` makes an armed letter **free** (bypasses the budget check entirely) and clears the flag after.
- Rollback test: use → armed + qty−1; buy any letter → free (spent unchanged), letter revealed, flag cleared.

## Client
- `selectLetter` treats letters as free/selectable when Overdrive is armed (`climb.equipped` includes `overdrive`).
- Power-up tray shows Overdrive **only when stuck** ("Use it when you run out of money"), Cash-Game-only.
- 🏧 icon + Store/inventory descriptions.
- While armed, a green **"Overdrive armed — pick any letter, it's free"** banner replaces the red out-of-money warning.

## Verification
Server rollback-verified end to end. Live: confirmed Overdrive is buyable in the Store with its description, no page errors. (The full in-game arm→free-letter flow follows directly from the verified server logic + the client wiring.)

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
