### PR TITLE
Cash Game: don't replay the opening reveal on resume

### DIFF
--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -468,7 +468,8 @@ export async function fetchClimbGame() {
 		if (!board) return false;
 		if (board.needs_tier) return 'needs_tier';
 		reconcileClimbBoard(board);
-		maybeArmClimbIntro();
+		// Resume = no dramatic reveal (you've already seen this puzzle). The reveal is armed
+		// only on genuine new puzzles — startCashGame, climbAdvance, free-skip, Heat-Shield jump.
 		await refreshClimbClue();
 		return true;
 	} catch (err) {


### PR DESCRIPTION
`fetchClimbGame` (the Cash Game *resume* path) called `maybeArmClimbIntro()`, so re-entering an in-progress run **replayed the dramatic reveal** — including the exact case flagged: open a fresh puzzle, go to the menu, come back (no letters bought), and the slot-machine reveal plays again.

Matches already avoid this — `resumeMatch` deliberately doesn't arm ("resume = no dramatic reveal (you've seen this puzzle)"). This makes Cash Game match: the reveal now fires **only on genuine new puzzles** — `startCashGame`, `climbAdvance`, free-skip, and the Heat-Shield jump — and never on resume.

Context from the investigation: **Daily** already plays its reveal once (gated on the once-per-day attendance signal, survives menu→back and reload) and **Challenges** already skip it on resume — so this was the last remaining gap. Solve-time recording, separately, was already in place on all three modes (`game_results.time_ms` for Daily/Cash Game, `challenge_participants` timestamps for Challenges).

Gates: prettier ✓, `npm run check` 0 errors / 1 pre-existing warning, build ✓. One-line change mirroring the existing `resumeMatch` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)