### PR TITLE
Wealth leaderboard: rank by true net worth + show Net Worth and Cash

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -101,6 +101,10 @@
 					]
 				: board === 'wealth'
 					? [
+							{
+								label: 'Net Worth',
+								cell: (/** @type {any} */ r) => fmt(r.net_worth ?? r.cash)
+							},
 							{ label: 'Cash', cell: (/** @type {any} */ r) => fmt(r.cash ?? r.net_worth) },
 							{ label: 'Credit', cell: (/** @type {any} */ r) => r.credit ?? 650 }
 						]
@@ -133,7 +137,14 @@
 							{ term: 'Win %', desc: 'Share of the challenges you played that you won.' }
 						]
 					: [
-							{ term: 'Cash', desc: 'Your Available Balance — total net worth.' },
+							{
+								term: 'Net Worth',
+								desc: 'Your true wealth — Available Balance minus any loan you owe. This is what the board ranks by.'
+							},
+							{
+								term: 'Cash',
+								desc: 'Your Available Balance — spendable money, before subtracting debt.'
+							},
 							{
 								term: 'Credit',
 								desc: 'Your credit score (300-850) — reputation from responsible money management.'

--- a/supabase-wealth-lb-networth.sql
+++ b/supabase-wealth-lb-networth.sql
@@ -1,0 +1,32 @@
+-- Wealth leaderboard: true net worth (bank - loan owed), not raw bank.
+-- Fixes ranking + the net_worth field (was = bank, ignoring loans → gameable by borrowing).
+CREATE OR REPLACE FUNCTION public.get_wealth_leaderboard(p_scope text DEFAULT 'friends'::text, p_period text DEFAULT 'week'::text, p_group uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); v_rows JSONB; v_ws DATE := date_trunc('week', CURRENT_DATE)::date;
+BEGIN
+  IF v_uid IS NULL THEN RETURN '[]'::jsonb; END IF;
+  WITH pool AS (
+    SELECT p.id, (COALESCE(p.bank,0) - COALESCE(p.loan,0)) AS nw, COALESCE(p.bank,0) AS cash,
+           COALESCE(p.credit_score, 650) AS credit,
+           ct.value AS title, cc.value AS color,
+           COALESCE((SELECT net_worth FROM public.networth_snapshots s WHERE s.user_id = p.id AND s.week_start = v_ws), COALESCE(p.bank,0)) AS ws_nw
+    FROM public.profiles p
+    LEFT JOIN public.cosmetics ct ON ct.id = p.equipped_title
+    LEFT JOIN public.cosmetics cc ON cc.id = p.equipped_color
+    WHERE p.bank IS NOT NULL AND (
+      p_scope = 'global' OR p.id = v_uid
+      OR (p_scope = 'friends' AND p.id IN (SELECT friend_id FROM public.friendships WHERE user_id = v_uid))
+      OR (p_scope = 'group' AND p.id IN (SELECT user_id FROM public.group_members WHERE group_id = p_group)))
+  ),
+  metric AS (SELECT *, CASE WHEN p_period = 'week' THEN nw - ws_nw ELSE nw END AS m FROM pool),
+  ranked AS (SELECT *, row_number() OVER (ORDER BY m DESC, cash DESC) AS rank FROM metric ORDER BY m DESC, cash DESC LIMIT 50)
+  SELECT jsonb_agg(jsonb_build_object('rank', rank, 'name', public._display_name(id), 'metric', m,
+    'net_worth', nw, 'cash', cash, 'credit', credit, 'title', title, 'color', color, 'is_me', id = v_uid) ORDER BY rank)
+  INTO v_rows FROM ranked;
+  RETURN COALESCE(v_rows, '[]'::jsonb);
+END; $function$
+
+;


### PR DESCRIPTION
Per your question — yes, show both, and the board should rank by **net worth**.

**The bug I found:** the Wealth board ranked by (and its `net_worth` field returned) raw `p.bank` — **loans were never subtracted**, so "Cash" and "net worth" were the same number. That made debt invisible and the board **gameable**: take a big loan → your cash spikes → you climb the Wealth board, even though borrowing didn't make you richer (the loan offsets it). Meanwhile `get_bank` already computes the honest `bank − loan`.

**Fix:**
- **Server** (`supabase-wealth-lb-networth.sql`, applied to prod): `nw = bank − loan`, so both the ranking metric *and* the `net_worth` field are the true figure. Verified: a $14,165-bank user with a $400 loan now reports net_worth **$13,765**, cash **$14,165**.
- **Client:** the Wealth board now shows **Net Worth** (primary, what it ranks by) + **Cash** (available) + Credit; legend fixed (the Cash entry no longer wrongly calls itself "net worth").

For the ~99% with no loan the two columns match; for borrowers it's honest and un-gameable. Fits the phone (no horizontal scroll). `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)