### PR TITLE
Free Play: gold ★ points unit on budget + keyboard prices

### DIFF
--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -121,6 +121,8 @@
 			: $gameStore.gameMode === 'daily' || $gameStore.gameMode === 'freeplay'
 				? Number($gameStore.dailyLive?.remaining ?? $gameStore.bankroll ?? 0)
 				: Number($gameStore.bankroll ?? 0);
+	// Free Play spends points, not Cash — mark letter prices with the ★ unit, not $.
+	$: priceMark = $gameStore.gameMode === 'freeplay' ? '★' : '$';
 	// 🔹 Disable keys that are unaffordable or already marked incorrect (modifier-adjusted prices).
 	$: disabledKeys = Object.keys(letterCosts).filter(
 		(letter: string) => (effCosts[letter] ?? 0) > affordPool || incorrectLetters.includes(letter)
@@ -246,7 +248,7 @@
 				<span class="braille">{BRAILLE[letter]}</span>
 				<div class="letter">{letter}</div>
 				<div class="price">
-					${effCosts[letter] ?? 0}
+					{priceMark}{effCosts[letter] ?? 0}
 				</div>
 			</button>
 		{/each}
@@ -274,7 +276,7 @@
 				<span class="braille">{BRAILLE[letter]}</span>
 				<div class="letter">{letter}</div>
 				<div class="price">
-					${effCosts[letter] ?? 0}
+					{priceMark}{effCosts[letter] ?? 0}
 				</div>
 			</button>
 		{/each}
@@ -302,7 +304,7 @@
 				<span class="braille">{BRAILLE[letter]}</span>
 				<div class="letter">{letter}</div>
 				<div class="price">
-					${effCosts[letter] ?? 0}
+					{priceMark}{effCosts[letter] ?? 0}
 				</div>
 			</button>
 		{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4593,7 +4593,12 @@
 								}}>${Math.max(0, Math.round($tweenNet)).toLocaleString()}</button
 							>
 						{:else if $gameStore.gameMode === 'freeplay'}
-							<span class="bp-amount">{Math.max(0, Math.round($tweenNet)).toLocaleString()}</span>
+							<span class="bp-amount"
+								><span class="bp-fp-mark" aria-hidden="true">★</span>{Math.max(
+									0,
+									Math.round($tweenNet)
+								).toLocaleString()}</span
+							>
 						{:else}
 							<span class="bp-amount"
 								>{$tweenNet >= 0 ? '$' : '−$'}{Math.abs(
@@ -8329,6 +8334,15 @@
 		text-shadow: 0 0 18px rgba(52, 211, 153, 0.5);
 		font-variant-numeric: tabular-nums;
 		transition: color 0.2s;
+	}
+	/* Free Play "currency" mark — a gold star before the points budget (the star is
+	   Free Play's unit, like $ is for the money modes). */
+	.bp-fp-mark {
+		color: var(--brand-2, #fde047);
+		font-size: 0.62em;
+		margin-right: 5px;
+		vertical-align: 0.2em;
+		text-shadow: 0 0 12px rgba(253, 224, 71, 0.55);
 	}
 	.bp-amount-btn {
 		background: none;


### PR DESCRIPTION
The Free Play budget number looked bare, and the keyboard still showed `$` prices (it's points, not money). Add a gold **★** as Free Play's "currency" mark:

- **Budget hero:** a gold ★ before the points number (★980), matching the glow treatment — the pop the bare number was missing.
- **Keyboard prices:** `$N` → `★N` in freeplay only (`priceMark = freeplay ? '★' : '$'`), across all three rows.

Now the star reads consistently as points everywhere — the **★ pts** chip, the budget hero, and every key price.

Verified at 390px: hero shows **★980**, keys show **★20 / ★40 / …**, no `$` anywhere in Free Play. Money modes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)