### PR TITLE
Lock Daily/Cash Game: retire dead skip path, mark Blitz retired, fix QA harness

### DIFF
--- a/scripts/qa-e2e.mjs
+++ b/scripts/qa-e2e.mjs
@@ -205,18 +205,29 @@ try {
 		bad('daily-open', 'no Solve button — board did not load');
 	} else {
 		ok('daily-open');
-		// NOTE: today's Twist auto-reveals a letter, so only the remaining slots are editable.
-		// Typing the full DAILY answer misaligns the guess — this step is a known harness gap
-		// (the solve path itself is verified server-side). TODO: type only unrevealed slots.
 		await page
 			.getByRole('button', { name: /^solve$/i })
 			.first()
 			.click()
 			.catch(() => {}); // enter guess mode
 		await wait(700);
-		for (const ch of DAILY) {
-			await page.keyboard.press(ch);
-			await wait(70);
+		// Each .letter-box maps 1:1 to an answer letter in order; already-revealed ones
+		// (Twist auto-reveal, purchased) carry class `locked`. inputGuessLetter fills only
+		// the editable slots, so press a key ONLY for non-locked boxes — otherwise the full
+		// answer overflows and misaligns. Boxes align to DAILY char-for-char (spaces are word
+		// gaps, not boxes), so box k needs DAILY[k].
+		const boxes = await page.locator('.letter-box').all();
+		if (boxes.length !== DAILY.length) {
+			bad(
+				'daily-solve',
+				`board has ${boxes.length} slots but answer has ${DAILY.length} — wrong DAILY_ANSWER?`
+			);
+		}
+		for (let k = 0; k < boxes.length && k < DAILY.length; k++) {
+			const cls = (await boxes[k].getAttribute('class')) || '';
+			if (cls.includes('locked')) continue; // already revealed → not editable
+			await page.keyboard.press(DAILY[k]);
+			await wait(60);
 		}
 		await wait(500);
 		await shot('03-daily-filled');
@@ -225,17 +236,19 @@ try {
 			.first()
 			.click()
 			.catch(() => {});
-		// the redesigned Daily plays a slot-machine reveal before the SOLVED! banner — wait it out
+		// A solve plays a slot-machine reveal, then shows the DEPOSIT SLIP receipt
+		// (DEPOSIT / AVAILABLE BALANCE) — wait it out.
+		const winRe = /deposit|available balance|banking with wordbank/i;
 		await page
-			.getByText(/solved!|profit/i)
+			.getByText(winRe)
 			.first()
 			.waitFor({ timeout: 9000 })
 			.catch(() => {});
 		await shot('04-daily-result');
-		const won = await page.getByText(/solved!|profit/i).count();
+		const won = await page.getByText(winRe).count();
 		won > 0
-			? ok('daily-solve', 'win banner shown')
-			: bad('daily-solve', 'no win banner after submit');
+			? ok('daily-solve', 'deposit slip shown')
+			: bad('daily-solve', 'no deposit slip after submit');
 	}
 
 	// ---------- 6. Verify it landed in History ----------

--- a/src/lib/features.js
+++ b/src/lib/features.js
@@ -1,8 +1,9 @@
 // Feature flags — flip to re-enable a hidden feature (code + DB stay intact).
 
-// ⚡ Blitz (timed, money-staked mode) is HIDDEN for the first App Store submission.
-// Timed money modes are the hardest to anti-cheat, so per the launch plan Blitz is a
-// planned fast-follow. `false` hides the Play-menu Blitz tile AND the Standard/Blitz
-// toggle in the challenge builder (all challenges default to Standard). In-flight Blitz
-// matches still resolve. Set to `true` to restore it.
+// ⚡ Blitz (timed, money-staked mode) is RETIRED — kept behind this flag rather than
+// ripped out. `false` hides the Play-menu Blitz tile AND the Standard/Blitz toggle in
+// the challenge builder (all challenges are Standard). Its power-ups are deactivated in
+// the `powerups` catalog. Leaving this off is the intended state; the remaining Blitz
+// code is dead weight slated for a dedicated excision. Only flip to `true` if the
+// product decision to drop Blitz is reversed.
 export const BLITZ_ENABLED = false;

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -38,7 +38,6 @@ import {
 	climbNext,
 	climbLeave,
 	climbForfeit,
-	climbSkip,
 	climbDoubleOrNothing,
 	climbUsePowerup,
 	getClimbClue
@@ -736,22 +735,6 @@ export async function climbLeaveGame() {
 		await climbLeave();
 	} catch {
 		/* non-fatal */
-	}
-}
-
-/** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). */
-export async function climbSkipPuzzle() {
-	if (dailyInFlight) return;
-	dailyInFlight = true;
-	try {
-		const board = await climbSkip();
-		if (board) {
-			reconcileClimbBoard(board);
-			maybeArmClimbIntro();
-			await refreshClimbClue();
-		}
-	} finally {
-		dailyInFlight = false;
 	}
 }
 

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -815,15 +815,6 @@ export async function climbForfeit() {
 	}
 	return data;
 }
-/** Skip the current Cash Game puzzle for a fresh one (resets heat to ×1.0). @returns {Promise<any>} */
-export async function climbSkip() {
-	const { data, error } = await supabase.rpc('climb_skip');
-	if (error) {
-		console.error('❌ climb_skip:', error);
-		return null;
-	}
-	return data;
-}
 /** Arm Double-or-Nothing on the current Cash Game puzzle (heat ≥ ×1.5). @returns {Promise<any>} */
 export async function climbDoubleOrNothing() {
 	const { data, error } = await supabase.rpc('climb_double_or_nothing');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,6 @@
 		climbFreeSkip,
 		climbForfeitRun,
 		climbLeaveGame,
-		climbSkipPuzzle,
 		climbArmDoubleOrNothing,
 		climbPowerup,
 		startBlitz,
@@ -1113,13 +1112,10 @@
 		}
 		try {
 			fx(auto ? 'bust' : 'tap');
+			// Only Daily + Challenges reach this (brokeMode = match; Daily give-up = manual).
+			// Cash Game never folds here — it busts via the guess flow or forfeits its run.
 			if ($gameStore.gameMode === 'daily') await dailyFold();
 			else if ($gameStore.gameMode === 'match') await matchFold();
-			else if ($gameStore.gameMode === 'climb') {
-				await climbSkipPuzzle();
-				await tick();
-				playDailyIntroIfArmed();
-			} // fresh puzzle; heat resets; replay the dramatic build
 		} finally {
 			brokeFiring = false;
 		}
@@ -2624,20 +2620,16 @@
 		></button>
 		<div class="modal-content giveup-modal">
 			<h2 class="gu-title">
-				{isClimb
-					? 'Skip this puzzle?'
-					: `Give up ${$gameStore.gameMode === 'match' ? 'this puzzle' : "today's Daily"}?`}
+				Give up {$gameStore.gameMode === 'match' ? 'this puzzle' : "today's Daily"}?
 			</h2>
 			<p class="gu-text">
-				{isClimb
-					? `Your Interest resets to +0%${(climb?.spent ?? 0) > 0 ? ` and you forfeit the $${(climb?.spent ?? 0).toLocaleString()} spent on this one` : ''} — then a fresh puzzle.`
-					: $gameStore.gameMode === 'match'
-						? 'Skip this puzzle — you pay its full price and move on.'
-						: 'It counts as a loss — you deposit nothing and the answer is revealed.'}
+				{$gameStore.gameMode === 'match'
+					? 'Skip this puzzle — you pay its full price and move on.'
+					: 'It counts as a loss — you deposit nothing and the answer is revealed.'}
 			</p>
 			<div class="gu-actions">
 				<button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
-				<button class="gu-confirm" on:click={doGiveUp}>{isClimb ? '⏭️ Skip' : '🏳️ Give up'}</button>
+				<button class="gu-confirm" on:click={doGiveUp}>🏳️ Give up</button>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
Cleanup pass to close the loose ends on Daily + Cash Game before pivoting to Challenge polish.

## Dead skip removal
The old Cash Game "skip puzzle" path was **provably unreachable**:
- `brokeMode = (gameMode === 'match')` — the broke auto-fold timer never runs for climb
- the top-right give-up routes climb to `askForfeit` (forfeit run), never `confirmFold`

So `doFold`'s climb branch (→ `climbSkipPuzzle` → `climbSkip` → the no-op `climb_skip` RPC) never fired, and the give-up modal's `isClimb ? 'Skip this puzzle?'` branch never rendered. Removed:
- `climbSkipPuzzle` (GameStore) + its import
- `climbSkip` (statsStore) + its import
- the `doFold` climb branch
- the dead `isClimb` branches of the give-up modal (title/text/button)

Left the harmless DB `climb_skip` no-op in place (dropping it is a migration with no benefit).

## Blitz → retired
Blitz is already hidden behind `BLITZ_ENABLED=false` (menu tile, challenge Standard/Blitz toggle) and its power-ups were deactivated in #553. Updated the flag's comment so it reads as **retired**, not a "planned fast-follow" — so it isn't flipped back on by mistake. Full code excision (~87 refs) is deferred to a dedicated cleanup.

## QA harness fixes
Two stale bits were making the daily-solve step a false failure (solve worked server-side):
1. **Twist-safe typing** — press a key only for non-`locked` `.letter-box` slots, so a Twist auto-reveal doesn't overflow and misalign the guess (each box maps 1:1 to an answer letter in order).
2. **Deposit-slip detection** — the win check greps the redesigned DEPOSIT SLIP (`DEPOSIT` / `AVAILABLE BALANCE`) instead of the removed `SOLVED!/profit` banner.

## Verification
- `npm run check` 0 errors · lint clean · build ✓
- **Full QA sweep: 19/19 passed, 0 console errors** across all 11 pages, including a real Daily solve (verified the DEPOSIT SLIP: +$830, #2 of 4). Test accounts removed from prod after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
