### PR TITLE
Daily: last-stand danger treatment on the out-of-budget wall

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -95,6 +95,7 @@ import { track } from '$lib/analytics.js';
  *   bountyMult?: number,
  *   twistUsed?: boolean,
  *   wrongGuesses?: number,
+ *   dailyMustGuess?: boolean,
  *   clue?: string | null,
  *   challengeInfo?: any,
  *   makeupDate?: string | null,
@@ -171,6 +172,7 @@ export const gameStore = writable(
 		twistUsed: false, // have you used today's Twist? (unused → ×1.5 bounty)
 		bountyMult: 1, // bounty multiplier (1.0 once Twist used, else 1.5)
 		wrongGuesses: 0, // wrong phrase guesses this Daily (each −0.2× mult, floor 1.0)
+		dailyMustGuess: false, // Daily out-of-budget wall → last-guess danger treatment
 		clue: null, // witty one-line hint for the current puzzle
 		challengeInfo: null, // { mode, started_at, limit_seconds, play_state, score } for the active challenge
 		makeupDate: null, // YYYY-MM-DD of the make-up day being played (makeup mode only)
@@ -301,7 +303,10 @@ function reconcileDailyBoard(board) {
 			twistUsed: board.twist_used !== undefined ? board.twist_used : (prev.twistUsed ?? false),
 			bountyMult: board.bounty_mult !== undefined ? board.bounty_mult : (prev.bountyMult ?? 1),
 			wrongGuesses:
-				board.wrong_guesses !== undefined ? board.wrong_guesses : (prev.wrongGuesses ?? 0)
+				board.wrong_guesses !== undefined ? board.wrong_guesses : (prev.wrongGuesses ?? 0),
+			// Daily out-of-budget wall: bankroll < cheapest buyable letter on an active board.
+			dailyMustGuess:
+				board.must_guess !== undefined ? !!board.must_guess : (prev.dailyMustGuess ?? false)
 		})
 	);
 	// Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -493,13 +493,14 @@
 		_attTimer = setTimeout(() => gameStore.update((s) => ({ ...s, cashToast: null })), 4000);
 	}
 	$: isClimb = $gameStore.gameMode === 'climb';
+	$: isDaily = $gameStore.gameMode === 'daily';
 	$: climb = $gameStore.climbInfo; // { wallet, bounty, budget_left, solve_reward, spent, heat, must_guess, cheapest, last_gain, state, run_solves, wiped, pups_locked, equipped }
 	$: overdriveArmed = isClimb && (climb?.equipped ?? []).includes('overdrive');
-	// 🚨 Last-stand: out of money, this guess decides the run. Persistent while stuck
+	// 🚨 Last-stand: out of budget, this guess decides it. Persistent while stuck
 	// (drives the red screen treatment + keyboard lock). Overdrive lifts the lock.
+	// Cash Game = your run is on the line; Daily = your one shot at today's win.
 	$: dangerMode =
-		isClimb &&
-		!!climb?.must_guess &&
+		((isClimb && !!climb?.must_guess) || (isDaily && !!$gameStore.dailyMustGuess)) &&
 		gameActive &&
 		$gameStore.gameState !== 'won' &&
 		$gameStore.gameState !== 'lost';
@@ -4270,7 +4271,7 @@
 
 		<!-- 🚨 Last-stand red vignette — frames the whole screen when you're out of money. -->
 		{#if dangerMode}
-			<div class="danger-vignette" aria-hidden="true"></div>
+			<div class="danger-vignette" class:daily={isDaily} aria-hidden="true"></div>
 		{/if}
 
 		<!-- 🧠 Game Logo -->
@@ -4396,6 +4397,15 @@
 					<button class="bn-forfeit" on:click={askForfeit}>Give up?</button>
 				</div>
 			{/if}
+		{/if}
+
+		<!-- 🚨 Daily out-of-budget wall — softer than Cash Game (no run to lose, just
+		     today's win on the line). Same red screen + keyboard lock structure. -->
+		{#if isDaily && dangerMode}
+			<div class="danger-cue daily" role="alert">
+				<span class="dc-title">💸 OUT OF BUDGET</span>
+				<span class="dc-sub">Last guess — get it right to win today</span>
+			</div>
 		{/if}
 
 		<!-- ⚔️ Challenge match HUD -->
@@ -5791,6 +5801,16 @@
 	.danger-cue.armed .dc-title {
 		color: #4ade80;
 		text-shadow: 0 0 14px rgba(74, 222, 128, 0.55);
+	}
+	/* Daily wall: same danger language, a notch calmer — no run on the line. */
+	.danger-cue.daily {
+		animation-duration: 1.5s;
+	}
+	.danger-cue.daily .dc-title {
+		font-size: 1.05rem;
+	}
+	.danger-vignette.daily {
+		opacity: 0.62;
 	}
 	/* full-screen red vignette framing the moment */
 	.danger-vignette {

--- a/supabase-daily-must-guess-start.sql
+++ b/supabase-daily-must-guess-start.sql
@@ -1,0 +1,68 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.daily_start(p_powerups text[] DEFAULT '{}'::text[], p_use_twist boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; s public.daily_sessions; v_mod TEXT;
+  v_streak INT; v_high INT; v_last DATE; v_freezes INT; v_day INT; v_att INT := 0; v_new BOOLEAN := false;
+  v_fv TEXT; v_reveal INT[] := '{}'; i INT; v_base INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_start: not authenticated'; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_pid := public._todays_puzzle_id();
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
+    v_mod := public._daily_modifier();
+    v_base := public._daily_reward(v_pid);   -- the Prize (k = 1.0)
+    INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining, active_powerups, spent, twist_used)
+    VALUES (v_uid, CURRENT_DATE, v_pid, v_base, 999, ARRAY[v_mod], 0, true) RETURNING * INTO s;
+    v_new := true;
+    -- auto-apply: reveal letters for the reveal-type Twists (free)
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = v_pid;
+    IF v_mod = 'free_vowel' THEN
+      SELECT substr(v_phrase, g.i+1, 1) INTO v_fv FROM generate_series(0, length(v_phrase)-1) g(i)
+        WHERE substr(v_phrase, g.i+1, 1) IN ('A','E','I','O','U') ORDER BY g.i LIMIT 1;
+      IF v_fv IS NOT NULL THEN
+        SELECT array_agg(g.i) INTO v_reveal FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1, 1) = v_fv;
+      END IF;
+    ELSIF v_mod = 'head_start' THEN
+      FOR i IN 0 .. length(v_phrase)-1 LOOP
+        IF substr(v_phrase, i+1, 1) <> ' ' AND (i = 0 OR substr(v_phrase, i, 1) = ' ') THEN v_reveal := v_reveal || i; END IF;
+      END LOOP;
+    END IF;
+    IF array_length(v_reveal, 1) > 0 THEN
+      UPDATE public.daily_sessions SET revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_reveal) ORDER BY 1)
+        WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE RETURNING * INTO s;
+    END IF;
+    -- attendance + play streak (unchanged)
+    SELECT current_daily_play_streak, best_daily_play_streak, last_daily_play_date, COALESCE(streak_freezes,0)
+      INTO v_streak, v_high, v_last, v_freezes FROM public.profiles WHERE id = v_uid;
+    IF v_last = CURRENT_DATE THEN v_day := COALESCE(v_streak,0);
+    ELSIF v_last = CURRENT_DATE - 1 THEN v_day := COALESCE(v_streak,0) + 1;
+    ELSIF v_last = CURRENT_DATE - 2 AND v_freezes > 0 AND COALESCE(v_streak,0) > 0 THEN v_freezes := v_freezes - 1; v_day := COALESCE(v_streak,0) + 1;
+    ELSE v_day := 1; END IF;
+    IF v_day > 0 AND v_day % 7 = 0 THEN v_freezes := LEAST(v_freezes + 1, 3); END IF;
+    v_high := GREATEST(COALESCE(v_high,0), v_day);
+    UPDATE public.profiles SET current_daily_play_streak = v_day, best_daily_play_streak = v_high,
+      last_daily_play_date = CURRENT_DATE, streak_freezes = v_freezes WHERE id = v_uid;
+    v_att := 50 + CASE WHEN v_day % 30 = 0 THEN 1500 WHEN v_day % 14 = 0 THEN 500
+                       WHEN v_day % 7 = 0 THEN 250 WHEN v_day = 3 THEN 100 ELSE 0 END;
+    PERFORM public._bank_credit(v_uid, v_att, 'attendance');
+    IF v_day >= 7 THEN PERFORM public._award_badge(v_uid, 'streak_7'); END IF;
+    IF v_day >= 30 THEN PERFORM public._award_badge(v_uid, 'streak_30'); END IF;
+  END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory, '') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+  RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining, s.revealed_positions, s.incorrect_letters, v_cat, v_sub)
+    || jsonb_build_object('live', public._daily_live(s.bankroll, public._daily_bounty_mult(v_uid)),
+         'base', public._daily_reward(s.puzzle_id),
+         'modifier', s.active_powerups[1], 'twist_used', s.twist_used, 'bounty_mult', public._daily_bounty_mult(v_uid),
+         'wrong_guesses', COALESCE(s.p_wrong_guesses,0),
+         'must_guess', (s.state = 'active' AND public._daily_cheapest_buyable(s, v_phrase) IS NOT NULL
+            AND s.bankroll < public._daily_cheapest_buyable(s, v_phrase)))
+    || CASE WHEN v_new THEN jsonb_build_object('attendance', v_att, 'attendance_day', v_day) ELSE '{}'::jsonb END;
+END; $function$;
+
+COMMIT;

--- a/supabase-daily-must-guess.sql
+++ b/supabase-daily-must-guess.sql
@@ -1,0 +1,54 @@
+-- ============================================================================
+-- Daily: expose a `must_guess` flag on the board — true when you're out of budget
+-- (bankroll < cheapest buyable letter) on an active session. Drives the Daily
+-- "out of budget, last guess" danger treatment (mirrors Cash Game's must_guess).
+-- Added to _daily_resolve_and_return, which every budget-changing path returns
+-- (letter buy + wrong-guess drain).
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._daily_resolve_and_return(p_uid uuid, p_phrase text, p_cat text, p_sub text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE s public.daily_sessions; v_won BOOLEAN; v_board JSONB; v_base INT; v_kept INT; v_mult NUMERIC; v_winnings INT;
+  v_loan BIGINT; v_loan_repaid BIGINT := 0; v_attendance BIGINT := 0; v_cheapest INT;
+BEGIN
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+  v_cheapest := public._daily_cheapest_buyable(s, p_phrase);
+  v_base := public._daily_reward(s.puzzle_id);
+  v_kept := GREATEST(0, s.bankroll);
+  v_mult := public._daily_bounty_mult(p_uid);                 -- pre-finalize → incoming streak
+  v_winnings := (round(v_kept * v_mult / 10.0) * 10)::int;
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(p_phrase)-1) g(i)
+    WHERE substr(p_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(s.revealed_positions)));
+  IF v_won AND s.state = 'active' THEN
+    UPDATE public.daily_sessions SET state = 'won', updated_at = NOW(), finished_at = COALESCE(finished_at, NOW())
+      WHERE user_id = p_uid AND puzzle_date = CURRENT_DATE;
+    s.state := 'won';
+    -- Skim preview: accrue first (idempotent same-day) so v_loan is what _bank_credit skims against.
+    PERFORM public._accrue_loan(p_uid);
+    SELECT COALESCE(loan,0) INTO v_loan FROM public.profiles WHERE id = p_uid;
+    v_loan_repaid := LEAST(v_loan, floor(v_winnings * 0.5)::bigint);
+    PERFORM public._finalize_daily(p_uid, true, s.spent, v_kept, COALESCE(array_length(s.incorrect_letters,1),0));
+    PERFORM public._record_category_solve(p_uid, p_cat);
+  END IF;
+  v_board := public._daily_board(p_phrase, s.state, s.bankroll, s.guesses_remaining, s.revealed_positions, s.incorrect_letters, p_cat, p_sub)
+    || jsonb_build_object('live', public._daily_live(s.bankroll, v_mult), 'base', v_base,
+         'modifier', s.active_powerups[1], 'twist_used', s.twist_used, 'bounty_mult', v_mult,
+         'wrong_guesses', COALESCE(s.p_wrong_guesses,0),
+         'must_guess', (s.state = 'active' AND v_cheapest IS NOT NULL AND s.bankroll < v_cheapest));
+  IF s.state = 'won' THEN
+    -- Today's show-up reward (credited at daily_start; already in the balance).
+    SELECT COALESCE(sum(delta),0) INTO v_attendance FROM public.bank_ledger
+      WHERE user_id = p_uid AND reason = 'attendance' AND created_at::date = CURRENT_DATE;
+    v_board := v_board || jsonb_build_object('daily_result', jsonb_build_object(
+      'won', true, 'base', v_base, 'spent', s.spent, 'kept', v_kept, 'mult', v_mult,
+      'winnings', v_winnings, 'banked', v_winnings, 'score', v_winnings, 'twist_used', s.twist_used,
+      'reward', v_winnings, 'net', v_winnings, 'loan_repaid', v_loan_repaid, 'attendance', v_attendance));
+  END IF;
+  RETURN v_board;
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
## What
Extends the Cash Game "last stand" danger mode to the **Daily's out-of-budget wall** — the moment your budget drops below the cheapest buyable letter and one wrong guess ends today's run.

Per the chosen **adapted** direction, it reuses the same structure but dials the intensity down for the Daily's lower stakes:
- Softer red vignette (`opacity 0.62`) + calmer pulse
- `💸 OUT OF BUDGET` / *"Last guess — get it right to win today"* — no "lose your run" framing, no give-up link
- Keyboard dims + locks (can't buy letters when broke), and **re-enables in guess mode** so you can type the solve

## Server
Adds a `must_guess` flag to the Daily board on both entry points so the danger shows the instant you hit the wall *and* survives a resume:
- `_daily_resolve_and_return` (returned after every letter-buy / wrong-guess drain)
- `daily_start` (fresh load / resume)

`must_guess = state='active' AND cheapest_buyable IS NOT NULL AND bankroll < cheapest`, computed via existing `_daily_cheapest_buyable`. Both migrations applied to prod; verified with BEGIN/ROLLBACK (stuck → true, flush → false).

## Client
- `GameStore.reconcileDailyBoard` captures `board.must_guess` → `dailyMustGuess`
- `dangerMode` reactive now fires for `isDaily && dailyMustGuess` too
- New `.danger-cue.daily` block + softer CSS variants

## Verification
- Gates: prettier ✓, svelte-check 0 errors ✓, lint ✓, build ✓
- Live Playwright: signed up a test account, seeded a stuck Daily, confirmed the vignette + cue + locked keyboard on resume, and the keyboard re-enabling in guess mode. Test account removed from prod after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
