### PR TITLE
Emoji→icon: Community, Store, leaderboards & loans

### DIFF
--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -18,6 +18,7 @@
 		getGroupStandings
 	} from '$lib/stores/statsStore.js';
 	import { requireConfirm } from '$lib/confirm.js';
+	import Icon from '$lib/components/Icon.svelte';
 	import { supabase } from '$lib/supabaseClient.js';
 
 	/** Optional: list-view back button (e.g. the route's "← Menu"). Hidden if absent.
@@ -344,7 +345,9 @@
 						{#each open.members as m}
 							<tr class={m.is_me ? 'me-row' : (m.rank ?? 0) <= 3 ? 'top-three' : ''}>
 								<td class="rank"
-									>{#if m.rank === 1}🥇{:else if m.rank === 2}🥈{:else if m.rank === 3}🥉{:else}{m.rank}{/if}</td
+									>{#if m.rank >= 1 && m.rank <= 3}<span class="rk-medal rk-{m.rank}"
+											><Icon name="medal" size={16} /></span
+										>{:else}{m.rank}{/if}</td
 								>
 								<td class="name"
 									>{#if m.is_me}<span style={m.color ? `color:${m.color}` : ''}>You</span
@@ -390,7 +393,9 @@
 						{#each standings.members as m, i}
 							<tr class={m.is_me ? 'me-row' : i < 3 && m.wins > 0 ? 'top-three' : ''}>
 								<td class="rank"
-									>{#if i === 0 && m.wins > 0}🏆{:else}{i + 1}{/if}</td
+									>{#if i === 0 && m.wins > 0}<span class="rk-medal rk-1"
+											><Icon name="trophy" size={16} /></span
+										>{:else}{i + 1}{/if}</td
 								>
 								<td class="name">{m.is_me ? 'You' : m.name}</td>
 								<td class="score-cell">{m.wins}</td>
@@ -407,7 +412,10 @@
 					{#each standings.recent as r}
 						<div class="recent-row">
 							<span class="r-win"
-								>{#if r.winner}🏆 @{r.winner}{:else}🤝 Tie · no winner{/if}</span
+								>{#if r.winner}<Icon name="trophy" size={14} /> @{r.winner}{:else}<Icon
+										name="handshake"
+										size={14}
+									/> Tie · no winner{/if}</span
 							>
 							<span class="r-meta"
 								>{r.players} players · {r.pack_size} puzzle{r.pack_size === 1
@@ -477,7 +485,7 @@
 		{/if}
 
 		<div class="chat">
-			<h2 class="chat-title">💬 Chat</h2>
+			<h2 class="chat-title"><Icon name="chat" size={18} /> Chat</h2>
 			<div class="chat-msgs" bind:this={chatScroll}>
 				{#if messages.length}
 					{#each messages as m}
@@ -876,6 +884,19 @@
 	}
 	td.rank {
 		width: 36px;
+	}
+	.rk-medal {
+		display: inline-flex;
+		vertical-align: middle;
+	}
+	.rk-1 {
+		color: #fbbf24;
+	}
+	.rk-2 {
+		color: #cbd5e1;
+	}
+	.rk-3 {
+		color: #d19a66;
 	}
 	td.name {
 		font-weight: 600;

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -44,6 +44,8 @@
 		lock: `<svg ${A}><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg>`,
 		unlock: `<svg ${A}><rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 7.5-2"/></svg>`,
 		key: `<svg ${A}><circle cx="8" cy="15" r="3.4"/><path d="M10.4 12.6L20 3M16.5 6.5l2.2 2.2M14.5 8.5l2 2"/></svg>`,
+		bag: `<svg ${A}><path d="M5.5 8h13l-1 11.5a1.5 1.5 0 0 1-1.5 1.4H8a1.5 1.5 0 0 1-1.5-1.4L5.5 8z"/><path d="M9 8.5V6.8a3 3 0 0 1 6 0v1.7"/></svg>`,
+		globe: `<svg ${A}><circle cx="12" cy="12" r="8.5"/><path d="M3.6 12h16.8M12 3.5c2.6 2.4 2.6 14.6 0 17M12 3.5c-2.6 2.4-2.6 14.6 0 17"/></svg>`,
 
 		// ── money / economy ─────────────────────────────────────────────────────
 		cash: `<svg ${A}><rect x="3" y="6.5" width="18" height="11" rx="2"/><circle cx="12" cy="12" r="2.6"/><path d="M6.5 9.5v5M17.5 9.5v5"/></svg>`,

--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -3,6 +3,7 @@
 	// scope dropdown: Everyone · Friends · a specific group.
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import Icon from '$lib/components/Icon.svelte';
 	import {
 		getDailyBoard,
 		getClimbLeaderboard,
@@ -157,10 +158,6 @@
 		void board;
 		load();
 	});
-
-	/** @param {number} rank */
-	const medal = (rank) =>
-		rank === 1 ? '🥇' : rank === 2 ? '🥈' : rank === 3 ? '🥉' : String(rank);
 </script>
 
 <!-- Game-type tabs -->
@@ -179,16 +176,17 @@
 <!-- Scope: Everyone · Friends · a specific group -->
 <div class="filters">
 	<select class="filter-select" bind:value={scope}>
-		<option value="global">🌍 Everyone</option>
-		<option value="friends">👋 Friends</option>
-		{#each groups as g}<option value={g.id}>👥 {g.name}</option>{/each}
+		<option value="global">Everyone</option>
+		<option value="friends">Friends</option>
+		{#each groups as g}<option value={g.id}>{g.name}</option>{/each}
 	</select>
 </div>
 
 <!-- ⓘ Column key: explains what each column on the current board means. -->
 <div class="lb-key-row">
 	<button class="lb-key-toggle" onclick={() => (showKey = !showKey)}>
-		{showKey ? '✕ Close key' : 'ⓘ What do these mean?'}
+		{#if showKey}<Icon name="close" size={13} /> Close key{:else}<Icon name="info" size={13} /> What
+			do these mean?{/if}
 	</button>
 </div>
 {#if showKey}
@@ -221,7 +219,11 @@
 			<tbody>
 				{#each rows as r}
 					<tr class={r.is_me ? 'me' : r.rank <= 3 ? 'top' : ''}>
-						<td class="rank">{medal(r.rank)}</td>
+						<td class="rank"
+							>{#if r.rank >= 1 && r.rank <= 3}<span class="rk-{r.rank}"
+									><Icon name="medal" size={15} /></span
+								>{:else}{r.rank}{/if}</td
+						>
 						<td class="name">
 							{#if r.is_me}
 								<button
@@ -310,7 +312,11 @@
 			<tbody>
 				{#each sortedRows as r}
 					<tr class={r.is_me ? 'me' : r._place <= 3 ? 'top' : ''}>
-						<td class="rank">{medal(r._place)}</td>
+						<td class="rank"
+							>{#if r._place >= 1 && r._place <= 3}<span class="rk-{r._place}"
+									><Icon name="medal" size={15} /></span
+								>{:else}{r._place}{/if}</td
+						>
 						<td class="name">
 							{#if r.is_me}
 								<button
@@ -471,6 +477,15 @@
 	td.rank {
 		width: 30px;
 		padding-left: 0.5rem;
+	}
+	td.rank .rk-1 {
+		color: #fbbf24;
+	}
+	td.rank .rk-2 {
+		color: #cbd5e1;
+	}
+	td.rank .rk-3 {
+		color: #d19a66;
 	}
 	td.name {
 		font-weight: 600;

--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -4,6 +4,7 @@
 	import { requirePin } from '$lib/pinConfirm.js';
 	import { track } from '$lib/analytics.js';
 	import { fx } from '$lib/sound.js';
+	import Icon from '$lib/components/Icon.svelte';
 
 	/** The get_bank payload (loan detail added in loans-v3)
 	 * @type {{ bank:number, net_worth:number, loan:number, loan_cap:number, in_the_red:boolean,
@@ -152,8 +153,8 @@
 			<span class="loan-owed">{fmt(owed)}</span>
 		</div>
 		<div class="loan-facts">
-			<span>📈 {activeRatePct}%/day</span>
-			<span>⏳ {loanDays}d out</span>
+			<span><Icon name="growth" size={13} /> {activeRatePct}%/day</span>
+			<span><Icon name="timer" size={13} /> {loanDays}d out</span>
 			<span>→ {fmt(owedTomorrow)} tomorrow</span>
 		</div>
 		<p class="loan-note">
@@ -272,12 +273,19 @@
 				<div class="la-spinner" aria-hidden="true"></div>
 				<div class="la-title">Reviewing your application…</div>
 				<ul class="la-checks">
-					{#if applyStep >= 1}<li>✓ Credit — {creditScore} {creditTier}</li>{/if}
-					{#if applyStep >= 2}<li>✓ Limit — up to {fmt(loanCap)}</li>{/if}
-					{#if applyStep >= 3}<li>✓ Amount — {fmt(borrowAmt)}</li>{/if}
+					{#if applyStep >= 1}<li>
+							<Icon name="check" size={13} /> Credit — {creditScore}
+							{creditTier}
+						</li>{/if}
+					{#if applyStep >= 2}<li>
+							<Icon name="check" size={13} /> Limit — up to {fmt(loanCap)}
+						</li>{/if}
+					{#if applyStep >= 3}<li>
+							<Icon name="check" size={13} /> Amount — {fmt(borrowAmt)}
+						</li>{/if}
 				</ul>
 			{:else if applyState === 'approved'}
-				<div class="la-verdict ok">✓ Approved</div>
+				<div class="la-verdict ok"><Icon name="check" size={20} /> Approved</div>
 				<div class="la-sub">
 					{fmt(applyResult?.borrowed ?? borrowAmt)} deposited to your account.
 				</div>
@@ -287,7 +295,7 @@
 				</div>
 				<button class="loan-btn borrow la-btn" on:click={closeApply}>Done</button>
 			{:else}
-				<div class="la-verdict no">✗ Not Approved</div>
+				<div class="la-verdict no"><Icon name="close" size={20} /> Not Approved</div>
 				<div class="la-sub">{declineReason}</div>
 				<button class="loan-btn ghost la-btn" on:click={closeApply}>Close</button>
 			{/if}

--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
+	import Icon from '$lib/components/Icon.svelte';
 
 	/** @type {any} */
 	export let detail = null; // get_match_detail() result, or { loading:true }
@@ -14,8 +15,6 @@
 	$: noSolve = parts.length > 0 && parts.every((/** @type {any} */ p) => (p.solved ?? 0) === 0);
 	$: title = detail?.group_name || (opp ? '@' + (opp.name || 'player') : 'Challenge');
 	$: wagered = Number(m?.wager) > 0;
-	const rankIcon = (/** @type {number} */ r) =>
-		r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
 	const money = (/** @type {any} */ n) =>
 		(Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
 	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '');
@@ -64,11 +63,17 @@
 	>
 		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions a11y_no_noninteractive_element_interactions a11y_no_noninteractive_tabindex -->
 		<div class="md" role="dialog" tabindex="0" on:click|stopPropagation on:keydown={() => {}}>
-			<button class="md-x" on:click={close}>✕</button>
+			<button class="md-x" on:click={close}><Icon name="close" size={16} /></button>
 			{#if detail.loading}
 				<p class="md-msg">Loading…</p>
 			{:else}
-				<h2 class="md-title">{noSolve ? '🤝' : '⚔️'} {title}</h2>
+				<h2 class="md-title">
+					{#if noSolve}<Icon name="handshake" size={18} />{:else}<Icon
+							name="swords"
+							size={18}
+						/>{/if}
+					{title}
+				</h2>
 				<p class="md-sub">
 					{m?.pack_size} puzzle{m?.pack_size === 1 ? '' : 's'}
 					· {m?.payout === 'podium' ? 'podium 3·2·1' : 'winner-take-all'}
@@ -88,13 +93,20 @@
 				{/if}
 
 				{#if tieback}
-					<p class="md-tieback">🎯 {tieback}</p>
+					<p class="md-tieback"><Icon name="target" size={14} /> {tieback}</p>
 				{/if}
 
 				<div class="md-standings">
 					{#each parts as p}
 						<div class="md-row" class:me={p.is_me}>
-							<span class="md-rank">{noSolve ? '🤝' : rankIcon(p.rank)}</span>
+							<span class="md-rank"
+								>{#if noSolve}<Icon
+										name="handshake"
+										size={16}
+									/>{:else if p.rank >= 1 && p.rank <= 3}<span class="rk-{p.rank}"
+										><Icon name="medal" size={16} /></span
+									>{:else}#{p.rank}{/if}</span
+							>
 							<span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
 							<span class="md-meta">
 								{#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null}
@@ -116,7 +128,7 @@
 								<span class="md-pos">{pk.position}</span>
 								<span class="md-cat">{pk.category}</span>
 								<span class="md-ans"
-									>{pk.phrase ? '“' + pk.phrase + '”' : '🔒 hidden until settled'}</span
+									>{#if pk.phrase}“{pk.phrase}”{:else}<Icon name="lock" size={13} /> hidden until settled{/if}</span
 								>
 							</div>
 						{/each}
@@ -247,6 +259,15 @@
 	.md-rank {
 		flex: 0 0 28px;
 		font-weight: 700;
+	}
+	.md-rank .rk-1 {
+		color: #fbbf24;
+	}
+	.md-rank .rk-2 {
+		color: #cbd5e1;
+	}
+	.md-rank .rk-3 {
+		color: #d19a66;
 	}
 	.md-name {
 		flex: 1;

--- a/src/lib/components/StandingStrip.svelte
+++ b/src/lib/components/StandingStrip.svelte
@@ -3,6 +3,7 @@
 	// spend to beat) + a lead celebration. The money (left to spend + bar) lives in the
 	// top bankroll bar now. Hidden until at least one rival has finished.
 	import { fx } from '$lib/sound.js';
+	import Icon from '$lib/components/Icon.svelte';
 
 	/** @type {{ field_size:number, finished:number, rank:number, state:'lead'|'behind'|'tied'|'first_to_play', provisional?:boolean } | null} */
 	export let standing = null;
@@ -20,8 +21,6 @@
 			v = n % 100;
 		return n + (s[(v - 20) % 10] || s[v] || s[0]);
 	};
-	const medal = (/** @type {number} */ r) =>
-		r === 1 ? '🥇' : r === 2 ? '🥈' : r === 3 ? '🥉' : '#' + r;
 	$: ranked = !!standing && standing.state !== 'first_to_play';
 </script>
 
@@ -29,12 +28,16 @@
 	{#key standing.state}
 		<div class="standing {standing.state}">
 			<span class="rank"
-				>{medal(standing.rank)}
+				>{#if standing.rank >= 1 && standing.rank <= 3}<span class="rk-{standing.rank}"
+						><Icon name="medal" size={15} /></span
+					>{/if}
 				{ord(standing.rank)} of {standing.field_size}{#if standing.provisional}<span class="sofar"
 						>so far</span
 					>{/if}</span
 			>
-			{#if standing.state === 'lead'}<span class="lead-badge">✓ In the lead</span>{/if}
+			{#if standing.state === 'lead'}<span class="lead-badge"
+					><Icon name="check" size={13} /> In the lead</span
+				>{/if}
 		</div>
 	{/key}
 {/if}
@@ -66,6 +69,15 @@
 			transform: scale(1);
 			opacity: 1;
 		}
+	}
+	.rk-1 {
+		color: #fbbf24;
+	}
+	.rk-2 {
+		color: #cbd5e1;
+	}
+	.rk-3 {
+		color: #d19a66;
 	}
 	.sofar {
 		margin-left: 6px;

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -436,7 +436,7 @@ function reconcileClimbBoard(board, wrong = false) {
 	} else if (board.shielded) {
 		// 🛡️ Heat Shield turned a would-be bust into a fresh puzzle (Payout + interest kept).
 		fx('multiplier');
-		flashTwistCue('🛡️ Heat Shield · saved your run!');
+		flashTwistCue('Heat Shield · saved your run!');
 	} else playMoveCue(prev, board);
 }
 

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -147,8 +147,8 @@
 	<PageNav back={backTo} showHome={false} />
 
 	<div class="head">
-		<h1>🛍️ Store</h1>
-		<span class="bank-chip">💰 ${bank.toLocaleString()}</span>
+		<h1><Icon name="bag" size={22} /> Store</h1>
+		<span class="bank-chip"><Icon name="cash" size={16} /> ${bank.toLocaleString()}</span>
 	</div>
 	<p class="sub">Power-ups for the Cash Game &amp; challenges, plus cosmetics.</p>
 
@@ -157,13 +157,13 @@
 	{:else if loan > 0}
 		<!-- 🔒 Store locked while you owe — no buying anything until the loan is paid off. -->
 		<div class="locked">
-			<div class="locked-ic">🔒</div>
+			<div class="locked-ic"><Icon name="lock" size={30} /></div>
 			<h2>Store locked</h2>
 			<p class="locked-msg">
 				You owe <b>${loan.toLocaleString()}</b> on a loan. The Store stays closed until it's paid off
 				— no cosmetics, power-ups, or boosts.
 			</p>
-			<a class="pay-btn" href="/loans">🦈 Pay off loan →</a>
+			<a class="pay-btn" href="/loans"><Icon name="shark" size={16} /> Pay off loan →</a>
 			<p class="locked-sub">
 				Solve the Daily or a Cash Game to earn — half of every deposit auto-pays your loan down.
 			</p>
@@ -173,13 +173,13 @@
 
 		{#key inventoryKey}
 			<details class="inv-details">
-				<summary class="inv-summary">🎒 What you own</summary>
+				<summary class="inv-summary"><Icon name="bag" size={16} /> What you own</summary>
 				<InventoryList />
 			</details>
 		{/key}
 
 		{#if dboost.length}
-			<h2 class="section">💥 Interest Boosts</h2>
+			<h2 class="section"><Icon name="boost" size={18} /> Interest Boosts</h2>
 			<p class="section-note">
 				Stock up, then tap one in before you solve the Daily to add Interest to your deposit — they
 				stack (carry up to 5 of each).
@@ -194,14 +194,16 @@
 						>
 						<span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
 						{#if item.owned >= 5}
-							<button class="c-btn equip on" disabled>✓ Maxed (5)</button>
+							<button class="c-btn equip on" disabled
+								><Icon name="check" size={14} /> Maxed (5)</button
+							>
 						{:else}
 							<button
 								class="c-btn buy"
 								disabled={busy === item.id || bank < item.price}
 								onclick={() => buyPup(item)}
 							>
-								💰 ${item.price.toLocaleString()}
+								<Icon name="cash" size={14} /> ${item.price.toLocaleString()}
 							</button>
 						{/if}
 					</div>
@@ -209,7 +211,7 @@
 			</div>
 		{/if}
 
-		<h2 class="section">⚡ Power-ups</h2>
+		<h2 class="section"><Icon name="bolt" size={18} /> Power-ups</h2>
 		<div class="grid">
 			{#each pups as item}
 				<div class="card pup" class:owned={item.owned > 0}>
@@ -217,14 +219,16 @@
 					<span class="c-label">{item.name}</span>
 					<span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
 					{#if item.owned > 0}
-						<button class="c-btn equip on" disabled>✓ In your bag</button>
+						<button class="c-btn equip on" disabled
+							><Icon name="check" size={14} /> In your bag</button
+						>
 					{:else}
 						<button
 							class="c-btn buy"
 							disabled={busy === item.id || bank < item.price}
 							onclick={() => buyPup(item)}
 						>
-							💰 ${item.price.toLocaleString()}
+							<Icon name="cash" size={14} /> ${item.price.toLocaleString()}
 						</button>
 					{/if}
 				</div>
@@ -232,7 +236,7 @@
 		</div>
 
 		{#if sabs.length}
-			<h2 class="section">😈 Sabotage</h2>
+			<h2 class="section"><Icon name="sabotage" size={18} /> Sabotage</h2>
 			<p class="section-note">
 				Bring these to a challenge with power-ups on, then hit an opponent — they get notified.
 			</p>
@@ -245,14 +249,16 @@
 						<span class="c-label">{item.name}</span>
 						<span class="pup-desc">{PUP_META[item.id]?.desc ?? ''}</span>
 						{#if item.owned > 0}
-							<button class="c-btn equip on" disabled>✓ In your bag</button>
+							<button class="c-btn equip on" disabled
+								><Icon name="check" size={14} /> In your bag</button
+							>
 						{:else}
 							<button
 								class="c-btn buy"
 								disabled={busy === item.id || bank < item.price}
 								onclick={() => buyPup(item)}
 							>
-								💰 ${item.price.toLocaleString()}
+								<Icon name="cash" size={14} /> ${item.price.toLocaleString()}
 							</button>
 						{/if}
 					</div>
@@ -272,7 +278,7 @@
 							disabled={busy === item.id}
 							onclick={() => equip(item)}
 						>
-							{item.equipped ? '✓ Equipped' : 'Equip'}
+							{#if item.equipped}<Icon name="check" size={14} /> Equipped{:else}Equip{/if}
 						</button>
 					{:else}
 						<button
@@ -280,7 +286,7 @@
 							disabled={busy === item.id || bank < item.price}
 							onclick={() => buy(item)}
 						>
-							💰 ${item.price.toLocaleString()}
+							<Icon name="cash" size={14} /> ${item.price.toLocaleString()}
 						</button>
 					{/if}
 				</div>
@@ -299,7 +305,7 @@
 							disabled={busy === item.id}
 							onclick={() => equip(item)}
 						>
-							{item.equipped ? '✓ Equipped' : 'Equip'}
+							{#if item.equipped}<Icon name="check" size={14} /> Equipped{:else}Equip{/if}
 						</button>
 					{:else}
 						<button
@@ -307,7 +313,7 @@
 							disabled={busy === item.id || bank < item.price}
 							onclick={() => buy(item)}
 						>
-							💰 ${item.price.toLocaleString()}
+							<Icon name="cash" size={14} /> ${item.price.toLocaleString()}
 						</button>
 					{/if}
 				</div>


### PR DESCRIPTION
Next wave of the app-wide emoji→line-icon sweep.

**Converted:**
- **GroupsPanel** — rank medals (colored gold/silver/bronze), winner trophy, tie handshake, chat header
- **Store** — bag/cash/lock/shark headers, section icons, check on owned/maxed/equipped, cash on price buttons
- **MatchDetailModal** — close, swords/handshake title, target tieback, colored rank medals, locked-phrase lock
- **StandingStrip** — colored rank medal, "in the lead" check
- **LeaderboardPanel** — colored rank medals, key toggle info/close; scope `<option>`s drop emoji (HTML options can't hold inline SVG)
- **LoanPanel** — rate growth, days timer, approval checks / decline X
- **GameStore** — drop Heat-Shield toast emoji prefix

Adds `bag` + `globe` to Icon.svelte. Gates: prettier ✓, `npm run check` 0 errors / 1 pre-existing warning, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)