### PR TITLE
Free Play: confirm + explain before skipping a puzzle

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1784,6 +1784,23 @@
 		showMainMenu = false;
 		hasInitialized = true;
 	}
+	// Skip → new puzzle. After a solve it's just "Next" (no confirm). Skipping an unsolved
+	// puzzle forfeits the points you could have banked from it, so confirm + explain first.
+	async function handleFreePlayNext() {
+		fx('tap');
+		if ($gameStore.gameState === 'won') {
+			freePlayNext();
+			return;
+		}
+		const ok = await requireConfirm({
+			title: 'Skip this puzzle?',
+			message:
+				"You'll get a fresh puzzle and won't bank any points from this one. Your points total stays safe — you just won't earn anything for the puzzle you're skipping.",
+			confirmText: 'Skip',
+			cancelText: 'Keep playing'
+		});
+		if (ok) freePlayNext();
+	}
 
 	// Today's shared Daily Modifier banner (id lives in the game store, set by fetchDailyGame).
 	$: dailyMod =
@@ -4338,12 +4355,8 @@
 		<!-- ★ Free Play HUD — points earned this device + Next/Skip (freeplay only, no money). -->
 		{#if $gameStore.gameMode === 'freeplay'}
 			<div class="fp-hud">
-				<button
-					class="fp-next"
-					on:click={() => {
-						fx('tap');
-						freePlayNext();
-					}}>{$gameStore.gameState === 'won' ? 'Next puzzle →' : 'Skip →'}</button
+				<button class="fp-next" on:click={handleFreePlayNext}
+					>{$gameStore.gameState === 'won' ? 'Next puzzle →' : 'Skip →'}</button
 				>
 			</div>
 		{/if}


### PR DESCRIPTION
Adds a confirm layer to the Free Play **Skip** button that explains what skipping does.

- Tapping **Skip** (on an unsolved puzzle) opens: *"Skip this puzzle? You'll get a fresh puzzle and won't bank any points from this one. Your points total stays safe — you just won't earn anything for the puzzle you're skipping."* with **Skip** / **Keep playing**.
- Only prompts on an **unsolved** skip. After a win, the button reads "Next puzzle →" and advances directly — no unnecessary confirm.
- Reuses the existing app-wide `requireConfirm` / `ConfirmModal` (globally mounted), so it matches the app's confirm styling.

Verified at 390px: modal appears with the explanation, Keep-playing backs out, Skip loads a fresh puzzle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)