### PR TITLE
Receipt print: slow to ~3s + slot bar + printer sound

### DIFF
--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -123,6 +123,48 @@ const SOUNDS = {
 		tone(58, 0.42, 'triangle', 0.24, 0.05); // low body
 		tone(360, 0.2, 'triangle', 0.07, 0.04); // metallic ring
 		sweep(520, 180, 0.3, 'sawtooth', 0.06, 0.05); // dampened resonance
+	},
+	// 🧾 Thermal-receipt printer: a buzzy stepper-motor ratchet that feeds for ~2.8s while
+	// the slip prints, then a soft cut. Built from a bandpassed sawtooth gated by a fast
+	// square LFO (the "brrrt"), with a gentle overall fade in/out.
+	print: () => {
+		const c = ac();
+		if (!c) return;
+		const t0 = c.currentTime;
+		const dur = 2.8;
+		const out = c.createGain();
+		out.gain.value = 0.6;
+		out.connect(c.destination);
+		// Motor whine carrier, drifting slightly down as the roll spins out.
+		const osc = c.createOscillator();
+		osc.type = 'sawtooth';
+		osc.frequency.setValueAtTime(152, t0);
+		osc.frequency.linearRampToValueAtTime(136, t0 + dur);
+		// Bandpass → mechanical buzz rather than a raw saw.
+		const bp = c.createBiquadFilter();
+		bp.type = 'bandpass';
+		bp.frequency.value = 880;
+		bp.Q.value = 3.2;
+		// Ratchet: a square LFO gates amplitude on/off (~46 steps/sec) → the "brrr".
+		const gate = c.createGain();
+		gate.gain.value = 0.5;
+		const lfo = c.createOscillator();
+		lfo.type = 'square';
+		lfo.frequency.value = 46;
+		const lfoAmt = c.createGain();
+		lfoAmt.gain.value = 0.45;
+		lfo.connect(lfoAmt).connect(gate.gain);
+		// Overall envelope.
+		const env = c.createGain();
+		env.gain.setValueAtTime(0, t0);
+		env.gain.linearRampToValueAtTime(0.055, t0 + 0.08);
+		env.gain.setValueAtTime(0.055, t0 + dur - 0.18);
+		env.gain.linearRampToValueAtTime(0, t0 + dur);
+		osc.connect(bp).connect(gate).connect(env).connect(out);
+		osc.start(t0);
+		lfo.start(t0);
+		osc.stop(t0 + dur + 0.05);
+		lfo.stop(t0 + dur + 0.05);
 	}
 };
 
@@ -138,7 +180,9 @@ const HAPTICS = {
 	bust: [60, 30, 60],
 	multiplier: [10, 24, 10],
 	lead: [12, 20, 16],
-	vault: [50, 30, 90]
+	vault: [50, 30, 90],
+	// Light stutter that rides along with the ~2.8s print buzz.
+	print: [14, 60, 14, 60, 14, 60, 14, 60, 14, 60, 14, 60, 14]
 };
 
 /** Play an audio cue by name (no-op when disabled). @param {string} name */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1685,6 +1685,12 @@
 		location.reload();
 	}
 
+	/** Svelte action: play the printer buzz the moment a receipt mounts (feeds out). */
+	function printSound(/** @type {HTMLElement} */ _node) {
+		fx('print');
+		return {};
+	}
+
 	/** Start daily: resume if in progress, else show "already played" or fetch new daily.
 	 *  Daily has no personal power-ups — everyone shares the same Daily Modifier. */
 	async function handleMenuDaily() {
@@ -4714,7 +4720,8 @@
 						<!-- Account before today: back out the show-up bonus + this deposit (net of the skim). -->
 						{@const startBal = acctNow - attendance - banked + loanRepaid}
 						<!-- 🧾 Daily DEPOSIT slip: Budget − Letters = Subtotal ×Interest = Deposit -->
-						<div class="receipt">
+						<div class="rcpt-slot" aria-hidden="true"></div>
+						<div class="receipt" use:printSound>
 							<div class="rcpt-brand">
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
@@ -4813,7 +4820,8 @@
 						>
 					{:else if isDailyResult}
 						<!-- 🧾 Daily VOID slip: didn't solve → no deposit, balance untouched -->
-						<div class="receipt void">
+						<div class="rcpt-slot" aria-hidden="true"></div>
+						<div class="receipt void" use:printSound>
 							<div class="rcpt-brand">
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
@@ -4856,7 +4864,8 @@
 						{@const skim = Math.round(co.loan_repaid ?? 0)}
 						{@const endBal = Math.round(menuBank ?? 0)}
 						{@const startBal = Math.round(co.run_start_bal ?? endBal - prof + skim)}
-						<div class="receipt">
+						<div class="rcpt-slot" aria-hidden="true"></div>
+						<div class="receipt" use:printSound>
 							<div class="rcpt-brand">
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
@@ -4947,7 +4956,8 @@
 						{@const runInt = Math.max(0, Math.round((climb?.heat ?? 100) - 100))}
 						{@const tierName =
 							(climb?.tier ?? '').charAt(0).toUpperCase() + (climb?.tier ?? '').slice(1)}
-						<div class="receipt">
+						<div class="rcpt-slot" aria-hidden="true"></div>
+						<div class="receipt" use:printSound>
 							<div class="rcpt-brand">
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
@@ -5030,7 +5040,8 @@
 						{@const ante = Math.round(climb?.buy_in ?? 0)}
 						{@const endBal = Math.round(menuBank ?? 0)}
 						{@const startBal = endBal + ante}
-						<div class="receipt void">
+						<div class="rcpt-slot" aria-hidden="true"></div>
+						<div class="receipt void" use:printSound>
 							<div class="rcpt-brand">
 								<img class="rcpt-coin" src="/logo-coin.png" alt="" width="40" height="40" />
 								<img class="rcpt-mark" src="/wordmark.png" alt="WordBank" />
@@ -9231,11 +9242,45 @@
 		}
 	}
 	/* 🧾 Receipt-style Cash Game results */
+	/* 🖨️ Printer slot the receipt feeds out of — a dark housing bar just above the slip,
+	   with a black paper-exit gap. Sits above the paper (z-index) so the slip emerges from
+	   behind it. It's a sibling of .receipt (not a child) so the slip's clip-path reveal
+	   doesn't clip it. */
+	.rcpt-slot {
+		width: 100%;
+		max-width: 306px;
+		height: 13px;
+		margin: 0.4rem auto -7px;
+		position: relative;
+		z-index: 2;
+		border-radius: 7px 7px 4px 4px;
+		background: linear-gradient(#45454f, #17171d 62%, #0b0b0f);
+		box-shadow:
+			inset 0 1px 0 rgba(255, 255, 255, 0.09),
+			inset 0 -3px 5px rgba(0, 0, 0, 0.7),
+			0 3px 8px rgba(0, 0, 0, 0.5);
+	}
+	.rcpt-slot::after {
+		content: '';
+		position: absolute;
+		left: 9px;
+		right: 9px;
+		bottom: 2px;
+		height: 3px;
+		border-radius: 2px;
+		background: #05050a;
+		box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.9);
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.rcpt-slot {
+			display: none;
+		}
+	}
 	.receipt {
 		font-family: 'Courier New', 'Courier', ui-monospace, monospace;
 		width: 100%;
 		max-width: 290px;
-		margin: 0.4rem auto 1.1rem;
+		margin: 0 auto 1.1rem;
 		padding: 18px 20px 20px;
 		background: #f6f1e6;
 		color: #23201a;
@@ -9249,14 +9294,16 @@
 		mask:
 			linear-gradient(#000 0 0) top / 100% calc(100% - 7px) no-repeat,
 			radial-gradient(6px 7px at 6px 0, #0000 98%, #000) bottom left / 12px 7px repeat-x;
-		/* 🧾 Feed out of the printer: reveal top→bottom in mechanical steps (paper emerging,
-		   torn edge last) with a faint side-to-side jitter like a thermal head. */
+		/* 🧾 Feed out of the printer: reveal top→bottom in mechanical steps (paper emerging
+		   from behind the slot, torn edge last) with a faint side-to-side jitter like a
+		   thermal head. Slow (~3s) so you can watch it print. */
 		position: relative;
+		z-index: 1;
 		transform-origin: top center;
 		will-change: clip-path, transform;
 		animation:
-			receipt-print 1.15s steps(24, end) both,
-			receipt-jitter 0.15s steps(2, end) 7 both;
+			receipt-print 3s steps(60, end) both,
+			receipt-jitter 0.14s steps(2, end) 21 both;
 	}
 	@keyframes receipt-print {
 		from {


### PR DESCRIPTION
Follow-up to #619 with the requested tweaks.

## Changes
- **Slower** — feed-out goes from 1.15s → **3s** (steps 24→60), so you can actually watch it print.
- **Printer slot bar** — a dark housing (`.rcpt-slot`) with a black paper-exit gap sits above each receipt; the slip emerges **from behind it**. It's a *sibling* of `.receipt` (a child would get clipped by the reveal's `clip-path`), overlapped `-7px` with a `z-index`. Hidden under `prefers-reduced-motion`.
- **Print sound** — a new synthesized `print` cue: a bandpassed sawtooth **gated by a ~46 Hz square LFO** → a mechanical "brrr" for 2.8 s, plus a light haptic stutter. A tiny `printSound` Svelte action fires `fx('print')` the instant each receipt mounts, so audio and the visual reveal start together.

Applied to all five receipts (Daily deposit slip + Cash Game cash-out / bust scorecards).

## Verified
Real Daily win: at ~0.6s only the top ~20% has fed out from behind the slot bar; it ends fully printed with the torn zigzag edge. Screenshots in the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)