### PR TITLE
Fix auth lockout: Supabase session cookie must not be httpOnly

### DIFF
--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -20,7 +20,12 @@ export const load = async ({ cookies }) => {
 				cookies.set(name, value, {
 					...options,
 					path: '/',
-					httpOnly: true,
+					// MUST stay non-httpOnly: the browser Supabase client (createBrowserClient)
+					// reads the session token from this cookie via document.cookie. Forcing
+					// httpOnly hides it from the client, so after the server refreshes an expired
+					// token (rewriting the cookie httpOnly) the client can't see the session at
+					// all — every client call becomes unauthenticated and the app hangs on load.
+					httpOnly: false,
 					sameSite: 'lax',
 					secure: import.meta.env.PROD // false in dev so cookies persist on http://localhost
 				});
@@ -29,7 +34,7 @@ export const load = async ({ cookies }) => {
 				cookies.delete(name, {
 					...options,
 					path: '/',
-					httpOnly: true,
+					httpOnly: false,
 					sameSite: 'lax',
 					secure: import.meta.env.PROD
 				});


### PR DESCRIPTION
## The real root cause
This is the deeper cause behind the loading-screen hang (#613 was the client-side symptom).

`+page.server.js`'s `createServerClient` wrote the Supabase auth cookies with **`httpOnly: true`**. But the browser client (`createBrowserClient`) reads the session token from that cookie via `document.cookie` — and **httpOnly cookies are invisible to JavaScript**. So:

1. Sign up → the *client* sets a non-httpOnly cookie → everything works.
2. Later, an SSR load calls `getUser()`, which refreshes the now-expired access token and **rewrites the cookie as httpOnly**.
3. On the next load the client can no longer read the session → `getSession()` returns `null` → every client RPC runs unauthenticated (`401` / `not authenticated` / `permission denied`), while SSR `getUser()` still reports a valid user.

That server-says-yes / client-says-no split is the hang: `loggedIn=true` (from SSR `data.user`) but no usable client session, so the app stalls on "Loading…" or renders the game with `Daily puzzle failed to load` and a wall of auth errors.

It only affected sessions old enough to need a **token refresh** — fresh signups kept the client's own non-httpOnly cookie, which is why every test passed until a session aged past its access-token lifetime.

## Fix
Set `httpOnly: false` on the auth cookies in both the `set` and `remove` handlers — the standard `@supabase/ssr` requirement (the browser client must be able to read them). Works together with #613's client-side no-session fallback.

## Verified
After signup + a full SSR reload: the `sb-*-auth-token` cookie is client-readable (`httpOnly: false`), the menu loads, and there are **zero auth errors**.

## Note for already-stuck browsers
An existing httpOnly cookie won't be overwritten until cleared, and `localStorage.clear()` doesn't touch cookies. To escape the stuck state once: **DevTools → Application → Clear site data** (or clear cookies for localhost), then reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)