### PR TITLE
Perf: two audit indexes (game_results, challenge_participants)

### DIFF
--- a/supabase-perf-indexes.sql
+++ b/supabase-perf-indexes.sql
@@ -1,0 +1,9 @@
+-- Perf indexes from the 2026-07-16 audit. Cheap to add now while tables are small; prevents
+-- silent leaderboard/settle degradation as game_results and challenge_participants grow.
+-- Serves the daily-window + challenge-filter leaderboard aggregates:
+CREATE INDEX IF NOT EXISTS idx_game_results_mode_played
+  ON public.game_results (game_mode, played_at DESC);
+-- Removes the seq scan of challenge_participants in the _match_settle win-count subquery
+-- (pkey is (match_id, user_id), so WHERE user_id = ... had no usable index):
+CREATE INDEX IF NOT EXISTS idx_challenge_participants_user
+  ON public.challenge_participants (user_id);


### PR DESCRIPTION
Applied to prod 2026-07-16 (Tier 3 audit item). Adds `game_results(game_mode, played_at DESC)` (serves the daily/challenge leaderboard aggregates) and `challenge_participants(user_id)` (removes the seq scan in _match_settle). Zero-risk at current table sizes; `IF NOT EXISTS` idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)