### PR TITLE
Daily: fix opening reveal replaying on menu → resume

### DIFF
--- a/src/lib/components/PhraseDisplay.svelte
+++ b/src/lib/components/PhraseDisplay.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { gameStore } from '$lib/stores/GameStore.js';
+	import { get } from 'svelte/store';
 	import { onDestroy, createEventDispatcher } from 'svelte';
 	import { getGlobalIndex } from '$lib/helpers/gameUtils.js';
 	import { fx } from '$lib/sound.js';
@@ -11,7 +12,9 @@
 	// by gameStore.dailyIntro, which bumps once on a fresh daily open.
 	const INTRO_STEP = 0.34; // seconds between box landings (slow, dramatic)
 	let introActive = false;
-	let introToken = 0;
+	// Seed from the persisted store value so a REMOUNT (menu → resume) doesn't replay a reveal
+	// that already played — introToken is component-local and would otherwise reset to 0.
+	let introToken = get(gameStore).dailyIntroGo || 0;
 	/** @type {ReturnType<typeof setTimeout>[]} */
 	let introTimers = [];
 	/** @param {number} gi */


### PR DESCRIPTION
**Bug (reported by user):** start the Daily → go back to the menu → resume the Daily, and the slow box-drop reveal **plays again**, even on a fresh untouched puzzle.

**Root cause:** PhraseDisplay's `introToken` guard — which stops it re-playing the same `dailyIntroGo` token — is **component-local** and resets to `0` when the component **remounts** on resume. The store side was correct (`playDailyIntroIfArmed` returns early because `dailyIntro === dailyIntroPlayed`), but the freshly-remounted PhraseDisplay saw the persisted `dailyIntroGo` (1) ≠ its reset `introToken` (0) and re-ran `runIntro()`.

**Fix:** seed `introToken` from the persisted store value at mount (`get(gameStore).dailyIntroGo`), so a remount doesn't treat an already-played reveal as new. Genuine new reveals still play (a new token bumps `dailyIntroGo` beyond the seed), and this reinforces reveal-once across **all** modes at the shared PhraseDisplay layer.

**Verified** by instrumenting `runIntro`: on first open it fires (introToken 0 → tok 1); on menu→resume it now **skips** (introToken 1 === tok 1). `npm run check` 0 errors, build ✓.

(This corrects my earlier assessment that Daily reveal-once already worked — the attendance gate prevents re-*arming*, but the box-drop replayed at the component layer. Good catch testing the actual flow.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)