### PR TITLE
Challenge results redesign + builder tweaks (All Categories, remove spend bar)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-challenge-results-and-builder.md
+++ b/docs/superpowers/plans/2026-07-16-challenge-results-and-builder.md
@@ -1,0 +1,101 @@
+# Challenge Results Modal + Builder Tweaks — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Ship the three approved challenge changes: an "All Categories" builder chip, removal of the yellow spending bar, and a redesigned results modal (verdict + single pot line + kept-score head-to-head + per-puzzle ✓/✗, cutting the gold band).
+
+**Architecture:** All client except one small server add (`solved_positions` for the ✓/✗ strip). The results modal is `MatchDetailModal.svelte`, fed by `get_match_detail`. Per-participant `score` (=`total_score`=kept bounty) is ALREADY in the payload (just unused); only per-puzzle solve status is new.
+
+**Tech Stack:** SvelteKit 2.16 (Svelte 5); Supabase Postgres (dump→transform→rollbacktest→apply); svelte-check + build.
+
+## Global Constraints
+
+- Match-mode only. Daily / Cash Game / Free Play unchanged; every change gated on `isMatch`/match data.
+- Verify with `npm run check` (svelte-check — catches reactive ReferenceErrors that `npm run build`/Vite miss) AND `npm run build`. Known-pre-existing-OK: `points.test.js:31`, `profile/+page.svelte:408` a11y warning. No NEW errors.
+- Server change follows the dump→transform→rollbacktest→apply pattern; commit as `supabase-*.sql`.
+- Commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: "All Categories" chip in the builder
+
+**Files:** Modify `src/routes/+page.svelte` (category picker `~3944-3968`; state `mbCategories` `~2031`; `toggleCategory` `~2157`).
+
+- [ ] **Step 1: Add the chip + logic**
+
+Render an "All Categories" chip as the FIRST option in the picker (`~3944-3968`), styled like the existing `.ch-catrow` toggles. Selected state = `mbCategories.length === 0` (empty = any = all). Behavior:
+- Tapping "All Categories" sets `mbCategories = []` (clears individual picks).
+- Tapping an individual category continues to use `toggleCategory` (which adds/removes it); when any are selected, "All Categories" renders unselected; when the list empties, it renders selected.
+- Keep the hint line (`~3965-3967`) or fold its meaning into the chip. Do NOT change the submit flow — empty `mbCategories` already = all via `_pick_casual_pack`.
+
+- [ ] **Step 2: Verify** — `npm run check` (zero new) + `npm run build`. Confirm empty selection shows the chip active and picking a category deactivates it. Commit: "Challenges: explicit All Categories chip in the builder".
+
+---
+
+### Task 2: Remove the yellow spending bar
+
+**Files:** Modify `src/routes/+page.svelte` (markup `4778-4787`; CSS `.ante-bar`/`.ante-fill` `~8480-8496`; `class:ante-empty` `:4664`).
+
+- [ ] **Step 1: Remove the bar**
+
+Delete the `{#if isMatch && matchLive}<div class="ante-bar"><span class="ante-fill" .../></div>{/if}` block (`4778-4787`) and the `.ante-bar` + `.ante-fill` CSS rules (`~8480-8496`). Check `class:ante-empty={isMatch && matchLeft <= 0}` on `.bounty-panel` (`:4664`): if `.ante-empty` CSS only dimmed/styled the now-removed bar, remove the class binding and its rule; if it also styles the panel meaningfully (e.g. a low-bounty warning tint that's still wanted), keep it. Report which.
+
+- [ ] **Step 2: Verify** — `npm run check` (zero new) + `npm run build`; confirm no dangling `.ante-*` references (grep). Confirm Daily/Cash Game/Free Play unaffected (the bar was match-gated). Commit: "Challenges: remove the yellow bounty-spend bar during match play".
+
+---
+
+### Task 3: Server — per-puzzle solve tracking for the ✓/✗ strip
+
+**Files:** Create `supabase-match-solved-positions.sql`. Touches live `_match_resolve_and_advance`, `get_match_detail`.
+
+**Interfaces — Produces:** `get_match_detail().participants[].solved_positions int[]` consumed by Task 4.
+
+- [ ] **Step 1: Column + append-on-solve**
+
+`ALTER TABLE public.challenge_participants ADD COLUMN IF NOT EXISTS solved_positions int[] NOT NULL DEFAULT '{}';`
+This is a MATCH-LEVEL accumulator — do NOT add it to any per-puzzle reset list. Dump live `_match_resolve_and_advance`; in its WIN path (`v_won` true), in BOTH econ branches AND both final/non-final sub-branches, append the just-solved `cp.position` to `solved_positions` in the participant UPDATE:
+`solved_positions = array_append(solved_positions, cp.position),`
+(A folded puzzle goes through `_match_do_fold`, which does NOT append — so folds correctly stay ✗.)
+
+- [ ] **Step 2: Expose in get_match_detail**
+
+Dump live `get_match_detail`; in the `participants` jsonb_agg, add `'solved_positions', t.solved_positions` and include `cp.solved_positions` in the inner `SELECT ... FROM challenge_participants cp` subquery. Purely additive.
+
+- [ ] **Step 3: Rollback-test** — seed a 3-puzzle match; solve puzzles 1 and 3, fold puzzle 2; assert `solved_positions = {1,3}` and `get_match_detail` returns it; a fully-solved player → `{1,2,3}`. `BEGIN…ROLLBACK`. (If full seeding impractical, compile-in-transaction + structural assertion the append is in the win path only; say so.)
+
+- [ ] **Step 4: Apply + commit** — `psql -f supabase-match-solved-positions.sql`; confirm live greps. Commit: "Challenges: track solved puzzle positions + expose in match detail".
+
+---
+
+### Task 4: Redesign the results modal
+
+**Files:** Modify `src/lib/components/MatchDetailModal.svelte` (whole file, 344 lines).
+
+**Interfaces — Consumes:** existing `participants[].{is_me,name,rank,solved,score,spent,net,elapsed_seconds,state}`, `match.{pack_size,wager,status}`, `pack[].{position,category,phrase}`, and Task 3's `participants[].solved_positions`.
+
+- [ ] **Step 1: Rework the template + reason logic**
+
+Redesign per the spec (verdict → pot line → kept-score head-to-head → per-puzzle ✓/✗), match-only. Concretely:
+- **Header** (`~94-107`): keep `⚔ {title}` + "{pack_size} puzzles · winner-take-all/podium". Remove the "$X buy-in" fragment from the sub-line (the pot line carries money).
+- **Verdict block** (replaces `.md-outcome` `~109-117`): a big **VICTORY / DEFEAT / TIE** headline, color-coded from `iWon`/`isTie`/`winner`, with a one-line reason. Reuse/repurpose the existing derived flags. Prefer a solve-count reason when solves differ (`me.solved` vs `winner.solved`), else a kept/speed reason (you already have `sameSpend`/`speedGap` — reframe to kept). This REPLACES the `tieback` gold band's role.
+- **Pot line** (new, only when `wagered && status==='settled' && !noSolve`): a single clearly-labeled real-money line from `me.net` — `+$500` "Pot won" / `−$500` "Buy-in lost". Friendly (`!wagered`) → "Friendly — no stakes" or omit.
+- **Head-to-head** (`.md-standings` `~123-146`): keep two rows + the `.md-row.me` highlight, but change the meta (`~135-143`) to lead with **Kept ${p.score}** (higher = better) instead of "${p.spent} spent"; keep `solved X/N` and `fmtSecs(elapsed_seconds)`; keep the per-row `net` only if you want it secondary (the pot line already shows it — consider dropping from the row to avoid repeat). Winner gets the medal/crown (existing `.md-rank`).
+- **Per-puzzle strip** (`.md-pack` `~148-163`): for each `pk`, after the phrase add a ✓/✗ per participant: ✓ when `pk.position` ∈ that player's `solved_positions`, else ✗. Show `me` then `opp` (label with initials or the medal color). GRACEFUL FALLBACK: when every participant's `solved_positions` is empty/absent (pre-existing match), render the current plain phrase list with NO marks.
+- **Cut** the gold summary band: remove the `.md-tieback` render (`~119-121`); either delete the `tieback` computed (`~50-75`) or repurpose its logic into the verdict reason. Remove `.md-tieback` CSS (`~250-260`).
+- Keep the close/overlay/actions.
+
+- [ ] **Step 2: CSS**
+
+Add styles for the verdict block (large, color-coded win/loss/tie), the pot line, the ✓/✗ marks (green check / dim cross). Remove the now-dead `.md-tieback` rule and the `you spent` label styling if orphaned. Keep the dark neon-arcade token palette; do not introduce the removed amber "underline" look under the money.
+
+- [ ] **Step 3: Verify** — `npm run check` (zero new) + `npm run build`. Read through: verdict shows correct win/loss/tie + reason; single pot line; head-to-head shows Kept (not spent as headline); per-puzzle ✓/✗ when data present, plain list when not; no gold band; friendly matches render sensibly (no pot line). Commit: "Challenges: redesign results modal — verdict, single pot line, kept-score, per-puzzle ✓/✗".
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** All Categories (T1), remove spending bar (T2), results redesign (T4) with its server data (T3). ✔
+- **`score` already in payload** → head-to-head kept-score needs no server change; only ✓/✗ does (T3). ✔
+- **solved_positions is a match-level accumulator** (never per-puzzle-reset) — appended only on solve, so folds stay ✗. ✔
+- **Graceful fallback** for pre-existing matches (empty solved_positions → plain phrase list). ✔
+- **No mode leakage:** every change gated on match data / `isMatch`. ✔

--- a/docs/superpowers/specs/2026-07-16-challenge-results-and-builder.md
+++ b/docs/superpowers/specs/2026-07-16-challenge-results-and-builder.md
@@ -1,0 +1,71 @@
+# Challenge Results Modal + Builder Tweaks — Design Spec
+
+**Date:** 2026-07-16
+**Source:** Playtest feedback + approved redesign discussion.
+
+## Goal
+
+Three approved changes to 1v1 challenge (`gameMode:'match'`) UX:
+1. Add an explicit **"All Categories"** option to the challenge builder's category picker.
+2. Remove the **yellow spending bar** (`.ante-fill`) that recedes during match play.
+3. **Redesign the challenge results modal** (`MatchDetailModal.svelte`) to fix money-confusion + redundancy.
+
+## Global constraints
+
+- Scoped to match mode. Daily / Cash Game / Free Play unchanged.
+- Server authoritative; the modal only reflects `get_match_detail` data.
+- svelte-check must be clean (no new errors); build passes.
+
+---
+
+## 1. "All Categories" button (builder)
+
+**Current:** Builder Step 2 (`+page.svelte:3944-3968`) shows a multi-select of the 12 `CATEGORIES` labeled "Categories (optional)". Selecting **none** = "Any category" (draws the pack from all categories via `_pick_casual_pack` with `p_categories='{}'`). The all-categories behavior exists but is invisible/implicit; the hint only reads "Any category" when zero are selected.
+
+**New:** Add an explicit **"All Categories"** chip at the TOP of the picker.
+- It represents the "any/all" state (empty `mbCategories`), selected/highlighted by default.
+- Tapping it clears any individual selections (back to "all").
+- Tapping an individual category deselects "All Categories" (and adds that category, as today).
+- When ≥1 individual category is selected, "All Categories" is unselected; when the selection is empty, "All Categories" shows selected.
+- No change to the underlying flow (`mbCategories` → `createMatch({categories})` → `create_match(p_categories)` → `_pick_casual_pack`); empty array already = all.
+
+## 2. Remove the yellow spending bar
+
+**Current:** `+page.svelte:4778-4787` renders `.ante-bar` > `.ante-fill` (gold gradient `#fbbf24→#fde047`, `width = matchLeft/budget %`) — a bar that shrinks as bounty is spent, match-only. CSS at `~8480-8496`. The bounty-panel also carries `class:ante-empty={isMatch && matchLeft <= 0}` (`:4664`).
+
+**New:** Remove the `.ante-bar`/`.ante-fill` markup block and its CSS. Review `ante-empty` — if it only styled the bar's empty state, remove it too; if it also does something else useful on the panel, keep that behavior. No other mode touches these (match-gated).
+
+## 3. Results modal redesign (`MatchDetailModal.svelte`)
+
+**Problems today:** (a) two different "moneys" blurred — the ±$500 pot P&L (real cash) vs the per-puzzle bounty "spent" (play-money, less = better); (b) it leads with **spent** (inverted: lower is better) instead of the **score** that actually ranks players (score = `total_score` = leftover bounty, higher = better; ties broken by time); (c) it buries the real reason (solve count); (d) it repeats "you spent $X" three times (hero, gold band, row).
+
+**New layout (top→bottom):**
+1. **Header** (keep): `⚔ @opponent` + "N puzzles · winner-take-all". (Drop the "$500 buy-in" from here — the pot line below carries it.)
+2. **Verdict block**: big **VICTORY / DEFEAT** (color-coded, replaces the raw −$500 hero), with a one-line reason derived from the standings (e.g. "Flactivate solved 3 — you got 2", or on equal solves "Flactivate kept more" / "faster on the tiebreaker").
+3. **Pot line**: the ONLY real-money line — `+$500` / `−$500` clearly labeled ("Pot won" / "Buy-in lost"). For a friendly (wager 0) show nothing or "Friendly — no stakes".
+4. **Head-to-head scoreboard**: two rows, winner marked (👑/rank medal), each showing `name · solved X/N · Score $KEPT · m:ss`. Frame the money as **Kept** (= `score`/`total_score`, higher = better), NOT "spent". Optional subtle score-comparison bar. Keep the current `.md-row.me` highlight but DROP the gold summary band entirely (kills the redundancy + the "yellow line under money").
+5. **Per-puzzle strip**: `# · category-icon · "phrase"` with a **✓/✗ per player** (who solved each). Requires per-puzzle solve data (see server change). When that data is absent (pre-existing matches), fall back to the current phrase list with no marks.
+6. **Actions** (keep whatever exists): Rematch / Close.
+
+**Cut:** the gold `.md-tieback` summary band (lines 50-75 compute + 119-121 render + 250-260 CSS); the "spent" framing as the headline; the triple-repeat of spent.
+
+**Copy:** "Kept" for the score (leftover bounty). Keep solve time (tiebreaker). "Spent" may appear as a de-emphasized secondary detail if useful, but is not the headline.
+
+### Server support for the ✓/✗ strip
+
+`get_match_detail` currently returns per-participant totals + a `pack` (position/category/phrase) but no per-puzzle solve status. Add:
+- `challenge_participants.solved_positions int[] default '{}'` — a **match-level accumulator** (NOT reset per puzzle): append `position` in `_match_resolve_and_advance`'s win path (every solve, both econ branches, final + non-final). Never reset mid-match (only defaults at match start).
+- Expose `'solved_positions', t.solved_positions` per participant in `get_match_detail`.
+- Client renders ✓ when a pack position ∈ that player's `solved_positions`, else ✗; when all participants' `solved_positions` are empty (old match), render the plain phrase list (no marks).
+
+## Testing
+
+- svelte-check + build clean for all client changes.
+- Server: rollback-test that solving pack puzzles appends the right positions to `solved_positions`; `get_match_detail` returns them; a folded puzzle's position is NOT appended.
+- Visual: the redesigned modal shows verdict + single pot line + kept-score head-to-head + per-puzzle ✓/✗; no gold band; builder shows an "All Categories" chip selected by default; no spending bar during match play.
+
+## Out of scope
+
+- Daily / Cash Game / Free Play.
+- Group (3+) results layout beyond what generalizes (rows already support N participants).
+- Any economy/scoring change (only the *presentation* of score changes: spent → kept).

--- a/src/lib/components/MatchDetailModal.svelte
+++ b/src/lib/components/MatchDetailModal.svelte
@@ -26,6 +26,7 @@
 	$: noSolve = parts.length > 0 && parts.every((/** @type {any} */ p) => (p.solved ?? 0) === 0);
 	$: title = detail?.group_name || (opp ? '@' + (opp.name || 'player') : 'Challenge');
 	$: wagered = Number(m?.wager) > 0;
+	$: settled = m?.status === 'settled';
 	const money = (/** @type {any} */ n) =>
 		(Number(n) < 0 ? '−$' : '+$') + Math.abs(Math.round(Number(n ?? 0))).toLocaleString();
 	const mult = (/** @type {any} */ x) => (x ? (Number(x) / 100).toFixed(1) + '×' : '');
@@ -36,43 +37,49 @@
 	};
 	const dollars = (/** @type {any} */ n) => '$' + Number(n ?? 0).toLocaleString();
 
-	// The spend "tie-back": frame the outcome in the universal metric — who solved
-	// for the least. Works for 1v1 and groups, wagered or friendly.
 	$: field = parts.length;
 	$: winner = parts.find((/** @type {any} */ p) => Number(p.rank) === 1);
 	$: iWon = me && Number(me.rank) === 1;
-	// A 1v1 tie: both participants share rank 1 (equal spend AND equal time).
+	// A 1v1 tie: both participants share rank 1 (equal kept score AND equal time).
 	$: isTie = field === 2 && !!me && !!opp && Number(me.rank) === 1 && Number(opp.rank) === 1;
-	// 1v1 speed gap — the decider when spends are equal.
+	// 1v1 speed gap — the decider when kept scores are equal.
 	$: haveTimes = field === 2 && me?.elapsed_seconds != null && opp?.elapsed_seconds != null;
 	$: speedGap = haveTimes ? Math.abs(me.elapsed_seconds - opp.elapsed_seconds) : null;
-	$: sameSpend = !!me && !!opp && Number(me.spent) === Number(opp.spent);
-	$: tieback = (() => {
-		if (!me || noSolve || m?.status !== 'settled') return '';
-		const myS = dollars(me.spent);
-		if (isTie) return me.solved ? `Dead heat — you both solved for ${myS}.` : `Tie — no winner.`;
+	$: sameScore = !!me && !!opp && Number(me.score) === Number(opp.score);
+
+	$: verdictKind = noSolve || isTie ? 'tie' : iWon ? 'win' : 'loss';
+	$: verdictHead = noSolve ? 'NO CONTEST' : isTie ? 'TIE' : iWon ? 'VICTORY' : 'DEFEAT';
+
+	// The one-line reason: solve count first (the real driver), then kept score,
+	// then speed — never leads with "spent" (inverted: lower used to read as better).
+	$: reason = (() => {
+		if (!me || !settled) return '';
+		if (noSolve) return wagered ? 'Nobody solved — buy-in refunded.' : 'Nobody solved.';
+		if (isTie) return me.solved ? `Dead heat — you both kept ${dollars(me.score)}.` : 'Tie — no winner.';
 		if (field === 2 && opp) {
-			const oS = dollars(opp.spent),
-				on = '@' + (opp.name || 'opponent');
+			const on = '@' + (opp.name || 'opponent');
+			const solvedDiff = Number(me.solved ?? 0) !== Number(opp.solved ?? 0);
 			if (iWon) {
-				if (me.solved && sameSpend && speedGap)
-					return `Matched ${on}'s ${oS} — you solved ${fmtSecs(speedGap)} faster.`;
-				return me.solved
-					? `You solved for ${myS} — beat ${on}'s ${oS}.`
-					: `You took it — ${on} didn't solve.`;
+				if (!opp.solved) return `You took it — ${on} didn't solve.`;
+				if (solvedDiff) return `You solved ${me.solved} — ${on} got ${opp.solved}.`;
+				if (sameScore && speedGap) return `Tied on kept — you were ${fmtSecs(speedGap)} faster.`;
+				return `You kept ${dollars(me.score)} — ${on} kept ${dollars(opp.score)}.`;
 			}
-			if (Number(opp.rank) === 1) {
-				if (opp.solved && sameSpend && speedGap)
-					return `Matched ${on}'s ${oS} — but ${on} solved ${fmtSecs(speedGap)} faster.`;
-				return opp.solved ? `${on} solved for ${oS} — you spent ${myS}.` : `You spent ${myS}.`;
-			}
-			return `You spent ${myS}.`;
+			if (!me.solved) return `${on} solved — you didn't.`;
+			if (solvedDiff) return `${on} solved ${opp.solved} — you got ${me.solved}.`;
+			if (sameScore && speedGap) return `Tied on kept — ${on} was ${fmtSecs(speedGap)} faster.`;
+			return `${on} kept ${dollars(opp.score)} — you kept ${dollars(me.score)}.`;
 		}
-		if (iWon) return `You solved for ${myS} — cheapest of ${field}.`;
+		// Group / podium (3+).
+		if (iWon) return `You solved ${me.solved} — best of ${field}.`;
 		if (winner)
-			return `Winner @${winner.name || 'player'} solved for ${dollars(winner.spent)} — you placed ${ordinal(Number(me.rank))} (${myS}).`;
-		return `You placed ${ordinal(Number(me.rank))} — you spent ${myS}.`;
+			return `@${winner.name || 'player'} solved ${winner.solved} — you placed ${ordinal(Number(me.rank))} with ${me.solved}.`;
+		return `You placed ${ordinal(Number(me.rank))}.`;
 	})();
+
+	// Per-puzzle ✓/✗ needs solved_positions on at least one participant; older
+	// matches (recorded before this field existed) fall back to a plain list.
+	$: hasMarks = parts.some((/** @type {any} */ p) => (p.solved_positions?.length ?? 0) > 0);
 </script>
 
 {#if detail}
@@ -101,23 +108,26 @@
 				<p class="md-sub">
 					{m?.pack_size} puzzle{m?.pack_size === 1 ? '' : 's'}
 					· {field >= 3 ? 'podium 3·2·1' : 'winner-take-all'}
-					{#if wagered}· ${Number(m.wager).toLocaleString()} buy-in{:else}· friendly{/if}
+					{#if !wagered}· friendly{/if}
 					{#if m?.status !== 'settled'}· <em>in progress</em>{/if}
 					{#if noSolve && wagered}· buy-in refunded{/if}
 				</p>
 
-				{#if wagered && m?.status === 'settled' && me && me.net != null && !noSolve}
-					<div class="md-outcome {Number(me.net) >= 0 ? 'win' : 'loss'}">
-						<span class="md-out-net">{money(me.net)}</span>
-						<span class="md-out-lbl">
-							{#if Number(me.net) >= 0}you took the pot{#if mult(me.multiple_x100)}
-									· {mult(me.multiple_x100)}{/if}{:else}you spent ${me.spent}{/if}
-						</span>
+				{#if settled && me}
+					<div class="md-verdict {verdictKind}">
+						<div class="md-verdict-head">{verdictHead}</div>
+						{#if reason}<div class="md-verdict-reason">{reason}</div>{/if}
 					</div>
 				{/if}
 
-				{#if tieback}
-					<p class="md-tieback"><Icon name="target" size={14} /> {tieback}</p>
+				{#if wagered && settled && !noSolve && me?.net != null}
+					<p class="md-pot {Number(me.net) >= 0 ? 'win' : 'loss'}">
+						<span class="md-pot-amt">{money(me.net)}</span>
+						<span class="md-pot-lbl"
+							>{Number(me.net) >= 0 ? 'Pot won' : 'Buy-in lost'}{#if Number(me.net) >= 0 && mult(me.multiple_x100)}
+								· {mult(me.multiple_x100)}{/if}</span
+						>
+					</p>
 				{/if}
 
 				<div class="md-standings">
@@ -133,12 +143,8 @@
 							>
 							<span class="md-name">{p.is_me ? 'You' : '@' + (p.name || 'player')}</span>
 							<span class="md-meta">
-								{#if p.state === 'done'}solved {p.solved ?? 0}/{m?.pack_size}{#if p.spent != null}
-										· ${Number(p.spent).toLocaleString()} spent{/if}{#if p.elapsed_seconds != null}
-										· {fmtSecs(p.elapsed_seconds)}{/if}{#if wagered && p.net != null}
-										· <span class:pos={Number(p.net) >= 0} class:neg={Number(p.net) < 0}
-											>{money(p.net)}</span
-										>{/if}
+								{#if p.state === 'done'}Kept {dollars(p.score)} · solved {p.solved ?? 0}/{m?.pack_size}{#if p.elapsed_seconds != null}
+										· {fmtSecs(p.elapsed_seconds)}{/if}
 								{:else}{p.state}{/if}
 							</span>
 						</div>
@@ -147,7 +153,20 @@
 
 				{#if detail.pack?.length}
 					<div class="md-pack">
-						<div class="md-pack-h">Puzzles</div>
+						<div class="md-pack-h">
+							<span>Puzzles</span>
+							{#if hasMarks}
+								<span class="md-pack-legend">
+									{#each parts as p}
+										<span
+											class="md-pack-who"
+											title={p.is_me ? 'You' : '@' + (p.name || 'player')}
+											>{p.is_me ? 'Y' : (p.name || '?').charAt(0).toUpperCase()}</span
+										>
+									{/each}
+								</span>
+							{/if}
+						</div>
 						{#each detail.pack as pk}
 							<div class="md-pk">
 								<span class="md-pos">{pk.position}</span>
@@ -157,6 +176,20 @@
 								<span class="md-ans"
 									>{#if pk.phrase}“{pk.phrase}”{:else}<Icon name="lock" size={13} /> hidden until settled{/if}</span
 								>
+								{#if hasMarks}
+									<span class="md-marks">
+										{#each parts as p}
+											{@const got = (p.solved_positions ?? []).includes(pk.position)}
+											<span
+												class="md-mark"
+												class:got
+												title={(p.is_me ? 'You' : '@' + (p.name || 'player')) +
+													(got ? ' solved this' : " didn't solve this")}
+												><Icon name={got ? 'check' : 'close'} size={11} /></span
+											>
+										{/each}
+									</span>
+								{/if}
 							</div>
 						{/each}
 					</div>
@@ -214,55 +247,68 @@
 		padding: 24px 0;
 	}
 
-	.md-outcome {
-		display: flex;
-		align-items: baseline;
-		gap: 10px;
-		justify-content: center;
-		padding: 12px;
-		margin: 0 0 16px;
+	.md-verdict {
+		text-align: center;
+		padding: 16px 12px;
+		margin: 0 0 12px;
 		border-radius: var(--r-md);
 		border: 1px solid var(--border);
+		background: var(--surface);
 	}
-	.md-outcome.win {
+	.md-verdict.win {
 		background: rgba(126, 224, 168, 0.1);
 		border-color: rgba(126, 224, 168, 0.3);
 	}
-	.md-outcome.loss {
+	.md-verdict.loss {
 		background: rgba(251, 113, 133, 0.08);
 		border-color: rgba(251, 113, 133, 0.25);
 	}
-	.md-out-net {
+	.md-verdict.tie {
+		background: var(--surface);
+		border-color: var(--border-strong);
+	}
+	.md-verdict-head {
 		font-family: 'Orbitron', var(--font-display);
 		font-weight: 800;
-		font-size: 1.6rem;
+		font-size: 1.7rem;
+		letter-spacing: 0.04em;
 	}
-	.md-outcome.win .md-out-net {
+	.md-verdict.win .md-verdict-head {
 		color: #7ee0a8;
 	}
-	.md-outcome.loss .md-out-net {
+	.md-verdict.loss .md-verdict-head {
 		color: #fb7185;
 	}
-	.md-out-lbl {
-		color: var(--text-muted);
-		font-size: 0.82rem;
-	}
-	.md-tieback {
-		text-align: center;
-		font-size: 0.9rem;
-		font-weight: 600;
+	.md-verdict.tie .md-verdict-head {
 		color: var(--text);
-		margin: 0 0 16px;
-		padding: 10px 12px;
-		border-radius: var(--r-md);
-		background: rgba(251, 191, 36, 0.08);
-		border: 1px solid rgba(251, 191, 36, 0.25);
 	}
-	.md-meta .pos {
+	.md-verdict-reason {
+		margin-top: 6px;
+		color: var(--text-muted);
+		font-size: 0.86rem;
+	}
+
+	.md-pot {
+		display: flex;
+		align-items: baseline;
+		justify-content: center;
+		gap: 8px;
+		margin: 0 0 16px;
+	}
+	.md-pot-amt {
+		font-family: 'Orbitron', var(--font-display);
+		font-weight: 800;
+		font-size: 1.1rem;
+	}
+	.md-pot.win .md-pot-amt {
 		color: #7ee0a8;
 	}
-	.md-meta .neg {
+	.md-pot.loss .md-pot-amt {
 		color: #fb7185;
+	}
+	.md-pot-lbl {
+		color: var(--text-faint);
+		font-size: 0.8rem;
 	}
 
 	.md-standings {
@@ -312,11 +358,32 @@
 		padding-top: 12px;
 	}
 	.md-pack-h {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
 		color: var(--text-faint);
 		font-size: 0.72rem;
 		text-transform: uppercase;
 		letter-spacing: 0.08em;
 		margin-bottom: 8px;
+	}
+	.md-pack-legend {
+		display: flex;
+		gap: 4px;
+		text-transform: none;
+		letter-spacing: normal;
+	}
+	.md-pack-who {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 16px;
+		border-radius: 4px;
+		font-size: 0.62rem;
+		font-weight: 700;
+		color: var(--text-faint);
+		background: rgba(255, 255, 255, 0.04);
 	}
 	.md-pk {
 		display: flex;
@@ -335,10 +402,31 @@
 		font-size: 0.74rem;
 	}
 	.md-ans {
+		flex: 1 1 auto;
+		min-width: 0;
 		color: var(--gold);
 		font-weight: 600;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+	.md-marks {
+		display: flex;
+		flex: 0 0 auto;
+		gap: 4px;
+	}
+	.md-mark {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 16px;
+		height: 16px;
+		border-radius: 4px;
+		color: var(--text-faint);
+		background: rgba(255, 255, 255, 0.04);
+	}
+	.md-mark.got {
+		color: #7ee0a8;
+		background: rgba(126, 224, 168, 0.12);
 	}
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3944,6 +3944,18 @@
 							<div class="ch-field">
 								<span>Categories <em class="ch-opt">(optional)</em></span>
 								<div class="ch-catlist">
+									<button
+										type="button"
+										class="ch-catrow"
+										class:on={mbCategories.length === 0}
+										on:click={() => (mbCategories = [])}
+									>
+										<span class="ch-catemoji"><Icon name="globe" size={19} /></span>
+										<span class="ch-catname">All Categories</span>
+										<span class="ch-catcheck"
+											>{#if mbCategories.length === 0}<Icon name="check" size={13} />{/if}</span
+										>
+									</button>
 									{#each CATEGORIES as c}
 										<button
 											type="button"
@@ -3963,7 +3975,9 @@
 									{/each}
 								</div>
 								<p class="ch-hint">
-									{mbCategories.length ? mbCategories.length + ' selected' : 'Any category'}
+									{mbCategories.length
+										? mbCategories.length + ' selected'
+										: 'All Categories selected (default) — pack draws from every category'}
 								</p>
 							</div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4789,16 +4789,6 @@
 						<span class="carry-float">+${carryCue.toLocaleString()}</span>
 					{/if}
 				</div>
-				{#if isMatch && matchLive}
-					<div class="ante-bar">
-						<span
-							class="ante-fill"
-							style="width:{(matchLive.budget ?? 0) > 0
-								? Math.max(0, Math.min(100, (matchLeft / matchLive.budget) * 100))
-								: 100}%"
-						></span>
-					</div>
-				{/if}
 			{/if}
 		</section>
 
@@ -8492,23 +8482,6 @@
 		color: #cbd5e1;
 		text-shadow: none;
 	}
-	.ante-bar {
-		width: 100%;
-		max-width: 240px;
-		height: 7px;
-		margin: 6px auto 0;
-		border-radius: 999px;
-		background: rgba(255, 255, 255, 0.1);
-		overflow: hidden;
-	}
-	.ante-fill {
-		display: block;
-		height: 100%;
-		border-radius: 999px;
-		background: linear-gradient(90deg, #fbbf24, #fde047);
-		transition: width 0.35s ease;
-	}
-
 	/* lit gold bounty multiplier badge (left of the bounty) — ×1.0 today, boostable later */
 	/* badge · amount · badge row — a 3-col grid keeps the amount dead-centered and clear */
 	.bp-row {

--- a/supabase-match-solved-positions.sql
+++ b/supabase-match-solved-positions.sql
@@ -1,0 +1,110 @@
+-- Challenges: track solved puzzle positions + expose in match detail
+--
+-- Adds a MATCH-LEVEL accumulator `solved_positions int[]` on challenge_participants.
+-- It is appended on every solve in _match_resolve_and_advance (all four win-branch
+-- UPDATEs), and is NEVER added to any per-puzzle reset SET-list (so it survives the
+-- pack). Folds go through _match_do_fold, which does NOT append -> folded puzzles
+-- correctly stay ✗. get_match_detail exposes it additively for the ✓/✗ strip (Task 4).
+
+-- 1. Column (match-level accumulator; defaults only at row creation).
+ALTER TABLE public.challenge_participants
+  ADD COLUMN IF NOT EXISTS solved_positions int[] NOT NULL DEFAULT '{}';
+
+-- 2. Append cp.position on solve in all four win-branch UPDATEs.
+CREATE OR REPLACE FUNCTION public._match_resolve_and_advance(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_phrase TEXT; v_cat TEXT; v_won BOOLEAN;
+  v_score INT; v_combo INT; v_solved INT; v_budget BIGINT; v_next_bounty INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN public._match_board(p_id, p_uid); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_budget := GREATEST(COALESCE(m.wager,0), 500);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cp.revealed_positions)));
+  IF NOT v_won THEN RETURN public._match_board(p_id, p_uid); END IF;
+  IF COALESCE(m.wager,0) > 0 THEN PERFORM public._record_category_solve(p_uid, v_cat); END IF;  -- friendly (wager 0) earns no category credit
+  v_solved := cp.solved + 1;
+  IF m.econ_v = 2 THEN
+    IF cp.position >= m.pack_size THEN
+      UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+      WHERE match_id = p_id AND user_id = p_uid;
+      PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+    ELSE
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, position = position + 1,
+        bankroll = v_next_bounty, start_budget = COALESCE(start_budget,0) + v_next_bounty,
+        revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+        reveal_order = '{}', sabotaged_targets = '{}',
+        fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+        p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      WHERE match_id = p_id AND user_id = p_uid;
+    END IF;
+    RETURN public._match_board(p_id, p_uid);
+  END IF;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = bankroll.
+  IF cp.position >= m.pack_size THEN
+    UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+      total_score = cp.bankroll, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+    WHERE match_id = p_id AND user_id = p_uid;
+    PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+  ELSE
+    UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+      total_score = cp.bankroll, position = position + 1,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+      reveal_order = '{}', sabotaged_targets = '{}',
+      fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false,
+      p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+    WHERE match_id = p_id AND user_id = p_uid;
+  END IF;
+  RETURN public._match_board(p_id, p_uid);
+END; $function$;
+
+-- 3. Expose solved_positions in get_match_detail (purely additive).
+CREATE OR REPLACE FUNCTION public.get_match_detail(p_match_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_status text; v_settled boolean; v_budget bigint;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_match_id AND user_id = v_uid) THEN
+    RETURN NULL;
+  END IF;
+  SELECT status, GREATEST(COALESCE(wager,0), 500) INTO v_status, v_budget
+  FROM public.challenge_matches WHERE id = p_match_id;
+  v_settled := (v_status = 'settled');
+  RETURN jsonb_build_object(
+    'match', (SELECT jsonb_build_object('id', m.id, 'mode', m.mode, 'pack_size', m.pack_size,
+                'wager', m.wager, 'budget', v_budget, 'payout', m.payout, 'status', m.status, 'group_id', m.group_id)
+              FROM public.challenge_matches m WHERE m.id = p_match_id),
+    'group_name', (SELECT g.name FROM public.groups g
+                   JOIN public.challenge_matches cm ON cm.group_id = g.id WHERE cm.id = p_match_id),
+    'participants', (SELECT jsonb_agg(jsonb_build_object(
+        'user_id', t.user_id, 'name', public._display_name(t.user_id), 'is_me', (t.user_id = v_uid),
+        'solved', t.solved, 'score', t.total_score, 'spent', GREATEST(0, COALESCE(t.start_budget, v_budget) - t.total_score - CASE WHEN t.state = 'done' THEN 0 ELSE t.bankroll END),
+        'net', t.net, 'earned', t.earned, 'multiple_x100', t.multiple_x100,
+        'state', t.state, 'rank', t.rnk, 'elapsed_seconds', public._match_elapsed(t.started_at, t.finished_at, t.joined_at),
+        'solved_positions', t.solved_positions
+      ) ORDER BY t.total_score DESC)
+      FROM (SELECT cp.user_id, cp.solved, cp.total_score, cp.bankroll, cp.start_budget, cp.state, cp.started_at, cp.finished_at, cp.joined_at, cp.solved_positions,
+                   rank() OVER (ORDER BY cp.total_score DESC, public._match_elapsed(cp.started_at, cp.finished_at, cp.joined_at) ASC) AS rnk,
+                   gr.net, gr.earned, gr.multiple_x100
+            FROM public.challenge_participants cp
+            LEFT JOIN public.game_results gr ON gr.match_id = p_match_id AND gr.user_id = cp.user_id
+            WHERE cp.match_id = p_match_id) t),
+    'pack', (SELECT jsonb_agg(jsonb_build_object(
+        'position', pk.position, 'category', dp.category,
+        'phrase', CASE WHEN v_settled THEN dp.phrase ELSE NULL END
+      ) ORDER BY pk.position)
+      FROM public.challenge_pack pk JOIN public.daily_puzzles dp ON dp.id = pk.puzzle_id
+      WHERE pk.match_id = p_match_id)
+  );
+END; $function$;


### PR DESCRIPTION
Three approved playtest-driven changes to 1v1 challenges. Server SQL (per-puzzle solve tracking) applied to prod via rollback-tested migration; this PR brings the client. Spec + plan in `docs/superpowers/`.

## Changes
1. **"All Categories" chip** in the challenge builder — the "draw from all categories" behavior already existed (empty selection = any), but was invisible. Now there's an explicit, default-selected chip so it's discoverable.
2. **Removed the yellow bounty-spend bar** (`.ante-fill`) that receded during match play.
3. **Redesigned the results modal** (`MatchDetailModal.svelte`):
   - **VICTORY / DEFEAT / TIE** verdict with a one-line reason (leads with solve-count, the real decider) — replaces the raw −$500 hero.
   - **One** clearly-labeled real-money line (`+$500 Pot won` / `−$500 Buy-in lost`) — no more blurring the pot P&L with the play-money bounty.
   - Head-to-head rows now lead with **Kept $score** (higher = better, the metric that actually ranks players) instead of "spent" (which was inverted/confusing).
   - **Per-puzzle ✓/✗** showing who solved each puzzle (new `solved_positions` tracking; graceful plain-list fallback for pre-existing matches).
   - **Cut** the redundant gold summary band (which read as a "yellow line under the money") and the triple-repeated "you spent $X".

## Verification
- Server (Task 3) rollback-tested on a seeded match (`{1,3}` for solve-fold-solve, `{1,2,3}` all-solved) before prod apply; verified live byte-for-byte.
- Every task reviewed; `svelte-check` clean (no new errors); build passes.
- Match-scoped — Daily / Cash Game / Free Play unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)