### PR TITLE
Clear unread bell on inbox open + guard double-toast race

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -73,7 +73,7 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
       routes only `challenge_incoming` to Challenges; `challenge_your_turn` (carries
       `match_id`) dead-ends at `/profile?tab=alerts`, and `notifNav` opens the _list_, not the
       match. **Fix:** use `data.match_id` to open the specific match.
-- [ ] **15. Unread bell never clears from viewing inbox** — `markAllNotificationsRead`
+- [x] **15. Unread bell never clears from viewing inbox** — ✅ FIXED (PR #564): alerts tab now calls markAllNotificationsRead on open. Was: — `markAllNotificationsRead`
       (`notificationStore.js:107`) has zero callers; alerts tab doesn't mark-all-read.
       **Fix:** call it on inbox open (or add a control).
 - [ ] **16. "Your turn" nudge only for the first finisher** — `_match_notify_opponent_played`
@@ -83,7 +83,7 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
       waits until nobody is `active`/`invited`. **Fix:** gate on accepted players only.
 - [ ] **18. Group decline silent to host** when the match survives (`decline_match` only
       notifies on void). **Fix:** optionally notify "@x declined."
-- [ ] **19. Possible double-toast race** — `notificationStore.poll()` computes `fresh`
+- [x] **19. Possible double-toast race** — ✅ FIXED (PR #564): added an in-flight guard to notificationStore.poll(). Was: — `notificationStore.poll()` computes `fresh`
       before writing `knownIds`; concurrent polls can both flag a row. **Fix:** in-flight guard
       / add ids before the async gap.
 

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -27,23 +27,30 @@ let pollTimer;
 let knownIds = new Set();
 let started = false;
 let primed = false; // first poll seeds knownIds without toasting history
+let polling = false; // in-flight guard so concurrent polls can't double-toast the same row
 /** @type {(() => void)|undefined} */
 let onVis;
 /** @type {any} */
 let channel;
 
 async function poll() {
-	const res = await getNotifications();
-	const items = res.items ?? [];
-	notifications.set(items);
-	unreadCount.set(res.unread_count ?? 0);
-	if (primed) {
-		// newest first; toast anything new + still unread, oldest-of-the-new first
-		const fresh = items.filter((n) => !knownIds.has(n.id) && !n.read).reverse();
-		for (const n of fresh) pushToast(n);
+	if (polling) return; // a poll is already in flight — don't race on knownIds
+	polling = true;
+	try {
+		const res = await getNotifications();
+		const items = res.items ?? [];
+		notifications.set(items);
+		unreadCount.set(res.unread_count ?? 0);
+		if (primed) {
+			// newest first; toast anything new + still unread, oldest-of-the-new first
+			const fresh = items.filter((n) => !knownIds.has(n.id) && !n.read).reverse();
+			for (const n of fresh) pushToast(n);
+		}
+		for (const n of items) knownIds.add(n.id);
+		primed = true;
+	} finally {
+		polling = false;
 	}
-	for (const n of items) knownIds.add(n.id);
-	primed = true;
 }
 
 /** @param {any} n */

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -7,7 +7,11 @@
 	import Avatar from '$lib/components/Avatar.svelte';
 	import InventoryList from '$lib/components/InventoryList.svelte';
 	import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
-	import { unreadCount, requestInbox } from '$lib/stores/notificationStore.js';
+	import {
+		unreadCount,
+		requestInbox,
+		markAllNotificationsRead
+	} from '$lib/stores/notificationStore.js';
 	import { track } from '$lib/analytics.js';
 
 	/** @type {'overview'|'stats'|'alerts'} */
@@ -46,8 +50,11 @@
 		}
 	});
 
-	// Note: the unread count only drops when a notification is acted on or dismissed —
-	// NOT just from viewing the list. (No mark-all-read on open.)
+	// Opening the alerts inbox marks everything read (clears the bell badge). Items still
+	// show in the list — this just acknowledges you've seen them.
+	$effect(() => {
+		if (tab === 'alerts' && $unreadCount > 0) markAllNotificationsRead();
+	});
 	/** @param {any} n */
 	function notifNav(n) {
 		// Challenge invites/results → open the Challenges hub on the menu.


### PR DESCRIPTION
**Punch-list Tier 3 #15 + #19.**

- **#15** — `markAllNotificationsRead` existed but had zero callers, so the bell badge never cleared just from viewing the inbox. The profile alerts tab now calls it on open (`$effect` gated on `tab === 'alerts' && unread > 0`). Items still show in the list; this just acknowledges you've seen them.
- **#19** — `notificationStore.poll()` computed `fresh` from `knownIds` before writing back, so a realtime INSERT poll racing an interval/visibility poll could both flag the same new row and double-toast. Added an in-flight guard.

## Verification
`npm run check` 0 errors · lint clean · build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
