### PR TITLE
Daily: on-screen server-anchored solve timer (Phase 2)

### DIFF
--- a/src/lib/components/SolveTimer.svelte
+++ b/src/lib/components/SolveTimer.svelte
@@ -1,0 +1,70 @@
+<script>
+	import { onDestroy } from 'svelte';
+	import { fmtSecs } from '$lib/time.js';
+
+	/** @type {number|null} */ export let openedAt = null; // server-stamped epoch ms
+	/** @type {number|null} */ export let bestSeconds = null; // PB ghost, seconds
+	export let active = false; // running only while the puzzle is unsolved + on-screen
+	export let solved = false; // freeze + relabel once solved
+	export let revealOffsetMs = 1800; // don't charge the player for the opening reveal
+
+	let now = Date.now();
+	/** @type {ReturnType<typeof setInterval>|undefined} */ let timer;
+	/** @type {number|null} */ let frozen = null; // captured once at solve
+
+	$: if (active && openedAt && !timer) {
+		now = Date.now();
+		timer = setInterval(() => (now = Date.now()), 1000);
+	} else if ((!active || !openedAt) && timer) {
+		clearInterval(timer);
+		timer = undefined;
+	}
+	onDestroy(() => timer && clearInterval(timer));
+
+	// Elapsed = now − server open − reveal offset. Anchored to the server, so leaving the
+	// screen / quitting can't reset or pause it — it just keeps running.
+	$: live = openedAt ? Math.max(0, Math.round((now - openedAt - revealOffsetMs) / 1000)) : 0;
+	// Capture the final time exactly once at the solve transition; clear if a new day resets it.
+	$: if (solved && openedAt && frozen === null)
+		frozen = Math.max(0, Math.round((Date.now() - openedAt - revealOffsetMs) / 1000));
+	$: if (!solved) frozen = null;
+	$: shown = solved && frozen != null ? frozen : live;
+	$: mmss = `${Math.floor(shown / 60)}:${String(shown % 60).padStart(2, '0')}`;
+</script>
+
+{#if openedAt}
+	<div class="solve-timer" class:done={solved} aria-label="Solve time">
+		{#if solved}<span class="st-lbl">Solved in</span>{/if}
+		<span class="st-val">{mmss}</span>
+		{#if bestSeconds != null}<span class="st-pb">PB {fmtSecs(bestSeconds)}</span>{/if}
+	</div>
+{/if}
+
+<style>
+	.solve-timer {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 8px;
+		font-family: 'Orbitron', var(--font-display, monospace);
+		font-variant-numeric: tabular-nums;
+		color: var(--text-faint, #8090a0);
+		font-size: 0.8rem;
+		letter-spacing: 0.04em;
+	}
+	.st-lbl {
+		font-size: 0.68rem;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+	.st-val {
+		font-weight: 700;
+		color: var(--text-muted, #b0bcca);
+	}
+	.solve-timer.done .st-val {
+		color: var(--brand-2, #7ee0a8);
+	}
+	.st-pb {
+		font-size: 0.68rem;
+		opacity: 0.7;
+	}
+</style>

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -89,6 +89,8 @@ import { track } from '$lib/analytics.js';
  *   dailyIntro?: number,
  *   dailyIntroGo?: number,
  *   dailyIntroPlayed?: number,
+ *   dailyOpenedAt?: number|null,
+ *   dailyBestSeconds?: number|null,
  *   wrongTick?: number,
  *   twistCue?: { id:number, text:string } | null
  * }} GameState
@@ -163,6 +165,8 @@ export const gameStore = writable(
 		dailyIntro: 0, // bumps on a FRESH daily open → ARMS the opening reveal (pending)
 		dailyIntroGo: 0, // bumps once the board is actually visible → PLAYS the opening reveal
 		dailyIntroPlayed: 0, // the dailyIntro token that has already played (persists across remounts)
+		dailyOpenedAt: null, // epoch ms the server stamped for today's Daily (solve-timer anchor)
+		dailyBestSeconds: null, // player's fastest valid Daily solve, seconds (PB ghost)
 		wrongTick: 0, // bumps on a non-busting wrong whole-phrase guess → UI flashes a distinct "✗ Wrong" cue
 		twistCue: null // { id, text } — transient "the Twist just did X" toast (Daily), cleared by the UI
 	})
@@ -285,7 +289,11 @@ function reconcileDailyBoard(board) {
 				board.wrong_guesses !== undefined ? board.wrong_guesses : (prev.wrongGuesses ?? 0),
 			// Daily out-of-budget wall: bankroll < cheapest buyable letter on an active board.
 			dailyMustGuess:
-				board.must_guess !== undefined ? !!board.must_guess : (prev.dailyMustGuess ?? false)
+				board.must_guess !== undefined ? !!board.must_guess : (prev.dailyMustGuess ?? false),
+			// Solve-timer anchor (server opened_at, ms) + PB ghost. Keep prior value when a
+			// board refresh omits them, so buying letters mid-solve doesn't clear the timer.
+			dailyOpenedAt: board.opened_at ?? prev.dailyOpenedAt ?? null,
+			dailyBestSeconds: board.best_solve_seconds ?? prev.dailyBestSeconds ?? null
 		})
 	);
 	// Only celebrate a FRESH solve: a board carrying daily_result (set by the solve),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -116,6 +116,7 @@
 	import { goto, replaceState } from '$app/navigation';
 
 	import PhraseDisplay from '$lib/components/PhraseDisplay.svelte';
+	import SolveTimer from '$lib/components/SolveTimer.svelte';
 	import InventoryList from '$lib/components/InventoryList.svelte';
 	import VaultReveal from '$lib/components/VaultReveal.svelte';
 	import Keyboard from '$lib/components/Keyboard.svelte';
@@ -574,6 +575,14 @@
 			: matchLive
 				? { net: matchLeft }
 				: null;
+
+	// Solve timer runs on the Daily board while unsolved and past the opening reveal.
+	$: dailyTimerActive =
+		$gameStore.gameMode === 'daily' &&
+		!showMainMenu &&
+		!introBuilding &&
+		$gameStore.gameState !== 'won' &&
+		$gameStore.gameState !== 'lost';
 
 	// 🎰 Slot-machine money feel: count the hero number up/down; float a −$X off it on each spend.
 	const tweenNet = tweened(0, { duration: 900, easing: cubicOut });
@@ -4244,6 +4253,18 @@
 						).toLocaleString()}</span
 					>{/if}<span class="mp-info"><Icon name="info" size={13} /></span>
 			</button>
+		{/if}
+
+		<!-- Daily solve timer — subtle server-anchored count-up (Daily only). -->
+		{#if $gameStore.gameMode === 'daily' && $gameStore.currentPhrase}
+			<div class="daily-timer-wrap">
+				<SolveTimer
+					openedAt={$gameStore.dailyOpenedAt}
+					bestSeconds={$gameStore.dailyBestSeconds}
+					active={dailyTimerActive}
+					solved={$gameStore.gameState === 'won'}
+				/>
+			</div>
 		{/if}
 
 		<!-- 💰 Bankroll — top of every mode. Challenge ante now lives in the bounty hero below. -->
@@ -8855,6 +8876,11 @@
 		margin: -4px 0 8px;
 	}
 	/* 🏷️ Game-mode pill — centered under the wordmark, same for every mode */
+	.daily-timer-wrap {
+		display: flex;
+		justify-content: center;
+		margin-top: 3px;
+	}
 	.mode-pill {
 		display: inline-flex;
 		align-items: center;

--- a/supabase-daily-board-opened-at.sql
+++ b/supabase-daily-board-opened-at.sql
@@ -1,0 +1,69 @@
+-- Expose opened_at (session created_at, ms) + best_solve_seconds on daily_start,
+-- so the on-screen count-up timer can anchor to the server + show a PB ghost.
+CREATE OR REPLACE FUNCTION public.daily_start(p_powerups text[] DEFAULT '{}'::text[], p_use_twist boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; s public.daily_sessions; v_mod TEXT;
+  v_streak INT; v_high INT; v_last DATE; v_freezes INT; v_day INT; v_att INT := 0; v_new BOOLEAN := false;
+  v_fv TEXT; v_reveal INT[] := '{}'; i INT; v_base INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'daily_start: not authenticated'; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  v_pid := public._todays_puzzle_id();
+  SELECT * INTO s FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE;
+  IF NOT FOUND THEN
+    IF v_pid IS NULL THEN RAISE EXCEPTION 'daily_start: no puzzle available'; END IF;
+    v_mod := public._daily_modifier();
+    v_base := public._daily_reward(v_pid);   -- the Prize (k = 1.0)
+    INSERT INTO public.daily_sessions (user_id, puzzle_date, puzzle_id, bankroll, guesses_remaining, active_powerups, spent, twist_used)
+    VALUES (v_uid, CURRENT_DATE, v_pid, v_base, 999, ARRAY[v_mod], 0, true) RETURNING * INTO s;
+    v_new := true;
+    -- auto-apply: reveal letters for the reveal-type Twists (free)
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = v_pid;
+    IF v_mod = 'free_vowel' THEN
+      SELECT substr(v_phrase, g.i+1, 1) INTO v_fv FROM generate_series(0, length(v_phrase)-1) g(i)
+        WHERE substr(v_phrase, g.i+1, 1) IN ('A','E','I','O','U') ORDER BY g.i LIMIT 1;
+      IF v_fv IS NOT NULL THEN
+        SELECT array_agg(g.i) INTO v_reveal FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1, 1) = v_fv;
+      END IF;
+    ELSIF v_mod = 'head_start' THEN
+      FOR i IN 0 .. length(v_phrase)-1 LOOP
+        IF substr(v_phrase, i+1, 1) <> ' ' AND (i = 0 OR substr(v_phrase, i, 1) = ' ') THEN v_reveal := v_reveal || i; END IF;
+      END LOOP;
+    END IF;
+    IF array_length(v_reveal, 1) > 0 THEN
+      UPDATE public.daily_sessions SET revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_reveal) ORDER BY 1)
+        WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE RETURNING * INTO s;
+    END IF;
+    -- attendance + play streak (unchanged)
+    SELECT current_daily_play_streak, best_daily_play_streak, last_daily_play_date, COALESCE(streak_freezes,0)
+      INTO v_streak, v_high, v_last, v_freezes FROM public.profiles WHERE id = v_uid;
+    IF v_last = CURRENT_DATE THEN v_day := COALESCE(v_streak,0);
+    ELSIF v_last = CURRENT_DATE - 1 THEN v_day := COALESCE(v_streak,0) + 1;
+    ELSIF v_last = CURRENT_DATE - 2 AND v_freezes > 0 AND COALESCE(v_streak,0) > 0 THEN v_freezes := v_freezes - 1; v_day := COALESCE(v_streak,0) + 1;
+    ELSE v_day := 1; END IF;
+    IF v_day > 0 AND v_day % 7 = 0 THEN v_freezes := LEAST(v_freezes + 1, 3); END IF;
+    v_high := GREATEST(COALESCE(v_high,0), v_day);
+    UPDATE public.profiles SET current_daily_play_streak = v_day, best_daily_play_streak = v_high,
+      last_daily_play_date = CURRENT_DATE, streak_freezes = v_freezes WHERE id = v_uid;
+    v_att := 50 + CASE WHEN v_day % 30 = 0 THEN 1500 WHEN v_day % 14 = 0 THEN 500
+                       WHEN v_day % 7 = 0 THEN 250 WHEN v_day = 3 THEN 100 ELSE 0 END;
+    PERFORM public._bank_credit(v_uid, v_att, 'attendance');
+    IF v_day >= 7 THEN PERFORM public._award_badge(v_uid, 'streak_7'); END IF;
+    IF v_day >= 30 THEN PERFORM public._award_badge(v_uid, 'streak_30'); END IF;
+  END IF;
+  SELECT upper(phrase), category, COALESCE(subcategory, '') INTO v_phrase, v_cat, v_sub FROM public.daily_puzzles WHERE id = s.puzzle_id;
+  RETURN public._daily_board(v_phrase, s.state, s.bankroll, s.guesses_remaining, s.revealed_positions, s.incorrect_letters, v_cat, v_sub)
+    || jsonb_build_object('live', public._daily_live(s.bankroll, public._daily_bounty_mult(v_uid)),
+         'base', public._daily_reward(s.puzzle_id),
+         'modifier', s.active_powerups[1], 'twist_used', s.twist_used, 'bounty_mult', public._daily_bounty_mult(v_uid),
+         'wrong_guesses', COALESCE(s.p_wrong_guesses,0),
+         'must_guess', (s.state = 'active' AND public._daily_cheapest_buyable(s, v_phrase) IS NOT NULL
+            AND s.bankroll < public._daily_cheapest_buyable(s, v_phrase)))
+    || jsonb_build_object('opened_at', (extract(epoch from s.created_at)*1000)::bigint, 'best_solve_seconds', (SELECT round(min(time_ms)/1000.0)::int FROM public.game_results WHERE user_id = v_uid AND game_mode = 'daily' AND won AND time_ms BETWEEN 2000 AND 1800000))
+    || CASE WHEN v_new THEN jsonb_build_object('attendance', v_att, 'attendance_day', v_day) ELSE '{}'::jsonb END;
+END; $function$
+
+;

--- a/supabase-daily-board-solve-seconds.sql
+++ b/supabase-daily-board-solve-seconds.sql
@@ -22,7 +22,7 @@ BEGIN
       (CASE WHEN pr.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(pr.current_daily_solve_streak,0) ELSE 0 END) AS win_streak,
       g.score AS score,
       (CASE WHEN g.won AND v_base > 0 THEN GREATEST(0, LEAST(100, round(COALESCE(g.kept,0)::numeric / v_base * 100)::int)) ELSE NULL END) AS efficiency,
-      (CASE WHEN g.won AND g.time_ms BETWEEN 2000 AND 1800000 THEN round(g.time_ms/1000.0)::int ELSE NULL END) AS solve_seconds,
+      (CASE WHEN g.won AND g.time_ms BETWEEN 2000 AND 1800000 THEN round(GREATEST(0, g.time_ms - 1800)/1000.0)::int ELSE NULL END) AS solve_seconds,
       pr.equipped_title, pr.equipped_color
     FROM circle c
     JOIN public.profiles pr ON pr.id = c.id


### PR DESCRIPTION
Phase 2 of the Daily solve-timer plan — a subtle count-up timer under the Daily mode pill.

- `daily_start` exposes `opened_at` (server session `created_at`, ms) + `best_solve_seconds` (PB). Applied to prod.
- `SolveTimer.svelte`: count-up = `now − opened_at − reveal_offset`. **Server-anchored, so leaving/quitting/reload can't reset or pause it** — it just keeps running (away time counts, per the design). Freezes + relabels **"Solved in M:SS"** on solve, with a muted PB ghost.
- `get_daily_board.solve_seconds` now subtracts the same reveal offset, so the **leaderboard number equals the on-screen number**.

**Verified live (Playwright):** the counter starts ~0:00, ticks up, survives a **full page reload** showing accrued time (0:09 → 0:30 *through* the reload — proving it's quit-proof/server-anchored), and freezes at **"Solved in 0:33"** on solve. Server recorded `time_ms=34782` → board `solve_seconds=33` (match). Daily-only. `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)