### PR TITLE
Daily leaderboard: fastest-solve Time column (Phase 1)

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import Icon from '$lib/components/Icon.svelte';
+	import { fmtSecs } from '$lib/time.js';
 	import {
 		getDailyBoard,
 		getClimbLeaderboard,
@@ -33,7 +34,7 @@
 
 	// Sortable columns (client-side). Default: by place, best → worst. Tap # again to
 	// flip and bring LAST place to the top.
-	/** @typedef {'place'|'name'|'score'|'efficiency'|'play_streak'|'win_streak'} SortKey */
+	/** @typedef {'place'|'name'|'score'|'efficiency'|'play_streak'|'win_streak'|'time'} SortKey */
 	let sortKey = $state(/** @type {SortKey} */ ('place'));
 	let sortDir = $state(/** @type {'asc'|'desc'} */ ('asc'));
 	/** @param {SortKey} k */
@@ -41,7 +42,7 @@
 		if (sortKey === k) sortDir = sortDir === 'asc' ? 'desc' : 'asc';
 		else {
 			sortKey = k;
-			sortDir = k === 'name' || k === 'place' ? 'asc' : 'desc';
+			sortDir = k === 'name' || k === 'place' || k === 'time' ? 'asc' : 'desc';
 		}
 	}
 	/** @param {SortKey} k */
@@ -70,6 +71,12 @@
 						sensitivity: 'base'
 					})
 				);
+			if (sortKey === 'time') {
+				// Fastest-solve: ascending = fastest first; unsolved (null) always last.
+				const av = a.solve_seconds ?? Infinity;
+				const bv = b.solve_seconds ?? Infinity;
+				return dir * (av - bv) || a._place - b._place;
+			}
 			const nullLast = sortKey === 'score' || sortKey === 'efficiency';
 			const av = nullLast ? (a[sortKey] ?? -Infinity) : Number(a[sortKey] ?? 0);
 			const bv = nullLast ? (b[sortKey] ?? -Infinity) : Number(b[sortKey] ?? 0);
@@ -112,7 +119,11 @@
 						desc: "Share of the puzzle's base budget you kept. Same for everyone — pure spend-less skill."
 					},
 					{ term: 'Play', desc: "Play streak — days in a row you've shown up for the Daily." },
-					{ term: 'Win', desc: "Win streak — Dailies you've solved in a row." }
+					{ term: 'Win', desc: "Win streak — Dailies you've solved in a row." },
+					{
+						term: 'Time',
+						desc: "How fast you solved today's Daily — same puzzle for everyone, so fastest wins. Blank until you solve it."
+					}
 				]
 			: board === 'climb'
 				? [{ term: 'Furthest', desc: "The highest rung you've reached in the Cash Game." }]
@@ -307,6 +318,15 @@
 							onclick={() => setSort('win_streak')}>Win{arrow('win_streak')}</button
 						></th
 					>
+					<th class="num"
+						><button
+							class="sort"
+							class:on={sortKey === 'time'}
+							onclick={() => setSort('time')}
+							title="Solve time — how fast you cracked today's Daily (same puzzle for everyone)"
+							>Time{arrow('time')}</button
+						></th
+					>
 				</tr>
 			</thead>
 			<tbody>
@@ -337,6 +357,7 @@
 						<td class="metric eff">{r.efficiency != null ? r.efficiency + '%' : '—'}</td>
 						<td class="metric small">{r.play_streak > 0 ? r.play_streak : '—'}</td>
 						<td class="metric small">{r.win_streak > 0 ? r.win_streak : '—'}</td>
+						<td class="metric small">{fmtSecs(r.solve_seconds)}</td>
 					</tr>
 				{/each}
 			</tbody>

--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -3,6 +3,7 @@
 	import Icon from '$lib/components/Icon.svelte';
 	import CategoryIcon from '$lib/components/CategoryIcon.svelte';
 	import { CATEGORIES } from '$lib/categories.js';
+	import { fmtSecs } from '$lib/time.js';
 
 	// daily_puzzles.category carries a trailing emoji in the string; show the clean
 	// label + the line icon instead of the raw emoji.
@@ -34,12 +35,6 @@
 		return n + (s[(v - 20) % 10] || s[v] || s[0]);
 	};
 	const dollars = (/** @type {any} */ n) => '$' + Number(n ?? 0).toLocaleString();
-	// Human solve time, e.g. "12s" or "1m 05s".
-	const fmtSecs = (/** @type {any} */ s) => {
-		if (s == null) return '';
-		const n = Math.round(Number(s));
-		return n < 60 ? `${n}s` : `${Math.floor(n / 60)}m ${String(n % 60).padStart(2, '0')}s`;
-	};
 
 	// The spend "tie-back": frame the outcome in the universal metric — who solved
 	// for the least. Works for 1v1 and groups, wagered or friendly.

--- a/src/lib/time.js
+++ b/src/lib/time.js
@@ -1,0 +1,6 @@
+/** Human solve time: null → "—", <60s → "12s", else "1m 05s". @param {any} s */
+export function fmtSecs(s) {
+	if (s == null) return '—';
+	const n = Math.round(Number(s));
+	return n < 60 ? `${n}s` : `${Math.floor(n / 60)}m ${String(n % 60).padStart(2, '0')}s`;
+}

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -4,6 +4,7 @@
 	import { page } from '$app/stores';
 	import { getProfileDetail, getMyAvatar, getUserBadges } from '$lib/stores/statsStore.js';
 	import { badgeInfo } from '$lib/badges.js';
+	import { fmtSecs } from '$lib/time.js';
 	import Icon from '$lib/components/Icon.svelte';
 	import Avatar from '$lib/components/Avatar.svelte';
 	import InventoryList from '$lib/components/InventoryList.svelte';
@@ -81,12 +82,6 @@
 				: (Number(ms) / 60000).toFixed(1) + 'm';
 	const pct = (/** @type {number} */ w, /** @type {number} */ n) =>
 		n > 0 ? Math.round((w / n) * 100) + '%' : '—';
-	// Human solve time, e.g. "12s" or "1m 05s".
-	const fmtSecs = (/** @type {any} */ s) => {
-		if (s == null) return '—';
-		const n = Math.round(Number(s));
-		return n < 60 ? `${n}s` : `${Math.floor(n / 60)}m ${String(n % 60).padStart(2, '0')}s`;
-	};
 </script>
 
 <svelte:head><title>WordBank — Profile</title></svelte:head>

--- a/supabase-daily-board-solve-seconds.sql
+++ b/supabase-daily-board-solve-seconds.sql
@@ -1,0 +1,48 @@
+-- Add banded solve_seconds (today's Daily solve time) to get_daily_board.
+CREATE OR REPLACE FUNCTION public.get_daily_board(p_scope text DEFAULT 'everyone'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB; v_base int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  v_base := public._daily_reward(public._todays_puzzle_id());
+  WITH circle AS (
+    SELECT v_uid AS id
+    UNION SELECT friend_id FROM public.friendships WHERE user_id = v_uid AND p_scope = 'friends'
+    UNION SELECT user_id FROM public.group_members WHERE group_id = p_group AND p_scope = 'group'
+    UNION SELECT id FROM public.profiles WHERE p_scope IN ('global','everyone')
+  ),
+  d AS (
+    SELECT c.id,
+      (COALESCE(pr.bank, 0) - COALESCE(pr.loan, 0))::bigint AS net_worth,
+      COALESCE(pr.credit_score, 650) AS credit,
+      (CASE WHEN pr.last_daily_play_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_play_streak,0) ELSE 0 END) AS play_streak,
+      (CASE WHEN pr.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_solve_streak,0) ELSE 0 END) AS win_streak,
+      g.score AS score,
+      (CASE WHEN g.won AND v_base > 0 THEN GREATEST(0, LEAST(100, round(COALESCE(g.kept,0)::numeric / v_base * 100)::int)) ELSE NULL END) AS efficiency,
+      (CASE WHEN g.won AND g.time_ms BETWEEN 2000 AND 1800000 THEN round(g.time_ms/1000.0)::int ELSE NULL END) AS solve_seconds,
+      pr.equipped_title, pr.equipped_color
+    FROM circle c
+    JOIN public.profiles pr ON pr.id = c.id
+    LEFT JOIN LATERAL (
+      SELECT gr.score, gr.kept, gr.won, gr.time_ms FROM public.game_results gr
+      WHERE gr.user_id = c.id AND gr.game_mode = 'daily' AND gr.played_at::date = CURRENT_DATE
+      ORDER BY gr.played_at DESC LIMIT 1
+    ) g ON true
+    WHERE c.id IS NOT NULL
+  ),
+  ranked AS (
+    SELECT *, row_number() OVER (ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC) AS rank
+    FROM d ORDER BY (score IS NULL), score DESC NULLS LAST, net_worth DESC LIMIT 100
+  )
+  SELECT jsonb_agg(jsonb_build_object(
+    'rank', rank, 'name', public._display_name(id), 'net_worth', net_worth, 'score', score,
+    'efficiency', efficiency, 'solve_seconds', solve_seconds, 'credit', credit,
+    'play_streak', play_streak, 'win_streak', win_streak, 'played', score IS NOT NULL,
+    'is_me', id = v_uid, 'title', equipped_title, 'color', equipped_color) ORDER BY rank) INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$
+
+;


### PR DESCRIPTION
Phase 1 of the Daily solve-timer plan (`docs/superpowers/plans/2026-07-12-daily-solve-timer.md`).

Surfaces the **already-recorded** Daily solve time (`game_results.time_ms`) as a **sortable "Time" column** on the Daily leaderboard. Since it's the same puzzle for everyone, it's a fair speed comparison — and it breaks the big tie of $0 / max-efficiency solvers.

- `get_daily_board` returns a banded `solve_seconds` (2s floor / 30-min ceiling → `—` outside; applied to prod).
- `LeaderboardPanel`: Time column + `'time'` sort key (ascending = fastest first, unsolved last) + legend entry.
- Extracts the duplicated `fmtSecs` into `src/lib/time.js`.

Verified: rollback SQL test (45000ms → 45s; sub-floor → `—`), `npm run check` 0 errors, build ✓. On-screen timer is Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)