### PR TITLE
Icon.svelte foundation + emoji→icon Wave 1 (sound controls)

### DIFF
--- a/docs/emoji-to-icon-sweep.md
+++ b/docs/emoji-to-icon-sweep.md
@@ -8,57 +8,77 @@ UI surface is smaller. Existing coverage: `ModeIcon` (daily/climb/match/blitz),
 `CategoryIcon` (12 puzzle categories). Power-ups use a `PUP_ICON` map that is currently
 **emoji strings** (needs swapping to icons, not just find/replace).
 
+## Foundation ✅ (Icon.svelte shipped, PR #576 — starter control/sound set)
+
+### original plan:
+
 ## Foundation (do first)
+
 Build a single reusable **`Icon.svelte`** with a named line-icon set (inline SVG, `stroke`
-+ `currentColor`, sized like ModeIcon), so every replacement is `<Icon name="…" />`. Every
-wave below adds the names it needs. ~15–20 new icons need drawing.
+
+- `currentColor`, sized like ModeIcon), so every replacement is `<Icon name="…" />`. Every
+  wave below adds the names it needs. ~15–20 new icons need drawing.
 
 ---
 
 ## Wave 1 — Nav bar + controls + sound (highest visibility; you called these out)
+
+**Progress:** ✅ sound/haptics/music controls done (PR #576). Remaining: other nav/control glyphs.
+
 Standard glyphs, all have clean line-icon equivalents:
+
 - **Controls:** ☰ menu · ❌/⛔/✕ close/cancel · ▶ ◀ play/prev · ↗ ↪ ↩ arrows · ✅/✓ check · ⚙ settings · 🗑 trash · ✏/✍ edit · 🔍 search · ❓/ℹ help/info · 🏠 home · 🎒 vault/bag · 👤/🧑 profile · 🔗 link · 📤/📥 share/import · 🔄/🔁 refresh
 - **Sound/volume (the "sound one"):** 🔊 🔈 🔇 🔆 volume states · 📳 📴 vibrate · 🎵/🎶 music
 - **Lock/security:** 🔒 🔐 🔓 🔑 lock/pin
 
 ## Wave 2 — Money & economy (semantic, heavy use)
+
 Needs **new** line icons (design system has none yet):
+
 - 💰 💵 cash · 💳 card · 🏦 bank · 🏧 overdrive/ATM · 🪙 coin · 💸 out-of-budget ·
   🧾 receipt · 💎 jackpot/gem · 📈 💹 growth · 💱 exchange
 
 ## Wave 3 — Modes, ranks, awards
+
 - Modes: 📅/🗓 daily · ⚔ challenge · 🎰 cash game · 🧗 climb → mostly **ModeIcon already**;
   audit call sites still using the emoji.
 - Ranks/awards (**new icons**): 🏆 winner · 🥇 🥈 🥉 tiers/medals · 🏅 badge · 👑 owner ·
   🎯 objective/target · 🔥 heat/streak
 
 ## Wave 4 — Power-ups, buffs & sabotage (swap PUP_ICON map to icons)
+
 - Buffs: 🛡 heat-shield · 🏧 overdrive · ⏭ free-skip · 🔍 free-reveal · 🅰 free-vowel ·
   🏷 half-off · 👁 vowel-vision · 📖 reveal-word · 💡 hint · 🔚 last-letters · 💥 boost
 - Sabotage/debuffs: 😈 sabotage · 🌫 fog · 🚧 toll · 🚫 vowel-block · 🔒 lock · 💸 tax
 
 ## Wave 5 — Social, alerts, misc
+
 - Social: 👥 groups · 💬 chat · 🤝 friendly/tie · 🙋 request · 👋 hi
 - Alerts: 🚨 danger · ⚠ warning · 💀/😬 bust · 🔔 bell
 
 ## Wave 6 — Decorative flourishes (DECISION: convert or drop?)
+
 Mostly celebration/onboarding sparkle with no functional meaning:
+
 - ✨ 🎉 🎊 🌟 🎁 🧠 🚀 🌋 🩸 🎨 🌍 🖼 🧩 🔮 📣 🎲 🌀 …
 - **Recommendation:** drop most (or replace celebration with a single tasteful confetti/
   spark icon) rather than draw one-off icons for each.
 
 ## Category-puzzle emojis
+
 🍔 🎬 ✈ 🔬 📚 💻 … are puzzle categories — **CategoryIcon already exists**; just route call
 sites through it.
 
 ---
 
 ## Decisions needed
+
 1. **New icons OK?** Waves 2–4 need ~15–20 custom line-icons drawn. Confirm that's the plan
    (vs. keeping a few semantic emojis like 🏆/🔥).
 2. **Decorative (Wave 6):** drop them, or convert to icons? (Recommend drop/minimize.)
 3. **Order:** proposed Wave 1 → 6. Ship each wave as its own PR.
 
 ## Suggested sequencing
+
 Foundation `Icon.svelte` + **Wave 1 (nav/controls/sound)** first — highest visibility,
 lowest risk. Then money → modes/ranks → power-ups → social/alerts → decorative.

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,0 +1,67 @@
+<script>
+	/** Named line icon — see the SVG map below for available names. */
+	export let name = '';
+	/** Pixel size (square). */
+	export let size = 18;
+
+	// Shared line-icon attrs; stroke inherits via currentColor so callers set color.
+	// Matches ModeIcon/CategoryIcon so the whole set reads as one family.
+	const A =
+		'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" ' +
+		'stroke-linecap="round" stroke-linejoin="round" style="width:100%;height:100%" aria-hidden="true"';
+	const DOT = 'fill="currentColor" stroke="none"';
+
+	/** @type {Record<string,string>} */
+	const SVG = {
+		// ── sound / haptics / music ──────────────────────────────────────────────
+		volume: `<svg ${A}><path d="M4 9.5v5h3.5L12 18V6L7.5 9.5z"/><path d="M15.5 9a4 4 0 0 1 0 6"/><path d="M18 6.5a7.5 7.5 0 0 1 0 11"/></svg>`,
+		'volume-low': `<svg ${A}><path d="M4 9.5v5h3.5L12 18V6L7.5 9.5z"/><path d="M15.5 9.5a3.5 3.5 0 0 1 0 5"/></svg>`,
+		mute: `<svg ${A}><path d="M4 9.5v5h3.5L12 18V6L7.5 9.5z"/><path d="M16 9.5l5 5M21 9.5l-5 5"/></svg>`,
+		vibrate: `<svg ${A}><rect x="8.5" y="5" width="7" height="14" rx="1.5"/><path d="M4 9v6M20 9v6"/></svg>`,
+		'vibrate-off': `<svg ${A}><rect x="8.5" y="5" width="7" height="14" rx="1.5"/><path d="M4.5 4.5l15 15"/></svg>`,
+		music: `<svg ${A}><path d="M9 17V5l10-2v12"/><circle cx="6.5" cy="17" r="2.5"/><circle cx="16.5" cy="15" r="2.5"/></svg>`,
+
+		// ── nav / controls ───────────────────────────────────────────────────────
+		menu: `<svg ${A}><path d="M4 7h16M4 12h16M4 17h16"/></svg>`,
+		close: `<svg ${A}><path d="M6 6l12 12M18 6L6 18"/></svg>`,
+		check: `<svg ${A}><polyline points="4 12.5 9.5 18 20 6"/></svg>`,
+		'chevron-left': `<svg ${A}><polyline points="15 6 9 12 15 18"/></svg>`,
+		'chevron-right': `<svg ${A}><polyline points="9 6 15 12 9 18"/></svg>`,
+		play: `<svg ${A}><path d="M8 5.5v13l11-6.5z"/></svg>`,
+		'give-up': `<svg ${A}><path d="M14 4h3a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2h-3"/><polyline points="9 8 5 12 9 16"/><path d="M5 12h10"/></svg>`,
+		settings: `<svg ${A}><circle cx="12" cy="12" r="3.2"/><path d="M12 2.5v3.2M12 18.3v3.2M4.2 7l2.8 1.6M17 15.4l2.8 1.6M4.2 17l2.8-1.6M17 8.6l2.8-1.6"/></svg>`,
+		search: `<svg ${A}><circle cx="11" cy="11" r="6"/><path d="M20 20l-4.3-4.3"/></svg>`,
+		trash: `<svg ${A}><path d="M4 7h16M9.5 7V4.5h5V7M6.5 7l1 12.5h9L17.5 7"/></svg>`,
+		edit: `<svg ${A}><path d="M4 20h4L18.5 9.5l-4-4L4 16z"/><path d="M13.5 6.5l4 4"/></svg>`,
+		bell: `<svg ${A}><path d="M6 16.5V11a6 6 0 0 1 12 0v5.5l1.5 2h-15z"/><path d="M10 21a2 2 0 0 0 4 0"/></svg>`,
+		info: `<svg ${A}><circle cx="12" cy="12" r="9"/><path d="M12 11v5.5"/><circle cx="12" cy="7.8" r="0.7" ${DOT}/></svg>`,
+		help: `<svg ${A}><circle cx="12" cy="12" r="9"/><path d="M9.4 9.6a2.6 2.6 0 1 1 3.6 2.4c-.8.4-1 .9-1 1.7"/><circle cx="12" cy="16.8" r="0.7" ${DOT}/></svg>`,
+		home: `<svg ${A}><path d="M4 11l8-6 8 6"/><path d="M6.5 10v9.5h11V10"/></svg>`,
+		user: `<svg ${A}><circle cx="12" cy="8" r="3.5"/><path d="M5 20c0-3.6 3.1-6 7-6s7 2.4 7 6"/></svg>`,
+		share: `<svg ${A}><path d="M12 15V4.5M8 8l4-4 4 4"/><path d="M6 12v7.5h12V12"/></svg>`,
+		refresh: `<svg ${A}><path d="M4.5 12a7.5 7.5 0 0 1 12.8-5.3L20 9M20 4.5V9h-4.5"/><path d="M19.5 12a7.5 7.5 0 0 1-12.8 5.3L4 15M4 19.5V15h4.5"/></svg>`,
+		link: `<svg ${A}><path d="M10.5 13.5a3.5 3.5 0 0 0 5 .3l2-2a3.5 3.5 0 0 0-5-5l-1 1"/><path d="M13.5 10.5a3.5 3.5 0 0 0-5-.3l-2 2a3.5 3.5 0 0 0 5 5l1-1"/></svg>`,
+		lock: `<svg ${A}><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>`,
+		unlock: `<svg ${A}><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 7.5-2"/></svg>`,
+		key: `<svg ${A}><circle cx="8" cy="15" r="3.4"/><path d="M10.4 12.6L20 3M16.5 6.5l2.2 2.2M14.5 8.5l2 2"/></svg>`
+	};
+
+	$: html = SVG[name] ?? '';
+</script>
+
+{#if html}
+	<!-- SVG strings are hard-coded constants above, never user input. -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	<span class="line-ic" style="width:{size}px;height:{size}px">{@html html}</span>
+{/if}
+
+<style>
+	.line-ic {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		flex: none;
+		line-height: 0;
+		vertical-align: middle;
+	}
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -48,6 +48,7 @@
 	import { CATEGORIES, categoryLabel } from '$lib/categories.js';
 	import CategoryIcon from '$lib/components/CategoryIcon.svelte';
 	import ModeIcon from '$lib/components/ModeIcon.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import {
 		user,
 		userProfile,
@@ -2551,7 +2552,7 @@
 		on:click={() => {
 			fx('tap');
 			showAudio = true;
-		}}>{$soundEnabled || $musicEnabled ? '🔊' : '🔇'}</button
+		}}><Icon name={$soundEnabled || $musicEnabled ? 'volume' : 'mute'} size={18} /></button
 	>
 {/if}
 <!-- 🏳️ Give up (top-right) — Daily / Challenges / Cash Game (forfeit) -->
@@ -2560,7 +2561,7 @@
 		class="giveup-btn"
 		title="Give up"
 		aria-label="Give up"
-		on:click={isClimb ? askForfeit : confirmFold}>↪</button
+		on:click={isClimb ? askForfeit : confirmFold}><Icon name="give-up" size={18} /></button
 	>
 {/if}
 <!-- Skip retired in Cash Game V4 — Cash Out is the graceful bail. -->
@@ -3185,7 +3186,7 @@
 						if ($soundEnabled) fx('select');
 					}}
 				>
-					<span>{$soundEnabled ? '🔊' : '🔇'} Sound</span><span
+					<span><Icon name={$soundEnabled ? 'volume' : 'mute'} size={16} /> Sound</span><span
 						class="ap-state"
 						class:on={$soundEnabled}>{$soundEnabled ? 'On' : 'Off'}</span
 					>
@@ -3197,10 +3198,8 @@
 						if ($hapticsEnabled) fx('tap');
 					}}
 				>
-					<span>{$hapticsEnabled ? '📳' : '📴'} Haptics</span><span
-						class="ap-state"
-						class:on={$hapticsEnabled}>{$hapticsEnabled ? 'On' : 'Off'}</span
-					>
+					<span><Icon name={$hapticsEnabled ? 'vibrate' : 'vibrate-off'} size={16} /> Haptics</span
+					><span class="ap-state" class:on={$hapticsEnabled}>{$hapticsEnabled ? 'On' : 'Off'}</span>
 				</button>
 				<button class="ap-toggle" on:click={toggleMusic}>
 					<span>Music</span><span class="ap-state" class:on={$musicEnabled}
@@ -3210,7 +3209,7 @@
 			</div>
 			{#if $musicEnabled}
 				<div class="ma-music-ctl">
-					<span class="mmc-ic">🔈</span>
+					<span class="mmc-ic"><Icon name="volume-low" size={16} /></span>
 					<input
 						class="mmc-slider"
 						type="range"
@@ -4121,8 +4120,9 @@
 								if ($soundEnabled) fx('select');
 							}}
 						>
-							<span>🔊 Sound</span><span class="set-state" class:on={$soundEnabled}
-								>{$soundEnabled ? 'On' : 'Off'}</span
+							<span><Icon name={$soundEnabled ? 'volume' : 'mute'} size={16} /> Sound</span><span
+								class="set-state"
+								class:on={$soundEnabled}>{$soundEnabled ? 'On' : 'Off'}</span
 							>
 						</button>
 						<button
@@ -4132,7 +4132,9 @@
 								if ($hapticsEnabled) fx('tap');
 							}}
 						>
-							<span>📳 Haptics</span><span class="set-state" class:on={$hapticsEnabled}
+							<span
+								><Icon name={$hapticsEnabled ? 'vibrate' : 'vibrate-off'} size={16} /> Haptics</span
+							><span class="set-state" class:on={$hapticsEnabled}
 								>{$hapticsEnabled ? 'On' : 'Off'}</span
 							>
 						</button>
@@ -4143,7 +4145,7 @@
 						</button>
 						{#if $musicEnabled}
 							<div class="set-row sub">
-								<span class="mmc-ic">🔈</span>
+								<span class="mmc-ic"><Icon name="volume-low" size={16} /></span>
 								<input
 									class="mmc-slider"
 									type="range"


### PR DESCRIPTION
Foundation + first cut of the app-wide emoji → line-icon sweep (plan in `docs/emoji-to-icon-sweep.md`).

## Foundation
New **`Icon.svelte`** — a reusable named line-icon component matching the `ModeIcon`/`CategoryIcon` style (inline SVG, `stroke` + `currentColor`, square-sized). Starter set of ~28 icons: sound/haptics/music + common nav/controls.

## Wave 1 (this PR): sound + give-up
Replaced the emoji glyphs the user called out:
- In-game control bar: sound toggle 🔊/🔇 → `<Icon volume|mute>`, give-up ↪ → `<Icon give-up>`
- Both audio panels: 🔊/🔇 sound, 📳/📴 haptics, 🔈 volume-slider → icons

## Verification
All 28 icons render correctly (confirmed via a throwaway `/_iconpreview` route, since removed). `npm run check` 0 errors · build ✓.

Remaining Wave 1 (other nav/control glyphs) + Waves 2–6 tracked in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
