### PR TITLE
Fix leave_group: reassign ownership when the owner leaves

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -26,7 +26,7 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
   (bank ≥ wager, netWorth < wager) is shown "capped" yet debited the full wager.
   **Fix:** align UI + RPC on one balance definition. *(`+page.svelte:2242,2260-2277`;
   RPC `accept_match(uuid,boolean)`)*
-- [ ] **4. Group owner leaving orphans the group** — `leave_group` doesn't reassign
+- [x] **4. Group owner leaving orphans the group** — ✅ FIXED (PR #559, supabase-leave-group-owner-fix.sql): owner-leave now hands ownership to the oldest remaining member; rollback-verified handoff + empty-group deletion still works. `leave_group` doesn't reassign
   `owner_id`; every management RPC gates on `owner_id = uid`, so remaining members can
   never rename / kick / approve joins. **Fix:** reassign ownership to the oldest remaining
   member on owner-leave. *(RPC `leave_group`)*

--- a/supabase-leave-group-owner-fix.sql
+++ b/supabase-leave-group-owner-fix.sql
@@ -1,0 +1,34 @@
+-- ============================================================================
+-- Fix: leave_group deleted the caller's membership (and the group if now empty) but never
+-- reassigned groups.owner_id. When the OWNER left a group that still had members, owner_id
+-- kept pointing at the departed non-member, and every management RPC (rename_group,
+-- remove_group_member, respond_join_request) gates on owner_id = uid — so the remaining
+-- members were permanently locked out of admin. Now: on owner-leave with members
+-- remaining, hand ownership to the oldest remaining member.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.leave_group(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_owner UUID; v_new_owner UUID;
+BEGIN
+  IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+  SELECT owner_id INTO v_owner FROM public.groups WHERE id = p_id;
+  DELETE FROM public.group_members WHERE group_id = p_id AND user_id = v_uid;
+  -- If the group is now empty, remove it entirely.
+  DELETE FROM public.groups g WHERE g.id = p_id AND NOT EXISTS (SELECT 1 FROM public.group_members gm WHERE gm.group_id = g.id);
+  -- If the owner left but members remain, hand ownership to the oldest remaining member.
+  IF v_owner = v_uid THEN
+    SELECT user_id INTO v_new_owner FROM public.group_members
+      WHERE group_id = p_id ORDER BY joined_at ASC, user_id ASC LIMIT 1;
+    IF v_new_owner IS NOT NULL THEN
+      UPDATE public.groups SET owner_id = v_new_owner WHERE id = p_id;
+    END IF;
+  END IF;
+  RETURN jsonb_build_object('ok',true);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
**Punch-list Tier 1 #4.**

`leave_group` deleted the caller's membership and the group (if now empty), but never touched `groups.owner_id`. When the **owner** left a group that still had members, `owner_id` kept pointing at the departed non-member — and every management RPC (`rename_group`, `remove_group_member`, `respond_join_request`) gates on `owner_id = uid`. Result: the remaining members could never rename, kick, or approve join requests again.

## Fix
On owner-leave with members remaining, hand ownership to the **oldest remaining member** (`ORDER BY joined_at, user_id`). Empty-group deletion is unchanged.

## Verification (BEGIN/ROLLBACK)
Group with owner + M1 (older) + M2:
- Owner leaves → `owner_id` becomes **M1** ✅
- M2 then M1 leave → group **deleted** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
