### PR TITLE
Account card: show true Net Worth when you owe a loan

### DIFF
--- a/src/lib/components/AccountCard.svelte
+++ b/src/lib/components/AccountCard.svelte
@@ -25,6 +25,9 @@
 	$: holderName = (holder ? String(holder) : 'Wordbanker').toUpperCase();
 	$: memberLabel = member != null ? '#' + String(member).padStart(4, '0') : '—';
 	$: amount = Math.round(Number(balance) || 0).toLocaleString();
+	// True net worth = Available Balance − loan owed. Can go negative when deep in debt.
+	$: netWorthAmt = (Math.round(Number(balance) || 0) - loanAmt) | 0;
+	$: netWorthLabel = (netWorthAmt < 0 ? '−$' : '$') + Math.abs(netWorthAmt).toLocaleString();
 </script>
 
 <div class="acct-card {tierClass}">
@@ -41,7 +44,12 @@
 		<div class="ac-bal">
 			<div class="ac-cap">Available Balance</div>
 			<div class="ac-amt">${amount}</div>
-			{#if loanAmt > 0}<div class="ac-loan">Loan −${loanAmt.toLocaleString()}</div>{/if}
+			{#if loanAmt > 0}
+				<div class="ac-loan">Loan −${loanAmt.toLocaleString()}</div>
+				<div class="ac-net" class:neg={netWorthAmt < 0}>
+					<span class="ac-net-cap">Net worth</span>{netWorthLabel}
+				</div>
+			{/if}
 		</div>
 		<div class="ac-num">•••• •••• •••• {last4}</div>
 		<div class="ac-foot">
@@ -185,6 +193,26 @@
 		font-size: 0.82rem;
 		color: #fb7185;
 		font-variant-numeric: tabular-nums;
+	}
+	/* True net worth (Available − loan) — the real position, one line under the loan. */
+	.ac-net {
+		margin-top: 2px;
+		font-family: var(--font-display, sans-serif);
+		font-weight: 700;
+		font-size: 0.82rem;
+		color: #7ee0a8;
+		font-variant-numeric: tabular-nums;
+	}
+	.ac-net.neg {
+		color: #fb7185;
+	}
+	.ac-net-cap {
+		font-weight: 600;
+		opacity: 0.7;
+		margin-right: 6px;
+		text-transform: uppercase;
+		font-size: 0.68rem;
+		letter-spacing: 0.05em;
 	}
 	.ac-num {
 		font-family: 'Courier New', 'Courier', ui-monospace, monospace;


### PR DESCRIPTION
Per your suggestion — surface **net worth** (Available Balance − loan owed) so you don't have to do the math when you're carrying debt.

The card already showed **Available Balance** and a **Loan −$X** line, but not the real position. Added a **"Net worth $X"** line right under the loan line, **only when a loan is outstanding** (debt-free, it equals Available Balance, so it stays hidden to avoid clutter). Green when positive, **red** when net worth goes negative (deep in debt).

The AccountCard is reused on the **menu, the Bank hub, and /profile**, so this shows consistently everywhere.

**Verified (Playwright + screenshot):** with a $600 loan (owed $672), the card reads Available **$2,600** / Loan **−$672** / Net worth **$1,928** — matches `get_bank.net_worth` exactly. `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)