### PR TITLE
Cash Game leaderboard: personal bests (Best Run / Streak / Heat)

### DIFF
--- a/src/lib/components/LeaderboardPanel.svelte
+++ b/src/lib/components/LeaderboardPanel.svelte
@@ -89,7 +89,15 @@
 	// Metric columns for the simple (non-Daily) boards. Rows arrive pre-ranked from the server.
 	let modeCols = $derived(
 		board === 'climb'
-			? [{ label: 'Furthest', cell: (/** @type {any} */ r) => r.position ?? 0 }]
+			? [
+					{ label: 'Best Run', cell: (/** @type {any} */ r) => fmt(r.best_run ?? 0) },
+					{ label: 'Streak', cell: (/** @type {any} */ r) => r.best_streak ?? 0 },
+					{
+						label: 'Heat',
+						cell: (/** @type {any} */ r) =>
+							r.best_heat ? (r.best_heat / 100).toFixed(1) + '×' : '—'
+					}
+				]
 			: board === 'challenge'
 				? [
 						{ label: 'Wins', cell: (/** @type {any} */ r) => r.metric ?? 0 },
@@ -130,7 +138,17 @@
 					}
 				]
 			: board === 'climb'
-				? [{ term: 'Furthest', desc: "The highest rung you've reached in the Cash Game." }]
+				? [
+						{
+							term: 'Best Run',
+							desc: "The most Cash you've ever banked in a single run — the board is ranked by this."
+						},
+						{
+							term: 'Streak',
+							desc: 'Most puzzles solved in one run before you cashed out or busted.'
+						},
+						{ term: 'Heat', desc: "The highest heat multiplier you've reached in a run." }
+					]
 				: board === 'challenge'
 					? [
 							{ term: 'Wins', desc: "Challenge matches you've won (all-time)." },

--- a/supabase-climb-lb-bests.sql
+++ b/supabase-climb-lb-bests.sql
@@ -1,0 +1,33 @@
+-- Cash Game leaderboard: replace the transient "furthest rung" (current-run
+-- climb_state.position, which resets each run) with persistent personal bests.
+-- Ranks by best single-run profit; returns best run, best run streak, best heat.
+create or replace function public.get_climb_leaderboard(p_scope text default 'friends', p_group uuid default null)
+returns jsonb
+language plpgsql
+security definer
+as $function$
+declare v_uid uuid := auth.uid(); v_rows jsonb;
+begin
+  if v_uid is null then return '[]'::jsonb; end if;
+  with pool as (
+    select p.id as id,
+           coalesce(p.cg_best_run, 0)            as best_run,
+           coalesce(p.cg_best_run_streak, 0)     as best_streak,
+           coalesce(p.cg_best_multiple_x100, 0)  as best_heat
+    from public.profiles p
+    where coalesce(p.cg_best_run, 0) > 0
+      and (p_scope = 'global' or p.id = v_uid
+        or (p_scope = 'friends' and p.id in (select friend_id from public.friendships where user_id = v_uid))
+        or (p_scope = 'group' and p.id in (select user_id from public.group_members where group_id = p_group)))
+  ),
+  ranked as (
+    select *, row_number() over (order by best_run desc, best_streak desc) as rank
+    from pool order by best_run desc, best_streak desc limit 50
+  )
+  select jsonb_agg(jsonb_build_object(
+    'rank', rank, 'name', public._display_name(id),
+    'best_run', best_run, 'best_streak', best_streak, 'best_heat', best_heat,
+    'is_me', id = v_uid) order by rank) into v_rows from ranked;
+  return coalesce(v_rows, '[]'::jsonb);
+end;
+$function$;


### PR DESCRIPTION
"Furthest" ranked by `climb_state.position` — the rung in your *current* run, which resets each run and only exists while you're mid-run. That stopped making sense once Cash Game became an endless earn-and-bank mode.

Replaced with a **high-score board of persistent personal bests** (all already tracked on `profiles`):
- **Server** (applied to prod): pool from `profiles` where `cg_best_run > 0` (everyone who's played, not just active runs); rank by `cg_best_run`; return `best_run` / `best_streak` (`cg_best_run_streak`) / `best_heat` (`cg_best_multiple_x100`).
- **Client:** **Best Run ($)** · **Streak** · **Heat (×)** columns + legend.

Ranked by your biggest single-run cash-out — aspirational, always positive, can't be gamed by grinding. Verified live: Chefcharles **$2,040 / 9.8×**, test2 **$1,070 / 4.3×**; fits the phone. `npm run check` 0 errors, build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)