### PR TITLE
Don't auto-start the Daily for a new user on the menu

### DIFF
--- a/scripts/qa-pn-diag.mjs
+++ b/scripts/qa-pn-diag.mjs
@@ -1,0 +1,39 @@
+import { chromium } from 'playwright';
+import { execSync } from 'child_process';
+const BASE='http://localhost:5173'; const SS='/private/tmp/claude-501/-Users-admin-wordbankmaster/89648cc7-8d73-41b0-94b4-5f4813950333/scratchpad';
+const wait=(p,ms)=>p.waitForTimeout(ms);
+const q=(sql)=>execSync(`psql "$SUPABASE_DB_URL" -tA -c "${sql}"`).toString().trim();
+const EMAIL=`pnd_${Date.now()}@example.com`, UNAME=`pnd${Date.now()%100000}`;
+const b=await chromium.launch();
+const ctx=await b.newContext({viewport:{width:390,height:844}});
+const page=await ctx.newPage();
+const logs=[];
+page.on('console',m=>{const t=m.text(); if(/daily|Daily|start|track|❌|⚠️/.test(t)) logs.push(m.type()[0]+':'+t.slice(0,80));});
+page.on('request',r=>{ if(/daily_start/.test(r.url())) logs.push('REQ daily_start'); });
+await page.goto(BASE,{waitUntil:'networkidle'}); await wait(page,1200);
+await page.getByRole('button',{name:/^sign up$/i}).first().click().catch(()=>{}); await wait(page,400);
+await page.fill('input[type=email]',EMAIL); await page.fill('input[type=password]','Testpass123!');
+await page.getByRole('button',{name:/^sign up$/i}).first().click().catch(()=>{}); await wait(page,4000);
+const cl=page.locator('input.claim-input'); if(await cl.count()){await cl.fill(UNAME);await page.locator('button.claim-btn').click().catch(()=>{});await wait(page,1800);}
+for(const rx of [/skip for now/i,/^skip$/i]){const bt=page.getByRole('button',{name:rx});if(await bt.count()){await bt.first().click().catch(()=>{});await wait(page,700);}}
+await wait(page,1800);
+await page.screenshot({path:SS+'/pn-menu.png'});
+// list menu-card buttons + any overlay
+const info = await page.evaluate(()=>{
+  const cards=[...document.querySelectorAll('button.menu-card')].map(c=>c.textContent.replace(/\s+/g,' ').trim().slice(0,40));
+  const overlays=[...document.querySelectorAll('[class*=overlay],[class*=modal],[class*=objective],[class*=intro]')].filter(e=>e.offsetParent).map(e=>e.className);
+  return { cards, overlays };
+});
+console.log('menu-cards:', JSON.stringify(info.cards));
+console.log('visible overlays:', JSON.stringify(info.overlays));
+logs.length=0;
+await page.locator('button.menu-card').first().click().catch(e=>console.log('click err',e.message));
+await wait(page,4000);
+await page.screenshot({path:SS+'/pn-afterclick.png'});
+const U=q(`SELECT id FROM auth.users WHERE email='${EMAIL}'`);
+console.log('logs after click:', logs.slice(0,12));
+console.log('sessions:', q(`SELECT count(*) FROM daily_sessions WHERE user_id='${U}'`));
+const t=await page.evaluate(()=>document.body.innerText.slice(0,120).replace(/\n+/g,' | '));
+console.log('page text:', t);
+try{execSync(`psql "$SUPABASE_DB_URL" -c "DELETE FROM profiles WHERE id='${U}'"`,{stdio:'ignore'});}catch{}
+await b.close();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -395,10 +395,15 @@
 		hasInitialized &&
 		loggedIn &&
 		!showMainMenu &&
+		!needsUsername &&
 		$gameStore.currentPhrase === '' &&
 		!$gameWasRestored
 	) {
-		const gameMode = localStorage.getItem('gameMode') || 'daily';
+		// Restore an in-progress game when returning to this route (e.g. back from the Store).
+		// Only act on an EXPLICITLY-set gameMode — never default to 'daily', or a brand-new
+		// user mid-onboarding (showMainMenu still false, no gameMode yet) would silently
+		// auto-start the Daily: burning the attendance bonus + a session before they chose to.
+		const gameMode = localStorage.getItem('gameMode');
 		if (gameMode === 'makeup') {
 			fetchMakeupGame().then((ok) => {
 				if (!ok) showMainMenu = true;
@@ -407,14 +412,15 @@
 			fetchClimbGame().then((ok) => {
 				if (!ok) showMainMenu = true;
 			});
-		} else if (gameMode === 'match') {
-			// Matches need the active id — not deep-link restorable; fall back to Daily.
-			localStorage.setItem('gameMode', 'daily');
-			showMainMenu = true;
-		} else {
+		} else if (gameMode === 'daily') {
 			fetchDailyGame().then((ok) => {
 				if (!ok) initError = 'Daily puzzle failed to load.';
 			});
+		} else {
+			// 'match' isn't deep-link restorable, and no/unknown gameMode means nothing to
+			// resume — show the menu instead of auto-starting anything.
+			if (gameMode === 'match') localStorage.setItem('gameMode', 'daily');
+			showMainMenu = true;
 		}
 	}
 


### PR DESCRIPTION
## Bug (reported)
A brand-new account landed on the menu already showing **"Resume — Daily"** and **$2,050** (not $2,000), with a $50 credit it never earned.

## Cause
The reactive that restores an in-progress game defaulted an unset game mode to daily:
```js
const gameMode = localStorage.getItem('gameMode') || 'daily';
```
and fired `fetchDailyGame()` whenever `showMainMenu` was briefly false. For a new user mid-onboarding (`showMainMenu` still false, no `gameMode` yet), that silently called `daily_start` — creating an active session **and** crediting the $50 attendance bonus before the player chose to play. So the Daily was half-consumed on account creation.

## Fix
The restorer now acts only on an **explicitly-set** `gameMode` (the case it exists for — coming back to an in-progress game from another route like the Store). Unset / unknown / `match` → just show the menu, never auto-start. Also added a `!needsUsername` guard so it can't fire during onboarding. The intentional start path (**Play Now → Daily card → `handleMenuDaily` → `startDaily`**) is untouched.

## Verified
- Fresh signup: bank **$2,000**, **0** daily_sessions, **no** attendance credit, **no** "Resume" strip.
- Play Now → Daily: board loads, session created, attendance credited at that (correct) moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)