### PR TITLE
Stable match pot + honest payout label

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -44,11 +44,11 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
 - [ ] **7. Multi-puzzle "spent"/"budget" inflated** — `get_match` / `get_match_detail`
       compute `spent = start_budget − bankroll`, mixing accumulated multi-puzzle budget vs
       single-puzzle bankroll. **Fix:** `sum(per-position bounty) − total_score`.
-- [ ] **8. Pot chip shrinks as opponents finish** — `matchPot = wager × (opponents+1)`
+- [x] **8. Pot chip shrinks as opponents finish** — ✅ FIXED (PR #570, supabase-match-pot-fix.sql): _match_board now returns a stable `pot` (wager × non-declined players); client uses it; rollback-verified pot stays $1000 with an opponent done. Was: — `matchPot = wager × (opponents+1)`
       and `_match_board.opponents` excludes `done`. Opponent finishes → "Pot $1,000"→"$500".
       **Fix:** compute pot server-side from `sum(stake)` over all paid participants.
-      _(`+page.svelte:642-643`)_
-- [ ] **9. PIN confirm always "Winner takes all"** — `mbPayout='winner'` never reassigned;
+      _(`+page.svelte:642-643`)\_
+- [x] **9. PIN confirm always "Winner takes all"** — ✅ FIXED (PR #570): create + accept confirm sheets now say "Top finishers split the pot" for group/3+ pots, "Winner takes all" for 1:1. Was: — `mbPayout='winner'` never reassigned;
       group pots actually split 70/30 or 60/30/10. **Fix:** derive from field size / reuse
       `potSummary`. _(`+page.svelte:2020,2171`)_
 - [x] **10. Compete "recent matches" shows 🏆 on no-winner/ties** — ✅ FIXED (PR #568, supabase-group-standings-fix.sql): winner NULL unless a sole top scorer with score>0; client renders "🤝 Tie · no winner". Was: — `get_group_standings`

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -637,10 +637,13 @@
 	// dramatically count up at the climax (introDone). Cash Game stages the count-up manually
 	// (puzzle value → + carried run pile), so pause this auto-driver while climbStaging is on.
 	$: if (!climbStaging) tweenNet.set(introBuilding ? 0 : soloHero ? Math.round(soloHero.net) : 0);
-	// The Pot you're playing for = every player's ante. Reduced-stake joins can make
-	// the settled pot a bit lower; this is the headline "playing for" figure.
+	// The Pot you're playing for = every player's ante (server-computed over all
+	// non-declined players, so it stays stable as opponents finish). Reduced-stake joins
+	// can make the settled pot a bit lower; this is the headline "playing for" figure.
 	$: matchPot = isMatch
-		? Math.round((matchInfo?.wager ?? 0) * ((matchInfo?.opponents?.length ?? 0) + 1))
+		? Math.round(
+				matchInfo?.pot ?? (matchInfo?.wager ?? 0) * ((matchInfo?.opponents?.length ?? 0) + 1)
+			)
 		: 0;
 
 	// 🎰 Daily opening reveal coordination (boxes land → bounty counts up × multiplier).
@@ -2164,7 +2167,10 @@
 			},
 			{ label: 'Puzzles', value: String(mbPackSize) },
 			{ label: 'Buy-in', value: w > 0 ? '$' + w.toLocaleString() : 'Friendly' },
-			{ label: 'Payout', value: mbPayout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
+			{
+				label: 'Payout',
+				value: mbTarget === 'group' ? 'Top finishers split the pot' : 'Winner takes all'
+			}
 		];
 		try {
 			await requirePin(w > 0 ? 'Send & stake your buy-in' : 'Send this challenge', createStakes);
@@ -2216,7 +2222,11 @@
 				label: 'Buy-in',
 				value: Number(m.wager) > 0 ? '$' + Number(m.wager).toLocaleString() : 'Friendly'
 			},
-			{ label: 'Payout', value: m.payout === 'podium' ? 'Podium 3·2·1' : 'Winner takes all' }
+			// _match_settle: ≤2 paid → winner takes all; 3+ → top finishers split (70/30, 60/30/10).
+			{
+				label: 'Payout',
+				value: Number(m.players) > 2 ? 'Top finishers split the pot' : 'Winner takes all'
+			}
 		];
 		if (Number(m.wager) > 0 && netWorth != null)
 			s.push({ label: 'Available Balance', value: '$' + Math.round(netWorth).toLocaleString() });

--- a/supabase-match-pot-fix.sql
+++ b/supabase-match-pot-fix.sql
@@ -1,0 +1,88 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')),
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id)) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF m.mode = 'blitz' THEN
+    v_minfo := v_minfo || jsonb_build_object('started_at', cp.started_at, 'clock_seconds', m.pack_size * 30, 'combo', cp.combo_x100);
+  END IF;
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' AND m.mode <> 'blitz' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN 'fog' = ANY(COALESCE(cp.debuffs,'{}')) THEN NULL ELSE v_clue END);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
**Punch-list Tier 2 #8 + #9.**

- **#8** — the "Pot" chip was `wager × (opponents + 1)`, and `_match_board.opponents` **excludes `done`** — so the moment your opponent finished (they may play first), "Pot $1,000" dropped to "$500," implying the stake vanished. `_match_board` now returns a server-computed **`pot`** = `wager × count(non-declined players)` (stable as players finish, grows as they accept); the client uses `matchInfo.pot`.
- **#9** — the PIN confirm sheets always said **"Winner takes all"** (`mbPayout` was a hardcoded constant) even for group pots that split 70/30 or 60/30/10. Both the **create** and **accept** confirms now say **"Top finishers split the pot"** for group / 3+ fields and "Winner takes all" for 1:1, matching `_match_settle`.

## Verification
- `_match_board` rollback test: 1 opponent `done` → **pot = $1,000** ✅ (2 antes, was $500).
- `npm run check` 0 errors · build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
