### PR TITLE
Daily solve timer: use the standard UI font

### DIFF
--- a/src/lib/components/SolveTimer.svelte
+++ b/src/lib/components/SolveTimer.svelte
@@ -45,7 +45,7 @@
 		display: inline-flex;
 		align-items: baseline;
 		gap: 8px;
-		font-family: 'Orbitron', var(--font-display, monospace);
+		font-family: var(--font-ui);
 		font-variant-numeric: tabular-nums;
 		color: var(--text-faint, #8090a0);
 		font-size: 0.8rem;


### PR DESCRIPTION
The on-screen count-up clock used `'Orbitron'` (a display/monospace face). Swapped it for `var(--font-ui)` (Inter) so it matches the regular font used everywhere else in the app. Kept `font-variant-numeric: tabular-nums` so the digits stay aligned as they tick.

One-line CSS change in `SolveTimer.svelte`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)