### PR TITLE
Deep-link challenge notifications to the specific match

### DIFF
--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -7,11 +7,13 @@
 	function open(t) {
 		fx('select');
 		dismissToast(t.id);
-		// Your-turn challenge → home Community ▸ Challenges; everything else (results,
-		// sabotage, chat, friend requests) → your alerts inbox in Profile.
-		if (t.type === 'challenge_incoming') {
+		// Any challenge notification (invite, your-turn, result, sabotage) → home Community ▸
+		// Challenges, deep-linked to the specific match when we have its id. Everything else
+		// (friend requests, etc.) → your alerts inbox in Profile.
+		const matchId = t?.data?.match_id ?? null;
+		if (matchId || String(t.type || '').startsWith('challenge')) {
 			goto('/');
-			requestInbox('challenges');
+			requestInbox('challenges', matchId);
 		} else goto('/profile?tab=alerts');
 	}
 </script>

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -14,9 +14,12 @@ export const toasts = writable([]);
 export const inboxRequest = writable(0);
 /** Which Community tab the next inboxRequest should land on. */
 export const inboxTarget = writable(/** @type {'challenges'|'activity'|'people'} */ ('challenges'));
-/** @param {'challenges'|'activity'|'people'} [target] */
-export function requestInbox(target = 'challenges') {
+/** A specific match to auto-open once the Challenges hub loads (deep-link from a notification). */
+export const inboxMatch = writable(/** @type {string|null} */ (null));
+/** @param {'challenges'|'activity'|'people'} [target] @param {string|null} [matchId] */
+export function requestInbox(target = 'challenges', matchId = null) {
 	inboxTarget.set(target);
+	inboxMatch.set(matchId);
 	inboxRequest.update((n) => n + 1);
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -80,6 +80,7 @@
 		refreshNotifications,
 		inboxRequest,
 		inboxTarget,
+		inboxMatch,
 		markChallengeNotifRead
 	} from '$lib/stores/notificationStore.js';
 	import { track } from '$lib/analytics.js';
@@ -1507,7 +1508,16 @@
 		if ($inboxTarget === 'people') {
 			openCommunity('people');
 			peopleTab = 'friends';
-		} else openCommunity('challenges');
+		} else {
+			const targetMatch = $inboxMatch;
+			openCommunity('challenges').then(() => {
+				// Deep-link: auto-open the specific match the notification pointed at.
+				if (!targetMatch) return;
+				const m = (myMatches ?? []).find((/** @type {any} */ x) => x.id === targetMatch);
+				if (m) respondToMatch(m);
+				inboxMatch.set(null);
+			});
+		}
 	}
 	function dismissTutorial() {
 		showTutorial = false;

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -57,9 +57,9 @@
 	});
 	/** @param {any} n */
 	function notifNav(n) {
-		// Challenge invites/results → open the Challenges hub on the menu.
+		// Challenge invites/results → open the Challenges hub, deep-linked to the match if known.
 		if (n?.type === 'challenge_incoming' || n?.data?.match_id || n?.data?.challenge_id) {
-			requestInbox('challenges');
+			requestInbox('challenges', n?.data?.match_id ?? null);
 			goto('/');
 		}
 	}


### PR DESCRIPTION
**Punch-list Tier 3 #14.**

Two problems: `challenge_your_turn` toasts **dead-ended in the profile alerts inbox** (only `challenge_incoming` went to the Challenges hub), and even the ones that reached the hub opened the **list**, not the match — despite carrying `data.match_id`.

## Fix
- `requestInbox(target, matchId)` now carries an optional match id (`inboxMatch` store).
- **Toaster** routes any challenge notification (or anything with `data.match_id`) to the Challenges hub with the match id.
- **Profile `notifNav`** passes `data.match_id` too.
- **+page.svelte** opens Community ▸ Challenges, then `respondToMatch()`s the matching row (which opens accept / resume-play / results depending on state). Falls back to just the hub if the match isn't in the list.

## Verification
`npm run check` 0 errors · lint clean · build ✓. Graceful degradation preserved (no match → same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
