### PR TITLE
Match results: fix tie-as-win + leftover category emoji

### DIFF
--- a/scripts/qa-h2h.mjs
+++ b/scripts/qa-h2h.mjs
@@ -1,0 +1,249 @@
+// Two-player 1-on-1 (H2H) challenge E2E: two independent browser contexts play a
+// real friendly match end-to-end. Reports console errors + UX observations.
+// Run: set -a; . ./.env; set +a; BASE=http://localhost:5174 node scripts/qa-h2h.mjs
+import { chromium } from 'playwright';
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+
+const BASE = process.env.BASE || 'http://localhost:5174';
+const DB = process.env.SUPABASE_DB_URL;
+const PASS = 'TestPass123!';
+const PACK = Number(process.env.PACK || 2);
+const stamp = String(Date.now());
+const A = { email: `qaa${stamp}@example.com`, uname: 'qaa' + stamp.slice(-7) };
+const B = { email: `qab${stamp}@example.com`, uname: 'qab' + stamp.slice(-7) };
+mkdirSync('screenshots', { recursive: true });
+
+const sql = (q) =>
+	execSync(`psql "${DB}" -tA -c ${JSON.stringify(q)}`, { encoding: 'utf8' }).trim();
+
+const notes = [];
+const note = (t) => {
+	notes.push(t);
+	console.log('  • ' + t);
+};
+
+const browser = await chromium.launch();
+const errors = [];
+async function makePlayer(tag) {
+	const ctx = await browser.newContext({ viewport: { width: 430, height: 932 }, deviceScaleFactor: 2 });
+	const page = await ctx.newPage();
+	page.on('console', (m) => {
+		if (m.type() === 'error') errors.push(`[${tag}] ${m.text().slice(0, 200)}`);
+	});
+	page.on('pageerror', (e) => errors.push(`[${tag}] pageerror: ${String(e).slice(0, 200)}`));
+	return { ctx, page, tag };
+}
+const wait = (p, ms) => p.waitForTimeout(ms);
+const shot = (p, n) => p.screenshot({ path: `screenshots/h2h-${n}.png` }).catch(() => {});
+
+async function onboard(pl, who) {
+	const { page } = pl;
+	await page.goto(BASE, { waitUntil: 'networkidle' });
+	await wait(page, 1200);
+	// sign up
+	await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
+	await wait(page, 400);
+	await page.fill('input[type=email]', who.email);
+	await page.fill('input[type=password]', PASS);
+	await page.getByRole('button', { name: /^sign up$/i }).first().click().catch(() => {});
+	await wait(page, 3800);
+	// username gate
+	const claim = page.locator('input.claim-input');
+	if (await claim.count()) {
+		await claim.fill(who.uname);
+		await page.locator('button.claim-btn').click().catch(() => {});
+		await wait(page, 1800);
+	}
+	// PIN setup — skip (keeps requirePin a no-op)
+	const skipPin = page.getByRole('button', { name: /skip for now/i });
+	if (await skipPin.count()) {
+		await skipPin.first().click().catch(() => {});
+		await wait(page, 800);
+	}
+	// tutorial — skip
+	const skipTut = page.getByRole('button', { name: /^skip$/i });
+	if (await skipTut.count()) {
+		await skipTut.first().click().catch(() => {});
+		await wait(page, 700);
+	}
+	await wait(page, 500);
+	const reached = (await page.getByText(/play now/i).count()) > 0;
+	console.log(`  ${reached ? '✅' : '❌'} onboard ${pl.tag} (@${who.uname})`);
+	return reached;
+}
+
+// Solve `packSize` puzzles in match mode; phrases keyed by 1-based position.
+async function playMatch(pl, phrases, packSize) {
+	const { page, tag } = pl;
+	// dismiss objective card if present
+	const objGo = page.getByRole('button', { name: /let’s go|let's go/i });
+	if (await objGo.count()) {
+		await objGo.first().click().catch(() => {});
+		await wait(page, 700);
+	}
+	for (let pos = 1; pos <= packSize; pos++) {
+		// wait for the Solve button (board ready for this puzzle)
+		const solve = page.getByRole('button', { name: /^solve$/i });
+		try {
+			await solve.first().waitFor({ timeout: 14000 });
+		} catch {
+			// maybe a per-solve receipt is covering it — try to dismiss and retry
+			await page.keyboard.press('Escape').catch(() => {});
+			await page.getByRole('button', { name: /continue|next|keep going|play/i }).first().click().catch(() => {});
+			await wait(page, 1200);
+			try {
+				await solve.first().waitFor({ timeout: 8000 });
+			} catch {
+				note(`[${tag}] puzzle ${pos}: Solve button never appeared`);
+				await shot(page, `${tag}-stuck-p${pos}`);
+				return false;
+			}
+		}
+		const answer = (phrases[pos] || '').toUpperCase().replace(/[^A-Z]/g, '');
+		await solve.first().click().catch(() => {}); // enter guess mode
+		await wait(page, 600);
+		const boxes = await page.locator('.letter-box').all();
+		if (boxes.length !== answer.length) {
+			note(`[${tag}] puzzle ${pos}: ${boxes.length} slots vs answer len ${answer.length} ("${phrases[pos]}") — punctuation/reveal mismatch`);
+		}
+		for (let k = 0; k < boxes.length && k < answer.length; k++) {
+			const cls = (await boxes[k].getAttribute('class')) || '';
+			if (cls.includes('locked')) continue;
+			await page.keyboard.press(answer[k]);
+			await wait(page, 45);
+		}
+		await wait(page, 400);
+		await shot(page, `${tag}-p${pos}-filled`);
+		await page.getByRole('button', { name: /^submit$/i }).first().click().catch(() => {});
+		await wait(page, 3500); // reveal + advance
+	}
+	// finished the pack
+	const winRe = /deposit|available balance|waiting|banking with wordbank|you (won|took)|standings|no luck|bust/i;
+	await page.getByText(winRe).first().waitFor({ timeout: 9000 }).catch(() => {});
+	await shot(page, `${tag}-done`);
+	return true;
+}
+
+try {
+	console.log('\n──────── H2H two-player match ────────');
+	const pa = await makePlayer('A');
+	const pb = await makePlayer('B');
+	const okA = await onboard(pa, A);
+	const okB = await onboard(pb, B);
+	if (!okA || !okB) throw new Error('onboarding failed');
+
+	// ---- A creates a friendly challenge vs B ----
+	console.log('\n── A creates challenge ──');
+	await pa.page.getByRole('button', { name: /challenge friends/i }).first().click().catch(() => {});
+	await wait(pa.page, 1500);
+	await pa.page.getByRole('button', { name: /new challenge/i }).first().click().catch(() => {});
+	await wait(pa.page, 1000);
+	await shot(pa.page, 'A-wizard-step1');
+	// step 1: search B, pick from list
+	const oppInput = pa.page.locator('input.ch-input').first();
+	await oppInput.fill(B.uname);
+	await wait(pa.page, 1400); // debounced search
+	const pickrow = pa.page.locator('button.ch-pickrow');
+	if (await pickrow.count()) {
+		await pickrow.first().click().catch(() => {});
+		note('A: opponent found via search + picked');
+	} else {
+		note('A: ❗ no search results for B username — cannot pick opponent');
+		await shot(pa.page, 'A-nopick');
+	}
+	await wait(pa.page, 600);
+	await pa.page.getByRole('button', { name: /continue/i }).first().click().catch(() => {});
+	await wait(pa.page, 700);
+	// step 2: pack size
+	await pa.page.locator('button.ch-seg-btn', { hasText: new RegExp(`^${PACK}$`) }).first().click().catch(() => {});
+	await wait(pa.page, 400);
+	await pa.page.getByRole('button', { name: /continue/i }).first().click().catch(() => {});
+	await wait(pa.page, 700);
+	await shot(pa.page, 'A-wizard-step3');
+	// step 3: Friendly ante, send
+	await pa.page.locator('button.ante-chip', { hasText: /friendly/i }).first().click().catch(() => {});
+	await wait(pa.page, 400);
+	await pa.page.getByRole('button', { name: /send challenge/i }).first().click().catch(() => {});
+	await wait(pa.page, 4000);
+	await shot(pa.page, 'A-after-send');
+
+	// ---- read match id + pack phrases from DB ----
+	const mid = sql(`SELECT id FROM challenge_matches WHERE host_id=(SELECT id FROM profiles WHERE lower(username)=lower('${A.uname}')) ORDER BY created_at DESC LIMIT 1`);
+	if (!mid) throw new Error('no match row found for A — create_match failed');
+	note(`match id = ${mid}`);
+	const packRows = sql(`SELECT cp.position || '|' || dp.phrase FROM challenge_pack cp JOIN daily_puzzles dp ON dp.id=cp.puzzle_id WHERE cp.match_id='${mid}' ORDER BY cp.position`);
+	const phrases = {};
+	for (const line of packRows.split('\n')) {
+		const [pos, ...rest] = line.split('|');
+		if (pos) phrases[Number(pos)] = rest.join('|');
+	}
+	note(`pack (${Object.keys(phrases).length}): ` + Object.entries(phrases).map(([k, v]) => `${k}:"${v}"`).join('  '));
+	const packLen = Object.keys(phrases).length || PACK;
+
+	// ---- B accepts via Community → Challenges ----
+	console.log('\n── B accepts ──');
+	await pb.page.getByRole('button', { name: /challenge friends/i }).first().click().catch(() => {});
+	await wait(pb.page, 1800);
+	await shot(pb.page, 'B-challenges-tab');
+	const playBtn = pb.page.locator('button.ch-play', { hasText: /^play$/i });
+	if (await playBtn.count()) {
+		note('B: sees the invite with a Play button');
+		await playBtn.first().click().catch(() => {});
+		await wait(pb.page, 3500);
+	} else {
+		note('B: ❗ no "Play" invite row in Challenges tab');
+		await shot(pb.page, 'B-noinvite');
+	}
+
+	// ---- both play their pack ----
+	console.log('\n── A plays ──');
+	const aPlayed = await playMatch(pa, phrases, packLen);
+	console.log('\n── B plays ──');
+	const bPlayed = await playMatch(pb, phrases, packLen);
+	note(`A completed pack: ${aPlayed} · B completed pack: ${bPlayed}`);
+
+	// ---- settlement ----
+	console.log('\n── settlement ──');
+	await wait(pa.page, 3000);
+	let status = sql(`SELECT status FROM challenge_matches WHERE id='${mid}'`);
+	note(`match status after both finish: ${status}`);
+	if (status !== 'settled') {
+		// nudge server settlement path
+		sql(`SELECT settle_expired_matches()`);
+		await wait(pa.page, 1500);
+		status = sql(`SELECT status FROM challenge_matches WHERE id='${mid}'`);
+		note(`match status after settle_expired_matches(): ${status}`);
+	}
+	const parts = sql(`SELECT p.username || ' score=' || cp.total_score || ' spent=' || (cp.start_budget - cp.bankroll) || ' solved=' || cp.solved || ' state=' || cp.state FROM challenge_participants cp JOIN profiles p ON p.id=cp.user_id WHERE cp.match_id='${mid}' ORDER BY cp.total_score DESC`);
+	note('final standings (DB):');
+	parts.split('\n').forEach((r) => console.log('       ' + r));
+
+	// ---- A opens Results ----
+	console.log('\n── A views results ──');
+	await pa.page.goto(BASE, { waitUntil: 'networkidle' });
+	await wait(pa.page, 1200);
+	await pa.page.getByRole('button', { name: /challenge friends/i }).first().click().catch(() => {});
+	await wait(pa.page, 2000);
+	const resultsBtn = pa.page.getByRole('button', { name: /results/i });
+	if (await resultsBtn.count()) {
+		await resultsBtn.first().click().catch(() => {});
+		await wait(pa.page, 1500);
+		await shot(pa.page, 'A-results-modal');
+		const hasStandings = (await pa.page.locator('.md-standings .md-row').count()) > 0;
+		note(`A results modal standings rows: ${await pa.page.locator('.md-standings .md-row').count()} (${hasStandings ? 'ok' : 'MISSING'})`);
+	} else {
+		note('A: ❗ no "Results" button on the settled match row');
+		await shot(pa.page, 'A-noresults');
+	}
+} catch (e) {
+	console.log('\n❌ FATAL: ' + (e?.message || e));
+} finally {
+	console.log('\n──────── console/page errors ────────');
+	if (!errors.length) console.log('  ✅ none');
+	else errors.forEach((e) => console.log('  ⚠️  ' + e));
+	console.log('\n──────── observations ────────');
+	notes.forEach((n) => console.log('  • ' + n));
+	await browser.close();
+	console.log(`\nA=${A.email} @${A.uname} · B=${B.email} @${B.uname}`);
+}

--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -1,6 +1,16 @@
 <script>
 	import { createEventDispatcher } from 'svelte';
 	import Icon from '$lib/components/Icon.svelte';
+	import CategoryIcon from '$lib/components/CategoryIcon.svelte';
+	import { CATEGORIES } from '$lib/categories.js';
+
+	// daily_puzzles.category carries a trailing emoji in the string; show the clean
+	// label + the line icon instead of the raw emoji.
+	const catLabel = (/** @type {string} */ v) =>
+		CATEGORIES.find((c) => c.value === v)?.label ??
+		String(v ?? '')
+			.replace(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}\u{2B00}-\u{2BFF}️]/gu, '')
+			.trim();
 
 	/** @type {any} */
 	export let detail = null; // get_match_detail() result, or { loading:true }
@@ -30,9 +40,12 @@
 	$: field = parts.length;
 	$: winner = parts.find((/** @type {any} */ p) => Number(p.rank) === 1);
 	$: iWon = me && Number(me.rank) === 1;
+	// A 1v1 tie: both participants share rank 1 (equal spend). Never call that a win.
+	$: isTie = field === 2 && !!me && !!opp && Number(me.rank) === 1 && Number(opp.rank) === 1;
 	$: tieback = (() => {
 		if (!me || noSolve || m?.status !== 'settled') return '';
 		const myS = dollars(me.spent);
+		if (isTie) return me.solved ? `Tie — you both solved for ${myS}.` : `Tie — no winner.`;
 		if (field === 2 && opp) {
 			const oS = dollars(opp.spent),
 				on = '@' + (opp.name || 'opponent');
@@ -100,7 +113,7 @@
 					{#each parts as p}
 						<div class="md-row" class:me={p.is_me}>
 							<span class="md-rank"
-								>{#if noSolve}<Icon
+								>{#if noSolve || isTie}<Icon
 										name="handshake"
 										size={16}
 									/>{:else if p.rank >= 1 && p.rank <= 3}<span class="rk-{p.rank}"
@@ -126,7 +139,9 @@
 						{#each detail.pack as pk}
 							<div class="md-pk">
 								<span class="md-pos">{pk.position}</span>
-								<span class="md-cat">{pk.category}</span>
+								<span class="md-cat"
+									><CategoryIcon category={pk.category} size={13} /> {catLabel(pk.category)}</span
+								>
 								<span class="md-ans"
 									>{#if pk.phrase}“{pk.phrase}”{:else}<Icon name="lock" size={13} /> hidden until settled{/if}</span
 								>


### PR DESCRIPTION
Found by **playing a real 1v1 friendly end-to-end with two independent browser sessions** (new `scripts/qa-h2h.mjs`). Both players guessed for $0 → a genuine tie, which exposed two `MatchDetailModal` bugs:

1. **Tie rendered as a win for both players.** Tied participants share `rank === 1`, so `iWon` was true for each — both saw *"You solved for $0 — beat @X's $0"* and both got a gold medal. Added an `isTie` guard (1v1, both rank 1): the tieback now reads *"Tie — you both solved for $X."* and both rank cells show the handshake glyph instead of two golds.
2. **Leftover category emoji** (a miss from the emoji sweep): the pack list rendered `{pk.category}` raw, and `daily_puzzles.category` carries a trailing emoji (e.g. "Video Games 🎮"). Now renders `<CategoryIcon>` + a cleaned label.

Also adds the reusable two-player harness. Verified live: tie copy + handshakes + gamepad icon all correct, full flow green, **0 console errors**. Gates: check 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)