### PR TITLE
Net worth red-when-negative + WordBank coin on account cards

### DIFF
--- a/src/routes/bank/+page.svelte
+++ b/src/routes/bank/+page.svelte
@@ -27,6 +27,11 @@
 	});
 
 	const fmt = (/** @type {number} */ n) => '$' + Math.round(n ?? 0).toLocaleString();
+	// Signed money: renders a leading minus outside the $ (−$51, not $-51).
+	const fmtSigned = (/** @type {number} */ n) => {
+		const v = Math.round(n ?? 0);
+		return (v < 0 ? '−$' : '$') + Math.abs(v).toLocaleString();
+	};
 	const dateOnly = (/** @type {string} */ at) =>
 		at ? new Date(at).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) : '';
 
@@ -87,10 +92,13 @@
 		<!-- 💰 Available Balance — clean line, no card -->
 		<div class="bal-line">
 			<span class="bal-cap">Available Balance</span>
-			<span class="bal-amt">{fmt(b.bank)}</span>
+			<span class="bal-amt">
+				<img class="bal-coin" src="/logo-coin.png" alt="" width="28" height="28" />
+				{fmt(b.bank)}
+			</span>
 			{#if Number(b.loan ?? 0) > 0}
 				<span class="bal-net" class:neg={Number(b.net_worth ?? 0) < 0}
-					>Net worth {fmt(b.net_worth)}</span
+					>Net worth {fmtSigned(b.net_worth)}</span
 				>
 			{/if}
 		</div>
@@ -242,13 +250,22 @@
 		color: var(--text-muted);
 	}
 	.bal-amt {
-		display: block;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
 		font-family: var(--font-display, sans-serif);
 		font-weight: 800;
 		font-size: 2rem;
 		line-height: 1.1;
 		font-variant-numeric: tabular-nums;
 		color: var(--text);
+	}
+	.bal-coin {
+		width: 28px;
+		height: 28px;
+		object-fit: contain;
+		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
 	}
 	/* True net worth (Available − loan) — shown under the balance only when in debt. */
 	.bal-net {

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -73,6 +73,11 @@
 	}
 
 	const fmt = (/** @type {any} */ n) => '$' + Math.round(Number(n ?? 0)).toLocaleString();
+	// Signed money: renders a leading minus outside the $ (−$51, not $-51).
+	const fmtSigned = (/** @type {any} */ n) => {
+		const v = Math.round(Number(n ?? 0));
+		return (v < 0 ? '−$' : '$') + Math.abs(v).toLocaleString();
+	};
 	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '—');
 	const time = (/** @type {any} */ ms) =>
 		!ms
@@ -169,8 +174,11 @@
 				<span class="acct-bal">{fmt(d.cash ?? d.net_worth)}</span>
 				<span class="acct-lbl">Available Balance</span>
 				{#if Number(d.net_worth ?? 0) !== Number(d.cash ?? d.net_worth ?? 0)}
-					<span class="acct-net">Net worth {fmt(d.net_worth)}</span>
+					<span class="acct-net" class:neg={Number(d.net_worth ?? 0) < 0}
+						>Net worth {fmtSigned(d.net_worth)}</span
+					>
 				{/if}
+				<img class="acct-coin" src="/logo-coin.png" alt="" width="30" height="30" />
 			</button>
 
 			<button class="ov-sec-link" onclick={() => (tab = 'stats')}>
@@ -710,6 +718,7 @@
 
 	/* 🏦 Available Balance account row (bank-app style) */
 	.acct-card {
+		position: relative;
 		display: flex;
 		flex-direction: column;
 		width: 100%;
@@ -722,6 +731,17 @@
 		transition:
 			border-color 0.2s,
 			transform 0.15s;
+	}
+	/* WordBank coin — anchored to the bottom-left of the checking card. */
+	.acct-coin {
+		position: absolute;
+		left: 16px;
+		bottom: 14px;
+		width: 30px;
+		height: 30px;
+		object-fit: contain;
+		filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
+		pointer-events: none;
 	}
 	.acct-card:hover {
 		border-color: var(--brand-2);
@@ -759,6 +779,9 @@
 		font-size: 0.9rem;
 		color: #7ee0a8;
 		font-variant-numeric: tabular-nums;
+	}
+	.acct-net.neg {
+		color: #fb7185;
 	}
 	/* Badges: header link + item-style tiles */
 	.ov-sec-link {


### PR DESCRIPTION
Two small polish items on the account surfaces.

### Red negative net worth (the reported bug)
`/profile`'s net-worth line was always green, so a **−$51** net worth still rendered green. It now turns red (`#fb7185`) when negative, matching `/bank`. While here, the value renders as **−$51** (new `fmtSigned` helper) instead of the ugly `$-51` the plain `fmt` produced — applied on both `/profile` and `/bank`.

### WordBank coin
- **/profile** — coin anchored to the bottom-left of the "WordBank Checking" card.
- **/bank** — coin next to the Available Balance amount.

### Verified
390px, account with bank $600 / loan $651 → both pages show a red **"Net worth −$51"** with the coin in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)