### PR TITLE
Daily: keyboard affordability uses the Prize budget, not the overloaded bankroll

### DIFF
--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -111,12 +111,15 @@
 	$: lockedLetters = ($gameStore.lockedLetters || {}) as LockedLetters;
 	$: incorrectLetters = ($gameStore.incorrectLetters || []) as string[];
 
-	// The pool letters are bought from: Cash Game spends the per-puzzle BUDGET (not the
-	// accumulated Wallet); every other mode spends the bankroll.
+	// The pool letters are bought from the mode's own budget — NOT $gameStore.bankroll, which
+	// doubles as the user's Cash bank and can be stale mid-game. Cash Game → per-puzzle budget;
+	// Daily → the Prize budget the HUD shows (dailyLive.remaining, matches the server charge).
 	$: affordPool =
 		$gameStore.gameMode === 'climb'
 			? Number($gameStore.climbInfo?.budget_left ?? 0)
-			: $gameStore.bankroll;
+			: $gameStore.gameMode === 'daily'
+				? Number($gameStore.dailyLive?.remaining ?? $gameStore.bankroll ?? 0)
+				: Number($gameStore.bankroll ?? 0);
 	// 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
 	$: disabledKeys = Object.keys(letterCosts).filter(
 		(letter: string) => (effCosts[letter] ?? 0) > affordPool || incorrectLetters.includes(letter)


### PR DESCRIPTION
**Reported (with screenshot):** on the Daily, the priciest letters (E/R/S) couldn't be selected even though the HUD showed $81 and the server accepts the buy (verified: `daily_buy_letter('E')` charges the discounted $75 and succeeds).

**Root cause:** the keyboard's `affordPool` read `$gameStore.bankroll` — an **overloaded** field. Mid-Daily it holds the Prize budget, but `loadUserProfile` also sets it to the user's **Cash bank** ($0 for the affected account). The HUD number instead reads `dailyLive.remaining` (the authoritative Prize budget). So they can **desync**: HUD shows $81, but `affordPool` is stale/low → `effCost > affordPool` disables the expensive letters (E $75 / R $68 / S $68) while cheaper ones still work. On the server side `board.bankroll == live.remaining == 81`, so this was purely a client-field mismatch.

**Fix:** for the Daily, source `affordPool` from `$gameStore.dailyLive?.remaining` — the exact value the HUD shows and the server charges against — with a `bankroll` fallback. (Cash Game already uses its own per-puzzle budget; only Daily was on the fragile field.)

Now display + affordability + server all agree. Verified: normal buys track correctly (E affordable at 420 budget; S still affordable after spending down to ~345). `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)