### PR TITLE
Receipts: animate them feeding out of the printer

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9249,6 +9249,36 @@
 		mask:
 			linear-gradient(#000 0 0) top / 100% calc(100% - 7px) no-repeat,
 			radial-gradient(6px 7px at 6px 0, #0000 98%, #000) bottom left / 12px 7px repeat-x;
+		/* 🧾 Feed out of the printer: reveal top→bottom in mechanical steps (paper emerging,
+		   torn edge last) with a faint side-to-side jitter like a thermal head. */
+		position: relative;
+		transform-origin: top center;
+		will-change: clip-path, transform;
+		animation:
+			receipt-print 1.15s steps(24, end) both,
+			receipt-jitter 0.15s steps(2, end) 7 both;
+	}
+	@keyframes receipt-print {
+		from {
+			clip-path: inset(0 0 100% 0);
+		}
+		to {
+			clip-path: inset(0 0 -2% 0);
+		}
+	}
+	@keyframes receipt-jitter {
+		0%,
+		100% {
+			transform: translateX(0);
+		}
+		50% {
+			transform: translateX(0.6px);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.receipt {
+			animation: none;
+		}
 	}
 	.rcpt-brand {
 		display: flex;


### PR DESCRIPTION
Makes the thermal-paper receipts (Daily **deposit slip**, Cash Game **cash-out / bust** scorecards) look like they're **printing out**.

## How
Pure CSS on the shared `.receipt` class:
- The slip reveals **top → bottom** via an animated `clip-path: inset(...)` in `steps()` for a mechanical, line-by-line feed.
- A faint side-to-side `receipt-jitter` mimics a thermal print head.
- The existing torn-paper bottom edge naturally becomes the **leading edge**, emerging last.
- `prefers-reduced-motion` disables it.

No markup changes — every receipt instance gets it automatically. (I tried a printer-slot bar via `::before`, but the parent's `clip-path` clips pseudo-elements too, so it'd need a wrapper on all 5 receipts — not worth it; the feed reveal alone reads clearly as printing.)

## Verified
Solved a real Daily → the deposit slip: mid-animation it's revealed ~65% (top printed, bottom still feeding); it finishes fully printed with the zigzag torn edge. No layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)