### PR TITLE
Free Play: grey out already-owned letters

### DIFF
--- a/src/lib/freeplay/engine.js
+++ b/src/lib/freeplay/engine.js
@@ -75,12 +75,26 @@ export function toBoard(state) {
 	/** @type {Record<string,string>} */
 	const revealed = {};
 	for (const i of state.revealed) revealed[i] = state.phrase[i];
+	// A letter is "locked" (fully owned) once every one of its positions is revealed — the
+	// keyboard greys those so you can't try to re-buy an already-owned letter. Matches the
+	// server's _daily_board rule (GROUP BY letter HAVING all-positions-revealed).
+	const revealedSet = new Set(state.revealed);
+	const lockedLetters = [
+		...new Set(state.phrase.replace(/[^A-Z]/g, '').split(''))
+	]
+		.filter((ch) => {
+			for (let i = 0; i < state.phrase.length; i++) {
+				if (state.phrase[i] === ch && !revealedSet.has(i)) return false;
+			}
+			return true;
+		})
+		.sort();
 	const budgetLeft = Math.max(0, state.budget - state.spent);
 	return {
 		word_lengths: wordLengths,
 		revealed,
 		incorrect_letters: state.incorrect,
-		locked_letters: [],
+		locked_letters: lockedLetters,
 		bankroll: budgetLeft,
 		guesses_remaining: 99,
 		category: state.category,

--- a/src/lib/freeplay/engine.test.js
+++ b/src/lib/freeplay/engine.test.js
@@ -67,4 +67,15 @@ test('toBoard emits the server-shaped board', () => {
 	assert.equal(b.live.remaining, 360 - 100);
 	assert.equal(b.state, 'active');
 	assert.equal(b.phrase, undefined); // hidden until won
+	// A is fully revealed (both positions) → locked so the keyboard greys it; T/H aren't.
+	assert.deepEqual(b.locked_letters, ['A']);
+});
+
+test('toBoard locks a letter only when ALL its positions are revealed', () => {
+	// "AHA" has A at 0 and 2; revealing just index 0 must NOT lock A.
+	let s = newGame({ id: 'y', phrase: 'AHA', category: 'C', clue: 'k' });
+	s = { ...s, revealed: [0] };
+	assert.deepEqual(toBoard(s).locked_letters, []);
+	s = { ...s, revealed: [0, 2] };
+	assert.deepEqual(toBoard(s).locked_letters, ['A']);
 });


### PR DESCRIPTION
Fixes the reported "I can't buy O" confusion.

**Cause:** the Free Play engine's `toBoard` hardcoded `locked_letters: []`. So a letter that's *already fully revealed* on the board (like the O in "LOST TV REMOTE") never greyed out on the keyboard — it looked buyable, but tapping it did nothing (the engine correctly no-ops a re-buy of an owned letter). Reads as a broken key.

**Fix:** `toBoard` now computes `locked_letters` as the letters whose **every** position is revealed — the same rule the server's `_daily_board` uses (`GROUP BY letter HAVING all-positions-revealed`). Those keys now show the existing `purchased` (greyed) state, so you can see they're already owned and won't try to buy them.

- `src/lib/freeplay/engine.js`: compute `locked_letters` from fully-revealed letters.
- `+1 engine test` (partial vs. full reveal → not locked / locked). Suite now 11/11.

Verified: after buying a letter in Free Play, its key gets the `purchased` class and greys out, matching the money modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)