### PR TITLE
Group permissions: pending-requests UI + membership-gate leaderboard

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -89,12 +89,12 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
 
 ## 🔵 Tier 4 — Permissions & membership
 
-- [ ] **20. Roster control inconsistent** — any member can `add_group_member`, but
+- [ ] **20. Roster control inconsistent** — ⏸️ DEFERRED (product call): "members invite friends, owner moderates + approves requests" is a coherent, common model (Discord-style), not a clear bug. Was: — any member can `add_group_member`, but
       remove/rename/approve are owner-only. **Fix:** pick one model.
-- [ ] **21. Join-request approval only via transient notification** — `respond_join_request`
+- [x] **21. Join-request approval only via transient notification** — ✅ FIXED (PR #572, supabase-group-pending-requests.sql): get_group returns pending requests (owner-only); GroupsPanel renders a "Requests to join" section with Approve/Deny. Was: — `respond_join_request`
       is only called from `NotificationsPanel.svelte:28`; no pending-requests list in
       `GroupsPanel`. **Fix:** render pending requests in the owner view.
-- [ ] **22. Group leaderboard not membership-gated** — `get_challenge_leaderboard` group
+- [x] **22. Group leaderboard not membership-gated** — ✅ FIXED (PR #572, supabase-challenge-lb-gating-fix.sql): group scope now members-only + self-include scoped to friends; rollback-verified non-member gets []. Was: — `get_challenge_leaderboard` group
       scope lacks a membership check and always self-injects (`OR gr.user_id = v_uid`).
       **Fix:** gate on membership; drop the unconditional self-include for group scope.
 

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -10,6 +10,7 @@
 		leaveGroup,
 		addGroupMember,
 		removeGroupMember,
+		respondJoinRequest,
 		renameGroup,
 		listFriends,
 		getGroupMessages,
@@ -267,6 +268,15 @@
 			await refresh();
 		}
 	}
+	/** Approve or deny a pending join request (owner). @param {string} requesterId @param {boolean} approve */
+	async function respondRequest(requesterId, approve) {
+		if (busy) return;
+		busy = true;
+		await respondJoinRequest(open.id, requesterId, approve);
+		busy = false;
+		open = await getGroup(open.id); // refresh members + remaining requests
+		await refresh();
+	}
 </script>
 
 <div class="groups-panel">
@@ -389,6 +399,29 @@
 					{/each}
 				</div>
 			{/if}
+		{/if}
+
+		{#if open.is_owner && (open.requests ?? []).length}
+			<div class="req-panel">
+				<h2 class="req-title">🙋 Requests to join</h2>
+				{#each open.requests as r}
+					<div class="req-row">
+						<span class="uname">@{r.username}</span>
+						<span class="req-actions">
+							<button
+								class="g-btn sm"
+								onclick={() => respondRequest(r.requester_id, true)}
+								disabled={busy}>Approve</button
+							>
+							<button
+								class="g-btn sm ghost"
+								onclick={() => respondRequest(r.requester_id, false)}
+								disabled={busy}>Deny</button
+							>
+						</span>
+					</div>
+				{/each}
+			</div>
 		{/if}
 
 		<button
@@ -888,6 +921,40 @@
 		cursor: pointer;
 		font-weight: 700;
 		font-size: 0.9rem;
+	}
+	.g-btn.ghost {
+		background: transparent;
+		border: 1px solid var(--border);
+		color: var(--text-muted);
+	}
+	.req-panel {
+		margin-top: 0.75rem;
+		border: 1px solid rgba(251, 191, 36, 0.4);
+		border-radius: 14px;
+		background: var(--surface);
+		overflow: hidden;
+	}
+	.req-title {
+		font-size: 0.9rem;
+		font-weight: 700;
+		margin: 0;
+		padding: 0.6rem 0.9rem;
+		border-bottom: 1px solid var(--border);
+	}
+	.req-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.5rem;
+		padding: 0.6rem 0.9rem;
+		border-bottom: 1px solid var(--border);
+	}
+	.req-row:last-child {
+		border-bottom: none;
+	}
+	.req-actions {
+		display: flex;
+		gap: 0.4rem;
 	}
 	.add-panel {
 		margin-top: 0.5rem;

--- a/supabase-challenge-lb-gating-fix.sql
+++ b/supabase-challenge-lb-gating-fix.sql
@@ -1,0 +1,48 @@
+-- ============================================================================
+-- #22: get_challenge_leaderboard group scope wasn't membership-gated, and the
+-- `OR gr.user_id = v_uid` self-include applied to ALL scopes — so you always appeared on
+-- a group's board even if you weren't in it. Now: group scope requires membership (else
+-- empty), and self-include is scoped to 'friends' only (group members already include you).
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_challenge_leaderboard(p_scope text DEFAULT 'friends'::text, p_group uuid DEFAULT NULL::uuid, p_period text DEFAULT 'week'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_rows jsonb;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  -- Group board is members-only.
+  IF p_scope = 'group' AND (p_group IS NULL OR NOT EXISTS (
+       SELECT 1 FROM public.group_members WHERE group_id = p_group AND user_id = v_uid)) THEN
+    RETURN '[]'::jsonb;
+  END IF;
+  WITH pool AS (
+    SELECT gr.user_id AS id,
+      count(*) FILTER (WHERE gr.outcome = 'won') AS wins,
+      count(*) AS played,
+      COALESCE(sum(gr.net) FILTER (WHERE gr.outcome = 'won'), 0) AS pot_won
+    FROM public.game_results gr
+    WHERE gr.game_mode = 'challenge'
+      AND (p_period <> 'week' OR gr.played_at >= date_trunc('week', now()))
+      AND (p_scope = 'global'
+        OR (p_scope = 'friends' AND (gr.user_id = v_uid
+              OR gr.user_id IN (SELECT friend_id FROM public.friendships WHERE user_id = v_uid)))
+        OR (p_scope = 'group' AND gr.user_id IN (SELECT user_id FROM public.group_members WHERE group_id = p_group)))
+    GROUP BY gr.user_id
+  ),
+  ranked AS (SELECT *, row_number() OVER (ORDER BY wins DESC, pot_won DESC) AS rank
+             FROM pool WHERE played > 0 ORDER BY wins DESC, pot_won DESC LIMIT 50)
+  SELECT jsonb_agg(jsonb_build_object('rank', r.rank, 'name', public._display_name(r.id),
+    'metric', r.wins, 'played', r.played, 'pot_won', r.pot_won, 'is_me', r.id = v_uid,
+    'color', cc.value, 'title', ct.value) ORDER BY r.rank)
+  INTO v_rows FROM ranked r
+    LEFT JOIN public.profiles p ON p.id = r.id
+    LEFT JOIN public.cosmetics ct ON ct.id = p.equipped_title
+    LEFT JOIN public.cosmetics cc ON cc.id = p.equipped_color;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$;
+
+COMMIT;

--- a/supabase-group-pending-requests.sql
+++ b/supabase-group-pending-requests.sql
@@ -1,0 +1,46 @@
+-- ============================================================================
+-- #21: join-request approval was only reachable via a transient notification
+-- (respond_join_request called only from NotificationsPanel). If the owner missed/cleared
+-- it, the request in group_join_requests was orphaned with no UI to act on. get_group now
+-- returns the pending requests (owner view only) so GroupsPanel can render them.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_group(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); g public.groups; v_members jsonb; v_requests jsonb;
+begin
+  if v_uid is null then return null; end if;
+  select * into g from public.groups where id = p_id;
+  if not found or not exists (select 1 from public.group_members where group_id = p_id and user_id = v_uid) then return null; end if;
+  with m as (
+    select gm.user_id as id, pr.username as username, coalesce(pr.bank,0) as net_worth, coalesce(pr.bank,0) as cash,
+           ct.value as title, cc.value as color, (pr.id = g.owner_id) as is_owner
+    from public.group_members gm
+    join public.profiles pr on pr.id = gm.user_id
+    left join public.cosmetics ct on ct.id = pr.equipped_title
+    left join public.cosmetics cc on cc.id = pr.equipped_color
+    where gm.group_id = p_id
+  ),
+  ranked as (select *, row_number() over (order by net_worth desc, cash desc) as rank from m)
+  select jsonb_agg(jsonb_build_object('rank', rank, 'name', public._display_name(id), 'username', username,
+    'net_worth', net_worth, 'cash', cash, 'title', title, 'color', color, 'is_me', id = v_uid, 'is_owner', is_owner) order by rank)
+  into v_members from ranked;
+
+  -- Pending join requests — owner view only.
+  if g.owner_id = v_uid then
+    select jsonb_agg(jsonb_build_object('requester_id', r.requester_id,
+             'name', public._display_name(r.requester_id), 'username', pr.username) order by r.created_at)
+    into v_requests
+    from public.group_join_requests r join public.profiles pr on pr.id = r.requester_id
+    where r.group_id = p_id;
+  end if;
+
+  return jsonb_build_object('id', g.id, 'name', g.name, 'is_owner', g.owner_id = v_uid,
+    'members', coalesce(v_members,'[]'::jsonb), 'requests', coalesce(v_requests, '[]'::jsonb));
+end; $function$;
+
+COMMIT;


### PR DESCRIPTION
**Punch-list Tier 4 #21 + #22** (with #20 deferred).

- **#22** — `get_challenge_leaderboard` group scope had no membership check, and the `OR gr.user_id = v_uid` self-include applied to **all** scopes, so you appeared on any group's board even if you weren't in it. Group scope is now **members-only** (returns `[]` for non-members) and self-include is scoped to `friends`. Rollback-verified: non-member → `[]`.
- **#21** — `respond_join_request` was only reachable from a transient notification (`NotificationsPanel`); a missed/cleared notification orphaned the request with no UI. `get_group` now returns **pending requests (owner-only)** and `GroupsPanel` renders a **"🙋 Requests to join"** section with Approve/Deny. Rollback-verified: owner sees the request, non-owner sees none.
- **#20 deferred** — "members invite friends, owner moderates + approves requests" is a coherent, common (Discord-style) model, not a clear bug.

## Verification
`npm run check` 0 errors · build ✓; both server changes rollback-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
