### PR TITLE
Challenge tiebreaker: solve-time flourish + profile stats (client)

### DIFF
--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -34,27 +34,43 @@
 		return n + (s[(v - 20) % 10] || s[v] || s[0]);
 	};
 	const dollars = (/** @type {any} */ n) => '$' + Number(n ?? 0).toLocaleString();
+	// Human solve time, e.g. "12s" or "1m 05s".
+	const fmtSecs = (/** @type {any} */ s) => {
+		if (s == null) return '';
+		const n = Math.round(Number(s));
+		return n < 60 ? `${n}s` : `${Math.floor(n / 60)}m ${String(n % 60).padStart(2, '0')}s`;
+	};
 
 	// The spend "tie-back": frame the outcome in the universal metric — who solved
 	// for the least. Works for 1v1 and groups, wagered or friendly.
 	$: field = parts.length;
 	$: winner = parts.find((/** @type {any} */ p) => Number(p.rank) === 1);
 	$: iWon = me && Number(me.rank) === 1;
-	// A 1v1 tie: both participants share rank 1 (equal spend). Never call that a win.
+	// A 1v1 tie: both participants share rank 1 (equal spend AND equal time).
 	$: isTie = field === 2 && !!me && !!opp && Number(me.rank) === 1 && Number(opp.rank) === 1;
+	// 1v1 speed gap — the decider when spends are equal.
+	$: haveTimes = field === 2 && me?.elapsed_seconds != null && opp?.elapsed_seconds != null;
+	$: speedGap = haveTimes ? Math.abs(me.elapsed_seconds - opp.elapsed_seconds) : null;
+	$: sameSpend = !!me && !!opp && Number(me.spent) === Number(opp.spent);
 	$: tieback = (() => {
 		if (!me || noSolve || m?.status !== 'settled') return '';
 		const myS = dollars(me.spent);
-		if (isTie) return me.solved ? `Tie — you both solved for ${myS}.` : `Tie — no winner.`;
+		if (isTie) return me.solved ? `Dead heat — you both solved for ${myS}.` : `Tie — no winner.`;
 		if (field === 2 && opp) {
 			const oS = dollars(opp.spent),
 				on = '@' + (opp.name || 'opponent');
-			if (iWon)
+			if (iWon) {
+				if (me.solved && sameSpend && speedGap)
+					return `Matched ${on}'s ${oS} — you solved ${fmtSecs(speedGap)} faster.`;
 				return me.solved
 					? `You solved for ${myS} — beat ${on}'s ${oS}.`
 					: `You took it — ${on} didn't solve.`;
-			if (Number(opp.rank) === 1)
+			}
+			if (Number(opp.rank) === 1) {
+				if (opp.solved && sameSpend && speedGap)
+					return `Matched ${on}'s ${oS} — but ${on} solved ${fmtSecs(speedGap)} faster.`;
 				return opp.solved ? `${on} solved for ${oS} — you spent ${myS}.` : `You spent ${myS}.`;
+			}
 			return `You spent ${myS}.`;
 		}
 		if (iWon) return `You solved for ${myS} — cheapest of ${field}.`;
@@ -123,7 +139,8 @@
 							<span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
 							<span class="md-meta">
 								{#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null}
-										· ${Number(p.spent).toLocaleString()} spent{/if}{#if wagered && p.net != null}
+										· ${Number(p.spent).toLocaleString()} spent{/if}{#if p.elapsed_seconds != null}
+										· {fmtSecs(p.elapsed_seconds)}{/if}{#if wagered && p.net != null}
 										· <span class:pos={Number(p.net) >= 0} class:neg={Number(p.net) < 0}
 											>{money(p.net)}</span
 										>{/if}

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -81,6 +81,12 @@
 				: (Number(ms) / 60000).toFixed(1) + 'm';
 	const pct = (/** @type {number} */ w, /** @type {number} */ n) =>
 		n > 0 ? Math.round((w / n) * 100) + '%' : '—';
+	// Human solve time, e.g. "12s" or "1m 05s".
+	const fmtSecs = (/** @type {any} */ s) => {
+		if (s == null) return '—';
+		const n = Math.round(Number(s));
+		return n < 60 ? `${n}s` : `${Math.floor(n / 60)}m ${String(n % 60).padStart(2, '0')}s`;
+	};
 </script>
 
 <svelte:head><title>WordBank — Profile</title></svelte:head>
@@ -330,6 +336,10 @@
 					)}
 					{@render chip(pct(d.challenges_1v1.wins ?? 0, d.challenges_1v1.played ?? 0), 'Win rate')}
 					{@render chip(fmt(d.challenges_1v1.biggest_pot), 'Biggest pot')}
+					{#if d.challenges_1v1.best_solve_seconds != null}
+						{@render chip(fmtSecs(d.challenges_1v1.avg_solve_seconds), 'Avg solve')}
+						{@render chip(fmtSecs(d.challenges_1v1.best_solve_seconds), 'Fastest')}
+					{/if}
 				</div>
 			{:else}
 				<button class="st-empty" onclick={() => goto('/')}

--- a/supabase-profile-solve-time.sql
+++ b/supabase-profile-solve-time.sql
@@ -1,0 +1,65 @@
+-- Add per-puzzle avg/best solve time to get_profile_detail.challenges_1v1.
+CREATE OR REPLACE FUNCTION public.get_profile_detail()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); p public.profiles; v_climb int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  SELECT position INTO v_climb FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object(
+    'username', p.username, 'color', p.equipped_color, 'title', p.equipped_title,
+    'account_number', p.account_number, 'member_no', p.member_no,
+    'net_worth', COALESCE(p.bank,0), 'cash', COALESCE(p.bank,0),
+    'overall', (SELECT jsonb_build_object(
+        'puzzles_solved', COALESCE(sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)),0),
+        'games_played', count(*), 'earned', COALESCE(sum(earned),0), 'spent', COALESCE(sum(spent),0),
+        'avg_multiple', round(avg(multiple_x100) FILTER (WHERE multiple_x100 IS NOT NULL))::int,
+        'best_multiple', max(multiple_x100), 'clean_solves', count(*) FILTER (WHERE clean))
+      FROM public.game_results WHERE user_id = v_uid),
+    -- Daily includes make-ups (a make-up IS a daily, just played late).
+    'daily', (SELECT jsonb_build_object(
+        'current_streak', COALESCE(p.current_daily_play_streak,0), 'best_streak', COALESCE(p.best_daily_play_streak,0), 'win_streak', (CASE WHEN p.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(p.current_daily_solve_streak,0) ELSE 0 END), 'best_win_streak', COALESCE(p.best_daily_solve_streak,0),
+        'played', count(*), 'won', count(*) FILTER (WHERE outcome='won'),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'), 'best_bounty', COALESCE(max(net) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode IN ('daily','makeup')),
+    'cash_game', jsonb_build_object('position', COALESCE(v_climb,0)) ||
+      (SELECT jsonb_build_object('solved', count(*) FILTER (WHERE outcome='won'),
+        'earned', COALESCE(sum(earned) FILTER (WHERE outcome='won'),0),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'))
+       FROM public.game_results WHERE user_id = v_uid AND game_mode='climb') || jsonb_build_object('net', COALESCE(p.cg_lifetime_net,0)),
+    -- 1v1 = challenge rows with no group; record vs people
+    'challenges_1v1', (SELECT jsonb_build_object(
+        'wins', count(*) FILTER (WHERE outcome='won'), 'losses', count(*) FILTER (WHERE outcome='lost'),
+        'ties', count(*) FILTER (WHERE outcome='tie'), 'played', count(*),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0),
+        'avg_solve_seconds', (SELECT round(avg(extract(epoch from (cp.finished_at - cp.started_at))/greatest(cp.solved,1)))::int FROM public.challenge_participants cp JOIN public.challenge_matches cm ON cm.id=cp.match_id WHERE cp.user_id=v_uid AND cm.group_id IS NULL AND cp.state='done' AND cp.solved>0 AND cp.started_at IS NOT NULL AND cp.finished_at IS NOT NULL),
+        'best_solve_seconds', (SELECT round(min(extract(epoch from (cp.finished_at - cp.started_at))/greatest(cp.solved,1)))::int FROM public.challenge_participants cp JOIN public.challenge_matches cm ON cm.id=cp.match_id WHERE cp.user_id=v_uid AND cm.group_id IS NULL AND cp.state='done' AND cp.solved>0 AND cp.started_at IS NOT NULL AND cp.finished_at IS NOT NULL))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NULL),
+    -- group challenges = your placement in the pack
+    'challenges_group', (SELECT jsonb_build_object(
+        'played', count(*), 'wins', count(*) FILTER (WHERE rank = 1),
+        'podiums', count(*) FILTER (WHERE rank <= 3),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NOT NULL),
+    'categories', (SELECT COALESCE(jsonb_agg(jsonb_build_object('category', category, 'solves', solves, 'best_multiple', bm) ORDER BY solves DESC), '[]'::jsonb)
+      FROM (SELECT category, sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) AS solves, max(multiple_x100) AS bm
+            FROM public.game_results WHERE user_id = v_uid AND category IS NOT NULL
+            GROUP BY category HAVING sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) > 0) c),
+    -- Rivals: your head-to-head record vs each 1v1 opponent
+    'rivals', (SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'name', public._display_name(opponent_id), 'wins', wins, 'losses', losses, 'ties', ties) ORDER BY played DESC, wins DESC), '[]'::jsonb)
+      FROM (SELECT opponent_id, count(*) AS played,
+              count(*) FILTER (WHERE outcome='won') AS wins,
+              count(*) FILTER (WHERE outcome='lost') AS losses,
+              count(*) FILTER (WHERE outcome='tie') AS ties
+            FROM public.game_results
+            WHERE user_id = v_uid AND game_mode='challenge' AND opponent_id IS NOT NULL
+            GROUP BY opponent_id ORDER BY played DESC LIMIT 8) r)
+  );
+END; $function$
+
+;


### PR DESCRIPTION
Surfaces the server tiebreaker's timing data in the UI (server was #589).

- **MatchDetailModal** — speed-aware tie-back: when spends are equal and time was the decider, *"Matched @X's $0 — you solved 9s faster."* Each standings row now shows the player's solve time (*"solved 1/1 · $0 spent · 15s"*).
- **Profile → 1-on-1** — *Avg solve* + *Fastest* chips, from `get_profile_detail.challenges_1v1` (extended via `supabase-profile-solve-time.sql`, applied to prod — per-puzzle, real timing data only).

Verified live via the two-player harness: the winner shows gold/rank 1 with *"solved 9s faster"*, the slower player silver/rank 2, each with their solve time; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)