### PR TITLE
Self-heal stale auth cookie (suppress SSR user + server signout)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -140,6 +140,9 @@
 	let showResultModal = false;
 	let hasTriggeredModal = false;
 	let hasInitialized = false;
+	// Set once the client confirms it has no usable session — stops the SSR data.user
+	// reactive from re-asserting loggedIn (see the reactive below).
+	let noClientSession = false;
 	let sessionUid = ''; // current session user id (for the PIN gate)
 	let pinNotSet = false; // logged in on this device with no PIN yet → prompt setup
 	/** @type {string | null} */
@@ -282,6 +285,16 @@
 				// would otherwise strand the user on "Loading…" forever (loggedIn=true but init
 				// never completes). Purge the stale auth and fall through to the login screen.
 				console.warn('⛔ No client session — clearing stale auth, showing login.', error?.message);
+				noClientSession = true; // suppress the SSR data.user reactive so login actually shows
+				// Mismatch: SSR read a user from the cookie but the browser has no usable session.
+				// That means a stale server-side cookie (e.g. a legacy httpOnly one the client
+				// can't read or overwrite) — only the server can delete it, so bounce through the
+				// /signout route to purge it, then land on a clean login. Guard with a one-shot
+				// query flag so we never loop once the cookie is gone.
+				if (data?.user && !window.location.search.includes('signedout')) {
+					window.location.href = '/signout';
+					return;
+				}
 				try {
 					await supabase.auth.signOut({ scope: 'local' });
 				} catch {
@@ -405,8 +418,12 @@
 		}
 	}
 
-	// ✅ Set user from SSR if present (profile load happens once in onMount)
-	$: if (data?.user) {
+	// ✅ Set user from SSR if present (profile load happens once in onMount).
+	// Suppressed once the client confirms it has NO usable session (noClientSession): the
+	// SSR cookie can still decode server-side (esp. a legacy httpOnly cookie the browser
+	// can't read) and would otherwise re-assert loggedIn=true, stranding the user in the
+	// signed-in-but-every-call-401 game screen instead of the login screen.
+	$: if (data?.user && !noClientSession) {
 		user.set(/** @type {{ id: string }} */ (data.user));
 	}
 

--- a/src/routes/signout/+server.js
+++ b/src/routes/signout/+server.js
@@ -1,0 +1,52 @@
+// Server-side signout: deletes the Supabase auth cookies and redirects home.
+// Needed because a legacy httpOnly auth cookie can't be cleared by client JS — only the
+// server can delete it. The client bounces here when it detects a stale-session mismatch
+// (SSR sees a user, but the browser has no usable session), so the app self-heals to a
+// clean login instead of stranding the user.
+import { createServerClient } from '@supabase/ssr';
+import { redirect } from '@sveltejs/kit';
+
+export const GET = async ({ cookies }) => {
+	const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+	const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+	if (supabaseUrl && supabaseAnonKey) {
+		const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+			cookies: {
+				get(name) {
+					return cookies.get(name);
+				},
+				set(name, value, options) {
+					cookies.set(name, value, {
+						...options,
+						path: '/',
+						httpOnly: false,
+						sameSite: 'lax',
+						secure: import.meta.env.PROD
+					});
+				},
+				remove(name, options) {
+					cookies.delete(name, {
+						...options,
+						path: '/',
+						httpOnly: false,
+						sameSite: 'lax',
+						secure: import.meta.env.PROD
+					});
+				}
+			}
+		});
+		try {
+			await supabase.auth.signOut();
+		} catch {
+			/* ignore — we still purge cookies below */
+		}
+	}
+	// Belt-and-suspenders: delete every Supabase auth cookie by name, including a legacy
+	// httpOnly one the client can't touch. Server-side delete matches by name regardless
+	// of the httpOnly flag.
+	for (const { name } of cookies.getAll()) {
+		if (name.startsWith('sb-')) cookies.delete(name, { path: '/' });
+	}
+	// ?signedout=1 lets the home page's init break the loop if a cookie somehow survives.
+	throw redirect(303, '/?signedout=1');
+};


### PR DESCRIPTION
Finishes the auth-lockout fix for browsers still holding a **legacy httpOnly** cookie from before #614. Two remaining gaps:

## 1. SSR user overrode the client's no-session state
The server reads a valid user from the old httpOnly cookie (`data.user` → `loggedIn=true`), but the browser can't read it (`getSession()` = null). The `$: if (data?.user) user.set(...)` reactive kept re-asserting `loggedIn`, overriding #613's `user.set(null)` — so the user landed in the **signed-in-but-every-call-401 game screen** instead of a login screen.

**Fix:** a `noClientSession` flag suppresses that reactive once the client confirms no session.

## 2. A legacy httpOnly cookie can't be cleared by JavaScript
Neither `signOut` nor a fresh login can remove or overwrite an httpOnly cookie from the client — only the **server** can. So a stuck user couldn't escape even after reaching a login screen.

**Fix:** new `GET /signout` route deletes every `sb-*` auth cookie server-side (works regardless of the httpOnly flag) and redirects to `/?signedout=1`. When the app detects the stale-session mismatch (`data.user` set but no client session), it bounces through `/signout` — so it **self-heals to a clean login**, no manual cookie-clearing needed. A one-shot `?signedout` flag prevents any redirect loop.

## Verified end-to-end
A client-unreadable httpOnly cookie now auto-routes `/ → /signout → /?signedout=1`, clears the cookie, shows login, and a fresh login reaches the menu with a readable cookie and **zero auth errors**.

## Net effect for the reported issue
The stuck browser no longer needs manual cookie surgery — loading the app clears the bad cookie automatically and drops to a working login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)