### PR TITLE
Free Play: out-of-points danger + last-guess loss

### DIFF
--- a/src/lib/freeplay/engine.js
+++ b/src/lib/freeplay/engine.js
@@ -9,7 +9,7 @@ function distinctLetters(phrase) {
 }
 
 /** @param {{id:string,phrase:string,category:string,clue:string}} puzzle
- * @returns {{puzzleId:string,phrase:string,category:string,clue:string,budget:number,spent:number,revealed:number[],incorrect:string[],status:'active'|'won'}} */
+ * @returns {{puzzleId:string,phrase:string,category:string,clue:string,budget:number,spent:number,revealed:number[],incorrect:string[],status:'active'|'won'|'lost'}} */
 export function newGame(puzzle) {
 	const phrase = puzzle.phrase.toUpperCase();
 	const base = distinctLetters(phrase).reduce((sum, c) => sum + (LETTER_COSTS[c] || 0), 0);
@@ -24,7 +24,7 @@ export function newGame(puzzle) {
 		spent: 0,
 		/** @type {number[]} */ revealed: [],
 		/** @type {string[]} */ incorrect: [],
-		/** @type {'active'|'won'} */ status: 'active'
+		/** @type {'active'|'won'|'lost'} */ status: 'active'
 	};
 }
 
@@ -47,19 +47,55 @@ export function buyLetter(state, rawLetter) {
 	return { ...state, spent: state.spent + cost, revealed };
 }
 
+/** Cheapest letter you could still buy (not wrong, not already fully revealed), or null
+ * if none remain. @param {ReturnType<typeof newGame>} state @returns {number|null} */
+function cheapestBuyable(state) {
+	const revealedSet = new Set(state.revealed);
+	let min = Infinity;
+	for (const letter of Object.keys(LETTER_COSTS)) {
+		if (state.incorrect.includes(letter)) continue;
+		let fullyRevealed = true;
+		let present = false;
+		for (let i = 0; i < state.phrase.length; i++) {
+			if (state.phrase[i] === letter) {
+				present = true;
+				if (!revealedSet.has(i)) fullyRevealed = false;
+			}
+		}
+		if (present && fullyRevealed) continue; // already own every position → can't re-buy
+		if (LETTER_COSTS[letter] < min) min = LETTER_COSTS[letter];
+	}
+	return min === Infinity ? null : min;
+}
+
+/** Out of budget for any further letter → the next guess is the last chance.
+ * @param {ReturnType<typeof newGame>} state @returns {boolean} */
+export function mustGuess(state) {
+	if (state.status !== 'active') return false;
+	const cheapest = cheapestBuyable(state);
+	return cheapest === null || state.budget - state.spent < cheapest;
+}
+
 /** @param {ReturnType<typeof newGame>} state @param {Record<number,string>} filled
  * @returns {ReturnType<typeof newGame>} */
 export function applyGuess(state, filled) {
 	if (state.status !== 'active') return state;
+	let correct = true;
 	for (let i = 0; i < state.phrase.length; i++) {
 		if (state.phrase[i] === ' ') continue;
 		const ch = (filled[i] ?? (state.revealed.includes(i) ? state.phrase[i] : '')).toUpperCase();
-		if (ch !== state.phrase[i]) return state; // any mismatch → not solved (no penalty)
+		if (ch !== state.phrase[i]) {
+			correct = false;
+			break;
+		}
 	}
-	// every non-space position matches → win; reveal all
 	const all = [];
 	for (let i = 0; i < state.phrase.length; i++) if (state.phrase[i] !== ' ') all.push(i);
-	return { ...state, revealed: all, status: 'won' };
+	if (correct) return { ...state, revealed: all, status: 'won' };
+	// Wrong. If you can't afford another letter, that was your last chance → lost (reveal the
+	// answer). Otherwise no penalty — keep playing.
+	if (mustGuess(state)) return { ...state, revealed: all, status: 'lost' };
+	return state;
 }
 
 /** @param {ReturnType<typeof newGame>} state
@@ -69,7 +105,7 @@ export function scoreOnSolve(state) {
 }
 
 /** @param {ReturnType<typeof newGame>} state
- * @returns {{word_lengths:number[],revealed:Record<string,string>,incorrect_letters:string[],locked_letters:any[],bankroll:number,guesses_remaining:number,category:string,subcategory:string,clue:string,state:'active'|'won',phrase?:string,live:{remaining:number}}} */
+ * @returns {{word_lengths:number[],revealed:Record<string,string>,incorrect_letters:string[],locked_letters:any[],must_guess:boolean,bankroll:number,guesses_remaining:number,category:string,subcategory:string,clue:string,state:'active'|'won'|'lost',phrase?:string,live:{remaining:number}}} */
 export function toBoard(state) {
 	const wordLengths = state.phrase.split(' ').map((w) => w.length);
 	/** @type {Record<string,string>} */
@@ -79,9 +115,7 @@ export function toBoard(state) {
 	// keyboard greys those so you can't try to re-buy an already-owned letter. Matches the
 	// server's _daily_board rule (GROUP BY letter HAVING all-positions-revealed).
 	const revealedSet = new Set(state.revealed);
-	const lockedLetters = [
-		...new Set(state.phrase.replace(/[^A-Z]/g, '').split(''))
-	]
+	const lockedLetters = [...new Set(state.phrase.replace(/[^A-Z]/g, '').split(''))]
 		.filter((ch) => {
 			for (let i = 0; i < state.phrase.length; i++) {
 				if (state.phrase[i] === ch && !revealedSet.has(i)) return false;
@@ -95,6 +129,7 @@ export function toBoard(state) {
 		revealed,
 		incorrect_letters: state.incorrect,
 		locked_letters: lockedLetters,
+		must_guess: mustGuess(state),
 		bankroll: budgetLeft,
 		guesses_remaining: 99,
 		category: state.category,

--- a/src/lib/freeplay/engine.test.js
+++ b/src/lib/freeplay/engine.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { newGame, buyLetter, applyGuess, scoreOnSolve, toBoard } from './engine.js';
+import { newGame, buyLetter, applyGuess, scoreOnSolve, toBoard, mustGuess } from './engine.js';
 
 const P = { id: 'x', phrase: 'CAT HAT', category: 'C', clue: 'k' };
 
@@ -78,4 +78,24 @@ test('toBoard locks a letter only when ALL its positions are revealed', () => {
 	assert.deepEqual(toBoard(s).locked_letters, []);
 	s = { ...s, revealed: [0, 2] };
 	assert.deepEqual(toBoard(s).locked_letters, ['A']);
+});
+
+test('mustGuess flips true only when you cannot afford the cheapest letter', () => {
+	const s = newGame(P); // budget 360, cheapest buyable is 20
+	assert.equal(mustGuess(s), false);
+	const broke = { ...s, spent: s.budget - 10 }; // 10 left < 20
+	assert.equal(mustGuess(broke), true);
+	assert.equal(toBoard(broke).must_guess, true);
+});
+
+test('a wrong guess loses the puzzle only when out of budget', () => {
+	// With budget left, a wrong guess just keeps it active (no penalty).
+	let ok = applyGuess(newGame(P), { 0: 'X', 1: 'A', 2: 'T', 4: 'H', 5: 'A', 6: 'T' });
+	assert.equal(ok.status, 'active');
+	// Out of budget → the wrong guess is fatal: lost, answer revealed, 0 points.
+	const broke = { ...newGame(P), spent: newGame(P).budget };
+	const lost = applyGuess(broke, { 0: 'X', 1: 'A', 2: 'T', 4: 'H', 5: 'A', 6: 'T' });
+	assert.equal(lost.status, 'lost');
+	assert.equal(scoreOnSolve(lost), 0);
+	assert.equal(toBoard(lost).state, 'lost');
 });

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -402,28 +402,33 @@ function reconcileFreeplayBoard() {
 	const board = toBoard(freeplayState);
 	const prev = get(gameStore);
 	const won = board.state === 'won';
+	const lost = board.state === 'lost';
 	const justWon = won && prev.gameState !== 'won';
+	const justLost = lost && prev.gameState !== 'lost';
 	gameStore.set(
 		/** @type {GameState} */ ({
 			...prev,
 			...boardToState(board, prev),
 			gameMode: 'freeplay',
-			gameState: won ? 'won' : 'default',
+			gameState: won ? 'won' : lost ? 'lost' : 'default',
 			clue: board.clue ?? null,
 			dailyLive: board.live,
+			// Out-of-points "last guess" wall — reuses the Daily must-guess flag + danger screen.
+			dailyMustGuess: !!board.must_guess,
 			// freeplay never uses these money/daily fields:
 			climbInfo: null,
 			matchInfo: null,
 			dailyResult: null,
-			modifier: null,
-			dailyMustGuess: false
+			modifier: null
 		})
 	);
 	if (justWon) {
 		const gained = scoreOnSolve(freeplayState);
 		recordSolve(fpStorage(), gained);
 		fx('win');
-	} else if (!won) {
+	} else if (justLost) {
+		fx('bust');
+	} else if (!won && !lost) {
 		playMoveCue(prev, board);
 	}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -539,8 +539,11 @@
 	// 🚨 Last-stand: out of budget, this guess decides it. Persistent while stuck
 	// (drives the red screen treatment + keyboard lock). Overdrive lifts the lock.
 	// Cash Game = your run is on the line; Daily = your one shot at today's win.
+	$: isFreeplay = $gameStore.gameMode === 'freeplay';
 	$: dangerMode =
-		((isClimb && !!climb?.must_guess) || (isDaily && !!$gameStore.dailyMustGuess)) &&
+		((isClimb && !!climb?.must_guess) ||
+			(isDaily && !!$gameStore.dailyMustGuess) ||
+			(isFreeplay && !!$gameStore.dailyMustGuess)) &&
 		gameActive &&
 		$gameStore.gameState !== 'won' &&
 		$gameStore.gameState !== 'lost';
@@ -1788,7 +1791,8 @@
 	// puzzle forfeits the points you could have banked from it, so confirm + explain first.
 	async function handleFreePlayNext() {
 		fx('tap');
-		if ($gameStore.gameState === 'won') {
+		// Already resolved (solved or lost) → just advance, no confirm.
+		if ($gameStore.gameState === 'won' || $gameStore.gameState === 'lost') {
 			freePlayNext();
 			return;
 		}
@@ -4356,7 +4360,9 @@
 		{#if $gameStore.gameMode === 'freeplay'}
 			<div class="fp-hud">
 				<button class="fp-next" on:click={handleFreePlayNext}
-					>{$gameStore.gameState === 'won' ? 'Next puzzle →' : 'Skip →'}</button
+					>{$gameStore.gameState === 'won' || $gameStore.gameState === 'lost'
+						? 'Next puzzle →'
+						: 'Skip →'}</button
 				>
 			</div>
 		{/if}
@@ -4456,6 +4462,22 @@
 				<span class="dc-title"><Icon name="broke" size={16} /> OUT OF BUDGET</span>
 				<span class="dc-sub">Last guess — get it right to win today</span>
 				<button class="bn-forfeit" on:click={confirmFold}>Give up?</button>
+			</div>
+		{/if}
+
+		<!-- 🚨 Free Play out-of-points wall — last guess (no money, just this puzzle). -->
+		{#if isFreeplay && dangerMode}
+			<div class="danger-cue daily" role="alert">
+				<span class="dc-title"><Icon name="broke" size={16} /> OUT OF POINTS</span>
+				<span class="dc-sub">Last guess — solve it, or skip to a new puzzle</span>
+				<button class="bn-forfeit" on:click={handleFreePlayNext}>Skip →</button>
+			</div>
+		{/if}
+		<!-- 💀 Free Play miss — out of points and the last guess was wrong; answer revealed. -->
+		{#if isFreeplay && $gameStore.gameState === 'lost'}
+			<div class="danger-cue daily" role="alert">
+				<span class="dc-title"><Icon name="broke" size={16} /> OUT OF POINTS</span>
+				<span class="dc-sub">No points that time — here's the answer. Try the next one!</span>
 			</div>
 		{/if}
 


### PR DESCRIPTION
Gives Free Play the same danger/last-stand + loss flow the money modes have, in points.

## Behavior
- When your points budget can't afford the **cheapest** buyable letter, the red **danger screen** shows: *"OUT OF POINTS — Last guess — solve it, or skip to a new puzzle."* The keyboard greys out (nothing's affordable), matching the money-mode last-stand.
- A **wrong guess while out of points** ends the puzzle in a **loss**: *"OUT OF POINTS — No points that time — here's the answer. Try the next one!"*, the answer reveals, and the HUD button becomes **Next puzzle →**.
- A wrong guess while you **still have budget** is unchanged — no penalty, keep playing.

## Changes
- **`engine.js`**: `mustGuess()` (budget < cheapest still-buyable letter) + a new `'lost'` status; `applyGuess` returns `'lost'` on a wrong guess when out of budget (reveals the answer); `toBoard` exposes `must_guess`. **+2 tests (suite 13/13).**
- **`GameStore.reconcileFreeplayBoard`**: passes `must_guess` through (reuses the Daily must-guess flag → existing danger screen), handles the lost transition with `fx('bust')`.
- **`+page.svelte`**: adds Free Play to `dangerMode`, a Free Play danger cue + loss cue, and makes the HUD button read "Next puzzle →" on won **or** lost (no confirm).

## Verified end-to-end
Drained a real puzzle's budget 780 → 18 → the danger screen appeared; a wrong guess → the loss screen with the answer revealed + Next puzzle. Screenshots in branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)