### PR TITLE
Retire Blitz mode — server removal (completes #26)

### DIFF
--- a/supabase-blitz-removal-server.sql
+++ b/supabase-blitz-removal-server.sql
@@ -1,0 +1,226 @@
+-- ============================================================================
+-- Retire Blitz — server side. Standalone blitz_* RPCs already dropped; this strips the
+-- dead mode='blitz' branches from the shared match engine so no blitz match can exist.
+-- ============================================================================
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.create_match(p_opponent text, p_group_id uuid, p_categories text[], p_pack_size integer, p_wager bigint, p_mode text, p_payout text, p_window_seconds integer, p_items_allowed boolean)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); v_id uuid; v_opp uuid; v_size int; v_wager bigint; v_mode text; v_payout text;
+  v_n int; v_budget bigint; v_cash bigint; v_uids uuid[]; r record;
+begin
+  if v_uid is null then return jsonb_build_object('ok',false,'reason','auth'); end if;
+  v_size := least(greatest(coalesce(p_pack_size,1),1),10);
+  v_wager := greatest(coalesce(p_wager,0),0);
+  if v_wager > 0 and v_wager < 500 then return jsonb_build_object('ok',false,'reason','min_wager'); end if;
+  v_mode := 'standard';  -- Blitz retired; all matches are standard
+  v_payout := case when p_payout = 'podium' then 'podium' else 'winner' end;
+  if p_group_id is not null then
+    if not exists (select 1 from public.group_members where group_id = p_group_id and user_id = v_uid) then
+      return jsonb_build_object('ok',false,'reason','not_member'); end if;
+    select array_agg(user_id) into v_uids from public.group_members where group_id = p_group_id;
+  else
+    select id into v_opp from public.profiles where lower(username) = lower(trim(coalesce(p_opponent,'')));
+    if v_opp is null then return jsonb_build_object('ok',false,'reason','no_opponent'); end if;
+    if v_opp = v_uid then return jsonb_build_object('ok',false,'reason','self'); end if;
+    v_uids := array[v_uid, v_opp];
+  end if;
+  if v_wager > 0 then
+    perform public._ensure_bank(v_uid);
+    select bank into v_cash from public.profiles where id = v_uid;
+    if v_cash < v_wager then return jsonb_build_object('ok',false,'reason','insufficient'); end if;
+    perform public._bank_credit(v_uid, -v_wager, 'wager_stake');
+  end if;
+  insert into public.challenge_matches(host_id, group_id, mode, categories, pack_size, wager, payout, settles_at, items_allowed, econ_v)
+  values (v_uid, p_group_id, v_mode, coalesce(p_categories,'{}'), v_size, v_wager, v_payout, now() + (least(greatest(coalesce(p_window_seconds,172800),3600),604800) || ' seconds')::interval, coalesce(p_items_allowed,false), 2)
+  returning id into v_id;
+  insert into public.challenge_pack(match_id, position, puzzle_id)
+  select v_id, row_number() over (), pid
+  from public._pick_casual_pack(v_uids, coalesce(p_categories,'{}'), v_size, 8) pid;
+  select count(*) into v_n from public.challenge_pack where match_id = v_id;
+  if v_n = 0 then return jsonb_build_object('ok',false,'reason','no_puzzles'); end if;
+  -- NEW: budget = puzzle-1 bounty (standardized), not GREATEST(wager,500).
+  v_budget := public._match_pos_bounty(v_id, 1);
+  insert into public.challenge_participants(match_id, user_id, paid, state, joined_at, bankroll, start_budget, stake)
+  values (v_id, v_uid, v_wager > 0, 'active', now(), v_budget, v_budget, v_wager);
+  perform public._mark_seen_many(v_uid, (select array_agg(puzzle_id) from public.challenge_pack where match_id = v_id));
+  if p_group_id is not null then
+    for r in select user_id from public.group_members where group_id = p_group_id and user_id <> v_uid loop
+      insert into public.challenge_participants(match_id, user_id) values (v_id, r.user_id) on conflict do nothing;
+      perform public._notify(r.user_id, 'challenge_incoming', 'Group challenge',
+        public._display_name(v_uid) || ' challenged your group' || case when v_wager>0 then ' — $' || v_wager else '' end,
+        jsonb_build_object('match_id', v_id));
+    end loop;
+  else
+    insert into public.challenge_participants(match_id, user_id) values (v_id, v_opp);
+    perform public._notify(v_opp, 'challenge_incoming', 'New challenge',
+      public._display_name(v_uid) || ' challenged you — ' || v_n || ' puzzle' || case when v_n=1 then '' else 's' end ||
+      case when v_wager>0 then ' · $' || v_wager else '' end, jsonb_build_object('match_id', v_id, 'route','challenge'));
+  end if;
+  return jsonb_build_object('ok',true, 'match', public.get_match(v_id));
+end; $function$;
+
+CREATE OR REPLACE FUNCTION public.match_start(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; m public.challenge_matches;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_start: not authenticated'; END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid;
+  IF NOT FOUND THEN RAISE EXCEPTION 'match_start: not a participant'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public._match_tick(p_id uuid, p_uid uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN true; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  RETURN false;
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')),
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id)) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN 'fog' = ANY(COALESCE(cp.debuffs,'{}')) THEN NULL ELSE v_clue END);
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public._match_resolve_and_advance(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_phrase TEXT; v_cat TEXT; v_won BOOLEAN;
+  v_score INT; v_combo INT; v_solved INT; v_budget BIGINT; v_next_bounty INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN public._match_board(p_id, p_uid); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_budget := GREATEST(COALESCE(m.wager,0), 500);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cp.revealed_positions)));
+  IF NOT v_won THEN RETURN public._match_board(p_id, p_uid); END IF;
+  PERFORM public._record_category_solve(p_uid, v_cat);            -- NEW: counts toward category badges
+  v_solved := cp.solved + 1;
+  IF m.econ_v = 2 THEN
+    IF cp.position >= m.pack_size THEN
+      UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, state = 'done', joined_at = COALESCE(joined_at, now())
+      WHERE match_id = p_id AND user_id = p_uid;
+      PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+    ELSE
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, position = position + 1,
+        bankroll = v_next_bounty, start_budget = COALESCE(start_budget,0) + v_next_bounty,
+        revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+        p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      WHERE match_id = p_id AND user_id = p_uid;
+    END IF;
+    RETURN public._match_board(p_id, p_uid);
+  END IF;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = bankroll.
+  IF cp.position >= m.pack_size THEN
+    UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+      total_score = cp.bankroll, state = 'done', joined_at = COALESCE(joined_at, now())
+    WHERE match_id = p_id AND user_id = p_uid;
+    PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+  ELSE
+    UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+      total_score = cp.bankroll, position = position + 1,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}', p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+    WHERE match_id = p_id AND user_id = p_uid;
+  END IF;
+  RETURN public._match_board(p_id, p_uid);
+END; $function$;
+
+COMMIT;


### PR DESCRIPTION
Server-side completion of the full Blitz excision (client was #578).

## Dropped (standalone blitz engine — 10 RPCs)
`blitz_start`, `blitz_buy_letter`, `blitz_submit_guess`, `blitz_skip`, `blitz_end`, `get_blitz_meta`, `_blitz_board`, `_blitz_resolve`, `_blitz_settle`, `_blitz_tier`, `get_blitz_leaderboard` — verified no live function references them.

## Stripped `mode='blitz'` from the shared match engine
- **create_match** → `v_mode := 'standard'` (no blitz match can be created)
- **match_start** → removed the blitz `started_at` clock init
- **_match_tick** → removed the blitz timeout-settle (now a no-op for standard)
- **_match_board** → removed the blitz clock/combo `minfo`; simplified the standing gate (`mode <> 'blitz'` → always)
- **_match_resolve_and_advance** → removed the blitz combo-scoring branch

## Verification (BEGIN/ROLLBACK)
Standard `econ_v=2` match: `_match_board` returns a board with **no `clock_seconds`**, `match_start` returns a board, `_match_tick` is a **no-op** (false). All recreated functions compile and the standard path is byte-identical minus the blitz blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
