### PR TITLE
Group polish: chat unread dot + Compete refresh

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -119,11 +119,11 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
 
 ## ⚪ Tier 6 — Polish
 
-- [ ] **27. Group chat has no unread indicator** (match chat has `matchChatUnread`).
-      _(`GroupsPanel.svelte:96-127`)_
-- [ ] **28. ActivityPanel uses emoji icons** instead of the line-icon system.
-      _(`ActivityPanel.svelte:16-22`)_
-- [ ] **29. Compete tab caches standings** — doesn't refresh after a settle while open.
+- [x] **27. Group chat has no unread indicator** — ✅ FIXED (PR #573, supabase-group-last-message.sql): get*my_groups returns last_message_at; group list shows an unread dot vs a localStorage per-group last-seen, cleared on open. Was: (match chat has `matchChatUnread`).
+      *(`GroupsPanel.svelte:96-127`)\_
+- [ ] **28. ActivityPanel uses emoji icons** — ⏸️ DEFERRED: ModeIcon/CategoryIcon only cover 2 of 5 activity types (daily*win, challenge); big_solve/badge/group_join have no line icon, so a partial swap is less consistent than the current uniform emoji set. Needs new icons. Was: instead of the line-icon system.
+      *(`ActivityPanel.svelte:16-22`)\_
+- [x] **29. Compete tab caches standings** — ✅ FIXED (PR #573): switchTab reloads standings every time Compete opens (spinner only on first load). Was: — doesn't refresh after a settle while open.
       _(`GroupsPanel.svelte:63`)_
 
 ---

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -61,10 +61,29 @@
 	let standings = $state(null);
 	let standingsLoading = $state(false);
 
+	// Unread group-chat dot: compare each group's latest message time against a per-group
+	// last-seen stamp kept in localStorage. seenBump re-evaluates the dots after marking seen.
+	let seenBump = $state(0);
+	/** @param {any} g */
+	function groupUnread(g) {
+		void seenBump;
+		if (typeof localStorage === 'undefined' || !g?.last_message_at) return false;
+		const seen = localStorage.getItem('grpSeen:' + g.id);
+		return !seen || new Date(g.last_message_at) > new Date(seen);
+	}
+	/** @param {string} id */
+	function markGroupSeen(id) {
+		if (typeof localStorage === 'undefined' || !id) return;
+		localStorage.setItem('grpSeen:' + id, new Date().toISOString());
+		seenBump++;
+	}
+
 	async function switchTab(/** @type {string} */ t) {
 		gtab = t;
-		if (t === 'compete' && !standings && open) {
-			standingsLoading = true;
+		// Reload standings every time Compete is opened so a match settled while the panel
+		// was open shows up (previously cached on first open and never refreshed).
+		if (t === 'compete' && open) {
+			standingsLoading = !standings;
 			standings = await getGroupStandings(open.id);
 			standingsLoading = false;
 		}
@@ -175,6 +194,7 @@
 	/** @param {any} g */
 	async function openGroup(g) {
 		open = g;
+		markGroupSeen(g?.id); // opening the group clears its unread dot
 		renaming = false;
 		showAdd = false;
 		addMsg = '';
@@ -523,9 +543,10 @@
 					{#each shownGroups as g}
 						<button class="g-card" onclick={() => view(g.id)}>
 							<div class="gc-body">
-								<span class="gc-name">{g.name}</span><span class="gc-meta"
-									>{g.members} member{g.members === 1 ? '' : 's'}</span
-								>
+								<span class="gc-name"
+									>{g.name}{#if groupUnread(g)}<span class="gc-unread" title="New messages"
+										></span>{/if}</span
+								><span class="gc-meta">{g.members} member{g.members === 1 ? '' : 's'}</span>
 							</div>
 							<span class="gc-arrow">→</span>
 						</button>
@@ -758,6 +779,15 @@
 	}
 	.g-card:hover {
 		border-color: rgba(253, 224, 71, 0.4);
+	}
+	.gc-unread {
+		display: inline-block;
+		width: 8px;
+		height: 8px;
+		margin-left: 6px;
+		border-radius: 50%;
+		background: #fb7185;
+		vertical-align: middle;
 	}
 	.gc-body {
 		display: flex;

--- a/supabase-group-last-message.sql
+++ b/supabase-group-last-message.sql
@@ -1,0 +1,27 @@
+-- ============================================================================
+-- #27: group chat had no unread indicator on the group list — you had to open each group
+-- to discover new messages. Expose the group's latest message timestamp so the client can
+-- show an unread dot (compared against a per-group last-seen it tracks locally).
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_my_groups()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('id', g.id, 'name', g.name, 'join_code', g.join_code,
+    'members', (SELECT count(*) FROM public.group_members gm2 WHERE gm2.group_id = g.id),
+    'is_owner', g.owner_id = v_uid,
+    'last_message_at', (SELECT max(created_at) FROM public.group_messages gmsg WHERE gmsg.group_id = g.id),
+    'added_at', (SELECT gm3.joined_at FROM public.group_members gm3
+                 WHERE gm3.group_id = g.id AND gm3.user_id = v_uid)) ORDER BY g.created_at), '[]'::jsonb)
+  INTO v_rows FROM public.groups g
+  WHERE EXISTS (SELECT 1 FROM public.group_members gm WHERE gm.group_id = g.id AND gm.user_id = v_uid);
+  RETURN v_rows;
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
**Punch-list Tier 6 #27 + #29** (with #28 deferred).

- **#27** — group chat had no unread indicator, so you had to open each group to find new messages. `get_my_groups` now returns `last_message_at`; the group list shows an **unread dot** compared against a per-group last-seen kept in `localStorage`, cleared when you open the group.
- **#29** — the Compete tab fetched standings only on first open (`!standings`) and never refreshed. `switchTab` now reloads standings **each time Compete is opened** (spinner only on first load), so a match settled while the panel was open shows up.
- **#28 deferred** — `ModeIcon`/`CategoryIcon` only cover 2 of the 5 activity types (`daily_win`, `challenge`); `big_solve`/`badge`/`group_join` have no line icon, so a partial swap is *less* consistent than the current uniform emoji set (needs new icons).

## Verification
`npm run check` 0 errors · build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
