### PR TITLE
Fix Daily auto-start during the signup/login window

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -301,6 +301,12 @@
 					/* ignore — nothing to clear */
 				}
 				user.set(null);
+				// Also show the menu (not just init): if the user then logs in / signs up on this
+				// same page instance (Auth flips loggedIn before its window.location reload), a
+				// false showMainMenu would let the game-restorer reactive fire and auto-start a
+				// game from a leftover gameMode. showMainMenu=true keeps that guard closed; the
+				// <Auth/> screen still shows because loggedIn is false.
+				showMainMenu = true;
 				hasInitialized = true;
 				return;
 			}
@@ -333,6 +339,13 @@
 				return;
 			}
 
+			// Cold open → land on the menu. Drop any stale transient gameMode first: it's a
+			// device-global key (not per-account), so a value left over from a previous session
+			// or a different account on this device would otherwise let the game-restorer
+			// auto-start/resume a game the user never chose — e.g. silently firing daily_start
+			// on a brand-new account (burning the attendance bonus). Real starts re-set it;
+			// Resume uses the per-user saved slot, not this.
+			if (localStorage.getItem('gameMode')) localStorage.removeItem('gameMode');
 			// Into the menu immediately — the loading screen only gates on auth + profile.
 			showMainMenu = true;
 			// Load any in-progress game so the menu shows "Resume" (not "Missed") after


### PR DESCRIPTION
Follow-up to #616. That PR stopped the *unset*-gameMode default, but a browser with a **leftover `gameMode='daily'`** (it's a device-global key, not per-account) still auto-started the Daily on a brand-new account — creating a session and burning the $50 attendance bonus. This is what the user kept hitting.

## Root cause (found by tracing `fetchDailyGame`'s caller)
The game-restorer reactive fired inside the Auth flow's **pre-reload window**:
1. App loads with **no session** → the no-session handler set `hasInitialized=true` but left `showMainMenu=false` (fine — `<Auth/>` shows because `!loggedIn`).
2. User signs up / logs in → Auth sets `loggedIn=true` and `await`s `loadUserProfile` **before** its `window.location` reload.
3. In that await window: `hasInitialized && loggedIn && !showMainMenu && gameMode==='daily'` → the reactive fires `fetchDailyGame` → `daily_start`. The reload then lands on the menu, hiding that it already ran.

The trace made it unambiguous: the reactive fired twice with `hi=true, smm=false, mode=daily` **before** onMount's own clear ran.

## Fixes
- **No-session branch also sets `showMainMenu=true`** — so if `loggedIn` flips before the reload, the reactive's `!showMainMenu` guard stays closed. `<Auth/>` still renders because `loggedIn` is false.
- **Cold-open onMount clears any stale transient `gameMode`** before showing the menu — a device-global key shouldn't leak into a new session/account.

## Verified
Leftover `gameMode='daily'` + fresh signup → bank **$2,000**, **0** daily_sessions, no attendance, no "Resume". Play Now → Daily still starts a session normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)