### PR TITLE
Live sabotage debuff refresh on the victim's board

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -64,11 +64,11 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
 
 ## 🟡 Tier 3 — Notifications & turn-flow (the async heart of Challenges)
 
-- [ ] **13. Sabotage debuffs + opponent standing not live** — only realtime channel is
+- [x] **13. Sabotage debuffs + opponent standing not live** — ✅ FIXED (PR #567): added a realtime challenge*participants UPDATE subscription → refreshMatchMeta (meta-only, never disrupts typing); the sabotage debuff lands on the victim’s own row (RLS-visible) so the banner shows instantly. Standing still refreshes on the victim’s own actions (RLS blocks direct opponent-row reads). Was: — only realtime channel is
       `match_messages` (chat); the `sabotaged` notification never calls `reconcileMatchBoard`.
       Victim sees the "you got hit" banner only after buying a letter (i.e. after overpaying).
       **Fix:** subscribe to the victim's `challenge_participants` row / refresh board on the
-      sabotaged notification. _(`+page.svelte:1315,4476`)_
+      sabotaged notification. *(`+page.svelte:1315,4476`)\_
 - [ ] **14. Turn notifications don't deep-link to the match** — `Toaster.svelte:12-15`
       routes only `challenge_incoming` to Challenges; `challenge_your_turn` (carries
       `match_id`) dead-ends at `/profile?tab=alerts`, and `notifNav` opens the _list_, not the

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -840,6 +840,21 @@ export async function matchTimeoutCheck() {
 	if (board) reconcileMatchBoard(board);
 }
 
+/** Light live refresh — re-pull only the match meta (my_debuffs, standing, opponents'
+ *  scores) without touching local input (guess mode / pending purchase). Called on
+ *  realtime participant changes so a sabotage debuff or an opponent's score shows instantly. */
+export async function refreshMatchMeta() {
+	if (!activeMatchId) return;
+	const board = await matchCheck(activeMatchId);
+	if (!board) return;
+	const match = board.match || {};
+	gameStore.update((s) =>
+		s.gameMode === 'match'
+			? { ...s, matchInfo: { ...match, id: activeMatchId, standing: board.standing ?? null } }
+			: s
+	);
+}
+
 /** Resume a match I'm already in. @param {string} id @returns {Promise<boolean>} */
 export async function resumeMatch(id) {
 	activeMatchId = id;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,6 +28,7 @@
 		acceptAndPlayMatch,
 		resumeMatch,
 		matchTimeoutCheck,
+		refreshMatchMeta,
 		matchPowerup,
 		matchSabotageOpponent,
 		dailyFold,
@@ -1317,6 +1318,18 @@
 				'postgres_changes',
 				{ event: 'INSERT', schema: 'public', table: 'match_messages', filter: `match_id=eq.${id}` },
 				loadMatchMsgs
+			)
+			// Live board meta: a sabotage debuff (my row) or an opponent's score (their row)
+			// updates the banner + standing instantly — meta only, so it never disrupts typing.
+			.on(
+				'postgres_changes',
+				{
+					event: 'UPDATE',
+					schema: 'public',
+					table: 'challenge_participants',
+					filter: `match_id=eq.${id}`
+				},
+				() => refreshMatchMeta()
 			)
 			.subscribe();
 		matchChatPoll = setInterval(loadMatchMsgs, 20000);

--- a/supabase-realtime-participants.sql
+++ b/supabase-realtime-participants.sql
@@ -1,0 +1,8 @@
+-- ============================================================================
+-- #13 live sabotage/standing refresh: add challenge_participants to the Supabase realtime
+-- publication so the client's postgres_changes UPDATE subscription fires. match_sabotage
+-- writes the debuff onto the VICTIM's own row, which RLS (cp_self: user_id = auth.uid())
+-- lets the victim receive live → the debuff banner shows instantly (before they overpay).
+-- PK includes match_id, so REPLICA IDENTITY DEFAULT is sufficient for the match_id filter.
+-- ============================================================================
+ALTER PUBLICATION supabase_realtime ADD TABLE public.challenge_participants;


### PR DESCRIPTION
**Punch-list Tier 3 #13.**

The only match realtime channel was `match_messages` (chat), so a sabotage debuff (`tax`/`toll`/…) only showed on the victim's board after their **next board RPC** — i.e. the "you got hit" warning appeared *after* they'd already overpaid for a letter.

## Fix
- Added a `postgres_changes` **UPDATE** subscription on `challenge_participants` (filter `match_id=eq.X`) to the existing `match:${id}` channel.
- New `refreshMatchMeta()` re-pulls **only** `matchInfo` (`my_debuffs`, `standing`, opponents) — not `gameState`/input — so the banner + standing update live and mid-typing (guess/purchase) is never disrupted.
- Added `challenge_participants` to the `supabase_realtime` publication.

`match_sabotage` writes the debuff onto the **victim's own row**, which RLS (`cp_self`: `user_id = auth.uid()`) lets the victim receive live → **the debuff banner now shows instantly, before they overpay.** Opponent standings still refresh on the victim's own actions (RLS correctly blocks direct opponent-row reads — not loosened for a UI nicety).

## Verification
`npm run check` 0 errors · lint clean · build ✓. Confirmed `match_sabotage` targets the victim's row and `challenge_participants` is now in the realtime publication. Degrades gracefully (no realtime → same as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
