### PR TITLE
Emoji→icon: achievements (badges, milestones, category tiers)

### DIFF
--- a/docs/emoji-to-icon-sweep.md
+++ b/docs/emoji-to-icon-sweep.md
@@ -66,6 +66,10 @@ Mostly celebration/onboarding sparkle with no functional meaning:
 - **Recommendation:** drop most (or replace celebration with a single tasteful confetti/
   spark icon) rather than draw one-off icons for each.
 
+## Wave 3b — Achievements ✅ (PR #580)
+
+Badges/milestones/collector/category-tiers now render via `<Icon>` (badges.js + categoryBadges.js hold Icon names; BadgesPanel + profile converted). Added icons: calendar, swords, rocket, shark, drop, sprout, bolt, star.
+
 ## Category-puzzle emojis
 
 🍔 🎬 ✈ 🔬 📚 💻 … are puzzle categories — **CategoryIcon already exists**; just route call

--- a/src/lib/badges.js
+++ b/src/lib/badges.js
@@ -1,45 +1,50 @@
 // Achievement badge catalog. Keys match the server's user_badges.badge values.
 // Organized by the unified 5-bucket framework: Progression · Skill · Big-moment · Consistency · Social.
-/** @type {Record<string, { emoji: string, name: string, desc: string }>} */
+// `icon` = Icon.svelte name (rendered via <Icon>).
+/** @type {Record<string, { icon: string, name: string, desc: string }>} */
 export const BADGES = {
-	// 🗓️ Daily
-	flawless: { emoji: '🎯', name: 'Flawless', desc: 'Solved a Daily with zero wrong letters' },
-	streak_7: { emoji: '🔥', name: 'Week Warrior', desc: '7-day Daily play streak' },
-	streak_30: { emoji: '👑', name: 'Iron Will', desc: '30-day Daily play streak' },
-	week_complete: { emoji: '🗓️', name: 'Perfect Week', desc: 'Played every day of a calendar week' },
+	// Daily
+	flawless: { icon: 'target', name: 'Flawless', desc: 'Solved a Daily with zero wrong letters' },
+	streak_7: { icon: 'fire', name: 'Week Warrior', desc: '7-day Daily play streak' },
+	streak_30: { icon: 'crown', name: 'Iron Will', desc: '30-day Daily play streak' },
+	week_complete: {
+		icon: 'calendar',
+		name: 'Perfect Week',
+		desc: 'Played every day of a calendar week'
+	},
 	month_complete: {
-		emoji: '📅',
+		icon: 'calendar',
 		name: 'Perfect Month',
 		desc: 'Played every day of a calendar month'
 	},
 
-	// 🎰 Cash Game
-	cg_bronze: { emoji: '🥉', name: 'Bronze Runner', desc: 'Cashed out a Bronze run' },
-	cg_silver: { emoji: '🥈', name: 'Silver Runner', desc: 'Cashed out a Silver run' },
-	cg_gold: { emoji: '🥇', name: 'Gold Runner', desc: 'Cashed out a Gold run' },
-	cg_run_5: { emoji: '📈', name: 'On a Heater', desc: '5 profitable cash-outs in a row' },
-	cg_multiple_10: { emoji: '🚀', name: 'Ten-Bagger', desc: 'Cashed out 10× your buy-in' },
-	cg_heat_max: { emoji: '🌋', name: 'Max Heat', desc: 'Rode heat to the tier ceiling' },
-	cg_high_roller: { emoji: '💎', name: 'High Roller', desc: 'A $25,000+ cash-out' },
+	// Cash Game
+	cg_bronze: { icon: 'medal', name: 'Bronze Runner', desc: 'Cashed out a Bronze run' },
+	cg_silver: { icon: 'medal', name: 'Silver Runner', desc: 'Cashed out a Silver run' },
+	cg_gold: { icon: 'medal', name: 'Gold Runner', desc: 'Cashed out a Gold run' },
+	cg_run_5: { icon: 'growth', name: 'On a Heater', desc: '5 profitable cash-outs in a row' },
+	cg_multiple_10: { icon: 'rocket', name: 'Ten-Bagger', desc: 'Cashed out 10× your buy-in' },
+	cg_heat_max: { icon: 'fire', name: 'Max Heat', desc: 'Rode heat to the tier ceiling' },
+	cg_high_roller: { icon: 'gem', name: 'High Roller', desc: 'A $25,000+ cash-out' },
 	gold_shark: {
-		emoji: '🦈',
+		icon: 'shark',
 		name: 'Gold Shark',
-		desc: 'Won a Gold Cash Game run — unlocks the 🦈 Gold Shark title'
+		desc: 'Won a Gold Cash Game run — unlocks the Gold Shark title'
 	},
 
-	// ⚔️ Challenges
-	first_blood: { emoji: '🩸', name: 'First Blood', desc: 'Won your first challenge' },
-	gold_duelist: { emoji: '⚔️', name: 'Gold Duelist', desc: 'Won a Gold challenge' },
-	hustler: { emoji: '🤝', name: 'Hustler', desc: 'Won 10 challenges' },
+	// Challenges
+	first_blood: { icon: 'drop', name: 'First Blood', desc: 'Won your first challenge' },
+	gold_duelist: { icon: 'swords', name: 'Gold Duelist', desc: 'Won a Gold challenge' },
+	hustler: { icon: 'handshake', name: 'Hustler', desc: 'Won 10 challenges' },
 
-	// 💸 Economy
-	paid_in_full: { emoji: '🧾', name: 'Paid in Full', desc: 'Cleared a loan from the Shark' },
-	credit_700: { emoji: '💳', name: '700 Club', desc: 'Reached a 700 credit score' },
-	credit_800: { emoji: '🏦', name: '800 Club', desc: 'Reached an 800 credit score' },
-	credit_850: { emoji: '💎', name: 'Perfect 850', desc: 'Hit a perfect 850 credit score' }
+	// Economy
+	paid_in_full: { icon: 'receipt', name: 'Paid in Full', desc: 'Cleared a loan from the Shark' },
+	credit_700: { icon: 'card', name: '700 Club', desc: 'Reached a 700 credit score' },
+	credit_800: { icon: 'bank', name: '800 Club', desc: 'Reached an 800 credit score' },
+	credit_850: { icon: 'gem', name: 'Perfect 850', desc: 'Hit a perfect 850 credit score' }
 };
 
 /** @param {string} id */
 export function badgeInfo(id) {
-	return BADGES[id] || { emoji: '🏅', name: id, desc: '' };
+	return BADGES[id] || { icon: 'badge', name: id, desc: '' };
 }

--- a/src/lib/categoryBadges.js
+++ b/src/lib/categoryBadges.js
@@ -1,11 +1,12 @@
 // Per-category level-up badges (from category_stats.solves) + global milestones.
 
 /** Ascending tiers — a category badge levels up as you solve more in it. */
+// icon = Icon.svelte name (rendered via <Icon>).
 export const CATEGORY_TIERS = [
-	{ key: 'bronze', name: 'Bronze', medal: '🥉', at: 3 },
-	{ key: 'silver', name: 'Silver', medal: '🥈', at: 10 },
-	{ key: 'gold', name: 'Gold', medal: '🥇', at: 25 },
-	{ key: 'diamond', name: 'Diamond', medal: '💎', at: 60 }
+	{ key: 'bronze', name: 'Bronze', icon: 'medal', at: 3 },
+	{ key: 'silver', name: 'Silver', icon: 'medal', at: 10 },
+	{ key: 'gold', name: 'Gold', icon: 'medal', at: 25 },
+	{ key: 'diamond', name: 'Diamond', icon: 'gem', at: 60 }
 ];
 
 /**
@@ -29,16 +30,16 @@ export function categoryProgress(solves) {
 
 /** Global "total puzzles solved" milestone achievements (any mode). */
 export const SOLVE_MILESTONES = [
-	{ id: 'm10', emoji: '🌱', name: 'Getting Started', at: 10, desc: 'Solve 10 puzzles' },
-	{ id: 'm50', emoji: '✍️', name: 'Wordsmith', at: 50, desc: 'Solve 50 puzzles' },
-	{ id: 'm150', emoji: '⚡', name: 'Phrase Fiend', at: 150, desc: 'Solve 150 puzzles' },
-	{ id: 'm500', emoji: '🧙', name: 'Word Wizard', at: 500, desc: 'Solve 500 puzzles' }
+	{ id: 'm10', icon: 'sprout', name: 'Getting Started', at: 10, desc: 'Solve 10 puzzles' },
+	{ id: 'm50', icon: 'edit', name: 'Wordsmith', at: 50, desc: 'Solve 50 puzzles' },
+	{ id: 'm150', icon: 'bolt', name: 'Phrase Fiend', at: 150, desc: 'Solve 150 puzzles' },
+	{ id: 'm500', icon: 'star', name: 'Word Wizard', at: 500, desc: 'Solve 500 puzzles' }
 ];
 
 /** A standalone achievement for earning Gold in every category. */
 export const COLLECTOR = {
 	id: 'collector',
-	emoji: '🏅',
+	icon: 'badge',
 	name: 'Collector',
 	desc: 'Reach Gold in all 12 categories'
 };

--- a/src/lib/components/BadgesPanel.svelte
+++ b/src/lib/components/BadgesPanel.svelte
@@ -10,6 +10,7 @@
 		COLLECTOR
 	} from '$lib/categoryBadges.js';
 	import { BADGES, badgeInfo } from '$lib/badges.js';
+	import Icon from '$lib/components/Icon.svelte';
 	import { fx } from '$lib/sound.js';
 
 	/** @type {{category: string, solves: number}[]} */
@@ -122,7 +123,7 @@
 		})),
 		...SOLVE_MILESTONES.map((m) => ({
 			id: m.id,
-			emoji: m.emoji,
+			icon: m.icon,
 			name: m.name,
 			desc: m.desc,
 			earned: total >= m.at,
@@ -132,7 +133,7 @@
 		})),
 		{
 			id: 'collector',
-			emoji: COLLECTOR.emoji,
+			icon: COLLECTOR.icon,
 			name: COLLECTOR.name,
 			desc: COLLECTOR.desc,
 			earned: goldCount >= 12,
@@ -164,7 +165,7 @@
 				cands.push({
 					remaining: n,
 					label: `${n} more ${n === 1 ? 'solve' : 'solves'}`,
-					target: `${m.emoji} ${m.name}`
+					target: m.name
 				});
 			}
 		}
@@ -173,7 +174,7 @@
 			cands.push({
 				remaining: n,
 				label: `${n} more Gold categor${n === 1 ? 'y' : 'ies'}`,
-				target: `${COLLECTOR.emoji} ${COLLECTOR.name}`
+				target: COLLECTOR.name
 			});
 		}
 		for (const r of rows) {
@@ -182,7 +183,7 @@
 				cands.push({
 					remaining: n,
 					label: `${n} more ${r.label} solve${n === 1 ? '' : 's'}`,
-					target: `${r.next.medal} ${r.next.name}`
+					target: r.next.name
 				});
 			}
 		}
@@ -214,7 +215,10 @@
 			{total === 1 ? 'puzzle' : 'puzzles'} solved · {rankedCats}/{rows.length} categories ranked
 		</div>
 		{#if closest}
-			<div class="bp-nudge">🎯 {closest.label} → <b>{closest.target}</b></div>
+			<div class="bp-nudge">
+				<Icon name="target" size={15} />
+				{closest.label} → <b>{closest.target}</b>
+			</div>
 		{/if}
 	</div>
 
@@ -254,12 +258,13 @@
 							/>
 						</svg>
 						<span class="ring-emoji"><CategoryIcon category={r.value} size={24} /></span>
-						{#if r.current}<span class="ring-medal">{r.current.medal}</span>{/if}
+						{#if r.current}<span class="ring-medal"><Icon name={r.current.icon} size={18} /></span
+							>{/if}
 					</div>
 					<div class="cat-name">{r.label}</div>
 					<div class="cat-sub">
 						{#if r.next}
-							{r.toNext} → {r.next.medal}
+							{r.toNext} → {r.next.name}
 						{:else}
 							💎 Maxed · {r.solves}
 						{/if}
@@ -289,7 +294,7 @@
 							}
 						}}
 					>
-						<span class="ach-emoji">{a.emoji}</span>
+						<span class="ach-emoji"><Icon name={a.icon} size={26} /></span>
 						<span class="ach-name">{a.name}</span>
 						<span class="ach-desc">{a.desc}</span>
 						{#if a.progText && !a.earned}
@@ -341,7 +346,7 @@
 				{#each CATEGORY_TIERS as t}
 					{@const got = detail.solves >= t.at}
 					<div class="cd-tier" class:got>
-						<span class="cd-medal">{t.medal}</span>
+						<span class="cd-medal"><Icon name={t.icon} size={24} /></span>
 						<span class="cd-tname">{t.name}</span>
 						<span class="cd-treq"
 							>{#if got}✓ Unlocked{:else}{t.at - detail.solves} more{/if}</span
@@ -359,7 +364,9 @@
 		<button class="cd-backdrop" aria-label="Close" onclick={() => (achDetail = null)}></button>
 		<div class="cd-card" role="dialog" aria-modal="true">
 			<button class="cd-x" onclick={() => (achDetail = null)} aria-label="Close">✕</button>
-			<div class="cd-emoji" class:ad-dim={!achDetail.earned}>{achDetail.emoji}</div>
+			<div class="cd-emoji" class:ad-dim={!achDetail.earned}>
+				<Icon name={achDetail.icon} size={40} />
+			</div>
 			<h3 class="cd-name">{achDetail.name}</h3>
 			<p class="cd-solves">{achDetail.desc}</p>
 			{#if achDetail.earned}

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -91,7 +91,17 @@
 		skull: `<svg ${A}><path d="M5.5 12.5a6.5 6.5 0 1 1 13 0v2.8l-1.5 1v2.4h-10v-2.4l-1.5-1z"/><circle cx="9.5" cy="12.5" r="1.4" ${DOT}/><circle cx="14.5" cy="12.5" r="1.4" ${DOT}/></svg>`,
 		'external-link': `<svg ${A}><path d="M14 5h5v5M19 5l-8.5 8.5"/><path d="M17 13.5V18a1.5 1.5 0 0 1-1.5 1.5H6A1.5 1.5 0 0 1 4.5 18V8.5A1.5 1.5 0 0 1 6 7h4.5"/></svg>`,
 		timer: `<svg ${A}><circle cx="12" cy="13.5" r="7.5"/><path d="M12 13.5V9M9.5 2.5h5M18.5 6.5l1.5-1.5"/></svg>`,
-		door: `<svg ${A}><path d="M6 20h12M8 20V4h8v16"/><circle cx="13.5" cy="12" r="0.9" ${DOT}/></svg>`
+		door: `<svg ${A}><path d="M6 20h12M8 20V4h8v16"/><circle cx="13.5" cy="12" r="0.9" ${DOT}/></svg>`,
+
+		// ── achievements / misc ─────────────────────────────────────────────────
+		calendar: `<svg ${A}><rect x="3.5" y="5" width="17" height="15" rx="2"/><path d="M3.5 9.5h17M8 3v4M16 3v4"/></svg>`,
+		swords: `<svg ${A}><polyline points="14.5 17.5 3 6 3 3 6 3 17.5 14.5"/><line x1="13" y1="19" x2="19" y2="13"/><line x1="16" y1="16" x2="20" y2="20"/><polyline points="14.5 6.5 18 3 21 3 21 6 17.5 9.5"/><line x1="5" y1="14" x2="9" y2="18"/><line x1="7" y1="17" x2="4" y2="20"/></svg>`,
+		rocket: `<svg ${A}><path d="M12 3c3 1.4 5 4.5 5 8.5L14 15h-4l-3-3.5C7 7.5 9 4.4 12 3z"/><circle cx="12" cy="10" r="1.6"/><path d="M9.5 15l-2.5 4.5M14.5 15l2.5 4.5M10 19.5h4"/></svg>`,
+		shark: `<svg ${A}><path d="M14 17c-.5-5 2.5-9.5 6.5-11.5-1 4.3-1.3 8.4-2.5 11.5"/><path d="M3 18.5c2.6 0 3.6-1.2 6-1.2s3.4 1.2 6 1.2 3-1 3-1"/></svg>`,
+		drop: `<svg ${A}><path d="M12 3.2c3 4 5 6.6 5 9.8a5 5 0 0 1-10 0c0-3.2 2-5.8 5-9.8z"/></svg>`,
+		sprout: `<svg ${A}><path d="M12 20.5V12"/><path d="M12 13c0-3-2.2-5-5.2-5 0 3 2.2 5 5.2 5z"/><path d="M12 11c0-2.6 2.2-4.6 5.2-4.6 0 2.6-2.2 4.6-5.2 4.6z"/></svg>`,
+		bolt: `<svg ${A}><path d="M13 2 5 13.5h6l-1 8.5 8.5-11.5H12z"/></svg>`,
+		star: `<svg ${A}><path d="M12 3.5l2.7 5.4 6 .9-4.3 4.2 1 6-5.4-2.8-5.4 2.8 1-6L5.3 9.8l6-.9z"/></svg>`
 	};
 
 	$: html = SVG[name] ?? '';

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/stores';
 	import { getProfileDetail, getMyAvatar, getUserBadges } from '$lib/stores/statsStore.js';
 	import { badgeInfo } from '$lib/badges.js';
+	import Icon from '$lib/components/Icon.svelte';
 	import Avatar from '$lib/components/Avatar.svelte';
 	import InventoryList from '$lib/components/InventoryList.svelte';
 	import NotificationsPanel from '$lib/components/NotificationsPanel.svelte';
@@ -243,8 +244,8 @@
 						<button
 							class="ov-badge-tile"
 							title={bdg.name}
-							onclick={() => (statInfo = { title: `${bdg.emoji} ${bdg.name}`, desc: bdg.desc })}
-							>{bdg.emoji}</button
+							onclick={() => (statInfo = { title: bdg.name, desc: bdg.desc })}
+							><Icon name={bdg.icon} size={24} /></button
 						>
 					{/each}
 				</div>


### PR DESCRIPTION
Continues the emoji → line-icon sweep — this wave converts the **achievements** (you noticed they hadn't been updated).

## What changed
- **badges.js** — `BADGES` now carry an `icon` (Icon.svelte name) instead of `emoji`: target, fire, crown, calendar, medal, growth, rocket, gem, shark, drop, swords, handshake, receipt, card, bank. `badgeInfo` fallback → `badge`.
- **categoryBadges.js** — `SOLVE_MILESTONES` (sprout / edit / bolt / star), `COLLECTOR` (badge), and `CATEGORY_TIERS` (medal / gem) carry `icon`.
- **BadgesPanel** — every badge/medal render site + the "N more → Badge" nudge use `<Icon>`; the text nudges drop the leading emoji.
- **profile** — earned-badge tiles render `<Icon>`.
- **Icon.svelte** — added 8 icons: calendar, swords, rocket, shark, drop, sprout, bolt, star (all verified via a throwaway preview route).

## Verification
`npm run check` 0 errors · lint clean · build ✓.

Remaining sweep (tracked in `docs/emoji-to-icon-sweep.md`): in-game vault/hotbar, money/rank one-offs in `+page.svelte`, section headers, and the Wave-6 decoratives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
