### PR TITLE
Emoji→icon: keypads, page headers, remaining panels

### DIFF
--- a/src/lib/components/BadgesPanel.svelte
+++ b/src/lib/components/BadgesPanel.svelte
@@ -266,7 +266,7 @@
 						{#if r.next}
 							{r.toNext} → {r.next.name}
 						{:else}
-							💎 Maxed · {r.solves}
+							<Icon name="gem" size={13} /> Maxed · {r.solves}
 						{/if}
 					</div>
 				</div>
@@ -318,7 +318,7 @@
 <!-- 🎉 New-unlock banner -->
 {#if newlyEarned.length}
 	<div class="bp-unlock" role="status">
-		🎉 New badge{newlyEarned.length > 1 ? 's' : ''} unlocked!
+		<Icon name="star" size={15} /> New badge{newlyEarned.length > 1 ? 's' : ''} unlocked!
 	</div>
 {/if}
 
@@ -335,7 +335,9 @@
 	<div class="cd-overlay">
 		<button class="cd-backdrop" aria-label="Close" onclick={() => (detail = null)}></button>
 		<div class="cd-card" role="dialog" aria-modal="true">
-			<button class="cd-x" onclick={() => (detail = null)} aria-label="Close">✕</button>
+			<button class="cd-x" onclick={() => (detail = null)} aria-label="Close"
+				><Icon name="close" size={16} /></button
+			>
 			<div class="cd-emoji"><CategoryIcon category={detail.value} size={42} /></div>
 			<h3 class="cd-name">{detail.label}</h3>
 			<p class="cd-solves">
@@ -349,7 +351,7 @@
 						<span class="cd-medal"><Icon name={t.icon} size={24} /></span>
 						<span class="cd-tname">{t.name}</span>
 						<span class="cd-treq"
-							>{#if got}✓ Unlocked{:else}{t.at - detail.solves} more{/if}</span
+							>{#if got}<Icon name="check" size={12} /> Unlocked{:else}{t.at - detail.solves} more{/if}</span
 						>
 					</div>
 				{/each}
@@ -363,14 +365,16 @@
 	<div class="cd-overlay">
 		<button class="cd-backdrop" aria-label="Close" onclick={() => (achDetail = null)}></button>
 		<div class="cd-card" role="dialog" aria-modal="true">
-			<button class="cd-x" onclick={() => (achDetail = null)} aria-label="Close">✕</button>
+			<button class="cd-x" onclick={() => (achDetail = null)} aria-label="Close"
+				><Icon name="close" size={16} /></button
+			>
 			<div class="cd-emoji" class:ad-dim={!achDetail.earned}>
 				<Icon name={achDetail.icon} size={40} />
 			</div>
 			<h3 class="cd-name">{achDetail.name}</h3>
 			<p class="cd-solves">{achDetail.desc}</p>
 			{#if achDetail.earned}
-				<div class="ad-status earned">✓ Unlocked</div>
+				<div class="ad-status earned"><Icon name="check" size={14} /> Unlocked</div>
 			{:else}
 				{#if achDetail.progText}
 					<div class="ad-prog">
@@ -381,7 +385,7 @@
 					</div>
 					<div class="ad-prog-t">{achDetail.progText}</div>
 				{/if}
-				<div class="ad-status locked">🔒 Locked</div>
+				<div class="ad-status locked"><Icon name="lock" size={14} /> Locked</div>
 			{/if}
 		</div>
 	</div>

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -317,7 +317,7 @@
 			{:else}
 				<h1>{open.name}</h1>
 				{#if open.is_owner}<button class="rename-btn" onclick={startRename} title="Rename group"
-						>✏️</button
+						><Icon name="edit" size={15} /></button
 					>{/if}
 			{/if}
 		</div>
@@ -325,10 +325,10 @@
 
 		<div class="g-tabs">
 			<button class="g-tab" class:active={gtab === 'wealth'} onclick={() => switchTab('wealth')}
-				>💰 Wealth</button
+				><Icon name="cash" size={14} /> Wealth</button
 			>
 			<button class="g-tab" class:active={gtab === 'compete'} onclick={() => switchTab('compete')}
-				>⚔️ Compete</button
+				><Icon name="swords" size={14} /> Compete</button
 			>
 		</div>
 
@@ -366,7 +366,7 @@
 												class="rm-btn"
 												onclick={() => removeMember(m.username)}
 												disabled={busy}
-												title="Remove">✕</button
+												title="Remove"><Icon name="close" size={14} /></button
 											>{/if}</td
 									>{/if}
 							</tr>
@@ -431,7 +431,7 @@
 
 		{#if open.is_owner && (open.requests ?? []).length}
 			<div class="req-panel">
-				<h2 class="req-title">🙋 Requests to join</h2>
+				<h2 class="req-title"><Icon name="hand" size={16} /> Requests to join</h2>
 				{#each open.requests as r}
 					<div class="req-row">
 						<span class="uname">@{r.username}</span>
@@ -496,7 +496,7 @@
 						</div>
 					{/each}
 				{:else}
-					<p class="chat-empty">No messages yet — say hi 👋</p>
+					<p class="chat-empty">No messages yet — say hi</p>
 				{/if}
 			</div>
 			<div class="g-row chat-input-row">

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -52,6 +52,8 @@
 		mail: `<svg ${A}><rect x="3" y="5.5" width="18" height="13" rx="2"/><path d="M3.6 6.8l8.4 5.9 8.4-5.9"/></svg>`,
 		doc: `<svg ${A}><path d="M6.5 3.5h7l4 4v13h-11z"/><path d="M13 3.5V8h4.5"/><path d="M9 12.5h6M9 15.5h6"/></svg>`,
 		puzzle: `<svg ${A}><path d="M10 4.5h4v2a1.5 1.5 0 0 0 3 0v-.2h2.5v4.2h-.2a1.5 1.5 0 0 0 0 3h.2V19h-4.3v-.2a1.5 1.5 0 0 0-3 0v.2H5v-4.5h.2a1.5 1.5 0 0 0 0-3H5V6.5h4.8a1.5 1.5 0 0 1 .2-2z"/></svg>`,
+		backspace: `<svg ${A}><path d="M9 5.5h9.5a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H9L3.5 12z"/><path d="M12.5 9.5l4 5M16.5 9.5l-4 5"/></svg>`,
+		enter: `<svg ${A}><path d="M20 6v5.5a2.5 2.5 0 0 1-2.5 2.5H5"/><path d="M8.5 10.5L4.8 14l3.7 3.5"/></svg>`,
 
 		// ── money / economy ─────────────────────────────────────────────────────
 		cash: `<svg ${A}><rect x="3" y="6.5" width="18" height="11" rx="2"/><circle cx="12" cy="12" r="2.6"/><path d="M6.5 9.5v5M17.5 9.5v5"/></svg>`,

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
+	import Icon from '$lib/components/Icon.svelte';
 	import {
 		gameStore,
 		selectLetter,
@@ -304,7 +305,7 @@
 
 		{#if $gameStore.gameState === 'guess_mode'}
 			<button tabindex="-1" class="key delete" on:click={deleteGuessLetter}>
-				<div class="letter">⌫</div>
+				<div class="letter"><Icon name="backspace" size={20} /></div>
 			</button>
 		{/if}
 	</div>

--- a/src/lib/components/NotificationsPanel.svelte
+++ b/src/lib/components/NotificationsPanel.svelte
@@ -5,6 +5,7 @@
 	import { notifications, dismissNotification } from '$lib/stores/notificationStore.js';
 	import { respondFriendRequest, respondJoinRequest } from '$lib/stores/statsStore.js';
 	import { fx } from '$lib/sound.js';
+	import Icon from '$lib/components/Icon.svelte';
 
 	/** @type {{ onNavigate?: ((n:any)=>void)|null, onChange?: (()=>void)|null }} */
 	let { onNavigate = null, onChange = null } = $props();
@@ -52,7 +53,7 @@
 						class="ni-dismiss"
 						onclick={() => dismissNotification(n.id)}
 						aria-label="Dismiss"
-						title="Dismiss">✕</button
+						title="Dismiss"><Icon name="close" size={14} /></button
 					>
 				{/if}
 				<button

--- a/src/lib/components/PinPad.svelte
+++ b/src/lib/components/PinPad.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
 	import { fx } from '$lib/sound.js';
+	import Icon from '$lib/components/Icon.svelte';
 
 	export let length = 4;
 	export let error = false; // parent sets true to flash/shake
@@ -49,17 +50,23 @@
 		<button class="key num" on:click={() => press('1')}>1</button>
 		<button class="key num" on:click={() => press('2')}>2</button>
 		<button class="key num" on:click={() => press('3')}>3</button>
-		<button class="key act cancel" on:click={clearAll} aria-label="Cancel">✕</button>
+		<button class="key act cancel" on:click={clearAll} aria-label="Cancel"
+			><Icon name="close" size={20} /></button
+		>
 
 		<button class="key num" on:click={() => press('4')}>4</button>
 		<button class="key num" on:click={() => press('5')}>5</button>
 		<button class="key num" on:click={() => press('6')}>6</button>
-		<button class="key act clear" on:click={backspace} aria-label="Delete">⌫</button>
+		<button class="key act clear" on:click={backspace} aria-label="Delete"
+			><Icon name="backspace" size={20} /></button
+		>
 
 		<button class="key num" on:click={() => press('7')}>7</button>
 		<button class="key num" on:click={() => press('8')}>8</button>
 		<button class="key num" on:click={() => press('9')}>9</button>
-		<button class="key act enter" on:click={enter} aria-label="Enter">⏎</button>
+		<button class="key act enter" on:click={enter} aria-label="Enter"
+			><Icon name="enter" size={20} /></button
+		>
 
 		<button class="key num zero" on:click={() => press('0')}>0</button>
 	</div>

--- a/src/lib/components/Toaster.svelte
+++ b/src/lib/components/Toaster.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { toasts, dismissToast, requestInbox } from '$lib/stores/notificationStore.js';
 	import { fx } from '$lib/sound.js';
+	import Icon from '$lib/components/Icon.svelte';
 
 	/** @param {any} t */
 	function open(t) {
@@ -24,7 +25,7 @@
 			<span class="t-title">{t.title}</span>
 			<span class="t-body">{t.body}</span>
 			<span class="t-x" role="presentation" on:click|stopPropagation={() => dismissToast(t.id)}
-				>✕</span
+				><Icon name="close" size={14} /></span
 			>
 		</button>
 	{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2571,7 +2571,7 @@
 	<div class="modal-overlay" role="dialog" aria-modal="true" aria-label="Welcome to WordBank">
 		<div class="modal-content welcome-modal">
 			<img class="wc-coin" src="/logo-coin.png" alt="" width="76" height="76" />
-			<h2 class="wc-title">Welcome to WordBank 🎉</h2>
+			<h2 class="wc-title">Welcome to WordBank</h2>
 			<p class="wc-sub">We’ve officially launched — and everyone’s starting fresh.</p>
 			<ul class="wc-list">
 				<li><span><Icon name="cash" size={16} /></span> <b>$2,000</b> in the bank to play with</li>
@@ -4266,7 +4266,7 @@
 		<!-- 🔍 Diagnostic banner (shows when init failed) -->
 		{#if initError}
 			<div class="diagnostic-banner">
-				<strong>⚠️ Diagnostic:</strong>
+				<strong><Icon name="warning" size={14} /> Diagnostic:</strong>
 				{initError}
 				<br />
 				<small>Open DevTools (F12) → Console for details.</small>

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import PageNav from '$lib/components/PageNav.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import ActivityPanel from '$lib/components/ActivityPanel.svelte';
 	import { track } from '$lib/analytics.js';
 	onMount(() => track('activity_view'));
@@ -10,7 +11,7 @@
 
 <main class="a-page">
 	<PageNav back="/" />
-	<h1>📣 Activity</h1>
+	<h1><Icon name="bell" size={22} /> Activity</h1>
 	<p class="sub">You, your friends, and your groups.</p>
 	<ActivityPanel />
 </main>

--- a/src/routes/avatar/fx/+page.svelte
+++ b/src/routes/avatar/fx/+page.svelte
@@ -46,12 +46,10 @@
 	</div>
 
 	<div class="fxp-toggles">
-		<button class="fxp-t" class:on={holo} on:click={() => (holo = !holo)}
-			>✨ Holographic Shirt</button
-		>
-		<button class="fxp-t" class:on={frame} on:click={() => (frame = !frame)}>🌀 Neon Frame</button>
-		<button class="fxp-t" class:on={crown} on:click={() => (crown = !crown)}>👑 Crown</button>
-		<button class="fxp-t" class:on={aura} on:click={() => (aura = !aura)}>🔆 Glow Aura</button>
+		<button class="fxp-t" class:on={holo} on:click={() => (holo = !holo)}>Holographic Shirt</button>
+		<button class="fxp-t" class:on={frame} on:click={() => (frame = !frame)}>Neon Frame</button>
+		<button class="fxp-t" class:on={crown} on:click={() => (crown = !crown)}>Crown</button>
+		<button class="fxp-t" class:on={aura} on:click={() => (aura = !aura)}>Glow Aura</button>
 	</div>
 </main>
 

--- a/src/routes/avatar/kit/+page.svelte
+++ b/src/routes/avatar/kit/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import PageNav from '$lib/components/PageNav.svelte';
 	import KitAvatar from '$lib/components/KitAvatar.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import { SLOTS, PARTS, DEFAULT_KIT, KIT_READY } from '$lib/avatarKit.js';
 
 	/** @type {any} */ let config = { ...DEFAULT_KIT };
@@ -37,7 +38,9 @@
 						class:on={config[s.key] === o.id}
 						on:click={() => pick(s.key, o.id)}
 					>
-						{o.label}{#if o.price}<span class="kp-price">🔒 {fmt(o.price)}</span>{/if}
+						{o.label}{#if o.price}<span class="kp-price"
+								><Icon name="lock" size={12} /> {fmt(o.price)}</span
+							>{/if}
 					</button>
 				{/each}
 			</div>

--- a/src/routes/badges/+page.svelte
+++ b/src/routes/badges/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import PageNav from '$lib/components/PageNav.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import BadgesPanel from '$lib/components/BadgesPanel.svelte';
 </script>
 
@@ -7,7 +8,7 @@
 
 <main class="badges-page">
 	<PageNav back="/" />
-	<h1>🏅 Badges</h1>
+	<h1><Icon name="medal" size={22} /> Badges</h1>
 	<BadgesPanel />
 </main>
 

--- a/src/routes/friends/+page.svelte
+++ b/src/routes/friends/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import PageNav from '$lib/components/PageNav.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import FriendsPanel from '$lib/components/FriendsPanel.svelte';
 	import { track } from '$lib/analytics.js';
 	onMount(() => track('friends_view'));
@@ -11,7 +12,7 @@
 
 <main class="friends-page">
 	<PageNav />
-	<h1>👥 Friends</h1>
+	<h1><Icon name="users" size={22} /> Friends</h1>
 	<FriendsPanel
 		onChallenge={(/** @type {string} */ u) => goto('/?challenge=' + encodeURIComponent(u))}
 	/>

--- a/src/routes/groups/+page.svelte
+++ b/src/routes/groups/+page.svelte
@@ -11,7 +11,7 @@
 
 <main class="groups-page">
 	<PageNav />
-	<GroupsPanel title="👥 Groups" onExit={() => goto('/')} />
+	<GroupsPanel title="Groups" onExit={() => goto('/')} />
 </main>
 
 <style>

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import PageNav from '$lib/components/PageNav.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import HistoryList from '$lib/components/HistoryList.svelte';
 </script>
 
@@ -7,7 +8,7 @@
 
 <main class="h-page">
 	<PageNav />
-	<h1>📜 History</h1>
+	<h1><Icon name="receipt" size={22} /> History</h1>
 	<HistoryList />
 </main>
 

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { onMount } from 'svelte';
 	import PageNav from '$lib/components/PageNav.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import LeaderboardPanel from '$lib/components/LeaderboardPanel.svelte';
 	import { track } from '$lib/analytics.js';
 	onMount(() => track('leaderboard_view'));
@@ -10,7 +11,7 @@
 
 <main class="lb-page">
 	<PageNav />
-	<h1>🏆 Leaderboard</h1>
+	<h1><Icon name="trophy" size={22} /> Leaderboard</h1>
 	<LeaderboardPanel />
 </main>
 

--- a/src/routes/my-friends/+page.svelte
+++ b/src/routes/my-friends/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import PageNav from '$lib/components/PageNav.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import { listFriends, removeFriend } from '$lib/stores/statsStore.js';
 	import { requireConfirm } from '$lib/confirm.js';
 	import { fx } from '$lib/sound.js';
@@ -91,7 +92,7 @@
 							disabled={busy === f.id}
 							onclick={() => remove(f)}
 							title="Remove friend"
-							aria-label="Remove friend">✕</button
+							aria-label="Remove friend"><Icon name="close" size={14} /></button
 						>
 					</div>
 				{/each}

--- a/src/routes/my-groups/+page.svelte
+++ b/src/routes/my-groups/+page.svelte
@@ -11,7 +11,7 @@
 
 <main class="groups-page">
 	<PageNav />
-	<GroupsPanel title="👥 Groups" onExit={() => goto('/')} />
+	<GroupsPanel title="Groups" onExit={() => goto('/')} />
 </main>
 
 <style>

--- a/src/routes/u/[username]/+page.svelte
+++ b/src/routes/u/[username]/+page.svelte
@@ -5,6 +5,7 @@
 	import { page } from '$app/stores';
 	import { getPublicProfile, addFriend, requestJoinGroup } from '$lib/stores/statsStore.js';
 	import Avatar from '$lib/components/Avatar.svelte';
+	import Icon from '$lib/components/Icon.svelte';
 	import AccountCard from '$lib/components/AccountCard.svelte';
 	import ModeIcon from '$lib/components/ModeIcon.svelte';
 	import { track } from '$lib/analytics.js';
@@ -38,7 +39,7 @@
 		addBusy = true;
 		const res = await addFriend(p.username);
 		if (res?.ok) {
-			addMsg = 'Request sent ✓';
+			addMsg = 'Request sent';
 			p = { ...p, request_outgoing: true };
 		} else addMsg = res?.reason || 'Could not send request';
 		addBusy = false;
@@ -117,7 +118,7 @@
 
 			<div class="u-actions">
 				{#if p.is_friend}
-					<span class="pill friend">✓ Friends</span>
+					<span class="pill friend"><Icon name="check" size={12} /> Friends</span>
 				{:else if p.request_outgoing}
 					<span class="pill muted">Request sent</span>
 				{:else if p.request_incoming}
@@ -187,7 +188,7 @@
 						{#if f.is_self}
 							<span class="soc-tag">You</span>
 						{:else if f.status === 'friends'}
-							<span class="soc-tag ok">✓ Friend</span>
+							<span class="soc-tag ok"><Icon name="check" size={12} /> Friend</span>
 						{:else if f.status === 'pending_out' || busyFriend[f.username] === 'sent'}
 							<span class="soc-tag">Requested</span>
 						{:else}
@@ -211,7 +212,7 @@
 					<div class="soc-row">
 						<span class="soc-main static">{g.name}</span>
 						{#if g.my_status === 'member'}
-							<span class="soc-tag">✓ Member</span>
+							<span class="soc-tag"><Icon name="check" size={12} /> Member</span>
 						{:else if groupState[g.id] === 'requested' || g.my_status === 'requested'}
 							<span class="soc-tag">Requested</span>
 						{:else}


### PR DESCRIPTION
Final wave of the app-wide emoji→line-icon sweep.

**Converted:**
- **PinPad + Keyboard** — ✕ / ⌫ / ⏎ → close / backspace / enter icons
- **Route headers** — Activity / Leaderboard / History / Badges / Friends h1s
- **BadgesPanel** — gem (maxed), star (new-unlock banner), close, check (unlocked), lock (locked)
- **GroupsPanel** — edit, cash (Wealth), swords (Compete), close (remove), hand (Requests); drop trailing 👋
- **Toaster / NotificationsPanel** — close on dismiss
- **u/[username]** — check on Friends / Friend / Member tags
- **avatar/kit** — lock on price; **avatar/fx** — plain FX labels
- **groups / my-groups** — drop emoji from GroupsPanel `title` prop (rendered as text)
- **+page** — drop decorative Welcome 🎉, warning icon on the init Diagnostic strip

Adds `backspace` + `enter` to Icon.svelte. Share-text emojis (external) and geometric UI carets (`▸ › ▾ ▲▼ ↗`) intentionally left. Gates: prettier ✓, `npm run check` 0 errors / 1 pre-existing warning, build ✓; all icon names verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)