### PR TITLE
Daily leaderboard: fit the Time column (no horizontal scroll)

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -285,7 +285,7 @@
 									r="1.2"
 								/></svg
 							>
-							Daily Earnings{arrow('score')}</button
+							Earned{arrow('score')}</button
 						></th
 					>
 					<th class="num"
@@ -482,12 +482,12 @@
 		text-transform: uppercase;
 		letter-spacing: 0.06em;
 		color: var(--text-faint);
-		padding: 0.6rem 0.45rem;
+		padding: 0.55rem 0.28rem;
 		text-align: left;
 		border-bottom: 1px solid var(--border);
 	}
 	td {
-		padding: 0.6rem 0.45rem;
+		padding: 0.55rem 0.28rem;
 		border-bottom: 1px solid var(--border);
 		font-size: 0.9rem;
 		text-align: left;
@@ -518,6 +518,12 @@
 		font: inherit;
 		color: inherit;
 		cursor: pointer;
+		display: inline-block;
+		max-width: 108px;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		vertical-align: bottom;
 		text-decoration: underline;
 		text-decoration-color: rgba(255, 255, 255, 0.2);
 		text-underline-offset: 2px;


### PR DESCRIPTION
Adding the Time column pushed the 7-column Daily table off the right edge on a 430px phone. Tightened so all columns fit:

- "Daily Earnings" header → **"Earned"** (the bullseye icon + the info key already convey it, and it parallels the one-word Eff / Play / Win / Time headers)
- cell padding `0.6/0.45rem` → `0.55/0.28rem`
- long player names **truncate with ellipsis** (max-width 108px) instead of widening the table

Verified live: `table-wrap.scrollWidth == clientWidth` (**no overflow**), all 7 columns visible, solver's time (33s) shown in-place. `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)