### PR TITLE
Bust slip: drop the 💔 emoji

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5091,7 +5091,7 @@
 							</div>
 							{#if wiped > 0}
 								<div class="rcpt-note">
-									💔 You also forfeited a ${wiped.toLocaleString()} run pile.
+									Also forfeited a ${wiped.toLocaleString()} run pile.
 								</div>
 							{/if}
 							<div class="rcpt-rule"></div>


### PR DESCRIPTION
An emoji looked out of place on the monospace receipt. Removed it from the forfeited line:

"💔 You also forfeited a $X run pile." → **"Also forfeited a $X run pile."**

Confirmed no 💔 remains anywhere in src/. Gates: prettier · check (0 errors, 1 pre-existing a11y warning) · lint · build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
