### PR TITLE
Give up: use the flag (surrender) icon

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2464,7 +2464,7 @@
 		class="giveup-btn"
 		title="Give up"
 		aria-label="Give up"
-		on:click={isClimb ? askForfeit : confirmFold}><Icon name="give-up" size={18} /></button
+		on:click={isClimb ? askForfeit : confirmFold}><Icon name="flag" size={18} /></button
 	>
 {/if}
 <!-- Skip retired in Cash Game V4 — Cash Out is the graceful bail. -->
@@ -2544,7 +2544,7 @@
 			<div class="gu-actions">
 				<button class="gu-cancel" on:click={cancelGiveUp}>Keep playing</button>
 				<button class="gu-confirm" on:click={doGiveUp}
-					><Icon name="give-up" size={15} /> Give up</button
+					><Icon name="flag" size={15} /> Give up</button
 				>
 			</div>
 		</div>


### PR DESCRIPTION
Swaps the give-up icon for a **flag** — a white surrender flag reads more naturally for forfeiting than the door/exit glyph it used.

- Top-right give-up button (Daily / Challenges / Cash Game forfeit)
- The matching button in the give-up confirm modal

Both now use the `flag` icon already defined in `Icon.svelte` (pole + banner), so no new icon was added. The old `give-up` glyph def is left in place, unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)