### PR TITLE
Groups: manual ownership transfer (closes punch-list #20)

### DIFF
--- a/docs/challenges-polish-punchlist.md
+++ b/docs/challenges-polish-punchlist.md
@@ -89,8 +89,15 @@ Live engine is `match_*` / `_match_*` (tables `challenge_matches` + `challenge_p
 
 ## 🔵 Tier 4 — Permissions & membership
 
-- [ ] **20. Roster control inconsistent** — ⏸️ DEFERRED (product call): "members invite friends, owner moderates + approves requests" is a coherent, common model (Discord-style), not a clear bug. Was: — any member can `add_group_member`, but
-      remove/rename/approve are owner-only. **Fix:** pick one model.
+- [x] **20. Roster control inconsistent** — ✅ RESOLVED (working as intended): the
+      asymmetry is the intended Discord/Slack model — any member invites their own
+      friends (`add_group_member`, friend-gated), the owner moderates (remove / rename /
+      approve requests, owner-only), and ownership auto-transfers on owner-leave (#19).
+      Client hides all owner-only controls behind `{#if open.is_owner}`. Added the one
+      cheap enhancement worth having: **manual ownership transfer** (PR #587,
+      supabase-transfer-group-ownership.sql) — owner "Make owner" (crown) button per
+      member; owner-only, target must be a member, notifies the new owner; rollback-tested
+      (transfer ✓ / not_owner / not_member / self all correct).
 - [x] **21. Join-request approval only via transient notification** — ✅ FIXED (PR #572, supabase-group-pending-requests.sql): get_group returns pending requests (owner-only); GroupsPanel renders a "Requests to join" section with Approve/Deny. Was: — `respond_join_request`
       is only called from `NotificationsPanel.svelte:28`; no pending-requests list in
       `GroupsPanel`. **Fix:** render pending requests in the owner view.

--- a/src/lib/components/GroupsPanel.svelte
+++ b/src/lib/components/GroupsPanel.svelte
@@ -12,6 +12,7 @@
 		removeGroupMember,
 		respondJoinRequest,
 		renameGroup,
+		transferGroupOwnership,
 		listFriends,
 		getGroupMessages,
 		sendGroupMessage,
@@ -289,6 +290,26 @@
 			await refresh();
 		}
 	}
+	/** Hand ownership of the group to another member (owner). @param {string} username */
+	async function makeOwner(username) {
+		if (busy) return;
+		if (
+			!(await requireConfirm({
+				title: 'Make owner?',
+				message: `Hand "${open.name}" to @${username}? They'll be able to rename it, remove members, and approve requests — and you'll lose those controls.`,
+				confirmText: 'Make owner',
+				danger: true
+			}))
+		)
+			return;
+		busy = true;
+		const res = await transferGroupOwnership(open.id, username);
+		busy = false;
+		if (res.ok) {
+			open = res.group;
+			await refresh();
+		}
+	}
 	/** Approve or deny a pending join request (owner). @param {string} requesterId @param {boolean} approve */
 	async function respondRequest(requesterId, approve) {
 		if (busy) return;
@@ -363,6 +384,11 @@
 								<td>{fmt(m.cash)}</td>
 								{#if open.is_owner}<td class="rm-cell"
 										>{#if !m.is_owner}<button
+												class="own-btn"
+												onclick={() => makeOwner(m.username)}
+												disabled={busy}
+												title="Make owner"><Icon name="crown" size={14} /></button
+											><button
 												class="rm-btn"
 												onclick={() => removeMember(m.username)}
 												disabled={busy}
@@ -947,19 +973,25 @@
 		white-space: nowrap;
 	}
 	.rm-cell {
-		width: 30px;
+		width: 56px;
 		text-align: right;
+		white-space: nowrap;
 	}
-	.rm-btn {
+	.rm-btn,
+	.own-btn {
 		background: none;
 		border: none;
 		color: var(--text-faint);
 		cursor: pointer;
 		font-size: 0.85rem;
 		padding: 2px 4px;
+		vertical-align: middle;
 	}
 	.rm-btn:hover {
 		color: #fb7185;
+	}
+	.own-btn:hover {
+		color: #fbbf24;
 	}
 	.add-toggle {
 		margin-top: 0.9rem;

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -276,6 +276,18 @@ export async function renameGroup(groupId, name) {
 	}
 	return data;
 }
+/** Owner hands the group to an existing member. @param {string} groupId @param {string} username @returns {Promise<{ok:boolean, reason?:string, group?:any}>} */
+export async function transferGroupOwnership(groupId, username) {
+	const { data, error } = await supabase.rpc('transfer_group_ownership', {
+		p_group_id: groupId,
+		p_username: username
+	});
+	if (error || !data) {
+		if (error) console.error('❌ transfer_group_ownership:', error);
+		return { ok: false };
+	}
+	return data;
+}
 /** @param {string} groupId @returns {Promise<any[]>} */
 export async function getGroupMessages(groupId) {
 	const { data, error } = await supabase.rpc('get_group_messages', { p_group_id: groupId });

--- a/supabase-transfer-group-ownership.sql
+++ b/supabase-transfer-group-ownership.sql
@@ -1,0 +1,57 @@
+-- Manual ownership transfer (punch-list #20 follow-up).
+-- Owner hands the group to an existing member. Owner-only; target must be a
+-- current member. Complements the auto-transfer-on-leave in leave_group (#19).
+create or replace function public.transfer_group_ownership(p_group_id uuid, p_username text)
+returns jsonb
+language plpgsql
+security definer
+as $function$
+declare
+  v_uid uuid := auth.uid();
+  v_owner uuid;
+  v_target uuid;
+begin
+  if v_uid is null then
+    return jsonb_build_object('ok', false, 'reason', 'auth');
+  end if;
+
+  select owner_id into v_owner from public.groups where id = p_group_id;
+  if v_owner is null then
+    return jsonb_build_object('ok', false, 'reason', 'not_found');
+  end if;
+  if v_owner <> v_uid then
+    return jsonb_build_object('ok', false, 'reason', 'not_owner');
+  end if;
+
+  select id into v_target
+  from public.profiles
+  where lower(username) = lower(trim(coalesce(p_username, '')));
+  if v_target is null then
+    return jsonb_build_object('ok', false, 'reason', 'not_found');
+  end if;
+  if v_target = v_uid then
+    return jsonb_build_object('ok', false, 'reason', 'self');
+  end if;
+  if not exists (
+    select 1 from public.group_members
+    where group_id = p_group_id and user_id = v_target
+  ) then
+    return jsonb_build_object('ok', false, 'reason', 'not_member');
+  end if;
+
+  update public.groups set owner_id = v_target where id = p_group_id;
+
+  -- Let the new owner know they're in charge now.
+  perform public._notify(
+    v_target,
+    'group_join',
+    'You''re now the owner',
+    'You now own the group "' || coalesce((select name from public.groups where id = p_group_id), 'a group') || '".',
+    jsonb_build_object('group_id', p_group_id)
+  );
+
+  return jsonb_build_object('ok', true, 'group', public.get_group(p_group_id));
+end;
+$function$;
+
+grant execute on function public.transfer_group_ownership(uuid, text) to authenticated;


### PR DESCRIPTION
Closes punch-list **#20 (roster control inconsistent)** — resolved as *working as intended*: the "any member invites their own friends, owner moderates" asymmetry is the intended Discord/Slack model, and the client already gates every owner-only control behind `{#if open.is_owner}`.

Added the one cheap enhancement worth having from our discussion: **an owner can manually hand the group to an existing member.**

**Server** — new `transfer_group_ownership(p_group_id, p_username)`: owner-only, target must be a current member; reassigns `owner_id` and notifies the new owner. Applied to prod; rollback-tested — transfer succeeds and updates `owner_id`; `not_owner` / `not_member` / `self` all reject correctly.

**Client** — `statsStore.transferGroupOwnership` + a "Make owner" crown button per member in the owner-only action column, behind a danger confirm that spells out the consequence ("you'll lose those controls"). Widened the action cell to fit two buttons.

Complements auto-transfer-on-leave (#19), which already handles owner abandonment. Gates: prettier ✓, `npm run check` 0 errors / 1 pre-existing warning, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)