### PR TITLE
Loan: fix apply card collapsing when you touch the amount slider

### DIFF
--- a/src/lib/components/LoanPanel.svelte
+++ b/src/lib/components/LoanPanel.svelte
@@ -213,7 +213,7 @@
 	</div>
 {:else if loanCap > 0}
 	<!-- No debt: borrow panel -->
-	<details class="loan-card" open={expanded}>
+	<details class="loan-card" bind:open={expanded}>
 		<summary class="loan-summary">Apply for a Loan <span class="loan-cv">▾</span></summary>
 		<p class="loan-tier">
 			Credit <b>{creditTier}</b> ({creditScore}) — sets your ${loanCap.toLocaleString()} limit{#if creditAdjBp(creditTier) !== 0}


### PR DESCRIPTION
**Reported:** applying for a loan, clicking/dragging the red amount bar instantly collapses the panel.

**Cause:** the apply form is a `<details>` with a **one-way** `open={expanded}`. Opening it via the summary is a *native* toggle that doesn't update `expanded`, so the prop stays stale (`false`). Then touching the slider changes `borrowAmt` → Svelte re-renders → **re-applies `open={expanded=false}`** → the `<details>` snaps shut.

**Fix:** `bind:open={expanded}` so the native toggle keeps `expanded` in sync; re-renders then use the current open state instead of forcing it closed.

**Verified (Playwright):** on `/bank`, expand the card → click the slider → still open; drag the slider → still open (was collapsing before). `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)