### PR TITLE
Add Free Skip power-up to Cash Game; retire Blitz power-ups

### DIFF
--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -22,6 +22,7 @@
 		vowel_vision: { icon: '👁️', desc: 'Reveal every vowel' },
 		heat_shield: { icon: '🛡️', desc: 'Escape one bust — keep your Payout & Interest' },
 		overdrive: { icon: '🏧', desc: 'Out of money? Reveal one more letter, free' },
+		free_skip: { icon: '⏭️', desc: 'Swap this puzzle for a fresh one — keep your Interest & run' },
 		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
 		extra_hint: { icon: '💡', desc: 'First letter of each word' },
 		last_letters: { icon: '🔚', desc: 'Last letter of each word' },

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -705,6 +705,23 @@ export async function climbAdvance() {
 	}
 }
 
+/** ⏭️ Free Skip power-up — swap the current puzzle for a fresh one mid-run, keeping
+ *  your Interest, secured pile, and run. Arms the dramatic reveal like a fresh puzzle. */
+export async function climbFreeSkip() {
+	if (dailyInFlight) return;
+	dailyInFlight = true;
+	try {
+		const board = await climbUsePowerup('free_skip');
+		if (board) {
+			reconcileClimbBoard(board);
+			maybeArmClimbIntro();
+			await refreshClimbClue();
+		}
+	} finally {
+		dailyInFlight = false;
+	}
+}
+
 /** Voluntarily give up the current Cash Game run — a clean bust (same as a wrong
  *  guess: wipes the pot, reveals the answer). Shows the VOID receipt. */
 export async function climbForfeitRun() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 		startCashGame,
 		cashOutClimb,
 		climbAdvance,
+		climbFreeSkip,
 		climbForfeitRun,
 		climbLeaveGame,
 		climbSkipPuzzle,
@@ -797,6 +798,8 @@
 							const matchUsed = (matchInfo?.used_powerups ?? []).includes(it.id);
 							// 🏧 Overdrive is a Cash-Game lifeline: only usable when you're out of money.
 							const isOverdrive = it.id === 'overdrive';
+							// ⏭️ Free Skip swaps the run's puzzle — Cash Game only, not Challenges.
+							const isFreeSkip = it.id === 'free_skip';
 							const climbAvail =
 								$gameStore.gameMode === 'climb' &&
 								gameActive &&
@@ -809,13 +812,20 @@
 								gameActive &&
 								!matchUsed &&
 								(it.owned ?? 0) > 0 &&
-								!isOverdrive;
+								!isOverdrive &&
+								!isFreeSkip;
 							const avail = climbAvail || matchAvail;
 							out.push({
 								id: it.id,
 								emoji: PUP_ICON[it.id] ?? '✨',
 								name: it.name,
-								blurb: avail ? (isOverdrive ? 'Then buy any letter — free' : 'Tap to use now') : '',
+								blurb: avail
+									? isOverdrive
+										? 'Then buy any letter — free'
+										: isFreeSkip
+											? 'Fresh puzzle — keep your Interest'
+											: 'Tap to use now'
+									: '',
 								count: it.owned,
 								usable: avail,
 								reason:
@@ -823,9 +833,11 @@
 										? 'Already used on this puzzle.'
 										: isOverdrive && $gameStore.gameMode === 'climb' && !climb?.must_guess
 											? 'Use it when you run out of money.'
-											: $gameStore.gameMode === 'climb' || isMatch
-												? ''
-												: 'For the Cash Game or Challenges — not this mode.'
+											: isFreeSkip && isMatch
+												? 'For the Cash Game — not Challenges.'
+												: $gameStore.gameMode === 'climb' || isMatch
+													? ''
+													: 'For the Cash Game or Challenges — not this mode.'
 							});
 						} else if (it.kind === 'sabotage') {
 							const sabAvail =
@@ -873,10 +885,19 @@
 			useBoost(item.id);
 			loadVault();
 		} else if ($gameStore.gameMode === 'climb') {
-			climbPowerup(item.id).then(() => {
-				refreshClimbPups();
-				loadVault();
-			});
+			if (item.id === 'free_skip') {
+				// Fresh puzzle mid-run — replay the dramatic opening reveal.
+				climbFreeSkip().then(() => {
+					refreshClimbPups();
+					loadVault();
+					tick().then(playDailyIntroIfArmed);
+				});
+			} else {
+				climbPowerup(item.id).then(() => {
+					refreshClimbPups();
+					loadVault();
+				});
+			}
 		} else if (isMatch && item?.kind === 'sabotage') {
 			openSabotagePicker(item);
 			return;
@@ -1197,6 +1218,7 @@
 		free_vowel: '🅰️',
 		last_letters: '🔚',
 		overdrive: '🏧',
+		free_skip: '⏭️',
 		sabotage_tax: '💸',
 		sabotage_fog: '🌫️',
 		sabotage_toll: '🚧',

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -40,6 +40,10 @@
 			icon: '🏧',
 			desc: 'Out of money? Reveal one more letter of your choice — free'
 		},
+		free_skip: {
+			icon: '⏭️',
+			desc: 'Swap this puzzle for a fresh one — keep your Interest, Payout & run. Anytime, no streak lost'
+		},
 		reveal_word: { icon: '📖', desc: 'Reveal a whole word' },
 		extra_hint: { icon: '💡', desc: 'Reveal the first letter of each word' },
 		last_letters: { icon: '🔚', desc: 'Reveal the last letter of each word' },

--- a/supabase-freeskip-powerup.sql
+++ b/supabase-freeskip-powerup.sql
@@ -1,0 +1,70 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.climb_use_powerup(p_id text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cs public.climb_state; v_eff TEXT; v_qty INT; v_phrase TEXT; v_positions INT[];
+  v_k NUMERIC; v_stake INT; v_bounty INT; v_budget_left INT; v_cheapest INT; v_next UUID;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'climb_use_powerup: not authenticated'; END IF;
+  SELECT effect_key INTO v_eff FROM public.powerups WHERE id = p_id AND kind = 'climb' AND active;
+  IF v_eff IS NULL THEN RAISE EXCEPTION 'climb_use_powerup: invalid power-up'; END IF;
+  SELECT * INTO cs FROM public.climb_state WHERE user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cs.state NOT IN ('active','stuck') THEN RETURN public._climb_board(v_uid); END IF;
+  -- Heat Shield is a passive safety net (auto-consumed on a bust) — tapping it never burns it.
+  IF v_eff = 'heat_shield' THEN RETURN public._climb_board(v_uid); END IF;
+  -- 🏧 Overdrive: only usable when you're out of money; arms one free letter of your choice.
+  IF v_eff = 'overdrive' THEN
+    v_k := COALESCE((public._cg_tier(cs.tier)->>'k')::numeric, 0.85);
+    v_stake := COALESCE((public._cg_tier(cs.tier)->>'stake')::int, 1);
+    v_bounty := round(public._climb_bounty(cs.puzzle_id, v_k) * v_stake * cs.heat_x100 / 100.0)::int;
+    v_budget_left := GREATEST(0, v_bounty - cs.spent);
+    v_cheapest := public._cg_cheapest(cs);
+    -- Not stuck (you can still afford a letter) → can't use it. Don't consume.
+    IF v_cheapest IS NOT NULL AND v_budget_left >= v_cheapest THEN RETURN public._climb_board(v_uid); END IF;
+    SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+    IF COALESCE(v_qty,0) <= 0 OR 'overdrive' = ANY(cs.active_powerups) THEN RETURN public._climb_board(v_uid); END IF;
+    UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+    UPDATE public.climb_state SET active_powerups = array_append(active_powerups, 'overdrive') WHERE user_id = v_uid;
+    RETURN public._climb_board(v_uid);
+  END IF;
+  -- ⏭️ Free Skip: swap this puzzle for a fresh one, keeping your Interest, secured pile, and run.
+  IF v_eff = 'free_skip' THEN
+    SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+    IF COALESCE(v_qty,0) <= 0 THEN RETURN public._climb_board(v_uid); END IF;
+    v_next := public._pick_casual(v_uid, null, cs.puzzle_id, 0);
+    IF v_next IS NULL THEN RETURN public._climb_board(v_uid); END IF;   -- no fresh puzzle available -> don't consume
+    UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+    -- New puzzle; reset per-puzzle progress. KEEP heat_x100, bankroll, run_solves, position.
+    UPDATE public.climb_state SET puzzle_id = v_next, revealed_positions = '{}', incorrect_letters = '{}',
+      spent = 0, last_gain = 0, active_powerups = '{}', next_puzzle_id = NULL, pups_locked = false,
+      state = 'active', puzzle_started_at = now(), updated_at = now() WHERE user_id = v_uid;
+    PERFORM public._mark_seen(v_uid, v_next);
+    RETURN public._climb_board(v_uid);
+  END IF;
+  -- Reveal-type power-ups (free_reveal, vowel_vision, reveal_word, …).
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._climb_board(v_uid); END IF;
+  IF v_eff = ANY(cs.active_powerups) THEN RETURN public._climb_board(v_uid); END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_id AND pool = 'cash';
+  UPDATE public.climb_state SET active_powerups = array_append(active_powerups, v_eff) WHERE user_id = v_uid;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = cs.puzzle_id;
+  v_positions := public._powerup_reveal(v_phrase, v_eff, cs.revealed_positions);
+  IF v_positions IS NOT NULL THEN
+    UPDATE public.climb_state SET revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_positions) ORDER BY 1) WHERE user_id = v_uid;
+  END IF;
+  RETURN public._climb_resolve(v_uid);
+END; $function$;
+
+-- New Cash Game power-up: Free Skip (expensive; anytime swap, keeps your streak).
+INSERT INTO public.powerups (id, name, price, active, effect_key, kind, sort)
+  VALUES ('free_skip', 'Free Skip', 300, true, 'free_skip', 'climb', 52)
+  ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, price = EXCLUDED.price,
+    active = EXCLUDED.active, effect_key = EXCLUDED.effect_key, kind = EXCLUDED.kind, sort = EXCLUDED.sort;
+
+-- Blitz is being retired -- pull its power-ups from the store.
+UPDATE public.powerups SET active = false WHERE kind = 'blitz';
+
+COMMIT;


### PR DESCRIPTION
## Free Skip — a Cash Game power-up
A consumable ($300, the priciest active power-up) that **swaps the current puzzle for a fresh one mid-run while keeping your Interest %, secured pile, and run intact.** Until now the only way off a puzzle you didn't like was to bust (wipes everything) or guess wrong — Free Skip is a clean, paid escape.

- **Usable anytime the puzzle is active** (not gated to "stuck"), Cash Game only — not Challenges
- **Keeps** `heat_x100` (Interest), `bankroll` (secured pile), `run_solves`, `position`
- **Resets** the per-puzzle state for the fresh draw: `spent`, `revealed_positions`, `incorrect_letters`, `active_powerups`
- **Costs** one token per use; the shop's single-hold model (own one at a time) is the natural guardrail against reshuffle-farming

### Server
`climb_use_powerup` gets a `free_skip` branch: verify a token, `_pick_casual` a fresh puzzle (no-op if none available so the token isn't wasted), decrement, swap the puzzle keeping the run-level fields. Catalog row inserted (`free_skip`, kind `climb`, $300, active).

### Client
- `climbFreeSkip` store action → RPC + reconcile + `maybeArmClimbIntro` so the new puzzle replays the dramatic opening reveal
- Vault lists it with blurb "Fresh puzzle — keep your Interest"; excluded from Challenge use with a clear reason
- Store + inventory `PUP_META` entries

### Blitz retirement
Blitz is being phased out, so its power-ups (`add_time`, `freeze`, `skip`, `combo_shield`, `auto_vowel`) are set `active = false` — pulled from the store.

## Verification
- **Server rollback test:** token 2→1, puzzle changed, kept heat/bankroll/run_solves, reset spent/revealed/incorrect, state active
- **Live Playwright:** seeded a +70% run with a token → vault showed "⏭️ Free Skip" → tapped it → puzzle swapped to a fresh one, Interest held at +70%, budget reset, letters cleared, token consumed. DB confirmed heat 170 / bankroll 500 / run_solves 3 kept, spent 0. Test account removed after.
- Gates: prettier ✓, svelte-check 0 errors ✓, lint ✓, build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
