### PR TITLE
Add scheduled settlement sweep (pg_cron) for expired matches

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -34,7 +34,7 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
   `state='done'`; a player who accepted+paid but didn't finish gets no `_notify` and no
   `_log_game_result`. Money loss never appears in history/leaderboards.
   **Fix:** include paid `active` participants with a DNF/lost result + notification.
-- [ ] **6. No scheduled settlement** — `get_my_matches` is the only sweeper (settles
+- [x] **6. No scheduled settlement** — ✅ FIXED (PR #561, supabase-scheduled-settlement.sql): added `settle_expired_matches()` + pg_cron job (every 5 min) that settles past-`settles_at` open matches server-side; enabling it immediately settled 1 real stuck match in prod. `get_my_matches` is the only sweeper (settles
   `status='open' AND settles_at < now()`); no pg_cron. Wagers stay escrowed and
   refund/settled notifications never fire until a participant next opens the list.
   **Fix:** scheduled sweeper (pg_cron or edge cron → `settle_expired_matches()`).

--- a/supabase-scheduled-settlement.sql
+++ b/supabase-scheduled-settlement.sql
@@ -1,0 +1,28 @@
+-- ============================================================================
+-- Fix: matches only settled when a participant next opened their Challenges list
+-- (get_my_matches was the only sweeper) — so if everyone stopped opening the app after
+-- the response window, wagers stayed escrowed and refund/settled notifications never
+-- fired. Add a pg_cron sweep that settles expired matches server-side on a schedule.
+-- Applied to prod (idempotent — safe to re-run).
+-- ============================================================================
+
+-- Sweeper: settle every open match whose window has closed. auth-free → cron-safe.
+CREATE OR REPLACE FUNCTION public.settle_expired_matches()
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE r record; n int := 0;
+BEGIN
+  FOR r IN SELECT id FROM public.challenge_matches WHERE status = 'open' AND settles_at < now() LOOP
+    PERFORM public._match_settle(r.id);   -- _match_settle re-checks status='open', so it's safe/idempotent
+    n := n + 1;
+  END LOOP;
+  RETURN n;
+END; $function$;
+
+-- Enable pg_cron (Supabase ships it; no-op if already enabled).
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Run every 5 minutes. cron.schedule upserts by job name, so re-running just updates it.
+SELECT cron.schedule('settle-expired-matches', '*/5 * * * *', $$SELECT public.settle_expired_matches();$$);


### PR DESCRIPTION
**Punch-list Tier 1 #6 — completes Tier 1.**

Matches only settled when a participant next opened their Challenges list (`get_my_matches` was the only sweeper; no cron). If everyone stopped opening the app after the response window, wagers stayed **escrowed** and refund/settled notifications never fired.

## Fix
- New `settle_expired_matches()` — settles every `status='open' AND settles_at < now()` match (mirrors the lazy sweep). auth-free → cron-safe; `_match_settle` re-checks status so it's idempotent.
- Enabled `pg_cron` (Supabase ships it) and scheduled the sweep **every 5 minutes**.

Applied to prod. The first manual run **immediately settled 1 real match** that was sitting unsettled — the bug in action. Cron job confirmed active, targeting the app database.

## Notes
Server/infra only — no client change. `cron.schedule` upserts by job name, so the migration is safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
