### PR TITLE
Cash Game give-up: make clear it ends the whole run

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2970,15 +2970,23 @@
 	<!-- Forced choice — Keep Playing or Give Up. -->
 	<div class="modal-overlay info-overlay dep-confirm-overlay">
 		<div class="info-card" role="dialog" aria-modal="true">
-			<div class="info-big neg">−${forfeitAmount.toLocaleString()}</div>
-			<h3 class="info-title">Give up this puzzle?</h3>
+			{#if forfeitAmount > 0}
+				<div class="info-big neg">−${forfeitAmount.toLocaleString()}</div>
+			{/if}
+			<h3 class="info-title">Give up your whole run?</h3>
 			<p class="info-sub">
-				You'll <b class="neg">lose your ${forfeitAmount.toLocaleString()} Payout</b> and see the answer.
-				This can't be undone.
+				{#if forfeitAmount > 0}
+					This <b class="neg">ends your Cash Game run</b> — not just this puzzle — and wipes the
+					<b class="neg">${forfeitAmount.toLocaleString()}</b> you've banked so far. You'll see the answer,
+					and it can't be undone.
+				{:else}
+					This <b class="neg">ends your Cash Game run</b> — not just this puzzle. You'll see the answer
+					and walk away with nothing, and it can't be undone.
+				{/if}
 			</p>
 			<div class="dep-actions">
 				<button class="dep-keep" on:click={() => (showForfeitConfirm = false)}>Keep Playing</button>
-				<button class="dep-go forfeit" disabled={cgBusy} on:click={confirmForfeit}>Give Up</button>
+				<button class="dep-go forfeit" disabled={cgBusy} on:click={confirmForfeit}>End Run</button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Problem
The top-right give-up in Cash Game calls `climb_forfeit` → `_cg_bust`, which **deletes the run and wipes the entire secured pile** (`v_wiped := cs.bankroll`). But the confirmation modal was titled *"Give up this puzzle?"* and said *"lose your $X Payout"* — which reads like it only skips the current puzzle, not ends the whole run.

## Fix
Rewrote the forfeit confirm modal so the stakes are unmistakable:
- **Title:** "Give up your whole run?"
- **Body:** "This **ends your Cash Game run** — not just this puzzle — and wipes the **$X** you've banked so far. You'll see the answer, and it can't be undone." (the `$X` matches the secured pile a bust wipes, consistent with the bust recap's "forfeited a $X run pile")
- **Button:** "Give Up" → "End Run"
- The banked amount / big −$ number is hidden when nothing is secured yet (fresh run), with copy adjusted to "walk away with nothing."

Same modal is reached from the top-right give-up button and the last-stand danger cue, so both paths get the clearer copy.

## Verification
- Gates: prettier ✓, svelte-check 0 errors ✓, lint ✓, build ✓
- Live Playwright (both branches):
  - Fresh run ($0 secured) → "walk away with nothing", no −$ number
  - Seeded $640 secured → "−$640 … wipes the $640 you've banked so far"
- Test account removed from prod afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
