### PR TITLE
1v1 challenge mechanics overhaul (fog, erase, timer, pot, sabotage prices, broke last-stand, caps)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-1v1-match-mechanics.md
+++ b/docs/superpowers/plans/2026-07-16-1v1-match-mechanics.md
@@ -1,0 +1,287 @@
+# 1v1 Challenge Mechanics Overhaul — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Ship the seven 1v1 challenge (`gameMode:'match'`) changes from the spec: fog rework, erase, in-match timer, pot relocation, sabotaged-price keyboard, broke last-stand, and usage caps.
+
+**Architecture:** Match state lives on `challenge_participants`; the board is built by `_match_board` (returns `_daily_board(...)` + a `match` metadata object `v_minfo`). Economy/effects are enforced in SECURITY DEFINER RPCs, most of which are **DB-only** (dump the live body, transform, rollback-test, apply). The client renders whatever the board reports; `_match_board.v_minfo` already exposes `used_powerups` (=`active_powerups`) and `my_debuffs` (=`debuffs`).
+
+**Tech Stack:** SvelteKit 2.16 (Svelte 5), Supabase Postgres, `psql "$SUPABASE_DB_URL"` direct-to-prod migrations, `node:test`, Playwright (`scripts/qa-h2h.mjs` two-player harness).
+
+## Global Constraints
+
+- **Scoped to `gameMode:'match'` only.** Daily, Cash Game, Free Play behavior must not change.
+- **Server is authoritative.** Every new effect/cap is enforced in the RPC; the client only reflects the board. Never gate an effect client-only.
+- **DB migration pattern:** `set -a; . ./.env; set +a`; dump live body with `pg_get_functiondef`; transform (perl/hand-edit into a committed `supabase-*.sql`); rollback-test with `BEGIN…ROLLBACK` on a seeded match; apply; commit. Repo files lag prod — always dump live first.
+- **Cost stack order (must be preserved exactly, server + client):** `Half Off (×0.5) → Tax (×1.5) → Vowel Block (×3 on vowels) → Toll (×3, then removed)`; `CEIL()` after ×0.5 and ×1.5.
+- **Reset-on-advance:** the new per-puzzle columns reset in `_match_resolve_and_advance` alongside the existing `revealed_positions/incorrect_letters/active_powerups/debuffs` resets (BOTH the `econ_v=2` and the old branch).
+- Git commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+## Current-state anchors (from live prod bodies)
+
+- `_match_board` clue line: `'clue', CASE WHEN 'fog' = ANY(COALESCE(cp.debuffs,'{}')) THEN NULL ELSE v_clue END`. `v_minfo` already has `used_powerups`, `my_debuffs`, `opponents` (id+name), `pot`, `target`. No `started_at`, no `must_guess`, opponents carry no `position`.
+- `match_buy_letter`: applies the cost stack (`half_off`/`tax`/`vowel_block`/`toll`), then reveals — `IF v_positions IS NULL THEN incorrect_letters := append ELSE revealed_positions := DISTINCT sorted END`.
+- `match_sabotage`: `lock` branch picks a **random** revealed letter (`ORDER BY random() LIMIT 1`) and rebuilds `revealed_positions` excluding it; the `ELSE` branch appends `v_debuff` to `debuffs[]` + `debuff_by`.
+- `match_use_powerup`: one-of-each gate is `IF v_eff = ANY(cp.active_powerups) THEN RETURN ...`.
+- `match_submit_guess`: wrong guess penalizes budget (`v_pen := GREATEST(10, round(0.2*bankroll/10)*10)`), never folds.
+- `_match_resolve_and_advance`: on advance (non-final), resets `revealed_positions='{}', incorrect_letters='{}', active_powerups='{}', debuffs='{}', p_vowels=0, p_reveals=0, p_wrong_guesses=0` in BOTH branches.
+
+---
+
+### Task 1: Schema foundation + advance reset
+
+**Files:** Create `supabase-match-mechanics-schema.sql`. Touches live `_match_resolve_and_advance`.
+
+**Interfaces — Produces:** new `challenge_participants` columns consumed by all later tasks:
+`pending_fog boolean`, `fog_buys_left int`, `reveal_order text[]`, `sabotaged_targets uuid[]`.
+
+- [ ] **Step 1: Add columns + seed/reset logic**
+
+Write `supabase-match-mechanics-schema.sql`:
+```sql
+ALTER TABLE public.challenge_participants
+  ADD COLUMN IF NOT EXISTS pending_fog boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS fog_buys_left int NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS reveal_order text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS sabotaged_targets uuid[] NOT NULL DEFAULT '{}';
+```
+
+- [ ] **Step 2: Update `_match_resolve_and_advance` reset**
+
+Dump the live body. In BOTH advance branches (the `econ_v=2` non-final `UPDATE ... position = position + 1` and the old-econ non-final `UPDATE`), extend the reset SET-list to also seed fog + clear the new per-puzzle columns:
+```sql
+        revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+        reveal_order = '{}', sabotaged_targets = '{}',
+        fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+        p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+```
+(The `fog_buys_left = 3 on pending_fog` seeding on advance is what makes fog land on the player's NEXT puzzle, never puzzle 1 — advances only happen after puzzle 1.) Add the full `CREATE OR REPLACE FUNCTION` for `_match_resolve_and_advance` to the SQL file.
+
+- [ ] **Step 3: Rollback-test**
+
+`BEGIN; <apply schema + fn>; ` seed a match participant on puzzle 1 with `pending_fog=true`, advance them (call `match_submit_guess` with a full correct solve, or directly simulate the advance UPDATE), assert the new puzzle row has `fog_buys_left=3, pending_fog=false, reveal_order='{}', sabotaged_targets='{}'`. `ROLLBACK;`. If seeding a full match is impractical, at minimum apply inside `BEGIN…ROLLBACK` to prove it compiles, and assert the SET-list contains the new columns.
+
+- [ ] **Step 4: Apply + commit**
+
+```bash
+set -a; . ./.env; set +a; psql "$SUPABASE_DB_URL" -v ON_ERROR_STOP=1 -f supabase-match-mechanics-schema.sql
+git add supabase-match-mechanics-schema.sql
+git commit -m "Match: add fog/erase/cap columns to challenge_participants + reset on advance"
+```
+
+---
+
+### Task 2: Fog → queued next-puzzle curse (3 buys)
+
+**Files:** Create `supabase-match-fog.sql`. Touches live `match_sabotage`, `_match_board`, `match_buy_letter`.
+
+**Interfaces — Consumes:** Task 1 columns. **Produces:** `matchInfo.opponents[].position`/`pack_size` for client castability; clue hidden while `fog_buys_left>0`.
+
+- [ ] **Step 1: `match_sabotage` fog branch → set `pending_fog`, guard next-puzzle**
+
+Dump live `match_sabotage`. Currently `fog` falls into the `ELSE` (debuffs[]) branch. Split it out: before the debuff `ELSE`, add a `fog` branch that sets `pending_fog` on the target **only if the target has an un-started next puzzle** (`tcp.position < m.pack_size`); otherwise reject (no charge). Move the inventory-decrement to AFTER validation so a rejected fog doesn't consume the item:
+```sql
+  ELSIF v_debuff = 'fog' THEN
+    IF tcp.position >= m.pack_size THEN
+      RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','no_next_puzzle');
+    END IF;
+    UPDATE public.challenge_participants SET pending_fog = true WHERE match_id = p_id AND user_id = p_target;
+```
+(Keep the `tax/toll/vowel_block` path in the remaining `ELSE`. Ensure the `user_powerups_v2` decrement only runs once validation passes — reorder if needed. Keep the existing `_notify` for fog: "your next puzzle starts foggy".)
+
+- [ ] **Step 2: `_match_board` — clue-hide by `fog_buys_left`; expose castability**
+
+Dump live `_match_board`. Change the clue line:
+```sql
+    'clue', CASE WHEN cp.fog_buys_left > 0 THEN NULL ELSE v_clue END
+```
+In the `opponents` sub-select inside `v_minfo`, add each opponent's `position` and the match `pack_size` so the client can tell whether Fog is castable:
+```sql
+      FROM public.challenge_participants o ... jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id),
+        'position', o.position, 'pack_size', m.pack_size, 'can_fog', o.position < m.pack_size)
+```
+Also add `'fog_buys_left', cp.fog_buys_left` to `v_minfo` (client shows a "foggy — N buys left" hint).
+
+- [ ] **Step 3: `match_buy_letter` — decrement `fog_buys_left`**
+
+Dump live `match_buy_letter`. In the final `UPDATE public.challenge_participants SET bankroll = ...`, add:
+```sql
+    fog_buys_left = GREATEST(0, cp.fog_buys_left - 1),
+```
+(Decrement on every buy, correct or wrong, so the clue reveals after the target's 3rd purchase.)
+
+- [ ] **Step 4: Rollback-test**
+
+Seeded 2-puzzle match: cast fog on a target on puzzle 1 → assert `pending_fog=true`; advance target to puzzle 2 → `fog_buys_left=3`, `_match_board.clue IS NULL`; 3 buys → `fog_buys_left=0`, clue non-null. Cast fog on a target on the last puzzle → rejected (`sabotage_reason=no_next_puzzle`, item not consumed). `ROLLBACK`.
+
+- [ ] **Step 5: Client — fog label + castable state**
+
+`src/routes/+page.svelte`: the sabotage picker (fog is a `kind:'sabotage'` item) must (a) label fog "Fog {opponent} — their next puzzle starts blind (3 buys)", (b) disable/grey the fog action when the chosen opponent's `can_fog === false`, with a tooltip "Nothing left to fog." Use `matchInfo.opponents[].can_fog`. Update the fog copy at the existing label map (`~:1243`, `:1249`).
+
+- [ ] **Step 6: Apply + commit** (`supabase-match-fog.sql`, message "Match: fog is a queued next-puzzle curse (3-buy clue hide)").
+
+---
+
+### Task 3: Lock → Erase (most-recently-revealed letter)
+
+**Files:** Create `supabase-match-erase.sql`. Touches live `match_buy_letter`, `match_use_powerup`, `match_sabotage`, and the `powerups` catalog row.
+
+**Interfaces — Consumes:** Task 1 `reveal_order`.
+
+- [ ] **Step 1: Track reveal order on reveal**
+
+Dump live `match_buy_letter`; in the reveal branch (`ELSE cp.revealed_positions := ...`), also append the letter to `reveal_order` when it's newly revealed, and persist it in the final UPDATE:
+```sql
+    -- in the reveal (v_positions not null) path:
+    cp.reveal_order := CASE WHEN v_letter = ANY(cp.reveal_order) THEN cp.reveal_order ELSE array_append(cp.reveal_order, v_letter) END;
+    -- add to the UPDATE SET: reveal_order = cp.reveal_order,
+```
+Dump live `match_use_powerup`; after a powerup reveals positions (`v_positions IS NOT NULL`), append the revealed letters to `reveal_order` (derive the distinct letters at those positions from `v_phrase`) so powerup-revealed letters are erasable too. Keep order stable.
+
+- [ ] **Step 2: `match_sabotage` lock branch → erase last-revealed**
+
+Dump live `match_sabotage`. Replace the random-letter `lock` branch: take the **last** element of the target's `reveal_order`, remove all its positions from `revealed_positions`, and pop it from `reveal_order`. No-op with a message if `reveal_order` is empty:
+```sql
+  IF v_debuff = 'lock' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, tcp.position);
+    v_lockletter := tcp.reveal_order[array_length(tcp.reveal_order,1)];  -- most recently revealed
+    IF v_lockletter IS NOT NULL THEN
+      UPDATE public.challenge_participants SET
+        revealed_positions = ARRAY(SELECT DISTINCT p FROM unnest(revealed_positions) p WHERE substr(v_phrase, p+1, 1) <> v_lockletter ORDER BY 1),
+        reveal_order = reveal_order[1:array_length(reveal_order,1)-1]
+      WHERE match_id = p_id AND user_id = p_target;
+    END IF;
+```
+Keep the `_notify` ("they wiped your {letter}s").
+
+- [ ] **Step 3: Rename catalog item to "Erase"**
+
+Update the `powerups` row for `sabotage_lock` (DB-only INSERT): `name='Erase'`, description "Wipe the opponent's most-recently-revealed letter." Include the `UPDATE public.powerups SET name='Erase', description='...' WHERE id='sabotage_lock';` in the SQL file. Client label/copy: `src/routes/+page.svelte` (`~:1239` icon/label map) and `src/routes/shop/+page.svelte:56` → "Erase" naming.
+
+- [ ] **Step 4: Rollback-test** — seed a target who reveals letters C, then A, then T (via buys); erase → asserts T's positions gone, `reveal_order` = {C,A}; erase again → A gone; erase on empty reveal_order → no-op. `ROLLBACK`.
+
+- [ ] **Step 5: Apply + commit** (`supabase-match-erase.sql`, "Match: Lock→Erase (wipe opponent's most-recently-revealed letter) + reveal-order tracking").
+
+---
+
+### Task 4: Usage caps (one power-up, one sabotage/opponent per puzzle)
+
+**Files:** Create `supabase-match-caps.sql`. Touches live `match_use_powerup`, `match_sabotage`.
+
+- [ ] **Step 1: `match_use_powerup` → one power-up total per puzzle**
+
+Dump live. Replace the one-of-each gate `IF v_eff = ANY(cp.active_powerups) THEN RETURN ...` with a one-total gate that returns a reason:
+```sql
+  IF COALESCE(array_length(cp.active_powerups,1),0) >= 1 THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('powerup_reason','one_per_puzzle'); END IF;
+```
+
+- [ ] **Step 2: `match_sabotage` → one sabotage per opponent per puzzle**
+
+Dump live. After validating the target but BEFORE applying the effect / decrementing inventory, reject a repeat against the same target this puzzle and otherwise record it:
+```sql
+  IF p_target = ANY((SELECT sabotaged_targets FROM public.challenge_participants WHERE match_id=p_id AND user_id=v_uid)) THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','already_sabotaged'); END IF;
+  -- ...after the effect applies and inventory is decremented:
+  UPDATE public.challenge_participants SET sabotaged_targets = array_append(sabotaged_targets, p_target)
+    WHERE match_id = p_id AND user_id = v_uid;
+```
+(`sabotaged_targets` resets on the attacker's own advance — Task 1. Fog, which lands next puzzle, still consumes the attacker's one-sabotage for their current puzzle.)
+
+- [ ] **Step 3: Rollback-test** — second `match_use_powerup` same puzzle → `powerup_reason=one_per_puzzle`, inventory unchanged; second `match_sabotage` same target → `sabotage_reason=already_sabotaged`, inventory unchanged; a *different* target still allowed. `ROLLBACK`.
+
+- [ ] **Step 4: Client — surface the notices**
+
+`src/routes/+page.svelte`: after a match powerup/sabotage RPC returns, if the board carries `powerup_reason`/`sabotage_reason`, show a toast ("One power-up per puzzle" / "You've already sabotaged {name} this puzzle"). Also proactively grey the power-up tray when `matchInfo.used_powerups.length >= 1` (mirror the server cap; the existing filter is at `~:1200-1204`).
+
+- [ ] **Step 5: Apply + commit** (`supabase-match-caps.sql`).
+
+---
+
+### Task 5: Broke = danger screen + one final guess + timer (server)
+
+**Files:** Create `supabase-match-broke.sql`. Touches live `_match_board`, `match_submit_guess`; dump `match_fold` to reuse its fold semantics.
+
+- [ ] **Step 1: `_match_board` — `must_guess` when broke**
+
+Dump live. Compute whether the player can afford the cheapest still-buyable letter under their active debuffs, and add `'must_guess', <bool>` to `v_minfo`. Cheapest buyable = min effective cost over letters not in `incorrect_letters` and not fully revealed; apply the same cost stack (`half_off`/`tax`/`vowel_block`; ignore one-shot `toll` for the floor). If no letter is affordable and the puzzle is unsolved → `must_guess=true`. (Model on Daily's `_daily_cheapest_buyable`; add a `_match_cheapest(cp, phrase)` helper if cleaner.)
+
+- [ ] **Step 2: `match_submit_guess` — broke + wrong ⇒ fold**
+
+Dump live `match_submit_guess` and `match_fold`. In the wrong-guess branch, if the player is broke (same `must_guess` predicate as Step 1), instead of just applying `v_pen`, **fold the puzzle** (end it as a loss and advance) reusing `match_fold`'s core path — i.e. set `last_score`/`total_score` from the current bankroll, `solved` unchanged, advance `position` (or `state='done'` + `_match_maybe_settle` on the last puzzle), resetting per-puzzle columns like the advance path. Extract the fold body into a shared internal (e.g. `_match_do_fold(p_id, p_uid)`) called by both `match_fold` and the broke-wrong path to avoid duplication.
+
+- [ ] **Step 3: Rollback-test** — broke player, wrong guess → puzzle folds (advances / done), not just penalized; solvent player, wrong guess → still just the `v_pen` penalty (unchanged). `must_guess` true only when nothing is affordable. `ROLLBACK`.
+
+- [ ] **Step 4: Apply + commit** (`supabase-match-broke.sql`).
+
+---
+
+### Task 6: Broke last-stand + timer (client)
+
+**Files:** Modify `src/routes/+page.svelte`, and the `SolveTimer` usage.
+
+**Interfaces — Consumes:** Task 5 `matchInfo.must_guess`; Task 2's board; `matchInfo.started_at` (add it in Step 1).
+
+- [ ] **Step 1: Server — expose `started_at` for the timer**
+
+In `_match_board`'s `v_minfo` (fold this small edit into `supabase-match-broke.sql` or a tiny `supabase-match-minfo-timer.sql`), add `'started_at', cp.started_at`. Apply + commit.
+
+- [ ] **Step 2: In-match count-up timer**
+
+`src/routes/+page.svelte`: relax the Daily-only timer gate (`~:4404`, `dailyTimerActive` at `~:638`) so the `SolveTimer` (count-up) also renders in the match HUD (`~:4518-4551`), driven by `matchInfo.started_at`. Match Daily's treatment.
+
+- [ ] **Step 3: Danger screen + single guess**
+
+Add `match` to `dangerMode` (`~:543-546`): `|| (isMatch && !!matchInfo?.must_guess)`. When `dangerMode` in a match, show the same danger vignette + "OUT OF MONEY — last guess" cue used by Daily/Free Play, plus the countdown. Replace the silent broke path (`brokeMode`/`isBroke`/`manageBrokeTimer` at `~:1062, 1091-1132`, broke bar `~:4589-4592`): the player gets ONE guess; a wrong guess (server folds via Task 5) or the timer expiring (`doFold(true)`) ends the puzzle. Keep the timer visible.
+
+- [ ] **Step 4: Verify** — `npm run build`; visual/functional check via the Task 8 harness (broke → danger + one guess + timer; wrong guess folds). Commit.
+
+---
+
+### Task 7: Move the Pot to the top bar (client only)
+
+**Files:** Modify `src/routes/+page.svelte`.
+
+- [ ] **Step 1: Relocate the pot chip**
+
+Remove the `.pot-chip` from `.match-meta` (`~:4526`). Find the top bar's WORDBANK title + chat control (grep the top-bar markup for the app title / chat button) and render the pot chip **to the left of the WORDBANK title**, opposite the chat control, only when `isMatch && matchPot > 0`. Reuse `matchPot` (`~:668-672`) and `.pot-chip` styling; adjust for the top-bar context.
+
+- [ ] **Step 2: Verify** — `npm run build`; confirm in the harness screenshot the pot sits top-left in a match and money/other modes are unaffected. Commit ("Match: pot moves to the top bar, left of the title").
+
+---
+
+### Task 8: Keyboard reflects sabotaged prices + E2E
+
+**Files:** Modify `src/lib/components/Keyboard.svelte`, `src/routes/+page.svelte`. Temp `scripts/qa-match-mechanics.mjs`.
+
+**Interfaces — Consumes:** `matchInfo.my_debuffs` + `matchInfo.used_powerups` (already on the board).
+
+- [ ] **Step 1: Real prices on the keyboard**
+
+`src/lib/components/Keyboard.svelte`: `effCosts` (`~:87-103`) gains a `gameMode==='match'` branch applying the exact cost stack from `$gameStore.matchInfo`: `half_off` if in `used_powerups` (×0.5, CEIL), `tax` if in `my_debuffs` (×1.5, CEIL), `vowel_block` ×3 on AEIOU, `toll` ×3 (show on all letters as the "next letter" surcharge). `disabledKeys` (`~:128-130`) and `affordPool` (`~:117-123`, match uses `bankroll`) must compare against these real costs. Add a "taxed" visual (tint/▲) on any key whose effective cost exceeds base. Consolidate so the broke detector `isBroke` (`+page.svelte:1091-1108`) uses the same effective-cost helper (single source of truth).
+
+- [ ] **Step 2: Build** — `npm run build` clean.
+
+- [ ] **Step 3: Two-player E2E harness** (adapt `scripts/qa-h2h.mjs` → `scripts/qa-match-mechanics.mjs`)
+
+Drive a 2-player, ≥2-puzzle match and assert:
+- Fog cast on the opponent hides their **next** puzzle's clue until their 3rd buy; never puzzle 1; greyed when they're on the last puzzle.
+- Erase removes the opponent's **most-recently-revealed** letter (deterministic).
+- The count-up timer is visible in-match; the pot renders top-left.
+- Under `tax`, the keyboard prices + disabled keys match the server charge (buy a taxed letter, compare bankroll delta to the displayed price).
+- Broke → danger screen + one guess + timer; a wrong guess folds.
+- Second power-up and second sabotage-vs-same-opponent are rejected with the notices.
+
+- [ ] **Step 4: Run, screenshot, clean up**
+
+`npm run dev` (background) then `node scripts/qa-match-mechanics.mjs`; save screenshots; assert all PASS. Delete the temp harness. Final `npm run build`. Commit any client fixes.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Fog (T1 seed + T2), Erase (T1 col + T3), timer (T6), pot (T7), keyboard costs (T8), broke (T5 server + T6 client), caps (T4). ✔
+- **Foundation first:** T1 adds all columns + the advance reset; every later task depends on it. ✔
+- **_match_board edited by T2/T5/T6** — safe because each task dumps the *live* body (which includes prior tasks' edits) and applies a fresh `CREATE OR REPLACE`; sequential composition, not git-file merges. ✔
+- **Type/name consistency:** `pending_fog`, `fog_buys_left`, `reveal_order`, `sabotaged_targets` used identically across T1–T5; board fields `must_guess`, `started_at`, `opponents[].can_fog`, `*_reason` produced server-side and consumed client-side by the named tasks. ✔
+- **No money-mode leakage:** all server predicates key on the match participant; all client changes gate on `isMatch`/`gameMode==='match'`. ✔

--- a/docs/superpowers/specs/2026-07-16-1v1-match-mechanics-design.md
+++ b/docs/superpowers/specs/2026-07-16-1v1-match-mechanics-design.md
@@ -1,0 +1,217 @@
+# 1v1 Challenge Mechanics Overhaul — Design Spec
+
+**Date:** 2026-07-16
+**Source:** Playtest feedback (1v1 with a friend). Seven changes to how challenge matches play.
+
+## Goal
+
+Make 1v1 challenge (`gameMode:'match'`) power-ups, sabotages, timing, and the broke
+state feel fair, legible, and deliberate — fixing the current invisible/timing-dependent
+behaviors surfaced in playtesting.
+
+## Background — current state (verified)
+
+- Challenge matches are **async**: both players play the same puzzle pack on their own
+  clocks (there are no literal turns). Play runs under `gameMode:'match'`; the board comes
+  from `_match_board`, and per-puzzle state lives on `challenge_participants`.
+- The authoritative RPCs `match_buy_letter` and `match_use_powerup` are **DB-only** (no
+  `CREATE FUNCTION` in the repo). `match_sabotage` is in `supabase-match-debuff-attribution.sql`;
+  `_match_board`/`_match_tick` in `supabase-blitz-removal-server.sql`; `match_start` /
+  `_match_resolve_and_advance` / `_match_settle` / `match_fold` in
+  `supabase-match-speed-tiebreak.sql`. **Implementation must dump the live bodies and
+  transform them** (repo files may lag prod).
+- Per-puzzle state on `challenge_participants` resets on advance: `debuffs='{}'`,
+  `active_powerups='{}'` (`supabase-match-speed-tiebreak.sql:59`).
+- `revealed_positions` is stored as a **sorted DISTINCT int array** — no reveal-order memory.
+
+## Global constraints
+
+- **Money mode unaffected elsewhere:** these changes are scoped to `gameMode:'match'`. Daily,
+  Cash Game, and Free Play behavior must not change.
+- Client letter-cost math is currently duplicated in `Keyboard.svelte` (`letterCosts`) and
+  `+page.svelte` (`LETTER_COSTS`, `isBroke`). Any cost change must be applied consistently to
+  all consumers (keyboard prices, affordability/`disabledKeys`, and the broke detector).
+- Server is authoritative for all economy/effects; the client only reflects what the board
+  reports. New effects must be enforced server-side, not just shown client-side.
+
+---
+
+## The seven changes
+
+### 1. Fog → a queued "next-puzzle" curse, 3-buy duration
+
+**Current:** `fog` sabotage hides the target's **clue** for their entire current puzzle
+(persistent debuff, cleared on advance). Applied instantly to the current puzzle, so it only
+does anything if it lands before the target reads the clue — whoever opens first is immune.
+Not discoverable; timing-dependent coin-flip.
+
+**New:** Fog is a **queued curse on the opponent's next un-started puzzle**.
+- **Cast anytime** (including while the opponent is mid-puzzle). It does not affect the
+  opponent's current puzzle at all — it attaches to the next puzzle they open that they have
+  **not started yet**.
+- On the fogged puzzle, the **clue is hidden until the opponent has made 3 letter purchases**,
+  then the clue appears. ("Letter purchase" = any `match_buy_letter` call, correct or wrong.)
+- **Never affects puzzle 1** — both players always open the match with their clue. (Naturally
+  enforced: fog only applies on an *advance*, and advances happen after puzzle 1.)
+- **Only castable when the opponent has an un-started next puzzle to attach to.** If they have
+  none (e.g., already on the last puzzle, or already opened their next puzzle before the cast),
+  the Fog action is **disabled/greyed with a tooltip** ("nothing left to fog"). If the cast
+  succeeds but the opponent races ahead and opens the intended puzzle first, the pending fog
+  attaches to their *next still-un-started* puzzle instead — it never lands on a puzzle they've
+  already seen.
+- Casting Fog spends the attacker's **one sabotage** for the puzzle the attacker is currently
+  on (see #7).
+
+**Data / mechanics:**
+- Add `pending_fog boolean default false` on `challenge_participants` — set on the target when
+  Fog is cast.
+- Add `fog_buys_left int default 0` — the active countdown on the current puzzle. On advance to
+  an un-started puzzle (not puzzle 1), if `pending_fog` then set `fog_buys_left := 3` and clear
+  `pending_fog`.
+- `_match_board`: return `clue = NULL` when `fog_buys_left > 0` (replaces the old
+  `'fog' = ANY(debuffs)` clue-hide).
+- `match_buy_letter`: `fog_buys_left := GREATEST(0, fog_buys_left - 1)` on each buy.
+- `match_sabotage` (`fog` branch): set target's `pending_fog := true`; reject (with a reason)
+  if the target has no un-started next puzzle.
+- Client: the match HUD must know whether Fog is castable (needs the target's position /
+  pack_size / started state, exposed via `matchInfo`), and label it clearly ("Fog Pat's next
+  puzzle — he starts it blind for 3 buys").
+
+### 2. Lock → **Erase** (wipe the most-recently-revealed letter)
+
+**Current:** `lock` sabotage instantly wipes a **random** revealed letter (all its positions)
+off the opponent's board (`supabase-match-debuff-attribution.sql:35-43`). Already an "erase,"
+just random. No reveal-order tracked.
+
+**New:**
+- Rename the item to **Erase** (display name + description; shop copy already says "Wipe a
+  letter an opponent revealed").
+- Erase the opponent's **most-recently-revealed letter** (all positions of it) instead of a
+  random one. Instant; hits the current puzzle.
+
+**Data / mechanics:**
+- **Track reveal order:** add `reveal_order text[] default '{}'` on `challenge_participants` —
+  the distinct letters in the order the player first revealed them. `match_buy_letter` appends
+  the bought letter (if it revealed ≥1 new position and isn't already in the array). Reset on
+  advance. (This ordering "may come in handy" for future features, per the ask.)
+- `match_sabotage` (`erase`/`lock` branch): take the **last** element of the target's
+  `reveal_order`, remove all its positions from `revealed_positions`, and pop it from
+  `reveal_order`. No-op with a clear message if the target has nothing revealed yet.
+
+### 3. Show the solve timer in 1v1
+
+**Current:** On-screen `SolveTimer` is gated to Daily only (`+page.svelte:4404`,
+`dailyTimerActive` at `:638`). The server already stamps `started_at` and computes
+`_match_elapsed()` for the fastest-solve tiebreaker, but never surfaces it.
+
+**New:** Show a **count-up** clock in the match HUD (same component/treatment as Daily), so the
+speed tiebreaker is visible.
+- Server: include `started_at` (and/or `elapsed`) in `_match_board`'s match payload
+  (`v_minfo`).
+- Client: render the timer in the match HUD block (`+page.svelte:4518-4551`) and relax the
+  Daily-only gate; drive it from the match's `started_at` like Daily's does.
+
+### 4. Move the Pot to the top bar
+
+**Current:** Pot renders as a `.pot-chip` inside `.match-meta`, under "Your Score"
+(`+page.svelte:4526`).
+
+**New:** Move the Pot to the **top bar, to the left of the WORDBANK title** (opposite the chat
+control). Client-only layout change; value source (`matchPot`) unchanged. Remove it from
+`.match-meta`.
+
+### 5. Keyboard shows the real (sabotaged) letter prices
+
+**Current:** Cost-raising sabotages exist — `tax` (+50%, persistent), `toll` (×3 next letter,
+one-shot), `vowel_block` (vowels ×3, persistent). The **keyboard shows base prices** while the
+server charges the raised amount, and affordability (`disabledKeys`) is computed on base cost —
+so a key can look affordable and cost more. The multipliers flow only through the DB
+`match_buy_letter`.
+
+**New:** The keyboard reflects the **real** current price per letter under active debuffs, and
+affordability uses those real prices.
+- Server: expose the player's own active cost debuffs in `_match_board`'s match payload (e.g.
+  `my_debuffs` with tax/toll/vowel_block flags, or a per-letter effective-cost multiplier
+  descriptor). Must mirror the exact server cost stack: `Half Off → Tax(+50%) → Vowel
+  Block(×3 vowels) → Toll(×3, then removed)`.
+- Client: `Keyboard.svelte` `effCosts` gains a `gameMode==='match'` branch that applies the
+  reported debuffs; `disabledKeys` and the `isBroke` detector (`+page.svelte`) use the same
+  real prices. Add a visual cue on taxed keys (e.g. a "taxed" tint / up-arrow) so the raise is
+  legible.
+- Consolidate the duplicated letter-cost math so keyboard price, affordability, and broke-
+  detection all read one source of truth.
+
+### 6. Broke = danger screen + one final guess + timer
+
+**Current:** When broke (`bankroll < cheapest buyable`), match starts a **silent 60-second
+auto-fold clock** with unlimited free guesses; `match` is deliberately excluded from
+`dangerMode` (`+page.svelte:543-546`). Solve within 60s or auto-fold.
+
+**New:** When broke, show the **Daily-style danger screen** with **exactly one final guess** and
+a **visible countdown**. A wrong guess **or** the timer expiring → you **fold** the puzzle.
+- Server: `_match_board` reports a must-guess/broke flag when the player can't afford the
+  cheapest letter. `match_submit_guess` (DB-only) enforces: while broke, a **wrong** guess folds
+  the puzzle (loss); guessing is the last action. The timer expiring folds the puzzle
+  (existing broke-timer path, but now surfaced).
+- Client: add `match` to `dangerMode`; reuse the danger vignette + last-stand cue (mirroring
+  Daily/Free Play's "OUT OF MONEY — last guess"); show the countdown; wire the single guess.
+
+### 7. Usage caps (with "already used" notifications)
+
+**Current:** Self power-ups are capped **one-of-each per puzzle** (client filters
+`used_powerups`). Sabotages have **no cap and no cooldown** — spammable (lock especially).
+
+**New:**
+- **One power-up per puzzle, total** (any type — tighter than one-of-each). Enforced server-side
+  in `match_use_powerup` (reject if `active_powerups` already non-empty this puzzle) and
+  reflected client-side. Trying a second shows a notification ("One power-up per puzzle").
+- **One sabotage per opponent per puzzle.** Enforced server-side in `match_sabotage`. Trying a
+  second against the same opponent shows "You've already sabotaged {name} this puzzle."
+- **Data:** add `sabotaged_targets uuid[] default '{}'` on `challenge_participants` (the
+  attacker's targets sabotaged during their current puzzle); reset on advance. `match_sabotage`
+  appends the target and rejects a repeat with a `reason`. Power-up cap reuses the existing
+  `active_powerups`.
+- The attacker's cap is keyed to **the attacker's current puzzle position** (casting Fog, which
+  lands on the opponent's next puzzle, still consumes the attacker's one-sabotage for the
+  attacker's current puzzle).
+
+---
+
+## Data model summary (`challenge_participants` additions)
+
+| Column | Purpose | Reset on advance |
+|---|---|---|
+| `pending_fog boolean` | queued fog for the player's next un-started puzzle | consumed → `fog_buys_left`, then false |
+| `fog_buys_left int` | active fog countdown on current puzzle (clue hidden while >0) | seeded from `pending_fog` (3), else 0 |
+| `reveal_order text[]` | letters in first-reveal order (for Erase; future use) | yes → `'{}'` |
+| `sabotaged_targets uuid[]` | opponents sabotaged during the attacker's current puzzle | yes → `'{}'` |
+
+Existing `active_powerups` (power-up cap) and `debuffs` (tax/toll/vowel_block) reset on advance
+as today.
+
+## Server functions touched (dump live, transform, rollback-test, apply)
+
+`match_sabotage`, `match_buy_letter` (DB-only), `match_use_powerup` (DB-only),
+`match_submit_guess` (DB-only), `_match_board`, `_match_resolve_and_advance`. Follow the repo's
+dump-transform-assert-rollbacktest-apply migration pattern.
+
+## Testing
+
+- **Two-player E2E** (adapt `scripts/qa-h2h.mjs`): play a pack and assert —
+  - Fog cast on the opponent hides their **next** puzzle's clue until their 3rd buy, never
+    touches puzzle 1, and is disabled when they have no un-started next puzzle.
+  - Erase removes the opponent's **last-revealed** letter (deterministic, not random).
+  - The count-up timer is visible in-match; the Pot renders in the top bar.
+  - Under a tax/toll/vowel_block debuff, the keyboard prices and disabled keys match what the
+    server actually charges.
+  - Going broke shows the danger screen + one guess + timer; a wrong guess folds.
+  - Second power-up and second sabotage-on-same-opponent are rejected with the right notices.
+- **Server rollback tests** for each RPC change (seeded match, `BEGIN…ROLLBACK`).
+
+## Out of scope
+
+- Any change to Daily, Cash Game, or Free Play.
+- New power-ups/sabotages beyond the Fog/Erase reworks.
+- Group (3+) challenge-specific balancing (rules apply per-opponent, which generalizes, but
+  group tuning is not a goal here).
+- The economic/anti-abuse audit items (separate track).

--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -35,7 +35,7 @@
 		sabotage_fog: { icon: 'fog', desc: "Hide an opponent's clue" },
 		sabotage_toll: { icon: 'toll', desc: "An opponent's next letter costs 3×" },
 		sabotage_vowel_block: { icon: 'block', desc: "An opponent's vowels cost 3×" },
-		sabotage_lock: { icon: 'lock', desc: 'Wipe a letter an opponent revealed' }
+		sabotage_lock: { icon: 'trash', desc: "Wipe the opponent's most-recently-revealed letter" }
 	};
 	// ticon = Icon.svelte name for the group heading (rendered via <Icon>).
 	const GROUPS = [

--- a/src/lib/components/Keyboard.svelte
+++ b/src/lib/components/Keyboard.svelte
@@ -82,8 +82,22 @@
 	// 1 everywhere else. Server (climb_buy_letter) charges the same.
 	$: climbMult =
 		$gameStore.gameMode === 'climb' ? Number($gameStore.climbInfo?.stake ?? 1) || 1 : 1;
-	// Effective per-letter prices after active discount / vowel_vision / tier stake (server matches):
-	// daily uses the shared modifier.
+	// Match (1v1 challenge) sabotage/power-up state — cost stack mirrors server
+	// match_buy_letter exactly: half_off (×0.5) → tax (×1.5) → vowel_block (×3 on
+	// vowels) → toll (×3 on all, one-shot "next letter" surcharge). CEIL after the
+	// ×0.5 and ×1.5 steps, same as the server's CEIL(v_cost * 0.5)::int etc.
+	$: matchHalfOff =
+		$gameStore.gameMode === 'match' &&
+		($gameStore.matchInfo?.used_powerups ?? []).includes('half_off');
+	$: matchDebuffs =
+		$gameStore.gameMode === 'match' ? ($gameStore.matchInfo?.my_debuffs ?? []) : [];
+	$: matchTax = matchDebuffs.includes('tax');
+	$: matchVowelBlock = matchDebuffs.includes('vowel_block');
+	$: matchToll = matchDebuffs.includes('toll');
+
+	// Effective per-letter prices after active discount / vowel_vision / tier stake / match
+	// sabotage (server matches): daily uses the shared modifier, match applies the debuff/
+	// power-up stack above.
 	$: effCosts = (() => {
 		let discount = false,
 			vowelHalf = false;
@@ -97,10 +111,25 @@
 			let c = letterCosts[k];
 			if (discount) c = Math.ceil(c * 0.75);
 			if (vowelHalf && 'AEIOU'.includes(k)) c = Math.ceil(c * 0.5);
-			out[k] = c * climbMult;
+			c = c * climbMult;
+			if ($gameStore.gameMode === 'match') {
+				if (matchHalfOff) c = Math.ceil(c * 0.5);
+				if (matchTax) c = Math.ceil(c * 1.5);
+				if (matchVowelBlock && 'AEIOU'.includes(k)) c = c * 3;
+				if (matchToll) c = c * 3;
+			}
+			out[k] = c;
 		}
 		return out;
 	})();
+	// A key is "taxed" (sabotage/tax inflated it above its plain base price) — flag it with
+	// a visual tint/▲ so the price shown is never a surprise vs. what the server charges.
+	$: taxedKeys =
+		$gameStore.gameMode === 'match'
+			? Object.keys(letterCosts).filter(
+					(k) => (effCosts[k] ?? 0) > letterCosts[k] * climbMult
+				)
+			: [];
 
 	type SelectedPurchase = { type: string; value?: string } | null;
 	type LockedLetters = Record<string, unknown>;
@@ -236,20 +265,23 @@
 			<button
 				tabindex="-1"
 				class="key
-      {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode' ? 'disabled' : ''} 
+      {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode' ? 'disabled' : ''}
       {selectedPurchase?.type === 'letter' &&
 				selectedPurchase.value === letter &&
 				$gameStore.gameState === 'purchase_pending'
 					? 'pending'
 					: ''}
       {lockedLetters[letter] ? 'purchased' : ''}
-      {incorrectLetters.includes(letter) ? 'incorrect' : ''}"
+      {incorrectLetters.includes(letter) ? 'incorrect' : ''}
+      {taxedKeys.includes(letter) ? 'taxed' : ''}"
 				on:click={() => handleLetterClick(letter)}
 			>
 				<span class="braille">{BRAILLE[letter]}</span>
 				<div class="letter">{letter}</div>
 				<div class="price">
-					{priceMark}{effCosts[letter] ?? 0}
+					{#if taxedKeys.includes(letter)}<span class="tax-mark">▲</span>{/if}{priceMark}{effCosts[
+						letter
+					] ?? 0}
 				</div>
 			</button>
 		{/each}
@@ -262,7 +294,7 @@
 				tabindex="-1"
 				class="key {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode'
 					? 'disabled'
-					: ''} 
+					: ''}
                 {selectedPurchase?.type === 'letter' &&
 				selectedPurchase.value === letter &&
 				$gameStore.gameState === 'purchase_pending'
@@ -271,13 +303,16 @@
 						? 'purchased'
 						: incorrectLetters.includes(letter)
 							? 'incorrect'
-							: ''}"
+							: ''}
+                {taxedKeys.includes(letter) ? 'taxed' : ''}"
 				on:click={() => handleLetterClick(letter)}
 			>
 				<span class="braille">{BRAILLE[letter]}</span>
 				<div class="letter">{letter}</div>
 				<div class="price">
-					{priceMark}{effCosts[letter] ?? 0}
+					{#if taxedKeys.includes(letter)}<span class="tax-mark">▲</span>{/if}{priceMark}{effCosts[
+						letter
+					] ?? 0}
 				</div>
 			</button>
 		{/each}
@@ -290,7 +325,7 @@
 				tabindex="-1"
 				class="key {disabledKeys.includes(letter) && $gameStore.gameState !== 'guess_mode'
 					? 'disabled'
-					: ''} 
+					: ''}
                 {selectedPurchase?.type === 'letter' &&
 				selectedPurchase.value === letter &&
 				$gameStore.gameState === 'purchase_pending'
@@ -299,13 +334,16 @@
 						? 'purchased'
 						: incorrectLetters.includes(letter)
 							? 'incorrect'
-							: ''}"
+							: ''}
+                {taxedKeys.includes(letter) ? 'taxed' : ''}"
 				on:click={() => handleLetterClick(letter)}
 			>
 				<span class="braille">{BRAILLE[letter]}</span>
 				<div class="letter">{letter}</div>
 				<div class="price">
-					{priceMark}{effCosts[letter] ?? 0}
+					{#if taxedKeys.includes(letter)}<span class="tax-mark">▲</span>{/if}{priceMark}{effCosts[
+						letter
+					] ?? 0}
 				</div>
 			</button>
 		{/each}
@@ -517,6 +555,24 @@
 		opacity: 0.4;
 		pointer-events: none;
 		transition: opacity 0.3s ease;
+	}
+
+	/* Match sabotage surcharge (tax/vowel_block/toll): a warm red tint + ▲ marker so an
+	   inflated price is never mistaken for the plain base price. */
+	.key.taxed:not(.purchased):not(.incorrect) {
+		border-color: rgba(248, 113, 113, 0.55);
+		box-shadow:
+			inset 0 0 10px rgba(248, 113, 113, 0.14),
+			0 2px 0 rgba(0, 0, 0, 0.6),
+			0 4px 8px rgba(0, 0, 0, 0.5);
+	}
+	.key.taxed:not(.purchased):not(.incorrect) .price {
+		color: rgba(248, 113, 113, 0.85);
+	}
+	.tax-mark {
+		font-size: 7px;
+		margin-right: 1px;
+		color: rgba(248, 113, 113, 0.9);
 	}
 
 	/* In guess mode, all letters are tappable */

--- a/src/lib/stores/GameStore.js
+++ b/src/lib/stores/GameStore.js
@@ -776,6 +776,7 @@ export async function matchPowerup(powerupId) {
 	try {
 		const board = await matchUsePowerup(activeMatchId, powerupId);
 		if (board) reconcileMatchBoard(board);
+		return board;
 	} finally {
 		dailyInFlight = false;
 	}
@@ -788,6 +789,7 @@ export async function matchSabotageOpponent(targetId, powerupId) {
 	try {
 		const board = await matchSabotage(activeMatchId, targetId, powerupId);
 		if (board) reconcileMatchBoard(board);
+		return board;
 	} finally {
 		dailyInFlight = false;
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -940,6 +940,12 @@
 	// 😈 Sabotage from the bag → pick a target (auto-applies vs a single opponent).
 	/** @type {{ item:any, opponents:any[] }|null} */
 	let sabPicker = null;
+	// 🌫️ Fog only lands on the target's NEXT puzzle → uncastable when they're on their last one.
+	/** @param {string} id → can this opponent be fogged right now? (server: opponents[].can_fog) */
+	function canFogTarget(id) {
+		const o = (matchInfo?.opponents ?? []).find((/** @type {any} */ x) => x.id === id);
+		return o ? o.can_fog !== false : true;
+	}
 	/** @param {any} item */
 	async function openSabotagePicker(item) {
 		showBag = false;
@@ -950,10 +956,15 @@
 			vaultMsg = 'No opponents left to hit.';
 			return;
 		}
+		// Auto-apply vs a single opponent — unless it's Fog with nothing left to fog,
+		// in which case fall through to the picker so the disabled row explains why.
 		if (opps.length === 1) {
-			await matchSabotageOpponent(opps[0].id, item.id);
-			await refreshClimbPups();
-			return;
+			const blocked = item.id === 'sabotage_fog' && !canFogTarget(opps[0].id);
+			if (!blocked) {
+				await matchSabotageOpponent(opps[0].id, item.id);
+				await refreshClimbPups();
+				return;
+			}
 		}
 		sabPicker = { item, opponents: opps };
 	}
@@ -1240,13 +1251,13 @@
 	});
 	const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({
 		tax: 'Taxed (letters +50%)',
-		fog: 'Fogged (clue hidden)',
+		fog: 'Fogged (clue hidden — buy 3 to clear)',
 		toll: 'Tolled (next letter 3×)',
 		vowel_block: 'Vowel-blocked (vowels 3×)'
 	});
 	const DEBUFF_DESC = /** @type {Record<string,string>} */ ({
 		tax: 'Every letter you buy costs +50% while this is active.',
-		fog: 'Your clue is hidden — you have to solve it blind.',
+		fog: 'Your next puzzle starts blind — buy 3 letters to clear the fog.',
 		toll: 'Your next letter purchase costs 3×, then it clears.',
 		vowel_block: 'Vowels cost 3× while this is active.'
 	});
@@ -3191,13 +3202,27 @@
 			<h3 class="info-title">{sabPicker.item.name} — hit who?</h3>
 			<div class="sab-target-list">
 				{#each sabPicker.opponents as o}
-					<button class="sab-target-row" on:click={() => applySabotage(o.id)}>
-						<span class="st-name">{o.name}</span>
-						<span class="st-stat"
-							><Icon name="puzzle" size={14} /> Puzzle {o.position} · ${Number(
-								o.ante_left ?? 0
-							).toLocaleString()}</span
-						>
+					{@const isFog = sabPicker.item.id === 'sabotage_fog'}
+					{@const fogBlocked = isFog && !canFogTarget(o.id)}
+					<button
+						class="sab-target-row"
+						class:is-disabled={fogBlocked}
+						disabled={fogBlocked}
+						title={fogBlocked ? 'Nothing left to fog.' : ''}
+						on:click={() => applySabotage(o.id)}
+					>
+						<span class="st-name">{isFog ? `Fog ${o.name}` : o.name}</span>
+						<span class="st-stat">
+							{#if fogBlocked}
+								Nothing left to fog.
+							{:else if isFog}
+								Their next puzzle starts blind (3 buys)
+							{:else}
+								<Icon name="puzzle" size={14} /> Puzzle {o.position} · ${Number(
+									o.ante_left ?? 0
+								).toLocaleString()}
+							{/if}
+						</span>
 					</button>
 				{/each}
 			</div>
@@ -5691,6 +5716,14 @@
 	}
 	.sab-target-row:active {
 		transform: scale(0.98);
+	}
+	.sab-target-row.is-disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
+		filter: grayscale(0.7);
+	}
+	.sab-target-row.is-disabled:active {
+		transform: none;
 	}
 	.st-name {
 		font-weight: 800;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -543,7 +543,8 @@
 	$: dangerMode =
 		((isClimb && !!climb?.must_guess) ||
 			(isDaily && !!$gameStore.dailyMustGuess) ||
-			(isFreeplay && !!$gameStore.dailyMustGuess)) &&
+			(isFreeplay && !!$gameStore.dailyMustGuess) ||
+			(isMatch && !!matchInfo?.must_guess)) &&
 		gameActive &&
 		$gameStore.gameState !== 'won' &&
 		$gameStore.gameState !== 'lost';
@@ -641,6 +642,18 @@
 		!introBuilding &&
 		$gameStore.gameState !== 'won' &&
 		$gameStore.gameState !== 'lost';
+
+	// Same server-anchored count-up for a live match — driven by matchInfo.started_at
+	// (challenge_participants.started_at, stamped once at match_start; not per-puzzle).
+	$: matchTimerActive =
+		isMatch &&
+		!!matchInfo &&
+		!matchInfo.done &&
+		!showMainMenu &&
+		!introBuilding &&
+		$gameStore.gameState !== 'won' &&
+		$gameStore.gameState !== 'lost';
+	$: matchOpenedAt = matchInfo?.started_at ? new Date(matchInfo.started_at).getTime() : null;
 
 	// 🎰 Slot-machine money feel: count the hero number up/down; float a −$X off it on each spend.
 	const tweenNet = tweened(0, { duration: 900, easing: cubicOut });
@@ -1040,38 +1053,12 @@
 		_prevNet = v ?? null;
 	}
 
-	// ── Fold + broke-timer (Daily + Challenges) ──────────────────────────────
-	// You're "broke" when you can't afford the cheapest still-buyable letter →
-	// a 60s clock starts; guess it or you auto-Fold (lose the puzzle).
-	// Mirror of the server-authoritative public.letter_cost() (economy v3.2: −25%, cheapest $20).
-	const LETTER_COSTS = {
-		Q: 20,
-		W: 40,
-		E: 100,
-		R: 90,
-		T: 90,
-		Y: 50,
-		U: 60,
-		I: 80,
-		O: 70,
-		P: 60,
-		A: 100,
-		S: 90,
-		D: 60,
-		F: 50,
-		G: 50,
-		H: 50,
-		J: 20,
-		K: 40,
-		L: 60,
-		Z: 30,
-		X: 30,
-		C: 60,
-		V: 40,
-		B: 50,
-		N: 80,
-		M: 50
-	};
+	// ── Fold + broke-timer (Match last-stand) ──────────────────────────────
+	// Broke = the server says nothing is affordable (matchInfo.must_guess —
+	// authoritative, already accounts for debuffs/tax/vowel_block/toll). The
+	// player gets the danger screen + a visible 60s countdown for ONE final
+	// guess: a wrong guess folds server-side (match_submit_guess), the timer
+	// expiring folds client-side via doFold(true).
 	// foldMode = modes with a "Give up" button (Daily + Challenges).
 	$: foldMode = $gameStore.gameMode === 'daily' || $gameStore.gameMode === 'match';
 	// brokeMode = modes with the out-of-Cash auto-fold CLOCK. The Daily has NO timer —
@@ -1136,24 +1123,9 @@
 			flashMatchNotice('They have no revealed letter to erase');
 	}
 
-	$: isBroke = (() => {
-		// Only while actively on a game screen — never on the menu.
-		if (!brokeMode || !gameActive || showMainMenu) return false;
-		const mod = $gameStore.modifier,
-			discount = mod === 'discount',
-			vowelHalf = mod === 'vowel_vision';
-		const purchased = new Set(($gameStore.purchasedLetters || []).filter(Boolean));
-		const incorrect = new Set($gameStore.incorrectLetters || []);
-		let minCost = Infinity;
-		for (const [L, base] of Object.entries(LETTER_COSTS)) {
-			if (purchased.has(L) || incorrect.has(L)) continue;
-			let c = base;
-			if (discount) c = Math.ceil(c * 0.75);
-			if (vowelHalf && 'AEIOU'.includes(L)) c = Math.ceil(c * 0.5);
-			if (c < minCost) minCost = c;
-		}
-		return minCost !== Infinity && ($gameStore.bankroll || 0) < minCost;
-	})();
+	// Server-authoritative: matchInfo.must_guess already applies the real cost
+	// stack (half_off/tax/vowel_block) for THIS player's debuffs — no local mirror needed.
+	$: isBroke = brokeMode && gameActive && !showMainMenu && !!matchInfo?.must_guess;
 	let brokeDeadline = 0,
 		brokeLeft = 0,
 		brokeFiring = false;
@@ -4476,6 +4448,20 @@
 			</div>
 		{/if}
 
+		<!-- Match solve timer — same server-anchored count-up treatment as Daily. Anchored to
+		     matchInfo.started_at (challenge_participants.started_at, stamped once when the
+		     player starts the match — NOT reset per puzzle), so it tracks total time in the
+		     match, pausing its visual only at each puzzle's win screen like Daily does. -->
+		{#if isMatch && matchInfo && !matchInfo.done && $gameStore.currentPhrase}
+			<div class="daily-timer-wrap">
+				<SolveTimer
+					openedAt={matchOpenedAt}
+					active={matchTimerActive}
+					solved={$gameStore.gameState === 'won'}
+				/>
+			</div>
+		{/if}
+
 		<!-- 💰 Bankroll — top of every mode. Challenge ante now lives in the bounty hero below. -->
 		{#if $gameStore.currentPhrase && $gameStore.gameMode}
 			<!-- 🪙 Small ambient bankroll chip — your account, shown quietly; the hero number
@@ -4578,6 +4564,20 @@
 			</div>
 		{/if}
 
+		<!-- 🚨 Match out-of-money last stand — same danger treatment as Daily/Free Play, plus
+		     a live countdown: ONE guess left. A wrong guess folds server-side
+		     (match_submit_guess); the countdown expiring folds it client-side (doFold(true)). -->
+		{#if isMatch && dangerMode}
+			<div class="danger-cue daily" role="alert">
+				<span class="dc-title"><Icon name="broke" size={16} /> OUT OF MONEY</span>
+				<span class="dc-sub">Last guess — solve it now, or you fold</span>
+				<span class="dc-sub"
+					><Icon name="timer" size={13} /> 0:{String(brokeLeft).padStart(2, '0')}</span
+				>
+				<button class="bn-forfeit" on:click={confirmFold}>Give up now?</button>
+			</div>
+		{/if}
+
 		<!-- ⚔️ Challenge match HUD -->
 		{#if isMatch && matchInfo && !matchInfo.done}
 			<!-- 🏆 Your Score — the accumulated bounty-kept you win the pot on. The center hero
@@ -4649,16 +4649,6 @@
 		<section class="phrase-section">
 			<PhraseDisplay on:revealComplete={onPhraseRevealComplete} on:introDone={onDailyIntroDone} />
 		</section>
-
-		<!-- ⏱ Out-of-Cash broke-timer — live Challenges only (Daily has no timer) -->
-		{#if brokeMode && gameActive && isBroke}
-			<div class="fold-bar broke">
-				<span class="fold-timer"
-					><Icon name="timer" size={13} /> 0:{String(brokeLeft).padStart(2, '0')}</span
-				>
-				<span class="fold-warn">Out of Cash — guess in time or you give up this one</span>
-			</div>
-		{/if}
 
 		<!-- 💰 Money hero -->
 		<section class="stats-section">
@@ -5607,15 +5597,6 @@
 		justify-content: safe center;
 	}
 
-	@keyframes pressurePulse {
-		0%,
-		100% {
-			box-shadow: 0 0 0 rgba(248, 113, 113, 0);
-		}
-		50% {
-			box-shadow: 0 0 16px rgba(248, 113, 113, 0.35);
-		}
-	}
 	.makeup-banner {
 		display: flex;
 		align-items: center;
@@ -6087,35 +6068,6 @@
 	}
 	.twist-chip:active {
 		transform: scale(0.92);
-	}
-	/* ⓘ re-open the "How to win" card */
-	.fold-bar {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 10px;
-		flex-wrap: wrap;
-		margin: 6px auto 2px;
-	}
-	.fold-bar.broke {
-		padding: 8px 14px;
-		border-radius: 12px;
-		max-width: 340px;
-		background: rgba(248, 113, 113, 0.12);
-		border: 1px solid rgba(248, 113, 113, 0.5);
-		animation: pressurePulse 1s ease-in-out infinite;
-	}
-	.fold-timer {
-		font-family: 'Orbitron', var(--font-display);
-		font-weight: 800;
-		font-size: 1.25rem;
-		color: #f87171;
-	}
-	.fold-warn {
-		font-size: 0.76rem;
-		color: #fca5a5;
-		flex: 1 1 140px;
-		text-align: left;
 	}
 	.puzzle-clue {
 		max-width: 340px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1247,7 +1247,7 @@
 		sabotage_fog: 'fog',
 		sabotage_toll: 'toll',
 		sabotage_vowel_block: 'block',
-		sabotage_lock: 'lock'
+		sabotage_lock: 'trash'
 	});
 	const DEBUFF_LABEL = /** @type {Record<string,string>} */ ({
 		tax: 'Taxed (letters +50%)',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2583,6 +2583,11 @@
 {/if}
 <!-- Skip retired in Cash Game V4 — Cash Out is the graceful bail. -->
 
+<!-- 🏆 Pot — top bar, left of the WORDBANK title, mirroring the chat control on the right -->
+{#if isMatch && matchPot > 0 && !showMainMenu}
+	<div class="pot-chip-top">Pot <b>${matchPot.toLocaleString()}</b></div>
+{/if}
+
 <!-- 💬 Match chat (1v1 + group challenges) — only inside a live match, never on the menu -->
 {#if isMatch && matchInfo && !showMainMenu}
 	<button
@@ -4587,7 +4592,6 @@
 				<span class="ms-val">{isFriendlyMatch ? '★' : '$'}{Math.round(matchInfo.total_score ?? 0).toLocaleString()}</span>
 			</div>
 			<div class="match-meta">
-				{#if matchPot > 0}<span class="pot-chip">Pot ${matchPot.toLocaleString()}</span>{/if}
 				{#if matchInfo.target != null}<span class="beat-chip"
 						>Beat {isFriendlyMatch ? '★' : '$'}{Number(
 							matchInfo.target
@@ -5658,18 +5662,6 @@
 		font-weight: 700;
 		font-size: 0.8rem;
 		color: var(--text-muted);
-	}
-	/* 🏆 Pot you're playing for — the prize, off the Score headline */
-	.pot-chip {
-		font-family: var(--font-display);
-		font-weight: 800;
-		font-size: 0.8rem;
-		color: #fcd34d;
-		background: rgba(252, 211, 77, 0.12);
-		border: 1px solid rgba(252, 211, 77, 0.3);
-		padding: 3px 11px;
-		border-radius: 999px;
-		font-variant-numeric: tabular-nums;
 	}
 	/* 🎯 The score to beat (opponent has played) — the async duel's live target */
 	.beat-chip {
@@ -7216,6 +7208,32 @@
 		transform: scale(0.93);
 	}
 	/* match chat — sits just below the help button so they never overlap */
+	/* 🏆 Pot — top bar, left of the title, mirrors .match-chat-btn on the opposite side */
+	.pot-chip-top {
+		position: fixed;
+		top: 60px;
+		left: 14px;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		padding: 9px 14px;
+		border-radius: 999px;
+		font-family: var(--font-display);
+		font-size: 0.84rem;
+		font-weight: 700;
+		color: #fcd34d;
+		background: var(--surface-strong, rgba(20, 28, 40, 0.9));
+		border: 1px solid rgba(252, 211, 77, 0.5);
+		backdrop-filter: blur(10px);
+		box-shadow:
+			0 2px 12px rgba(0, 0, 0, 0.4),
+			0 0 12px rgba(252, 211, 77, 0.15);
+		font-variant-numeric: tabular-nums;
+	}
+	.pot-chip-top b {
+		font-weight: 800;
+	}
 	.match-chat-btn {
 		position: fixed;
 		top: 60px;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -822,7 +822,9 @@
 							if (it.id === 'heat_shield') continue;
 							// Self-buffs work in BOTH the Cash Game and Challenges.
 							const climbUsed = (climb?.equipped ?? []).includes(it.id);
-							const matchUsed = (matchInfo?.used_powerups ?? []).includes(it.id);
+							// Match cap: ONE power-up total per puzzle (server: powerup_reason=one_per_puzzle).
+							// Grey the whole tray once any power-up has been used this puzzle, not just this one.
+							const matchCapReached = (matchInfo?.used_powerups ?? []).length >= 1;
 							// 🏧 Overdrive is a Cash-Game lifeline: only usable when you're out of money.
 							const isOverdrive = it.id === 'overdrive';
 							// ⏭️ Free Skip swaps the run's puzzle — Cash Game only, not Challenges.
@@ -837,7 +839,7 @@
 								isMatch &&
 								!!matchInfo?.items_allowed &&
 								gameActive &&
-								!matchUsed &&
+								!matchCapReached &&
 								(it.owned ?? 0) > 0 &&
 								!isOverdrive &&
 								!isFreeSkip;
@@ -856,7 +858,7 @@
 								count: it.owned,
 								usable: avail,
 								reason:
-									climbUsed || matchUsed
+									climbUsed || matchCapReached
 										? 'Already used on this puzzle.'
 										: isOverdrive && $gameStore.gameMode === 'climb' && !climb?.must_guess
 											? 'Use it when you run out of money.'
@@ -930,7 +932,8 @@
 			return;
 		} // keeps flow for the target step
 		else if (isMatch) {
-			matchPowerup(item.id).then(() => {
+			matchPowerup(item.id).then((board) => {
+				noticeFromBoard(board);
 				refreshClimbPups();
 				loadVault();
 			});
@@ -961,7 +964,8 @@
 		if (opps.length === 1) {
 			const blocked = item.id === 'sabotage_fog' && !canFogTarget(opps[0].id);
 			if (!blocked) {
-				await matchSabotageOpponent(opps[0].id, item.id);
+				const board = await matchSabotageOpponent(opps[0].id, item.id);
+				noticeFromBoard(board, opps[0].name);
 				await refreshClimbPups();
 				return;
 			}
@@ -972,8 +976,12 @@
 	async function applySabotage(targetId) {
 		if (!sabPicker) return;
 		const item = sabPicker.item;
+		const targetName = (sabPicker.opponents ?? []).find(
+			(/** @type {any} */ o) => o.id === targetId
+		)?.name;
 		sabPicker = null;
-		await matchSabotageOpponent(targetId, item.id);
+		const board = await matchSabotageOpponent(targetId, item.id);
+		noticeFromBoard(board, targetName);
 		await refreshClimbPups();
 	}
 
@@ -1099,6 +1107,35 @@
 		}, 2600);
 	}
 
+	// 💥 Match usage-cap notices: the server rejects a 2nd power-up / a repeat sabotage
+	// (or an uncastable fog/erase) and tags the board with powerup_reason/sabotage_reason.
+	// Flash a short toast so the tap doesn't feel like a silent no-op.
+	let matchNotice = /** @type {{ id:number, text:string }|null} */ (null);
+	let _matchNoticeId = 0;
+	/** @param {string} text */
+	function flashMatchNotice(text) {
+		if (!browser || !text) return;
+		const id = ++_matchNoticeId;
+		matchNotice = { id, text };
+		setTimeout(() => {
+			if (matchNotice?.id === id) matchNotice = null;
+		}, 2600);
+	}
+	/**
+	 * Inspect a returned match board for a cap/reject reason and toast it.
+	 * @param {any} board @param {string} [targetName]
+	 */
+	function noticeFromBoard(board, targetName) {
+		const pr = board?.powerup_reason,
+			sr = board?.sabotage_reason;
+		if (pr === 'one_per_puzzle') flashMatchNotice('One power-up per puzzle');
+		else if (sr === 'already_sabotaged')
+			flashMatchNotice(`You've already sabotaged ${targetName || 'them'} this puzzle`);
+		else if (sr === 'no_next_puzzle') flashMatchNotice('Nothing left to fog');
+		else if (sr === 'nothing_to_erase')
+			flashMatchNotice('They have no revealed letter to erase');
+	}
+
 	$: isBroke = (() => {
 		// Only while actively on a game screen — never on the menu.
 		if (!brokeMode || !gameActive || showMainMenu) return false;
@@ -1207,11 +1244,8 @@
 			).length
 		: 0;
 	$: usableMatchPups =
-		isMatch && matchInfo?.items_allowed
-			? selfPups.filter(
-					(/** @type {any} */ i) =>
-						(i.owned ?? 0) > 0 && !(matchInfo?.used_powerups ?? []).includes(i.id)
-				).length
+		isMatch && matchInfo?.items_allowed && (matchInfo?.used_powerups ?? []).length === 0
+			? selfPups.filter((/** @type {any} */ i) => (i.owned ?? 0) > 0).length
 			: 0;
 	/** @type {'heat'|'earn'|'streak'|null} ℹ️ Cash Game explainers (mirror of dailyInfo). */
 	let climbInfo = null;
@@ -2727,6 +2761,11 @@
 <!-- 🎁 Daily Twist "as it happens" explainer toast -->
 {#if twistToast}
 	<div class="twist-toast" role="status">{twistToast.text}</div>
+{/if}
+
+<!-- 💥 Match usage-cap notice (one power-up / already sabotaged / nothing to fog·erase) -->
+{#if matchNotice}
+	<div class="twist-toast" role="status">{matchNotice.text}</div>
 {/if}
 
 <!-- 🔐 Vault door-open animation (from the main menu, after the PIN) → then items -->

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -53,7 +53,7 @@
 		sabotage_fog: { icon: 'fog', desc: "Hide an opponent's clue" },
 		sabotage_toll: { icon: 'toll', desc: "An opponent's next letter costs 3×" },
 		sabotage_vowel_block: { icon: 'block', desc: "An opponent's vowels cost 3×" },
-		sabotage_lock: { icon: 'lock', desc: 'Wipe a letter an opponent revealed' },
+		sabotage_lock: { icon: 'trash', desc: "Wipe the opponent's most-recently-revealed letter" },
 		bounty_boost: { icon: 'boost', desc: 'Adds +50% Interest to your Daily deposit' },
 		jackpot_boost: { icon: 'gem', desc: 'Adds +100% Interest to your Daily deposit' }
 	});

--- a/supabase-match-broke.sql
+++ b/supabase-match-broke.sql
@@ -1,0 +1,258 @@
+-- Task 5: Broke = must_guess flag + broke-wrong-guess folds (shared _match_do_fold)
+-- Scope: gameMode:'match' only. Server-authoritative. Each body below was dumped
+-- LIVE from prod (includes Tasks 1-4) and transformed; everything else byte-identical.
+--
+-- Toll-in-floor choice: _match_cheapest IGNORES the one-shot `toll` debuff when
+-- computing the cheapest-buyable floor (documented in the brief). toll is a single-use
+-- x3 surcharge removed on the next buy; folding a player over a transient one-shot
+-- surcharge would be too punishing, and match_buy_letter would strip toll on that buy
+-- anyway. half_off / tax / vowel_block (persistent within the puzzle) ARE applied,
+-- in the same stack order as match_buy_letter.
+
+-- 1) Cheapest still-buyable EFFECTIVE cost for a match participant.
+--    Mirrors Daily's _daily_cheapest_buyable: MIN over distinct phrase letters at
+--    unrevealed positions. Applies the match cost stack (half_off -> tax -> vowel_block),
+--    ignoring one-shot toll. Returns NULL when no letter remains buyable.
+CREATE OR REPLACE FUNCTION public._match_cheapest(p_id uuid, p_uid uuid)
+ RETURNS integer
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE cp public.challenge_participants; v_phrase text; v_half boolean; v_tax boolean; v_vblock boolean;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  IF v_phrase IS NULL THEN RETURN NULL; END IF;
+  v_half   := 'half_off'    = ANY(COALESCE(cp.active_powerups,'{}'));
+  v_tax    := 'tax'         = ANY(COALESCE(cp.debuffs,'{}'));
+  v_vblock := 'vowel_block' = ANY(COALESCE(cp.debuffs,'{}'));
+  RETURN (
+    SELECT MIN(CASE WHEN x.is_vowel AND v_vblock THEN x.c2 * 3 ELSE x.c2 END)
+    FROM (
+      SELECT (t.ch IN ('A','E','I','O','U')) AS is_vowel,
+             CASE WHEN v_tax THEN CEIL(c1.base_half * 1.5)::int ELSE c1.base_half END AS c2
+      FROM (
+        SELECT DISTINCT substr(v_phrase, g.i+1, 1) AS ch
+        FROM generate_series(0, length(v_phrase)-1) g(i)
+        WHERE substr(v_phrase, g.i+1, 1) ~ '[A-Z]'
+          AND NOT (g.i = ANY(cp.revealed_positions))
+      ) t
+      CROSS JOIN LATERAL (
+        SELECT CASE WHEN v_half THEN CEIL(public.letter_cost(t.ch) * 0.5)::int ELSE public.letter_cost(t.ch) END AS base_half
+      ) c1
+      WHERE NOT (t.ch = ANY(COALESCE(cp.incorrect_letters,'{}')))
+    ) x
+  );
+END; $function$;
+
+-- 2) _match_board — add 'must_guess' to v_minfo (LIVE body + one field + v_cheapest var).
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT; v_cheapest INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  v_cheapest := public._match_cheapest(p_id, p_uid);  -- cheapest still-buyable effective cost (NULL if none)
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')), 'fog_buys_left', cp.fog_buys_left,
+    'must_guess', (cp.state = 'active' AND (v_cheapest IS NULL OR v_cheapest > cp.bankroll)),
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id),
+        'position', o.position, 'pack_size', m.pack_size, 'can_fog', o.position < m.pack_size) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN cp.fog_buys_left > 0 THEN NULL ELSE v_clue END);
+END; $function$;
+
+-- 3) _match_do_fold — faithful extraction of the LIVE match_fold body (v_uid -> p_uid).
+--    Byte-identical fold semantics: charge unrevealed base cost capped at bankroll, bank
+--    leftover, advance (reset per-puzzle cols incl. Task-1/3) or state='done' + settle on
+--    the last puzzle, finished_at fix preserved. Self-contained (tick + FOR UPDATE guard)
+--    so it is safe to call from both match_fold and the broke-wrong path.
+CREATE OR REPLACE FUNCTION public._match_do_fold(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare cp public.challenge_participants; m public.challenge_matches;
+  v_phrase text; v_charge bigint; v_left bigint; v_next_bounty int;
+begin
+  if p_uid is null then raise exception 'match_fold: not authenticated'; end if;
+  if public._match_tick(p_id, p_uid) then return public._match_board(p_id, p_uid); end if;
+  select * into cp from public.challenge_participants where match_id = p_id and user_id = p_uid for update;
+  if not found or cp.state <> 'active' then return public._match_board(p_id, p_uid); end if;
+  select * into m from public.challenge_matches where id = p_id;
+  -- full price of every still-unrevealed distinct letter (base cost), capped at remaining ante
+  select upper(phrase) into v_phrase from public.daily_puzzles where id = public._match_pid(p_id, cp.position);
+  select coalesce(sum(public.letter_cost(t.ch)), 0) into v_charge from (
+    select distinct substr(v_phrase, g.i+1, 1) as ch from generate_series(0, length(v_phrase)-1) g(i)
+    where substr(v_phrase, g.i+1, 1) ~ '[A-Z]' and not (g.i = any(cp.revealed_positions))
+  ) t;
+  v_charge := least(v_charge, cp.bankroll);
+  v_left := greatest(0, cp.bankroll - v_charge);
+
+  if m.econ_v = 2 then
+    -- Accumulate this puzzle's leftover; advance with a fresh bounty (mirrors the solve path).
+    if cp.position >= m.pack_size then
+      update public.challenge_participants
+        set state = 'done', bankroll = v_left, last_score = 0, total_score = total_score + v_left,
+            reveal_order = '{}',
+            finished_at = now(), joined_at = coalesce(joined_at, now())
+        where match_id = p_id and user_id = p_uid;
+      perform public._match_maybe_settle(p_id);
+      perform public._match_notify_opponent_played(p_id, p_uid);
+    else
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      update public.challenge_participants
+        set position = position + 1, bankroll = v_next_bounty,
+            start_budget = coalesce(start_budget, 0) + v_next_bounty,
+            last_score = 0, total_score = total_score + v_left,
+            revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+            reveal_order = '{}', sabotaged_targets = '{}',
+            fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+            p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+        where match_id = p_id and user_id = p_uid;
+    end if;
+    return public._match_board(p_id, p_uid);
+  end if;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = leftover.
+  if cp.position >= m.pack_size then
+    update public.challenge_participants
+      set state = 'done', bankroll = v_left, last_score = 0, total_score = v_left,
+          reveal_order = '{}',
+          finished_at = now(), joined_at = coalesce(joined_at, now())
+      where match_id = p_id and user_id = p_uid;
+    perform public._match_maybe_settle(p_id);
+  else
+    update public.challenge_participants
+      set position = position + 1, bankroll = v_left, last_score = 0, total_score = v_left,
+          revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+          reveal_order = '{}', sabotaged_targets = '{}',
+          fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+          p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      where match_id = p_id and user_id = p_uid;
+  end if;
+  return public._match_board(p_id, p_uid);
+end; $function$;
+
+-- 4) match_fold — thin wrapper delegating to the shared internal.
+CREATE OR REPLACE FUNCTION public.match_fold(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE sql
+ SECURITY DEFINER
+AS $function$
+  SELECT public._match_do_fold(p_id, auth.uid());
+$function$;
+
+-- 5) match_submit_guess — LIVE body + broke-wrong-guess folds (shared _match_do_fold).
+--    A solvent player's wrong guess keeps the existing v_pen penalty (unchanged).
+CREATE OR REPLACE FUNCTION public.match_submit_guess(p_id uuid, p_guess jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; v_phrase TEXT; v_editable INT[]; v_correct INT[] := '{}'; v_all BOOLEAN := true; pos INT; v_ch TEXT; v_pen INT; v_cheapest INT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_submit_guess: not authenticated'; END IF;
+  IF public._match_tick(p_id, v_uid) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  SELECT array_agg(g.i ORDER BY g.i) INTO v_editable FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) <> ' ' AND NOT (g.i = ANY(cp.revealed_positions));
+  IF v_editable IS NULL OR (SELECT count(*) FROM jsonb_object_keys(p_guess)) <> array_length(v_editable,1) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  FOREACH pos IN ARRAY v_editable LOOP
+    v_ch := upper(p_guess ->> pos::text);
+    IF v_ch IS NULL THEN v_all := false;
+    ELSIF v_ch = substr(v_phrase, pos+1, 1) THEN v_correct := v_correct || pos;
+    ELSE v_all := false; END IF;
+  END LOOP;
+  IF v_all THEN
+    cp.revealed_positions := ARRAY(SELECT DISTINCT unnest(cp.revealed_positions || v_correct) ORDER BY 1);
+    UPDATE public.challenge_participants SET revealed_positions = cp.revealed_positions
+      WHERE match_id = p_id AND user_id = v_uid;
+  ELSE
+    -- Broke last-stand: if the player can't afford the cheapest still-buyable letter,
+    -- a wrong full-length guess ENDS the puzzle (fold) instead of just a penalty.
+    v_cheapest := public._match_cheapest(p_id, v_uid);
+    IF v_cheapest IS NULL OR v_cheapest > cp.bankroll THEN
+      RETURN public._match_do_fold(p_id, v_uid);
+    END IF;
+    -- Wrong guess wastes budget (universal WordBank rule), lowering your score.
+    v_pen := GREATEST(10, (round(0.2 * cp.bankroll / 10.0) * 10)::int);
+    cp.bankroll := GREATEST(0, cp.bankroll - v_pen);
+    cp.p_wrong_guesses := cp.p_wrong_guesses + 1;
+    UPDATE public.challenge_participants SET bankroll = cp.bankroll, p_wrong_guesses = cp.p_wrong_guesses
+      WHERE match_id = p_id AND user_id = v_uid;
+  END IF;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;

--- a/supabase-match-caps.sql
+++ b/supabase-match-caps.sql
@@ -1,0 +1,124 @@
+-- Task 4: Usage caps for 1v1 matches (gameMode:'match') --------------------
+-- One power-up total per puzzle; one sabotage per opponent per puzzle.
+-- Bodies dumped live from prod (include Tasks 1-3 changes), transformed, and
+-- kept byte-identical elsewhere.
+
+-- 1) match_use_powerup: one power-up TOTAL per puzzle (was one-of-each).
+--    Gate returns a reason and runs BEFORE the inventory decrement so a
+--    rejected power-up does not consume the item.
+CREATE OR REPLACE FUNCTION public.match_use_powerup(p_id uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; cp public.challenge_participants; v_eff TEXT; v_name TEXT; v_qty INT; v_phrase TEXT; v_positions INT[]; r RECORD;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_use_powerup: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_eff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'climb' AND active;
+  IF v_eff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF COALESCE(array_length(cp.active_powerups,1),0) >= 1 THEN RETURN public._match_board(p_id, v_uid) || jsonb_build_object('powerup_reason','one_per_puzzle'); END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  UPDATE public.challenge_participants SET active_powerups = array_append(active_powerups, v_eff) WHERE match_id = p_id AND user_id = v_uid;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_positions := public._powerup_reveal(v_phrase, v_eff, cp.revealed_positions);
+  IF v_positions IS NOT NULL THEN
+    UPDATE public.challenge_participants SET
+      revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_positions) ORDER BY 1),
+      reveal_order = reveal_order || ARRAY(
+        SELECT q.l FROM (
+          SELECT substr(v_phrase, p+1, 1) AS l, min(p) AS firstpos
+          FROM unnest(v_positions) p
+          WHERE substr(v_phrase, p+1, 1) ~ '[A-Z]'
+          GROUP BY substr(v_phrase, p+1, 1)
+        ) q
+        WHERE q.l <> ALL(reveal_order)
+        ORDER BY q.firstpos)
+    WHERE match_id = p_id AND user_id = v_uid;
+  END IF;
+  FOR r IN SELECT user_id FROM public.challenge_participants WHERE match_id = p_id AND user_id <> v_uid AND state IN ('active','done') LOOP
+    PERFORM public._notify(r.user_id, 'powerup_used', '💥 Power-up used',
+      public._display_name(v_uid) || ' used ' || COALESCE(v_name, 'a power-up'), jsonb_build_object('match_id', p_id));
+  END LOOP;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;
+
+-- 2) match_sabotage: one sabotage per opponent per puzzle.
+--    already_sabotaged check runs after target validation but before the
+--    inventory decrement / effect branches (so a repeat never charges).
+--    The array_append(sabotaged_targets) runs ONLY at the end — after the
+--    decrement and effect applied — so it never fires on the no_next_puzzle
+--    or nothing_to_erase early-returns, and records exactly once per success.
+CREATE OR REPLACE FUNCTION public.match_sabotage(p_id uuid, p_target uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; v_debuff TEXT; v_name TEXT; v_qty INT; v_tstate TEXT;
+  tcp public.challenge_participants; v_phrase TEXT; v_lockletter TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_sabotage: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF p_target = v_uid THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_debuff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'sabotage' AND active;
+  IF v_debuff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid AND state = 'active') THEN
+    RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO tcp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_target;
+  IF tcp.user_id IS NULL OR tcp.state NOT IN ('active','invited') THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  -- One sabotage per opponent per puzzle: reject a repeat against the same
+  -- target this puzzle (before decrement / effect, so it never charges).
+  IF p_target = ANY(COALESCE((SELECT sabotaged_targets FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid), '{}'::uuid[])) THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','already_sabotaged');
+  END IF;
+  -- Fog lands on the target's NEXT puzzle; reject (WITHOUT consuming the item) if
+  -- they have no un-started next puzzle. Validate before decrementing inventory.
+  IF v_debuff = 'fog' AND tcp.position >= m.pack_size THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','no_next_puzzle');
+  END IF;
+  -- Erase with nothing revealed: reject (WITHOUT consuming the item) so we never charge for
+  -- a no-op or fire a false "they wiped your letter" notify. Validate before the decrement.
+  IF v_debuff = 'lock' AND COALESCE(array_length(tcp.reveal_order,1),0) = 0 THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','nothing_to_erase');
+  END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+
+  IF v_debuff = 'lock' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, tcp.position);
+    v_lockletter := tcp.reveal_order[array_length(tcp.reveal_order,1)];  -- most recently revealed
+    IF v_lockletter IS NOT NULL THEN
+      UPDATE public.challenge_participants SET
+        revealed_positions = ARRAY(SELECT DISTINCT p FROM unnest(revealed_positions) p WHERE substr(v_phrase, p+1, 1) <> v_lockletter ORDER BY 1),
+        reveal_order = reveal_order[1:array_length(reveal_order,1)-1]
+      WHERE match_id = p_id AND user_id = p_target;
+    END IF;
+  ELSIF v_debuff = 'fog' THEN
+    UPDATE public.challenge_participants SET pending_fog = true WHERE match_id = p_id AND user_id = p_target;
+  ELSE
+    UPDATE public.challenge_participants SET
+      debuffs = (SELECT ARRAY(SELECT DISTINCT unnest(COALESCE(debuffs,'{}') || ARRAY[v_debuff]))),
+      debuff_by = COALESCE(debuff_by, '{}'::jsonb) || jsonb_build_object(v_debuff, v_uid::text)
+    WHERE match_id = p_id AND user_id = p_target;
+  END IF;
+
+  PERFORM public._notify(p_target, 'sabotaged', '💥 You got hit!',
+    public._display_name(v_uid) || ' hit you with ' || COALESCE(v_name,'a sabotage') ||
+    CASE v_debuff WHEN 'tax' THEN ' — your letters cost +50%' WHEN 'fog' THEN ' — your next puzzle starts foggy'
+      WHEN 'toll' THEN ' — your next letter costs 3×' WHEN 'vowel_block' THEN ' — your vowels cost 3×'
+      WHEN 'lock' THEN COALESCE(' — they wiped your ' || v_lockletter || 's', ' — a revealed letter is gone') ELSE '' END,
+    jsonb_build_object('match_id', p_id));
+  -- Record the sabotage against this opponent (success paths only). Resets on
+  -- the attacker's own advance (Task 1). Placed after all early-returns so a
+  -- rejected fog/erase never burns the per-opponent slot.
+  UPDATE public.challenge_participants SET sabotaged_targets = array_append(sabotaged_targets, p_target)
+    WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;

--- a/supabase-match-erase-fixes.sql
+++ b/supabase-match-erase-fixes.sql
@@ -1,0 +1,167 @@
+-- Task 3 follow-up: three review gaps in the Erase feature (all reachable in normal play).
+-- Fix 1: match_reveal ("Buy hint") must record the revealed letter in reveal_order.
+-- Fix 2: match_fold must reset the new per-puzzle columns on advance (Task 1 gap).
+-- Fix 3: match_sabotage Erase on empty reveal_order -> no charge, no false notify.
+-- DB-only: dumped live bodies, transformed, keeping everything else byte-identical.
+
+-- ── Fix 1 ── match_reveal: append the hint-revealed letter to reveal_order (dedup),
+--    mirroring match_buy_letter, so hint-revealed letters are erasable and Erase targets
+--    the truly most-recent reveal.
+CREATE OR REPLACE FUNCTION public.match_reveal(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; v_phrase TEXT; v_letter TEXT; v_positions INT[]; v_cost INT := 150;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_reveal: not authenticated'; END IF;
+  IF public._match_tick(p_id, v_uid) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  SELECT t.ch INTO v_letter FROM (
+    SELECT substr(v_phrase, g.i+1,1) AS ch, count(*) AS c FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1,1) ~ '[A-Z]' AND NOT (g.i = ANY(cp.revealed_positions))
+    GROUP BY substr(v_phrase, g.i+1,1) ORDER BY c DESC, ch LIMIT 1) t;
+  IF cp.bankroll < v_cost OR v_letter IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  UPDATE public.challenge_participants SET bankroll = cp.bankroll - v_cost, p_reveals = cp.p_reveals + 1,
+    revealed_positions = ARRAY(SELECT DISTINCT unnest(cp.revealed_positions || v_positions) ORDER BY 1),
+    reveal_order = CASE WHEN v_letter = ANY(cp.reveal_order) THEN cp.reveal_order ELSE array_append(cp.reveal_order, v_letter) END
+  WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;
+
+-- ── Fix 2 ── match_fold: reset the new per-puzzle columns on advance, matching
+--    _match_resolve_and_advance. Non-final branches (both econ) seed fog + clear
+--    reveal_order/sabotaged_targets; final (state='done') branches clear reveal_order only
+--    (a done player can't be Erase-targeted, and there is no next puzzle to seed fog on).
+CREATE OR REPLACE FUNCTION public.match_fold(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); cp public.challenge_participants; m public.challenge_matches;
+  v_phrase text; v_charge bigint; v_left bigint; v_next_bounty int;
+begin
+  if v_uid is null then raise exception 'match_fold: not authenticated'; end if;
+  if public._match_tick(p_id, v_uid) then return public._match_board(p_id, v_uid); end if;
+  select * into cp from public.challenge_participants where match_id = p_id and user_id = v_uid for update;
+  if not found or cp.state <> 'active' then return public._match_board(p_id, v_uid); end if;
+  select * into m from public.challenge_matches where id = p_id;
+  -- full price of every still-unrevealed distinct letter (base cost), capped at remaining ante
+  select upper(phrase) into v_phrase from public.daily_puzzles where id = public._match_pid(p_id, cp.position);
+  select coalesce(sum(public.letter_cost(t.ch)), 0) into v_charge from (
+    select distinct substr(v_phrase, g.i+1, 1) as ch from generate_series(0, length(v_phrase)-1) g(i)
+    where substr(v_phrase, g.i+1, 1) ~ '[A-Z]' and not (g.i = any(cp.revealed_positions))
+  ) t;
+  v_charge := least(v_charge, cp.bankroll);
+  v_left := greatest(0, cp.bankroll - v_charge);
+
+  if m.econ_v = 2 then
+    -- Accumulate this puzzle's leftover; advance with a fresh bounty (mirrors the solve path).
+    if cp.position >= m.pack_size then
+      update public.challenge_participants
+        set state = 'done', bankroll = v_left, last_score = 0, total_score = total_score + v_left,
+            reveal_order = '{}',
+            finished_at = now(), finished_at = now(), joined_at = coalesce(joined_at, now())
+        where match_id = p_id and user_id = v_uid;
+      perform public._match_maybe_settle(p_id);
+      perform public._match_notify_opponent_played(p_id, v_uid);
+    else
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      update public.challenge_participants
+        set position = position + 1, bankroll = v_next_bounty,
+            start_budget = coalesce(start_budget, 0) + v_next_bounty,
+            last_score = 0, total_score = total_score + v_left,
+            revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+            reveal_order = '{}', sabotaged_targets = '{}',
+            fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+            p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+        where match_id = p_id and user_id = v_uid;
+    end if;
+    return public._match_board(p_id, v_uid);
+  end if;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = leftover.
+  if cp.position >= m.pack_size then
+    update public.challenge_participants
+      set state = 'done', bankroll = v_left, last_score = 0, total_score = v_left,
+          reveal_order = '{}',
+          finished_at = now(), finished_at = now(), joined_at = coalesce(joined_at, now())
+      where match_id = p_id and user_id = v_uid;
+    perform public._match_maybe_settle(p_id);
+  else
+    update public.challenge_participants
+      set position = position + 1, bankroll = v_left, last_score = 0, total_score = v_left,
+          revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+          reveal_order = '{}', sabotaged_targets = '{}',
+          fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+          p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      where match_id = p_id and user_id = v_uid;
+  end if;
+  return public._match_board(p_id, v_uid);
+end; $function$;
+
+-- ── Fix 3 ── match_sabotage: Erase on an empty reveal_order is now pre-validated BEFORE the
+--    inventory decrement (no charge) and returns sabotage_reason='nothing_to_erase'. With this
+--    guard the lock branch always removes a real letter, so the "they wiped your {letter}s"
+--    notify only fires on a genuine erase. Everything else byte-identical.
+CREATE OR REPLACE FUNCTION public.match_sabotage(p_id uuid, p_target uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; v_debuff TEXT; v_name TEXT; v_qty INT; v_tstate TEXT;
+  tcp public.challenge_participants; v_phrase TEXT; v_lockletter TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_sabotage: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF p_target = v_uid THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_debuff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'sabotage' AND active;
+  IF v_debuff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid AND state = 'active') THEN
+    RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO tcp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_target;
+  IF tcp.user_id IS NULL OR tcp.state NOT IN ('active','invited') THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  -- Fog lands on the target's NEXT puzzle; reject (WITHOUT consuming the item) if
+  -- they have no un-started next puzzle. Validate before decrementing inventory.
+  IF v_debuff = 'fog' AND tcp.position >= m.pack_size THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','no_next_puzzle');
+  END IF;
+  -- Erase with nothing revealed: reject (WITHOUT consuming the item) so we never charge for
+  -- a no-op or fire a false "they wiped your letter" notify. Validate before the decrement.
+  IF v_debuff = 'lock' AND COALESCE(array_length(tcp.reveal_order,1),0) = 0 THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','nothing_to_erase');
+  END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+
+  IF v_debuff = 'lock' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, tcp.position);
+    v_lockletter := tcp.reveal_order[array_length(tcp.reveal_order,1)];  -- most recently revealed
+    IF v_lockletter IS NOT NULL THEN
+      UPDATE public.challenge_participants SET
+        revealed_positions = ARRAY(SELECT DISTINCT p FROM unnest(revealed_positions) p WHERE substr(v_phrase, p+1, 1) <> v_lockletter ORDER BY 1),
+        reveal_order = reveal_order[1:array_length(reveal_order,1)-1]
+      WHERE match_id = p_id AND user_id = p_target;
+    END IF;
+  ELSIF v_debuff = 'fog' THEN
+    UPDATE public.challenge_participants SET pending_fog = true WHERE match_id = p_id AND user_id = p_target;
+  ELSE
+    UPDATE public.challenge_participants SET
+      debuffs = (SELECT ARRAY(SELECT DISTINCT unnest(COALESCE(debuffs,'{}') || ARRAY[v_debuff]))),
+      debuff_by = COALESCE(debuff_by, '{}'::jsonb) || jsonb_build_object(v_debuff, v_uid::text)
+    WHERE match_id = p_id AND user_id = p_target;
+  END IF;
+
+  PERFORM public._notify(p_target, 'sabotaged', '💥 You got hit!',
+    public._display_name(v_uid) || ' hit you with ' || COALESCE(v_name,'a sabotage') ||
+    CASE v_debuff WHEN 'tax' THEN ' — your letters cost +50%' WHEN 'fog' THEN ' — your next puzzle starts foggy'
+      WHEN 'toll' THEN ' — your next letter costs 3×' WHEN 'vowel_block' THEN ' — your vowels cost 3×'
+      WHEN 'lock' THEN COALESCE(' — they wiped your ' || v_lockletter || 's', ' — a revealed letter is gone') ELSE '' END,
+    jsonb_build_object('match_id', p_id));
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;

--- a/supabase-match-erase.sql
+++ b/supabase-match-erase.sql
@@ -1,0 +1,146 @@
+-- Task 3: Lock -> Erase (wipe opponent's most-recently-revealed letter) + reveal-order tracking
+-- Scoped to gameMode:'match'. DB-only migration: dump live, transform, rollback-test, apply.
+-- Touches: match_buy_letter, match_use_powerup, match_sabotage, powerups catalog row.
+-- Consumes Task 1 column challenge_participants.reveal_order text[] (resets on advance).
+
+-- 1) match_buy_letter: on a correct (revealing) buy, append the letter to reveal_order
+--    (dedup, order stable), and persist. Do NOT append on incorrect letters.
+CREATE OR REPLACE FUNCTION public.match_buy_letter(p_id uuid, p_letter text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[]; v_debuffs text[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_buy_letter: not authenticated'; END IF;
+  IF public._match_tick(p_id, v_uid) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'match_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  v_debuffs := COALESCE(cp.debuffs, '{}');
+  IF 'half_off' = ANY(cp.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  IF 'tax' = ANY(v_debuffs) THEN v_cost := CEIL(v_cost * 1.5)::int; END IF;
+  IF v_letter IN ('A','E','I','O','U') AND 'vowel_block' = ANY(v_debuffs) THEN v_cost := v_cost * 3; END IF;
+  IF 'toll' = ANY(v_debuffs) THEN v_cost := v_cost * 3; v_debuffs := array_remove(v_debuffs, 'toll'); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  IF v_letter = ANY(cp.incorrect_letters) OR cp.bankroll < v_cost THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cp.revealed_positions THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF v_letter IN ('A','E','I','O','U') THEN cp.p_vowels := cp.p_vowels + 1; END IF;
+  IF v_positions IS NULL THEN cp.incorrect_letters := array_append(cp.incorrect_letters, v_letter);
+  ELSE cp.revealed_positions := ARRAY(SELECT DISTINCT unnest(cp.revealed_positions || v_positions) ORDER BY 1);
+    cp.reveal_order := CASE WHEN v_letter = ANY(cp.reveal_order) THEN cp.reveal_order ELSE array_append(cp.reveal_order, v_letter) END; END IF;
+  UPDATE public.challenge_participants SET bankroll = cp.bankroll - v_cost, incorrect_letters = cp.incorrect_letters,
+    revealed_positions = cp.revealed_positions, reveal_order = cp.reveal_order, p_vowels = cp.p_vowels, debuffs = v_debuffs,
+    fog_buys_left = GREATEST(0, cp.fog_buys_left - 1) WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;
+
+-- 2) match_use_powerup: when a powerup reveals positions, append the distinct revealed
+--    letters (from v_phrase at those positions, position order, skip already-present) to
+--    reveal_order so powerup-revealed letters are erasable too. Keep order stable.
+CREATE OR REPLACE FUNCTION public.match_use_powerup(p_id uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; cp public.challenge_participants; v_eff TEXT; v_name TEXT; v_qty INT; v_phrase TEXT; v_positions INT[]; r RECORD;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_use_powerup: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_eff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'climb' AND active;
+  IF v_eff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF v_eff = ANY(cp.active_powerups) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  UPDATE public.challenge_participants SET active_powerups = array_append(active_powerups, v_eff) WHERE match_id = p_id AND user_id = v_uid;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_positions := public._powerup_reveal(v_phrase, v_eff, cp.revealed_positions);
+  IF v_positions IS NOT NULL THEN
+    UPDATE public.challenge_participants SET
+      revealed_positions = ARRAY(SELECT DISTINCT unnest(revealed_positions || v_positions) ORDER BY 1),
+      reveal_order = reveal_order || ARRAY(
+        SELECT q.l FROM (
+          SELECT substr(v_phrase, p+1, 1) AS l, min(p) AS firstpos
+          FROM unnest(v_positions) p
+          WHERE substr(v_phrase, p+1, 1) ~ '[A-Z]'
+          GROUP BY substr(v_phrase, p+1, 1)
+        ) q
+        WHERE q.l <> ALL(reveal_order)
+        ORDER BY q.firstpos)
+    WHERE match_id = p_id AND user_id = v_uid;
+  END IF;
+  FOR r IN SELECT user_id FROM public.challenge_participants WHERE match_id = p_id AND user_id <> v_uid AND state IN ('active','done') LOOP
+    PERFORM public._notify(r.user_id, 'powerup_used', '💥 Power-up used',
+      public._display_name(v_uid) || ' used ' || COALESCE(v_name, 'a power-up'), jsonb_build_object('match_id', p_id));
+  END LOOP;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;
+
+-- 3) match_sabotage: 'lock' branch now ERASES the target's most-recently-revealed letter
+--    (last element of reveal_order): remove all its revealed positions AND pop it from
+--    reveal_order. Graceful no-op when reveal_order is empty. Fog / tax / toll / vowel_block
+--    branches unchanged; _notify "they wiped your {letter}s" preserved.
+CREATE OR REPLACE FUNCTION public.match_sabotage(p_id uuid, p_target uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; v_debuff TEXT; v_name TEXT; v_qty INT; v_tstate TEXT;
+  tcp public.challenge_participants; v_phrase TEXT; v_lockletter TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_sabotage: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF p_target = v_uid THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_debuff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'sabotage' AND active;
+  IF v_debuff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid AND state = 'active') THEN
+    RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO tcp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_target;
+  IF tcp.user_id IS NULL OR tcp.state NOT IN ('active','invited') THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  -- Fog lands on the target's NEXT puzzle; reject (WITHOUT consuming the item) if
+  -- they have no un-started next puzzle. Validate before decrementing inventory.
+  IF v_debuff = 'fog' AND tcp.position >= m.pack_size THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','no_next_puzzle');
+  END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+
+  IF v_debuff = 'lock' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, tcp.position);
+    v_lockletter := tcp.reveal_order[array_length(tcp.reveal_order,1)];  -- most recently revealed
+    IF v_lockletter IS NOT NULL THEN
+      UPDATE public.challenge_participants SET
+        revealed_positions = ARRAY(SELECT DISTINCT p FROM unnest(revealed_positions) p WHERE substr(v_phrase, p+1, 1) <> v_lockletter ORDER BY 1),
+        reveal_order = reveal_order[1:array_length(reveal_order,1)-1]
+      WHERE match_id = p_id AND user_id = p_target;
+    END IF;
+  ELSIF v_debuff = 'fog' THEN
+    UPDATE public.challenge_participants SET pending_fog = true WHERE match_id = p_id AND user_id = p_target;
+  ELSE
+    UPDATE public.challenge_participants SET
+      debuffs = (SELECT ARRAY(SELECT DISTINCT unnest(COALESCE(debuffs,'{}') || ARRAY[v_debuff]))),
+      debuff_by = COALESCE(debuff_by, '{}'::jsonb) || jsonb_build_object(v_debuff, v_uid::text)
+    WHERE match_id = p_id AND user_id = p_target;
+  END IF;
+
+  PERFORM public._notify(p_target, 'sabotaged', '💥 You got hit!',
+    public._display_name(v_uid) || ' hit you with ' || COALESCE(v_name,'a sabotage') ||
+    CASE v_debuff WHEN 'tax' THEN ' — your letters cost +50%' WHEN 'fog' THEN ' — your next puzzle starts foggy'
+      WHEN 'toll' THEN ' — your next letter costs 3×' WHEN 'vowel_block' THEN ' — your vowels cost 3×'
+      WHEN 'lock' THEN COALESCE(' — they wiped your ' || v_lockletter || 's', ' — a revealed letter is gone') ELSE '' END,
+    jsonb_build_object('match_id', p_id));
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;
+
+-- 4) Catalog rename. NOTE: public.powerups has no `description` column (columns:
+--    id,name,kind,effect_key,price,sort,active) — the item copy is hardcoded client-side,
+--    so we update `name` only. Client desc updated in src/routes/shop/+page.svelte.
+UPDATE public.powerups SET name = 'Erase' WHERE id = 'sabotage_lock';

--- a/supabase-match-fog.sql
+++ b/supabase-match-fog.sql
@@ -1,0 +1,177 @@
+-- Match: fog is a queued next-puzzle curse (3-buy clue hide)
+-- Task 2 of the 1v1 match-mechanics overhaul.
+--   * match_sabotage: fog sets pending_fog on the target's NEXT puzzle; rejected
+--     (no charge) if the target has no un-started next puzzle. Inventory is
+--     decremented only after fog validation passes.
+--   * _match_board: hide the clue while fog_buys_left > 0; expose per-opponent
+--     position/pack_size/can_fog castability + my own fog_buys_left.
+--   * match_buy_letter: every buy (right or wrong) decrements fog_buys_left, so
+--     the clue reveals after the target's 3rd purchase.
+
+CREATE OR REPLACE FUNCTION public.match_sabotage(p_id uuid, p_target uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; v_debuff TEXT; v_name TEXT; v_qty INT; v_tstate TEXT;
+  tcp public.challenge_participants; v_phrase TEXT; v_lockletter TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_sabotage: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF p_target = v_uid THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_debuff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'sabotage' AND active;
+  IF v_debuff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid AND state = 'active') THEN
+    RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO tcp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_target;
+  IF tcp.user_id IS NULL OR tcp.state NOT IN ('active','invited') THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  -- Fog lands on the target's NEXT puzzle; reject (WITHOUT consuming the item) if
+  -- they have no un-started next puzzle. Validate before decrementing inventory.
+  IF v_debuff = 'fog' AND tcp.position >= m.pack_size THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','no_next_puzzle');
+  END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+
+  IF v_debuff = 'lock' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, tcp.position);
+    SELECT substr(v_phrase, p+1, 1) INTO v_lockletter FROM unnest(tcp.revealed_positions) p
+      WHERE substr(v_phrase, p+1, 1) ~ '[A-Z]' ORDER BY random() LIMIT 1;
+    IF v_lockletter IS NOT NULL THEN
+      UPDATE public.challenge_participants SET revealed_positions =
+        ARRAY(SELECT DISTINCT p FROM unnest(revealed_positions) p WHERE substr(v_phrase, p+1, 1) <> v_lockletter ORDER BY 1)
+      WHERE match_id = p_id AND user_id = p_target;
+    END IF;
+  ELSIF v_debuff = 'fog' THEN
+    UPDATE public.challenge_participants SET pending_fog = true WHERE match_id = p_id AND user_id = p_target;
+  ELSE
+    UPDATE public.challenge_participants SET
+      debuffs = (SELECT ARRAY(SELECT DISTINCT unnest(COALESCE(debuffs,'{}') || ARRAY[v_debuff]))),
+      debuff_by = COALESCE(debuff_by, '{}'::jsonb) || jsonb_build_object(v_debuff, v_uid::text)
+    WHERE match_id = p_id AND user_id = p_target;
+  END IF;
+
+  PERFORM public._notify(p_target, 'sabotaged', '💥 You got hit!',
+    public._display_name(v_uid) || ' hit you with ' || COALESCE(v_name,'a sabotage') ||
+    CASE v_debuff WHEN 'tax' THEN ' — your letters cost +50%' WHEN 'fog' THEN ' — your next puzzle starts foggy'
+      WHEN 'toll' THEN ' — your next letter costs 3×' WHEN 'vowel_block' THEN ' — your vowels cost 3×'
+      WHEN 'lock' THEN COALESCE(' — they wiped your ' || v_lockletter || 's', ' — a revealed letter is gone') ELSE '' END,
+    jsonb_build_object('match_id', p_id));
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')), 'fog_buys_left', cp.fog_buys_left,
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id),
+        'position', o.position, 'pack_size', m.pack_size, 'can_fog', o.position < m.pack_size) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN cp.fog_buys_left > 0 THEN NULL ELSE v_clue END);
+END; $function$;
+
+CREATE OR REPLACE FUNCTION public.match_buy_letter(p_id uuid, p_letter text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[]; v_debuffs text[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_buy_letter: not authenticated'; END IF;
+  IF public._match_tick(p_id, v_uid) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'match_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  v_debuffs := COALESCE(cp.debuffs, '{}');
+  IF 'half_off' = ANY(cp.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  IF 'tax' = ANY(v_debuffs) THEN v_cost := CEIL(v_cost * 1.5)::int; END IF;
+  IF v_letter IN ('A','E','I','O','U') AND 'vowel_block' = ANY(v_debuffs) THEN v_cost := v_cost * 3; END IF;
+  IF 'toll' = ANY(v_debuffs) THEN v_cost := v_cost * 3; v_debuffs := array_remove(v_debuffs, 'toll'); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  IF v_letter = ANY(cp.incorrect_letters) OR cp.bankroll < v_cost THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cp.revealed_positions THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF v_letter IN ('A','E','I','O','U') THEN cp.p_vowels := cp.p_vowels + 1; END IF;
+  IF v_positions IS NULL THEN cp.incorrect_letters := array_append(cp.incorrect_letters, v_letter);
+  ELSE cp.revealed_positions := ARRAY(SELECT DISTINCT unnest(cp.revealed_positions || v_positions) ORDER BY 1); END IF;
+  UPDATE public.challenge_participants SET bankroll = cp.bankroll - v_cost, incorrect_letters = cp.incorrect_letters,
+    revealed_positions = cp.revealed_positions, p_vowels = cp.p_vowels, debuffs = v_debuffs,
+    fog_buys_left = GREATEST(0, cp.fog_buys_left - 1) WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;

--- a/supabase-match-fold-dupfix.sql
+++ b/supabase-match-fold-dupfix.sql
@@ -1,0 +1,74 @@
+-- Critical fix: match_fold crashed on a final-puzzle fold.
+-- Both state='done' branches had a duplicate column assignment
+-- `finished_at = now(), finished_at = now()`, which Postgres rejects at execute time with
+-- ERROR: multiple assignments to same column "finished_at" — so folding on the LAST puzzle of a
+-- match errored in production. Predates our work (from the match-timing PR) but lives in the
+-- function Task 3 edited and Task 5's broke-fold will reuse this path. Dumped the live body and
+-- removed the SECOND `finished_at = now(),` in both done branches; everything else (incl. the
+-- Task-3 reveal_order='{}' additions) is byte-identical.
+CREATE OR REPLACE FUNCTION public.match_fold(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); cp public.challenge_participants; m public.challenge_matches;
+  v_phrase text; v_charge bigint; v_left bigint; v_next_bounty int;
+begin
+  if v_uid is null then raise exception 'match_fold: not authenticated'; end if;
+  if public._match_tick(p_id, v_uid) then return public._match_board(p_id, v_uid); end if;
+  select * into cp from public.challenge_participants where match_id = p_id and user_id = v_uid for update;
+  if not found or cp.state <> 'active' then return public._match_board(p_id, v_uid); end if;
+  select * into m from public.challenge_matches where id = p_id;
+  -- full price of every still-unrevealed distinct letter (base cost), capped at remaining ante
+  select upper(phrase) into v_phrase from public.daily_puzzles where id = public._match_pid(p_id, cp.position);
+  select coalesce(sum(public.letter_cost(t.ch)), 0) into v_charge from (
+    select distinct substr(v_phrase, g.i+1, 1) as ch from generate_series(0, length(v_phrase)-1) g(i)
+    where substr(v_phrase, g.i+1, 1) ~ '[A-Z]' and not (g.i = any(cp.revealed_positions))
+  ) t;
+  v_charge := least(v_charge, cp.bankroll);
+  v_left := greatest(0, cp.bankroll - v_charge);
+
+  if m.econ_v = 2 then
+    -- Accumulate this puzzle's leftover; advance with a fresh bounty (mirrors the solve path).
+    if cp.position >= m.pack_size then
+      update public.challenge_participants
+        set state = 'done', bankroll = v_left, last_score = 0, total_score = total_score + v_left,
+            reveal_order = '{}',
+            finished_at = now(), joined_at = coalesce(joined_at, now())
+        where match_id = p_id and user_id = v_uid;
+      perform public._match_maybe_settle(p_id);
+      perform public._match_notify_opponent_played(p_id, v_uid);
+    else
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      update public.challenge_participants
+        set position = position + 1, bankroll = v_next_bounty,
+            start_budget = coalesce(start_budget, 0) + v_next_bounty,
+            last_score = 0, total_score = total_score + v_left,
+            revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+            reveal_order = '{}', sabotaged_targets = '{}',
+            fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+            p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+        where match_id = p_id and user_id = v_uid;
+    end if;
+    return public._match_board(p_id, v_uid);
+  end if;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = leftover.
+  if cp.position >= m.pack_size then
+    update public.challenge_participants
+      set state = 'done', bankroll = v_left, last_score = 0, total_score = v_left,
+          reveal_order = '{}',
+          finished_at = now(), joined_at = coalesce(joined_at, now())
+      where match_id = p_id and user_id = v_uid;
+    perform public._match_maybe_settle(p_id);
+  else
+    update public.challenge_participants
+      set position = position + 1, bankroll = v_left, last_score = 0, total_score = v_left,
+          revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+          reveal_order = '{}', sabotaged_targets = '{}',
+          fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+          p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      where match_id = p_id and user_id = v_uid;
+  end if;
+  return public._match_board(p_id, v_uid);
+end; $function$;

--- a/supabase-match-mechanics-schema.sql
+++ b/supabase-match-mechanics-schema.sql
@@ -1,0 +1,66 @@
+-- Match mechanics overhaul — Task 1: schema foundation + advance reset
+-- Adds fog/erase/cap columns to challenge_participants, and seeds/clears them
+-- in _match_resolve_and_advance's non-final advance branches (both econ_v=2 and
+-- the old-econ path). Scoped to gameMode:'match'; purely additive.
+
+ALTER TABLE public.challenge_participants
+  ADD COLUMN IF NOT EXISTS pending_fog boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS fog_buys_left int NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS reveal_order text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS sabotaged_targets uuid[] NOT NULL DEFAULT '{}';
+
+CREATE OR REPLACE FUNCTION public._match_resolve_and_advance(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_phrase TEXT; v_cat TEXT; v_won BOOLEAN;
+  v_score INT; v_combo INT; v_solved INT; v_budget BIGINT; v_next_bounty INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN public._match_board(p_id, p_uid); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_budget := GREATEST(COALESCE(m.wager,0), 500);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cp.revealed_positions)));
+  IF NOT v_won THEN RETURN public._match_board(p_id, p_uid); END IF;
+  IF COALESCE(m.wager,0) > 0 THEN PERFORM public._record_category_solve(p_uid, v_cat); END IF;  -- friendly (wager 0) earns no category credit
+  v_solved := cp.solved + 1;
+  IF m.econ_v = 2 THEN
+    IF cp.position >= m.pack_size THEN
+      UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+      WHERE match_id = p_id AND user_id = p_uid;
+      PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+    ELSE
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, position = position + 1,
+        bankroll = v_next_bounty, start_budget = COALESCE(start_budget,0) + v_next_bounty,
+        revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+        reveal_order = '{}', sabotaged_targets = '{}',
+        fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+        p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      WHERE match_id = p_id AND user_id = p_uid;
+    END IF;
+    RETURN public._match_board(p_id, p_uid);
+  END IF;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = bankroll.
+  IF cp.position >= m.pack_size THEN
+    UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+      total_score = cp.bankroll, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+    WHERE match_id = p_id AND user_id = p_uid;
+    PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+  ELSE
+    UPDATE public.challenge_participants SET solved = v_solved, last_score = cp.bankroll,
+      total_score = cp.bankroll, position = position + 1,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+      reveal_order = '{}', sabotaged_targets = '{}',
+      fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+      p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+    WHERE match_id = p_id AND user_id = p_uid;
+  END IF;
+  RETURN public._match_board(p_id, p_uid);
+END; $function$

--- a/supabase-match-minfo-timer.sql
+++ b/supabase-match-minfo-timer.sql
@@ -1,0 +1,89 @@
+-- Task 6 Step 1: expose challenge_participants.started_at on the match board
+-- so the client can drive an in-match count-up SolveTimer.
+-- Pure additive change to _match_board.v_minfo — byte-identical otherwise.
+
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT; v_cheapest INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  v_cheapest := public._match_cheapest(p_id, p_uid);  -- cheapest still-buyable effective cost (NULL if none)
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(COALESCE(cp.debuffs,'{}')), 'fog_buys_left', cp.fog_buys_left,
+    'must_guess', (cp.state = 'active' AND (v_cheapest IS NULL OR v_cheapest > cp.bankroll)),
+    'started_at', cp.started_at,
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id),
+        'position', o.position, 'pack_size', m.pack_size, 'can_fog', o.position < m.pack_size) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN cp.fog_buys_left > 0 THEN NULL ELSE v_clue END);
+END; $function$;


### PR DESCRIPTION
Seven playtest-driven changes to 1v1 challenge (`gameMode:'match'`) play. All server SQL was applied to prod via the dump→transform→rollback-test→apply pattern (each task rollback-tested); this PR brings the client UI to master. Spec + plan in `docs/superpowers/`.

## Changes
1. **Fog → queued next-puzzle curse.** Casting fog curses the opponent's *next* puzzle: its clue is hidden until their 3rd letter buy. Never affects puzzle 1; greyed when they have no un-started puzzle left. Fixes the old start-first-immunity coin-flip. (`pending_fog`/`fog_buys_left` columns.)
2. **Lock → Erase.** Wipes the opponent's *most-recently-revealed* letter (was random). Added reveal-order tracking (`reveal_order`), covering buys, hints, and power-up reveals.
3. **In-match count-up timer** (surfaces the existing speed tiebreaker).
4. **Pot moved to the top bar**, left of the title.
5. **Keyboard shows real sabotaged prices** — tax/toll/vowel-block raise the displayed price + affordability, with a ▲ "taxed" cue. Cost stack mirrors the server byte-for-byte (live-verified: displayed price == charge).
6. **Broke = last stand.** Danger screen + one final guess + visible timer; a wrong guess (server-authoritative) or the clock folds the puzzle. (`must_guess` flag; broke-wrong-guess folds via a shared `_match_do_fold`.)
7. **Usage caps:** one power-up per puzzle (total) + one sabotage per opponent per puzzle, with rejection notices.

## Bonus fix
Discovered + fixed a **live production crash**: folding on the final puzzle of a match errored (`match_fold` had a duplicate `finished_at = now()` assignment, from an earlier PR). Already on prod.

## Verification
- Every server task rollback-tested (BEGIN…ROLLBACK on a seeded match) before applying to prod.
- Two-player E2E confirmed live: fog (p1-not-hidden / p2-hidden-until-3-buys), erase most-recently-revealed, taxed keyboard price == server charge, timer, broke danger, cap rejection.
- Final whole-branch review verified the **final live composed state** of all multiply-edited functions (`match_sabotage`, `match_fold`/`_match_do_fold`/`_match_resolve_and_advance`, `_match_board`, `match_buy_letter`) — rejections don't consume inventory or burn the sabotage slot; fold semantics identical across paths; every per-puzzle column resets on both advance paths.
- `svelte-check` clean (no new errors); build passes.

Scoped to match mode — Daily / Cash Game / Free Play unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)