### PR TITLE
Store: drop stale "the Daily stays power-up-free" line

### DIFF
--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -205,8 +205,7 @@
 
 		<h2 class="section">⚡ Power-ups</h2>
 		<p class="section-note">
-			Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like —
-			the Daily stays power-up-free.
+			Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like.
 		</p>
 		<div class="grid">
 			{#each pups as item}


### PR DESCRIPTION
The Daily has Interest Boosts now, so "the Daily stays power-up-free" was inaccurate. Trimmed the ⚡ Power-ups note to just the accurate part:

> Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
