### PR TITLE
Store: remove the Power-ups section note

### DIFF
--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -204,9 +204,6 @@
 		{/if}
 
 		<h2 class="section">⚡ Power-ups</h2>
-		<p class="section-note">
-			Carry one of each. Bring them to the Cash Game or a challenge and use them whenever you like.
-		</p>
 		<div class="grid">
 			{#each pups as item}
 				<div class="card pup" class:owned={item.owned > 0}>


### PR DESCRIPTION
"use them whenever you like" was inaccurate now that Overdrive is conditional (stuck-only), and the note was redundant anyway — each power-up card already states what it does and when, and the Store header already says power-ups are "for the Cash Game & challenges." Removed it entirely; the `⚡ Power-ups` heading + the cards carry it.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
