### PR TITLE
Cash Game last-stand: keyboard usable in guess mode + "Give up?"

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3207,7 +3207,7 @@
 	</div>
 {/if}
 
-<main class:danger-active={dangerMode && !overdriveArmed}>
+<main class:danger-active={dangerMode && !overdriveArmed && $gameStore.gameState !== 'guess_mode'}>
 	<!-- 👤 First-run: pick a username (required to play socially) -->
 	{#if loggedIn && hasInitialized && needsUsername}
 		<div
@@ -4393,7 +4393,7 @@
 				<div class="danger-cue" role="alert">
 					<span class="dc-title">💸 OUT OF MONEY</span>
 					<span class="dc-sub">Last guess — solve now, or lose your run</span>
-					<button class="bn-forfeit" on:click={askForfeit}>Don't know it? Give up →</button>
+					<button class="bn-forfeit" on:click={askForfeit}>Give up?</button>
 				</div>
 			{/if}
 		{/if}


### PR DESCRIPTION
Two fixes to the out-of-money "last stand":

1. **Keyboard now works when you tap Solve.** The danger keyboard-dim was disabling the keyboard even in guess mode, so you couldn't type your final guess. It's now gated on `gameState !== 'guess_mode'` — the red vignette + OUT OF MONEY headline stay up, but the keyboard re-enables so you can type.
2. **Button copy**: "Don't know it? Give up →" → **"Give up?"**.

Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
