### PR TITLE
Daily danger cue: add a Give up? link

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4405,6 +4405,7 @@
 			<div class="danger-cue daily" role="alert">
 				<span class="dc-title">💸 OUT OF BUDGET</span>
 				<span class="dc-sub">Last guess — get it right to win today</span>
+				<button class="bn-forfeit" on:click={confirmFold}>Give up?</button>
 			</div>
 		{/if}
 


### PR DESCRIPTION
Adds a `Give up?` link to the Daily out-of-budget danger cue, matching the Cash Game cue. It opens the standard Daily give-up confirmation modal (`confirmFold`) — the same flow as the top-bar give-up button — so folding is available right at the moment of decision.

## Verification
- prettier ✓, svelte-check 0 errors ✓, lint ✓, build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
