### PR TITLE
Early-settle group challenges once engaged players finish

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -79,7 +79,7 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
 - [x] **16. "Your turn" nudge only for the first finisher** — ✅ FIXED (PR #565, supabase-turnflow-notifs-fix.sql): removed the v_done<>1 gate so every finish nudges still-waiting players, deduped to one unread per match. Was: — `_match_notify_opponent_played`
       `IF v_done <> 1 THEN RETURN`. Later finishers never re-nudge stragglers.
       **Fix:** notify still-active players on each finish (deduped) / final reminder.
-- [ ] **17. Early settlement blocked by an idle invited member** — ⏸️ DEFERRED (product call): naively ignoring `invited` would let a 1:1 settle before the opponent ever accepts. #6 (scheduled settlement) already prevents indefinite escrow, so this is an early-settle-vs-late-accepters tradeoff, not a clean bug. Was: — `_match_maybe_settle`
+- [x] **17. Early settlement blocked by an idle invited member** — ✅ FIXED (PR #574, supabase-early-settle-fix.sql): settle once no player is `active` AND ≥2 are `done` — passes over never-accepted invitees, protects 1:1 (needs ≥2 done); rollback-verified all 3 cases. Prior note (product call): naively ignoring `invited` would let a 1:1 settle before the opponent ever accepts. #6 (scheduled settlement) already prevents indefinite escrow, so this is an early-settle-vs-late-accepters tradeoff, not a clean bug. Was: — `_match_maybe_settle`
       waits until nobody is `active`/`invited`. **Fix:** gate on accepted players only.
 - [x] **18. Group decline silent to host** — ✅ FIXED (PR #565): host now notified "@x declined — still on" when a decline leaves the match viable. Was: when the match survives (`decline_match` only
       notifies on void). **Fix:** optionally notify "@x declined."

--- a/supabase-early-settle-fix.sql
+++ b/supabase-early-settle-fix.sql
@@ -1,0 +1,23 @@
+-- ============================================================================
+-- #17: _match_maybe_settle only settled when NO participant was 'active' OR 'invited',
+-- so a group invitee who never accepted blocked early settlement — finishers waited out
+-- the whole window for payout. New rule: settle once everyone who accepted has finished
+-- (no 'active' left) AND at least 2 players actually completed ('done'). This passes over
+-- invitees who never accepted, while still protecting 1:1 — if the opponent never accepts,
+-- only 1 player is 'done' (< 2), so it waits for the window/cron instead of settling early.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public._match_maybe_settle(p_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_id AND state = 'active')
+     AND (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id AND state = 'done') >= 2 THEN
+    PERFORM public._match_settle(p_id);
+  END IF;
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
**Punch-list #17** (previously deferred; approved with a 1:1-protecting rule).

`_match_maybe_settle` settled only when **no** participant was `active` **or** `invited` — so a group invitee who never accepted blocked early settlement, and the finishers waited out the host's whole window (up to 7 days) for payout.

## Fix
Settle early once **no player is `active`** (everyone who accepted has finished) **AND ≥2 players are `done`** (a real contest happened). This:
- passes over invitees who **never accepted** (they put nothing in), and
- **protects 1:1** — if the opponent never accepts, only 1 player is `done` (< 2), so it waits for the window / pg_cron sweep instead of settling prematurely, and **never cuts off anyone who paid**.

## Verification (BEGIN/ROLLBACK)
- 1:1 money, host done + opponent never accepted → **open** ✅ (protected)
- Group, 2 done + 1 never-accepted → **settled** ✅ (early)
- One player still active → **open** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
