### PR TITLE
Fix infinite Loading when client session is stale/revoked

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -277,13 +277,18 @@
 				error
 			} = await supabase.auth.getSession();
 			if (!session || error) {
-				initError =
-					'No session (session: ' +
-					(session ? 'yes' : 'no') +
-					', error: ' +
-					(error?.message || 'none') +
-					')';
-				console.warn('⛔', initError);
+				// No usable client session. This can happen when an SSR cookie (or a hydrated
+				// $user) marks us logged-in while the client's token is expired/invalid — which
+				// would otherwise strand the user on "Loading…" forever (loggedIn=true but init
+				// never completes). Purge the stale auth and fall through to the login screen.
+				console.warn('⛔ No client session — clearing stale auth, showing login.', error?.message);
+				try {
+					await supabase.auth.signOut({ scope: 'local' });
+				} catch {
+					/* ignore — nothing to clear */
+				}
+				user.set(null);
+				hasInitialized = true;
 				return;
 			}
 


### PR DESCRIPTION
## The bug (reported live)
A user got stuck on the **"Loading…"** screen on sign-up and couldn't get past it, even after hard refreshes. Their console showed:
- `No session (session: no, error: none)` — WordBank's own init log
- a **406** on a Supabase `.single()` profile lookup for a UUID that no longer exists (a deleted test account)

## Root cause
`+page.server.js` reads the session from the **cookie** and returns `data.user`, which a reactive assigns to `$user` → `loggedIn = true`. But the browser client's `getSession()` independently validates/refreshes the token. When the token is expired or the session was revoked server-side (e.g. the account/profile was cleaned up), `getSession()` returns **no session** — and the no-session branch simply `return`ed, leaving `loggedIn=true` + `hasInitialized=false`.

The init gate renders `Loading…` in precisely that state:
```
{#if !loggedIn}      <Auth />
{:else if !hasInitialized}   Loading…   ← stuck here
```
So it hung forever, and survived reloads because the cookie re-asserted the dead session on every SSR pass.

## Fix
In the no-session branch: `signOut({ scope: 'local' })` (with `createBrowserClient` this clears the shared **cookie** too, so SSR won't resurrect it next load), null out `$user`, and set `hasInitialized` — so the gate falls through to the login screen.

## Verified
- Revoking `auth.sessions` server-side while the browser cookie stays (recreating the exact mismatch) → app now shows the **login screen in ~0.7s** instead of hanging. Screenshot in branch.
- Happy path unaffected: fresh signup and valid-session reload still reach the menu.

## For the affected browser
This fix makes it self-heal, but to clear the already-stuck state right now: run `localStorage.clear()` in the console (or use Incognito) and reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)