### PR TITLE
Daily give-up: spell out the money cost in the confirm message

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2611,7 +2611,7 @@
 					? `Your Interest resets to +0%${(climb?.spent ?? 0) > 0 ? ` and you forfeit the $${(climb?.spent ?? 0).toLocaleString()} spent on this one` : ''} — then a fresh puzzle.`
 					: $gameStore.gameMode === 'match'
 						? 'Skip this puzzle — you pay its full price and move on.'
-						: 'It counts as a loss and reveals the answer.'}
+						: 'It counts as a loss — you deposit nothing and the answer is revealed.'}
 			</p>
 			<div class="gu-actions">
 				<button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>


### PR DESCRIPTION
## Function — already correct
The top-right Daily give-up routes `confirmFold` → `doFold` → `daily_fold`, which:
- Marks today's `daily_sessions` row `state = 'lost'` and reveals the full answer
- Calls `_finalize_daily(won=false, kept=0)` — so you deposit nothing and it logs as a loss

No "run" to end (unlike Cash Game), so the title "Give up today's Daily?" is already scoped right.

## Message — tightened
The confirm text said *"It counts as a loss and reveals the answer."* — accurate but silent on the money. Updated to name the deposit consequence, matching the clarity we just gave the Cash Game give-up:

> It counts as a loss — you deposit nothing and the answer is revealed.

## Verification
- Verified `daily_fold` behavior directly from the RPC definition (loss + reveal + kept=0)
- Gates: prettier ✓, svelte-check 0 errors ✓, lint ✓, build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
