### PR TITLE
Show Net Worth on My Profile and My Account (bank)

### DIFF
--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -88,6 +88,11 @@
 		<div class="bal-line">
 			<span class="bal-cap">Available Balance</span>
 			<span class="bal-amt">{fmt(b.bank)}</span>
+			{#if Number(b.loan ?? 0) > 0}
+				<span class="bal-net" class:neg={Number(b.net_worth ?? 0) < 0}
+					>Net worth {fmt(b.net_worth)}</span
+				>
+			{/if}
 		</div>
 
 		<!-- 💳 Credit score — the hero -->
@@ -244,6 +249,19 @@
 		line-height: 1.1;
 		font-variant-numeric: tabular-nums;
 		color: var(--text);
+	}
+	/* True net worth (Available − loan) — shown under the balance only when in debt. */
+	.bal-net {
+		display: block;
+		margin-top: 4px;
+		font-family: var(--font-display, sans-serif);
+		font-weight: 700;
+		font-size: 0.98rem;
+		font-variant-numeric: tabular-nums;
+		color: #7ee0a8;
+	}
+	.bal-net.neg {
+		color: #fb7185;
 	}
 	.credit-sec {
 		margin: 4px 0 18px;

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -166,8 +166,11 @@
 					>WordBank Checking{#if d.account_number}
 						····{String(d.account_number).slice(-4)}{/if}</span
 				>
-				<span class="acct-bal">{fmt(d.net_worth)}</span>
+				<span class="acct-bal">{fmt(d.cash ?? d.net_worth)}</span>
 				<span class="acct-lbl">Available Balance</span>
+				{#if Number(d.net_worth ?? 0) !== Number(d.cash ?? d.net_worth ?? 0)}
+					<span class="acct-net">Net worth {fmt(d.net_worth)}</span>
+				{/if}
 			</button>
 
 			<button class="ov-sec-link" onclick={() => (tab = 'stats')}>
@@ -746,6 +749,16 @@
 		letter-spacing: 0.12em;
 		text-transform: uppercase;
 		color: var(--text-faint);
+	}
+	/* True net worth (Available − loan) — a small line under the balance when in debt. */
+	.acct-net {
+		text-align: right;
+		margin-top: 4px;
+		font-family: var(--font-display);
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: #7ee0a8;
+		font-variant-numeric: tabular-nums;
 	}
 	/* Badges: header link + item-style tiles */
 	.ov-sec-link {

--- a/supabase-profile-detail-networth.sql
+++ b/supabase-profile-detail-networth.sql
@@ -1,0 +1,65 @@
+-- Profile detail: net_worth = bank - loan (was just bank). cash stays = bank.
+CREATE OR REPLACE FUNCTION public.get_profile_detail()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); p public.profiles; v_climb int;
+BEGIN
+  IF v_uid IS NULL THEN RETURN NULL; END IF;
+  PERFORM public._ensure_bank(v_uid);
+  SELECT * INTO p FROM public.profiles WHERE id = v_uid;
+  SELECT position INTO v_climb FROM public.climb_state WHERE user_id = v_uid;
+  RETURN jsonb_build_object(
+    'username', p.username, 'color', p.equipped_color, 'title', p.equipped_title,
+    'account_number', p.account_number, 'member_no', p.member_no,
+    'net_worth', (COALESCE(p.bank,0) - COALESCE(p.loan,0)), 'cash', COALESCE(p.bank,0),
+    'overall', (SELECT jsonb_build_object(
+        'puzzles_solved', COALESCE(sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)),0),
+        'games_played', count(*), 'earned', COALESCE(sum(earned),0), 'spent', COALESCE(sum(spent),0),
+        'avg_multiple', round(avg(multiple_x100) FILTER (WHERE multiple_x100 IS NOT NULL))::int,
+        'best_multiple', max(multiple_x100), 'clean_solves', count(*) FILTER (WHERE clean))
+      FROM public.game_results WHERE user_id = v_uid),
+    -- Daily includes make-ups (a make-up IS a daily, just played late).
+    'daily', (SELECT jsonb_build_object(
+        'current_streak', COALESCE(p.current_daily_play_streak,0), 'best_streak', COALESCE(p.best_daily_play_streak,0), 'win_streak', (CASE WHEN p.last_daily_solve_date >= CURRENT_DATE - 1 THEN COALESCE(p.current_daily_solve_streak,0) ELSE 0 END), 'best_win_streak', COALESCE(p.best_daily_solve_streak,0),
+        'played', count(*), 'won', count(*) FILTER (WHERE outcome='won'),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'), 'best_bounty', COALESCE(max(net) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode IN ('daily','makeup')),
+    'cash_game', jsonb_build_object('position', COALESCE(v_climb,0)) ||
+      (SELECT jsonb_build_object('solved', count(*) FILTER (WHERE outcome='won'),
+        'earned', COALESCE(sum(earned) FILTER (WHERE outcome='won'),0),
+        'best_multiple', max(multiple_x100), 'fastest_ms', min(time_ms) FILTER (WHERE outcome='won'))
+       FROM public.game_results WHERE user_id = v_uid AND game_mode='climb') || jsonb_build_object('net', COALESCE(p.cg_lifetime_net,0)),
+    -- 1v1 = challenge rows with no group; record vs people
+    'challenges_1v1', (SELECT jsonb_build_object(
+        'wins', count(*) FILTER (WHERE outcome='won'), 'losses', count(*) FILTER (WHERE outcome='lost'),
+        'ties', count(*) FILTER (WHERE outcome='tie'), 'played', count(*),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0),
+        'avg_solve_seconds', (SELECT round(avg(extract(epoch from (cp.finished_at - cp.started_at))/greatest(cp.solved,1)))::int FROM public.challenge_participants cp JOIN public.challenge_matches cm ON cm.id=cp.match_id WHERE cp.user_id=v_uid AND cm.group_id IS NULL AND cp.state='done' AND cp.solved>0 AND cp.started_at IS NOT NULL AND cp.finished_at IS NOT NULL),
+        'best_solve_seconds', (SELECT round(min(extract(epoch from (cp.finished_at - cp.started_at))/greatest(cp.solved,1)))::int FROM public.challenge_participants cp JOIN public.challenge_matches cm ON cm.id=cp.match_id WHERE cp.user_id=v_uid AND cm.group_id IS NULL AND cp.state='done' AND cp.solved>0 AND cp.started_at IS NOT NULL AND cp.finished_at IS NOT NULL))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NULL),
+    -- group challenges = your placement in the pack
+    'challenges_group', (SELECT jsonb_build_object(
+        'played', count(*), 'wins', count(*) FILTER (WHERE rank = 1),
+        'podiums', count(*) FILTER (WHERE rank <= 3),
+        'biggest_pot', COALESCE(max(earned) FILTER (WHERE outcome='won'),0))
+      FROM public.game_results WHERE user_id = v_uid AND game_mode='challenge' AND group_id IS NOT NULL),
+    'categories', (SELECT COALESCE(jsonb_agg(jsonb_build_object('category', category, 'solves', solves, 'best_multiple', bm) ORDER BY solves DESC), '[]'::jsonb)
+      FROM (SELECT category, sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) AS solves, max(multiple_x100) AS bm
+            FROM public.game_results WHERE user_id = v_uid AND category IS NOT NULL
+            GROUP BY category HAVING sum(COALESCE(solved_count, CASE WHEN outcome='won' THEN 1 ELSE 0 END)) > 0) c),
+    -- Rivals: your head-to-head record vs each 1v1 opponent
+    'rivals', (SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'name', public._display_name(opponent_id), 'wins', wins, 'losses', losses, 'ties', ties) ORDER BY played DESC, wins DESC), '[]'::jsonb)
+      FROM (SELECT opponent_id, count(*) AS played,
+              count(*) FILTER (WHERE outcome='won') AS wins,
+              count(*) FILTER (WHERE outcome='lost') AS losses,
+              count(*) FILTER (WHERE outcome='tie') AS ties
+            FROM public.game_results
+            WHERE user_id = v_uid AND game_mode='challenge' AND opponent_id IS NOT NULL
+            GROUP BY opponent_id ORDER BY played DESC LIMIT 8) r)
+  );
+END; $function$
+
+;


### PR DESCRIPTION
Rounds out the net-worth surfacing — the two "mine" pages now show it too, matching the menu card, leaderboard (#603), and public profile (#606).

### The gaps
- **My Profile** (`/profile`) fed the account row `d.net_worth` but labeled it **"Available Balance"** — and `get_profile_detail` computed `net_worth` as just `bank`, never subtracting the loan (same bug as #603/#606).
- **My Account** (`/bank`) showed only `b.bank` and never surfaced net worth, even though it already had `b.net_worth` and `b.loan` in hand.

### Fix
- **Server** — `get_profile_detail`: `net_worth = bank − loan` (`cash` stays `= bank`). `supabase-profile-detail-networth.sql`, applied to prod.
- **/profile** — headline now shows `cash` (Available Balance) and adds a green **"Net worth $X"** line when it differs from the balance (i.e. a loan is owed).
- **/bank** — same **"Net worth $X"** line under the balance when `loan > 0` (green, red when underwater).

Net worth appears only when a loan makes it differ from the spendable balance — no redundant duplicate line for debt-free players, consistent with the menu card.

### Verified
390px, account with bank $2,600 / loan $672 → both pages read **"Net worth $1,928"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)