### PR TITLE
Challenge batch 2: timed challenges, payout choice, vowel-block nerf, store-gate, realtime social

### DIFF
--- a/docs/superpowers/plans/2026-07-17-challenge-batch-2.md
+++ b/docs/superpowers/plans/2026-07-17-challenge-batch-2.md
@@ -1,0 +1,81 @@
+# Challenge Batch 2 — Implementation Plan
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Ship the full slate discussed: vowel-block nerf, payout toggle, collapsible profile items, store-gate-during-games, realtime social layer + group-add notification, and configurable timed challenges.
+
+**Tech:** SvelteKit 2.16 (Svelte 5), Supabase Postgres (dump→transform→rollbacktest→apply), Supabase Realtime, `npm run check` + `npm run build`.
+
+## Global Constraints
+- Match/challenge-scoped where relevant; Daily/Cash Game/Free Play unchanged unless a task says otherwise (the store-gate touches all real modes by design).
+- **Verify with `npm run check` (svelte-check) AND `npm run build`** — Vite misses reactive ReferenceErrors. Known-OK pre-existing: `points.test.js:31`, `profile/+page.svelte:408`.
+- Server changes: dump live body, transform, rollback-test (BEGIN…ROLLBACK on seeded data), apply to prod, commit `supabase-*.sql`. Keep everything else byte-identical.
+- Commit messages end with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- Ground: `payout` and `mode` are already columns on `challenge_matches`; `_match_tick(p_id,p_uid)` exists as a no-op called atop `match_buy_letter`/`match_submit_guess`; `_match_do_fold(p_id,p_uid)` is the shared fold internal; participants have `started_at`; `challenge_participants` recently gained `fog_buys_left`/`reveal_order`/`sabotaged_targets`/`solved_positions`/`pending_fog` (patterns to mirror).
+
+---
+
+### Task 1: Vowel Block → lasts 3 buys
+**Files:** `supabase-vowel-block-buys.sql`. Live: `match_sabotage`, `match_buy_letter`, `_match_board`; column on `challenge_participants`.
+Mirror the Fog mechanism.
+- [ ] `ALTER TABLE challenge_participants ADD COLUMN IF NOT EXISTS vowel_block_left int NOT NULL DEFAULT 0;` (reset in the per-puzzle reset lists of `_match_resolve_and_advance` and `_match_do_fold`, like `fog_buys_left`).
+- [ ] `match_sabotage` vowel_block branch: instead of adding `'vowel_block'` to `debuffs[]`, set `vowel_block_left = 3` on the target (keep it OUT of the persistent debuffs path). Keep the `already_sabotaged`/inventory ordering intact.
+- [ ] `match_buy_letter`: apply the vowel ×3 when `cp.vowel_block_left > 0` (replace the `'vowel_block' = ANY(debuffs)` check), and decrement `vowel_block_left = GREATEST(0, vowel_block_left - 1)` on every buy (any letter). Keep the rest of the cost stack (half_off/tax/toll) unchanged.
+- [ ] `_match_board`: the client keyboard reads debuffs; expose `vowel_block_left` in `v_minfo` (or keep `vowel_block` in `my_debuffs` while `vowel_block_left>0`) so `Keyboard.svelte`'s vowel ×3 display still fires. Simplest: in `v_minfo.my_debuffs`, include `'vowel_block'` when `cp.vowel_block_left>0` (synthesize it) so the existing client cost logic is unchanged.
+- [ ] Rollback-test: cast vowel_block → `vowel_block_left=3`; 3 buys → 0, vowels normal again; resets on advance. Apply + commit.
+Note: "3 buys" = any 3 purchases (Fog model). Client copy (shop/inventory META) → "Vowels cost 3× for their next 3 buys."
+
+### Task 2: Payout creator toggle
+**Files:** `src/routes/+page.svelte` (builder Step 3 + confirm copy + `mbPayout`); `supabase-payout-choice.sql` (`_match_settle` respects `m.payout`; `create_match` stores it).
+- [ ] Client: in Step 3 ("The stakes"), for a GROUP (3+ possible) show a toggle: **Winner takes all** vs **Top finishers split**. Set `mbPayout = 'winner' | 'podium'`. For a 1v1 (friend target) force `'winner'` (hide the toggle — WTA only). Pass `payout: mbPayout` (already wired at ~2203) and update the confirm copy (~2184-2187, 2239-2243) to reflect the CHOICE, not the auto rule.
+- [ ] Server: `create_match` — dump live; store `p_payout` on the match (`payout` column already exists; ensure it's written from the param, defaulting by count if null for back-comat). `_match_settle` — dump live; where it currently derives podium-vs-winner by participant count, honor `m.payout` when set ('winner' → winner-take-all even for 3+; 'podium' → split). Rollback-test both a 'winner' and 'podium' group settle. Apply + commit.
+
+### Task 3: Collapsible items in profile
+**Files:** `src/routes/profile/+page.svelte` (~270-276, the "My Items" block).
+- [ ] Wrap the `<InventoryList>` block in a collapse (a `<details>`/`<summary>` or a toggle+`{#if}`), collapsed or expanded by default (default expanded, remembers via a local `let` is fine). Keep the "My Items" header; add a chevron. `npm run check` + build. Commit.
+
+### Task 4: Store — gate gameplay-item buying during active games
+**Files:** `supabase-store-active-game-gate.sql` (`buy_powerup`); `src/routes/+page.svelte` / shop (grey the mid-game store button).
+- [ ] `buy_powerup`: dump live. For gameplay items only (`v_kind IN ('climb','daily','sabotage')` — NOT cosmetics), reject with `reason='in_game'` when the user has an active real game: an active Cash Game run (`climb_state` state='active'), an in-progress Daily today (a `daily_sessions`/daily row unsolved for the current day), OR an active challenge (`challenge_participants` state='active'). Cosmetics always allowed. Rollback-test: buying a power-up with an active challenge participant → `in_game`; buying a cosmetic → allowed; buying with no active game → allowed. Apply + commit.
+- [ ] Client: grey/hide the in-game store button (`.bag-store` → `/shop`, ~+page.svelte:2775) while `gameActive`, and show the `in_game` rejection reason as a toast if hit. `npm run check` + build. Commit.
+
+### Task 5: Realtime social layer (friend requests + notifications)
+**Files:** `supabase-realtime-enable.sql` (publication/RLS); client subscriptions in the friends/notifications components (grep for the friends panel + notifications bell + `friend_requests`/`notifications` tables and their stores).
+- [ ] **Enable Realtime**: confirm/add `friend_requests` and `notifications` to the `supabase_realtime` publication (`ALTER PUBLICATION supabase_realtime ADD TABLE ...` — idempotent-guard). Verify RLS SELECT policies let a user see their own rows (needed for realtime delivery). Commit the SQL.
+- [ ] **Friend-request live flips**: in the friends UI, subscribe via `supabase.channel(...).on('postgres_changes', {event:'*', table:'friend_requests', filter for me as sender or recipient}, cb)` and re-derive pending/accepted state on change (sender sees "Pending" flip to accepted/disappear; recipient's incoming list updates). Unsubscribe on unmount.
+- [ ] **Notifications live + self-clearing**: subscribe to `notifications` where `user_id = me`; on INSERT show it live (badge/list), on UPDATE/DELETE remove dismissed ones. When a user ACCEPTS a friend request, mark/delete the corresponding "friend_request" notification (server-side in the accept RPC, or client dismiss) so it disappears for them. Ensure the accept flow removes the actioned notification.
+- [ ] `npm run check` + build. Commit. (If Realtime isn't reachable in the QA/headless env, verify subscription wiring compiles + a manual note; realtime is validated live by the user.)
+
+### Task 6: "Added to a group" notification
+**Files:** `supabase-group-add-notify.sql` (the add-member RPC).
+- [ ] Find the group add-member RPC (grep `group_members` insert / `add_group_member`/`add_to_group`). Dump live; after a successful add, `PERFORM public._notify(new_member_uid, 'group_added', 'Added to a group', <adder> || ' added you to ' || <group name>, jsonb_build_object('group_id', ...))`. Don't notify on self-join/creation. Rollback-test the notify row is written. Apply + commit. (Delivered live via Task 5's realtime.)
+
+### Task 7: Timed challenges — schema + config
+**Files:** `supabase-timed-schema.sql`. Per `docs/superpowers/specs/2026-07-17-timed-challenges.md`.
+- [ ] `ALTER TABLE challenge_matches ADD COLUMN IF NOT EXISTS clock_mode text NOT NULL DEFAULT 'none', ADD COLUMN IF NOT EXISTS clock_seconds int, ADD COLUMN IF NOT EXISTS time_scores boolean NOT NULL DEFAULT false;`
+- [ ] `ALTER TABLE challenge_participants ADD COLUMN IF NOT EXISTS puzzle_started_at timestamptz;`
+- [ ] `create_match`: dump live; accept `p_clock_mode text default 'none'`, `p_clock_seconds int default null`, `p_time_scores boolean default false`; store on the match. `match_start`: stamp `puzzle_started_at = now()` for the starter. Rollback-test config stored + puzzle_started_at set. Apply + commit.
+
+### Task 8: Timed challenges — clock enforcement + speed bonus (server)
+**Files:** `supabase-timed-engine.sql`. Live: `_match_tick`, `_match_resolve_and_advance`, `_match_do_fold`, `_match_board`.
+- [ ] `_match_tick`: implement per the spec — `clock_mode='puzzle'` & `now()-cp.puzzle_started_at > m.clock_seconds` & unsolved → `_match_do_fold` + return true; `clock_mode='match'` & `now()-cp.started_at > m.clock_seconds` → loop `_match_do_fold` until done + return true; else false.
+- [ ] `_match_resolve_and_advance` + `_match_do_fold`: re-stamp `puzzle_started_at = now()` on every advance (both, all branches), alongside the existing per-puzzle resets.
+- [ ] Speed bonus in `_match_resolve_and_advance` WIN path: when `m.time_scores`, add `GREATEST(0, m.clock_seconds - elapsed)*3` to the banked `total_score` (elapsed from puzzle_started_at for 'puzzle', from started_at for 'match'). `RATE=3` as a documented constant.
+- [ ] `_match_board`: expose `clock_mode`, `clock_seconds`, `time_scores`, and `puzzle_started_at` in `v_minfo` for the client countdown.
+- [ ] Rollback-test: puzzle-clock expiry folds; match-clock expiry ends match; speed bonus adds `remaining*3`; `none` unaffected. Apply + commit.
+
+### Task 9: Timed challenges — builder UI + client countdown
+**Files:** `src/routes/+page.svelte`.
+- [ ] Builder (Step 2): a "Timing" block — 3-way No timer / Per-puzzle / Whole-match; when set, a duration segmented control (per-puzzle 30s/1m/2m/5m; match 3m/10m/30m) + a "Speed bonus" toggle. State `mbClockMode`/`mbClockSeconds`/`mbTimeScores`; pass through `createMatch` (add the params in `statsStore.js createMatch` wrapper). Confirm-copy summary.
+- [ ] Client display: when `matchInfo.clock_mode !== 'none'`, render a **countdown** in the match timer slot (from `puzzle_started_at` for 'puzzle', `started_at` for 'match') instead of the count-up; drive the danger treatment near 0; on reaching 0 call the fold/guess path so the server tick resolves it. `npm run check` + build. Commit.
+
+### Task 10: E2E + final verification
+**Files:** temp `scripts/qa-batch2.mjs` (delete after).
+- [ ] Two-player harness (adapt qa-h2h): a short 30s per-puzzle timed match — countdown shows, expiry folds, a fast solve banks a visible speed bonus; vowel-block lasts 3 buys; payout choice honored (create a group 'winner' match, verify settle pays one winner); store buy blocked mid-game. Screenshot. Delete harness. Final `npm run check` + build.
+
+## Self-Review notes
+- Vowel-block + fog share the "N-buys counter reset on advance" pattern. ✔
+- Payout: column exists; task wires create→store→settle-respect + client toggle. ✔
+- Store-gate is the only intentionally cross-mode change (Daily/Cash Game/challenge active-check). ✔
+- Timed: `_match_tick` is the enforcement hook; `puzzle_started_at` re-stamped on every advance/fold; speed bonus flows through existing `total_score` ranking. ✔
+- Realtime needs publication + RLS; validated live by the user. ✔

--- a/docs/superpowers/specs/2026-07-17-timed-challenges.md
+++ b/docs/superpowers/specs/2026-07-17-timed-challenges.md
@@ -1,0 +1,104 @@
+# Timed Challenges — Design Spec
+
+**Date:** 2026-07-17
+
+## Goal
+
+Make challenge (`gameMode:'match'`) timing **creator-configurable**, identically for 1v1 and
+group (both are async, both rank by score→time). The creator picks a **clock scope** and
+whether **time affects score**.
+
+## Decisions (locked)
+
+**Two independent creator choices, set in the builder:**
+1. **Clock mode** — `none` (default, today's behavior) · `puzzle` (a countdown per puzzle) ·
+   `match` (one countdown for the whole pack).
+2. **Time affects score** (`time_scores`) — off (clock is a hard limit only; score stays
+   bounty-based, time only breaks ties as today) · on (a **speed bonus**: leftover time when
+   you solve adds points).
+
+Durations offered (live-play clocks, distinct from the existing async "respond-within"
+deadline):
+- Per-puzzle: **30s / 1m / 2m / 5m**.
+- Whole-match: **3m / 10m / 30m**.
+
+**1v1 == group:** the same system applies to both. No mode-specific timing.
+
+## Data model
+
+`challenge_matches` (new columns):
+- `clock_mode text NOT NULL DEFAULT 'none'` — 'none'|'puzzle'|'match'
+- `clock_seconds int` — the limit (per-puzzle if 'puzzle', total if 'match'); NULL when 'none'
+- `time_scores boolean NOT NULL DEFAULT false`
+
+`challenge_participants` (new column):
+- `puzzle_started_at timestamptz` — when the player opened their CURRENT puzzle (for the
+  per-puzzle clock). Set at `match_start` (puzzle 1) and re-stamped on every advance in
+  `_match_resolve_and_advance` and `_match_do_fold`. (The match-level `started_at` already
+  exists — used for the whole-match clock.)
+
+## Mechanics
+
+**Clock enforcement — repurpose `_match_tick(p_id,p_uid)`** (already a no-op called at the top
+of `match_buy_letter` and `match_submit_guess`; it has `cp` + `m` loaded). Make it authoritative:
+- `clock_mode='puzzle'`: if `now() - cp.puzzle_started_at > m.clock_seconds` and the puzzle is
+  unsolved → **force-fold the current puzzle** (call `_match_do_fold`) and return `true` (caller
+  returns the board). Folding advances/ends per existing rules; the folded puzzle scores its
+  current bankroll-kept like any fold.
+- `clock_mode='match'`: if `now() - cp.started_at > m.clock_seconds` → **end the match for this
+  player** — fold every remaining puzzle (loop `_match_do_fold` until `state='done'`) and return
+  `true`.
+- `clock_mode='none'`: unchanged (returns false).
+
+`_match_tick` fires on the player's own actions (buy/guess); the **client** is the live driver
+(countdown hits 0 → it calls a guess/fold so the server tick resolves it), with the server tick
+as the quit-proof backstop (mirrors the broke-timer pattern). Also call `_match_tick` inside
+`_match_board` reads for the acting player so an expired clock resolves when they reopen.
+
+**Speed bonus (`time_scores=true`)** — in `_match_resolve_and_advance`'s WIN path, add a bonus to
+the puzzle's kept-score:
+- `clock_mode='puzzle'`: `bonus = GREATEST(0, m.clock_seconds - elapsed_this_puzzle) * RATE`
+  where `elapsed_this_puzzle = extract(epoch from now() - cp.puzzle_started_at)`.
+- `clock_mode='match'`: apply the same formula against the **whole-match** remaining at each
+  solve (`m.clock_seconds - (now - started_at)`), so early solves in the match bank more.
+- `RATE` = **3 points/second** — a single tunable constant (documented; expect to tune after
+  playtest). Bonus is added into `total_score` alongside kept bounty, so it flows through the
+  existing rank-by-`total_score` (→ time tiebreak) unchanged.
+- When `time_scores=false`, no bonus; ranking is exactly as today.
+
+## Builder UI
+
+New "Timing" block in the builder (Step 2, "The match"), shared by 1v1 and group:
+- A 3-way selector: **No timer** (default) / **Per-puzzle timer** / **Whole-match timer**.
+- When a timer is chosen: a duration segmented control (the values above).
+- When a timer is chosen: a **"Speed bonus"** toggle → "Solve faster to earn bonus points."
+- Confirm-step copy summarizes it ("Per-puzzle · 1m · speed bonus").
+- State: `mbClockMode`, `mbClockSeconds`, `mbTimeScores`; passed through `createMatch` →
+  `create_match(p_clock_mode, p_clock_seconds, p_time_scores)`; stored on the match row.
+
+## Client display
+
+- Reuse the in-match timer slot. When `matchInfo.clock_mode !== 'none'`, render a **countdown**
+  (from `puzzle_started_at` for 'puzzle', `started_at` for 'match') instead of the count-up.
+  Expose `clock_mode`, `clock_seconds`, and the relevant anchor in `matchInfo` via `_match_board`.
+- On client-side expiry (countdown reaches 0), the client calls the existing fold/guess path so
+  the server resolves it; show the danger/last-stand treatment as it hits the final seconds.
+- Speed-bonus, when on, is surfaced in the results modal as part of the kept-score (a small
+  "+N speed" note is optional polish, not required v1).
+
+## Testing
+
+- Rollback-test `_match_tick`: puzzle clock expiry force-folds the current puzzle; match clock
+  expiry ends the match (all remaining folded); `clock_mode='none'` is a no-op.
+- Speed bonus: solving with time left adds `remaining*RATE` to `total_score`; `time_scores=false`
+  adds nothing.
+- `puzzle_started_at` is re-stamped on advance and fold; `create_match` stores the config.
+- Two-player E2E (with a short 30s per-puzzle clock): the countdown shows, expiry folds, and a
+  fast solve banks a visible bonus.
+
+## Out of scope / notes
+
+- Daily / Cash Game / Free Play unchanged.
+- The async "respond-within" deadline (24h etc.) is a SEPARATE existing mechanic (forfeit your
+  turn), not this live clock — untouched here.
+- `RATE` and the duration options are the obvious tuning knobs post-playtest.

--- a/src/lib/components/FriendsPanel.svelte
+++ b/src/lib/components/FriendsPanel.svelte
@@ -1,7 +1,7 @@
 <script>
 	// Friends management — search/add, requests, your list. Reused by the /friends
 	// route and the Community ▸ People ▸ Friends tab.
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import Icon from '$lib/components/Icon.svelte';
 	import {
@@ -14,6 +14,7 @@
 	} from '$lib/stores/statsStore.js';
 	import { requireConfirm } from '$lib/confirm.js';
 	import { fx } from '$lib/sound.js';
+	import { supabase } from '$lib/supabaseClient';
 
 	/** Optional: called to start a challenge with a friend (username). */
 	let { onChallenge = null } = $props();
@@ -40,11 +41,51 @@
 		outgoing = r.outgoing ?? [];
 	}
 
+	/** @type {any} */
+	let channel;
+	/** @type {ReturnType<typeof setTimeout>|undefined} */
+	let reloadTimer;
+	// Coalesce bursts of friend_requests changes into one re-fetch.
+	function scheduleReload() {
+		clearTimeout(reloadTimer);
+		reloadTimer = setTimeout(() => load(), 150);
+	}
+
 	onMount(async () => {
 		try {
 			await load();
 		} finally {
 			loading = false;
+		}
+		// Realtime: when a friend_requests row involving me changes, re-derive the
+		// incoming/outgoing/friends lists live. RLS ("friend_requests_self") scopes
+		// delivery to rows where I'm requester or addressee, so an unfiltered
+		// subscription only fires for me. On accept the server deletes the request
+		// row (+ inserts the friendship), so my outgoing "Pending" flips to a friend
+		// and the recipient's incoming request disappears — all without a poll.
+		try {
+			const { data } = await supabase.auth.getSession();
+			const uid = data?.session?.user?.id;
+			if (uid) {
+				channel = supabase
+					.channel(`friends:${uid}`)
+					.on(
+						'postgres_changes',
+						{ event: '*', schema: 'public', table: 'friend_requests' },
+						() => scheduleReload()
+					)
+					.subscribe();
+			}
+		} catch {
+			/* realtime is best-effort; the panel still works via manual load() */
+		}
+	});
+
+	onDestroy(() => {
+		clearTimeout(reloadTimer);
+		if (channel) {
+			supabase.removeChannel(channel);
+			channel = undefined;
 		}
 	});
 

--- a/src/lib/components/InventoryList.svelte
+++ b/src/lib/components/InventoryList.svelte
@@ -34,7 +34,7 @@
 		sabotage_tax: { icon: 'percent', desc: "An opponent's letters cost +50%" },
 		sabotage_fog: { icon: 'fog', desc: "Hide an opponent's clue" },
 		sabotage_toll: { icon: 'toll', desc: "An opponent's next letter costs 3×" },
-		sabotage_vowel_block: { icon: 'block', desc: "An opponent's vowels cost 3×" },
+		sabotage_vowel_block: { icon: 'block', desc: "An opponent's vowels cost 3× for their next 3 buys" },
 		sabotage_lock: { icon: 'trash', desc: "Wipe the opponent's most-recently-revealed letter" }
 	};
 	// ticon = Icon.svelte name for the group heading (rendered via <Icon>).

--- a/src/lib/components/SolveTimer.svelte
+++ b/src/lib/components/SolveTimer.svelte
@@ -1,16 +1,26 @@
 <script>
-	import { onDestroy } from 'svelte';
+	import { onDestroy, createEventDispatcher } from 'svelte';
 	import { fmtSecs } from '$lib/time.js';
 
-	/** @type {number|null} */ export let openedAt = null; // server-stamped epoch ms
-	/** @type {number|null} */ export let bestSeconds = null; // PB ghost, seconds
+	/** @type {number|null} */ export let openedAt = null; // server-stamped epoch ms (anchor)
+	/** @type {number|null} */ export let bestSeconds = null; // PB ghost, seconds (count-up only)
 	export let active = false; // running only while the puzzle is unsolved + on-screen
-	export let solved = false; // freeze + relabel once solved
-	export let revealOffsetMs = 1800; // don't charge the player for the opening reveal
+	export let solved = false; // freeze + relabel once solved (count-up only)
+	export let revealOffsetMs = 1800; // don't charge the player for the opening reveal (count-up only)
+	// 🕐 Countdown mode: when set, render `countdownSeconds - elapsed` (a live challenge clock)
+	// instead of the default count-up. No reveal offset — this must track the server's
+	// `now() - anchor` exactly, since the server folds on the same math (_match_tick).
+	/** @type {number|null} */ export let countdownSeconds = null;
+	export let dangerAt = 10; // seconds remaining that trip the "danger" bindable + styling
+	// Bindable outputs (countdown mode) — let a parent drive its own danger treatment.
+	/** @type {number|null} */ export let remaining = null;
+	export let danger = false;
+
+	const dispatch = createEventDispatcher();
 
 	let now = Date.now();
 	/** @type {ReturnType<typeof setInterval>|undefined} */ let timer;
-	/** @type {number|null} */ let frozen = null; // captured once at solve
+	/** @type {number|null} */ let frozen = null; // captured once at solve (count-up only)
 
 	$: if (active && openedAt && !timer) {
 		now = Date.now();
@@ -29,13 +39,43 @@
 		frozen = Math.max(0, Math.round((Date.now() - openedAt - revealOffsetMs) / 1000));
 	$: if (!solved) frozen = null;
 	$: shown = solved && frozen != null ? frozen : live;
-	$: mmss = `${Math.floor(shown / 60)}:${String(shown % 60).padStart(2, '0')}`;
+
+	/** @param {number} sec */
+	function mmss(sec) {
+		return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, '0')}`;
+	}
+
+	// 🕐 Countdown: remaining seconds since `openedAt`, floored at 0. Reset the "fired once"
+	// expiry guard whenever the anchor actually changes (a new puzzle/match clock started).
+	/** @type {number|null} */ let lastAnchor = null;
+	let expiredFired = false;
+	$: if (openedAt !== lastAnchor) {
+		lastAnchor = openedAt;
+		expiredFired = false;
+	}
+	$: remaining =
+		countdownSeconds != null && openedAt
+			? Math.max(0, countdownSeconds - Math.floor((now - openedAt) / 1000))
+			: null;
+	$: danger = remaining != null && remaining <= dangerAt;
+	// Fire once per anchor when the clock actually runs out, while still live — the caller
+	// pokes the server (a fold/guess round-trip) so the authoritative tick resolves it.
+	$: if (active && countdownSeconds != null && remaining === 0 && !expiredFired) {
+		expiredFired = true;
+		dispatch('expire');
+	}
 </script>
 
-{#if openedAt}
+{#if countdownSeconds != null}
+	{#if openedAt}
+		<div class="solve-timer countdown" class:danger aria-label="Time remaining">
+			<span class="st-val">{mmss(remaining ?? 0)}</span>
+		</div>
+	{/if}
+{:else if openedAt}
 	<div class="solve-timer" class:done={solved} aria-label="Solve time">
 		{#if solved}<span class="st-lbl">Solved in</span>{/if}
-		<span class="st-val">{mmss}</span>
+		<span class="st-val">{mmss(shown)}</span>
 		{#if bestSeconds != null}<span class="st-pb">PB {fmtSecs(bestSeconds)}</span>{/if}
 	</div>
 {/if}
@@ -66,5 +106,21 @@
 	.st-pb {
 		font-size: 0.68rem;
 		opacity: 0.7;
+	}
+	.solve-timer.countdown .st-val {
+		font-size: 0.86rem;
+	}
+	.solve-timer.countdown.danger .st-val {
+		color: var(--danger, #ff5d6c);
+		animation: countdown-pulse 1s ease-in-out infinite;
+	}
+	@keyframes countdown-pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.55;
+		}
 	}
 </style>

--- a/src/lib/stores/notificationStore.js
+++ b/src/lib/stores/notificationStore.js
@@ -79,13 +79,15 @@ export function startNotifications(uid) {
 		if (!document.hidden) poll();
 	};
 	document.addEventListener('visibilitychange', onVis);
-	// Realtime: a new challenge / friend request shows up instantly (not just on poll).
+	// Realtime: a new challenge / friend request shows up instantly (INSERT); a self-cleared
+		// one (e.g. the server deletes the friend-request notification when you accept)
+		// disappears live too (UPDATE = read, DELETE = dismissed).
 	if (uid) {
 		channel = supabase
 			.channel(`notifs:${uid}`)
 			.on(
 				'postgres_changes',
-				{ event: 'INSERT', schema: 'public', table: 'notifications', filter: `user_id=eq.${uid}` },
+				{ event: '*', schema: 'public', table: 'notifications', filter: `user_id=eq.${uid}` },
 				() => poll()
 			)
 			.subscribe();

--- a/src/lib/stores/statsStore.js
+++ b/src/lib/stores/statsStore.js
@@ -1043,7 +1043,8 @@ export async function makeupSubmitGuess(date, guess) {
 /* ===== Challenge Builder (configurable N-player packs) ===== */
 /**
  * @param {{ opponent?:string|null, group_id?:string|null, categories?:string[], pack_size?:number,
- *   mode?:string, wager?:number, payout?:string, window_seconds?:number, items_allowed?:boolean }} opts
+ *   mode?:string, wager?:number, payout?:string, window_seconds?:number, items_allowed?:boolean,
+ *   clock_mode?:string, clock_seconds?:number|null, time_scores?:boolean }} opts
  * @returns {Promise<{ok:boolean, reason?:string, match?:any}>}
  */
 export async function createMatch(opts) {
@@ -1056,7 +1057,10 @@ export async function createMatch(opts) {
 		p_wager: opts.wager ?? 0,
 		p_payout: opts.payout ?? 'winner',
 		p_window_seconds: opts.window_seconds ?? 172800,
-		p_items_allowed: opts.items_allowed ?? false
+		p_items_allowed: opts.items_allowed ?? false,
+		p_clock_mode: opts.clock_mode ?? 'none',
+		p_clock_seconds: opts.clock_seconds ?? null,
+		p_time_scores: opts.time_scores ?? false
 	});
 	if (error || !data) {
 		if (error) console.error('❌ create_match:', error);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2778,9 +2778,15 @@
 			</h3>
 			{#if showMainMenu}
 				<div class="bag-inv"><InventoryList /></div>
-				<button class="bag-store" on:click={() => goto('/shop')}
-					><Icon name="bag" size={15} /> Go to the Store →</button
-				>
+				{#if gameActive}
+					<button class="bag-store bag-store-locked" disabled
+						><Icon name="lock" size={15} /> Store closed during a game</button
+					>
+				{:else}
+					<button class="bag-store" on:click={() => goto('/shop')}
+						><Icon name="bag" size={15} /> Go to the Store →</button
+					>
+				{/if}
 			{:else}
 				<div class="bag-use-h">Your items</div>
 				{#if vaultItems.length}
@@ -8780,6 +8786,12 @@
 		font-weight: 800;
 		color: #3a2a00;
 		background: linear-gradient(135deg, #fde047, #f59e0b);
+	}
+	.bag-store-locked {
+		cursor: not-allowed;
+		color: rgba(255, 255, 255, 0.5);
+		background: rgba(255, 255, 255, 0.08);
+		border: 1px solid rgba(255, 255, 255, 0.12);
 	}
 	/* in-game bank modal */
 	.info-big {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2051,7 +2051,9 @@
 		mbWager === 0
 			? 'Friendly — no stakes, just bragging rights.'
 			: mbTarget === 'group'
-				? `Everyone antes $${mbWager.toLocaleString()} → the pot; top finishers split it. Spend less to keep more.`
+				? mbPayout === 'winner'
+					? `Everyone antes $${mbWager.toLocaleString()} → the pot; winner takes the whole pot. Spend less to keep more.`
+					: `Everyone antes $${mbWager.toLocaleString()} → the pot; top finishers split it. Spend less to keep more.`
 				: `You both ante $${mbWager.toLocaleString()} → $${(mbWager * 2).toLocaleString()} pot · winner takes all.`;
 	/** @type {{username:string,is_friend:boolean}[]} */
 	let mbResults = [];

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2031,7 +2031,7 @@
 	let mbCategories = [];
 	let mbPackSize = 3;
 	let mbWager = 500;
-	let mbPayout = 'winner'; // derived from field size at settle; kept for the RPC signature
+	let mbPayout = 'winner'; // 'winner' (whole pot to top scorer) | 'podium' (top finishers split). Group-only choice; 1v1 is always 'winner'.
 	// Challenge tier antes (ante = stake = pot size; payout is by field size at settle).
 	const CHALLENGE_TIERS = [
 		{ v: 0, label: 'Friendly' },
@@ -2045,6 +2045,8 @@
 	let mbBusy = false;
 	// Wizard: step 1 (Who) needs an opponent before Continue is allowed.
 	$: mbStep1Ok = mbTarget === 'friend' ? mbOpponent.trim().length > 0 : !!mbGroupId;
+	// A 1v1 is winner-take-all only — force it whenever the target is a friend (any entry path).
+	$: if (mbTarget === 'friend') mbPayout = 'winner';
 	$: potSummary =
 		mbWager === 0
 			? 'Friendly — no stakes, just bragging rights.'
@@ -2183,7 +2185,7 @@
 			{ label: 'Buy-in', value: w > 0 ? '$' + w.toLocaleString() : 'Friendly' },
 			{
 				label: 'Payout',
-				value: mbTarget === 'group' ? 'Top finishers split the pot' : 'Winner takes all'
+				value: mbPayout === 'podium' ? 'Top finishers split the pot' : 'Winner takes all'
 			}
 		];
 		try {
@@ -2236,10 +2238,12 @@
 				label: 'Buy-in',
 				value: Number(m.wager) > 0 ? '$' + Number(m.wager).toLocaleString() : 'Friendly'
 			},
-			// _match_settle: ≤2 paid → winner takes all; 3+ → top finishers split (70/30, 60/30/10).
+			// Payout is the creator's stored choice: 'winner' → whole pot to the top scorer;
+			// 'podium' → top finishers split (70/30 for 3, 60/30/10 for 4+). 1v1 is always winner.
 			{
 				label: 'Payout',
-				value: Number(m.players) > 2 ? 'Top finishers split the pot' : 'Winner takes all'
+				value:
+					(m.payout === 'podium' && Number(m.players) > 2) ? 'Top finishers split the pot' : 'Winner takes all'
 			}
 		];
 		if (Number(m.wager) > 0 && netWorth != null)
@@ -3881,7 +3885,10 @@
 									type="button"
 									class="ch-mode"
 									class:active={mbTarget === 'group'}
-									on:click={() => (mbTarget = 'group')}
+									on:click={() => {
+											mbTarget = 'group';
+											mbPayout = 'podium';
+										}}
 									><Icon name="users" size={16} /> A group<small>everyone in it</small></button
 								>
 							</div>
@@ -4011,6 +4018,31 @@
 									{/each}
 								</div>
 							</div>
+							{#if mbTarget === 'group'}
+								<div class="ch-field">
+									<span>Payout</span>
+									<div class="ch-seg">
+										<button
+											type="button"
+											class="ch-seg-btn"
+											class:on={mbPayout === 'winner'}
+											on:click={() => {
+												mbPayout = 'winner';
+												fx('tap');
+											}}>Winner takes all</button
+										>
+										<button
+											type="button"
+											class="ch-seg-btn"
+											class:on={mbPayout === 'podium'}
+											on:click={() => {
+												mbPayout = 'podium';
+												fx('tap');
+											}}>Top finishers split</button
+										>
+									</div>
+								</div>
+							{/if}
 							<label class="ch-field"
 								><span>Respond within</span>
 								<select class="ch-input" bind:value={mbWindow}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -659,6 +659,35 @@
 		$gameStore.gameState !== 'lost';
 	$: matchOpenedAt = matchInfo?.started_at ? new Date(matchInfo.started_at).getTime() : null;
 
+	// ⏱️ Timed challenges (creator-configurable): when a clock is set, the match timer slot
+	// shows a countdown instead of the count-up above — anchored to puzzle_started_at for a
+	// per-puzzle clock, started_at for a whole-match clock. Server is authoritative (_match_tick
+	// folds on expiry); the client just displays it and pokes the server once it hits 0.
+	$: matchClockOn = isMatch && !!matchInfo && matchInfo.clock_mode && matchInfo.clock_mode !== 'none';
+	$: matchClockAnchorMs = matchClockOn
+		? new Date(
+				matchInfo.clock_mode === 'match' ? matchInfo.started_at : matchInfo.puzzle_started_at
+			).getTime()
+		: null;
+	$: matchClockSeconds = matchClockOn ? (matchInfo?.clock_seconds ?? null) : null;
+	// Bound from SolveTimer's countdown; gated by matchTimerActive so it can't linger true
+	// after the puzzle/match ends (the timer stops ticking, freezing the last value otherwise).
+	let matchClockDangerRaw = false;
+	$: matchClockDanger = matchTimerActive && matchClockOn && matchClockDangerRaw;
+	let matchClockExpireFiring = false;
+	/** Countdown hit 0 — poke the server once so the authoritative tick (_match_tick) resolves
+	 *  it (force-folds the expired puzzle/match). Reuses the existing fold path; matchFold()
+	 *  itself is a no-op if the participant is no longer active, so this can't double-fold. */
+	async function handleMatchClockExpire() {
+		if (matchClockExpireFiring) return;
+		matchClockExpireFiring = true;
+		try {
+			await matchFold();
+		} finally {
+			matchClockExpireFiring = false;
+		}
+	}
+
 	// 🎰 Slot-machine money feel: count the hero number up/down; float a −$X off it on each spend.
 	const tweenNet = tweened(0, { duration: 900, easing: cubicOut });
 	// 🏆 Win-banner animations: profit counts up, then Cash scrolls to the new total.
@@ -2036,6 +2065,46 @@
 	let mbPackSize = 3;
 	let mbWager = 500;
 	let mbPayout = 'winner'; // 'winner' (whole pot to top scorer) | 'podium' (top finishers split). Group-only choice; 1v1 is always 'winner'.
+	// Live clock (creator-configurable; identical for 1v1 & group). 'none' = today's behavior
+	// (async, no live clock). 'puzzle' = a countdown per puzzle; 'match' = one countdown for
+	// the whole pack. mbClockSeconds is the chosen duration for whichever scope is picked.
+	let mbClockMode = 'none'; // 'none' | 'puzzle' | 'match'
+	/** @type {number|null} */
+	let mbClockSeconds = null;
+	let mbTimeScores = false; // speed bonus: leftover time on solve adds points (only when a clock is set)
+	const CLOCK_PUZZLE_DURATIONS = [
+		{ v: 30, l: '30s' },
+		{ v: 60, l: '1m' },
+		{ v: 120, l: '2m' },
+		{ v: 300, l: '5m' }
+	];
+	const CLOCK_MATCH_DURATIONS = [
+		{ v: 180, l: '3m' },
+		{ v: 600, l: '10m' },
+		{ v: 1800, l: '30m' }
+	];
+	/** @param {'none'|'puzzle'|'match'} mode */
+	function setClockMode(mode) {
+		fx('tap');
+		mbClockMode = mode;
+		if (mode === 'none') {
+			mbClockSeconds = null;
+			mbTimeScores = false;
+		} else {
+			const opts = mode === 'puzzle' ? CLOCK_PUZZLE_DURATIONS : CLOCK_MATCH_DURATIONS;
+			if (!opts.some((o) => o.v === mbClockSeconds)) mbClockSeconds = opts[0].v;
+		}
+	}
+	// "Per-puzzle · 1m · speed bonus" / null when no timer — the confirm-step summary line.
+	$: mbClockLabel =
+		mbClockMode === 'none'
+			? null
+			: (mbClockMode === 'puzzle' ? 'Per-puzzle' : 'Whole-match') +
+				' · ' +
+				((mbClockMode === 'puzzle' ? CLOCK_PUZZLE_DURATIONS : CLOCK_MATCH_DURATIONS).find(
+					(o) => o.v === mbClockSeconds
+				)?.l ?? '') +
+				(mbTimeScores ? ' · speed bonus' : '');
 	// Challenge tier antes (ante = stake = pot size; payout is by field size at settle).
 	const CHALLENGE_TIERS = [
 		{ v: 0, label: 'Friendly' },
@@ -2192,7 +2261,8 @@
 			{
 				label: 'Payout',
 				value: mbPayout === 'podium' ? 'Top finishers split the pot' : 'Winner takes all'
-			}
+			},
+			...(mbClockLabel ? [{ label: 'Timing', value: mbClockLabel }] : [])
 		];
 		try {
 			await requirePin(w > 0 ? 'Send & stake your buy-in' : 'Send this challenge', createStakes);
@@ -2210,7 +2280,10 @@
 			wager: Math.floor(Number(mbWager) || 0),
 			payout: mbPayout,
 			window_seconds: mbWindow,
-			items_allowed: mbItemsAllowed
+			items_allowed: mbItemsAllowed,
+			clock_mode: mbClockMode,
+			clock_seconds: mbClockSeconds,
+			time_scores: mbTimeScores
 		});
 		mbBusy = false;
 		if (res?.ok) {
@@ -3371,7 +3444,11 @@
 	</div>
 {/if}
 
-<main class:danger-active={dangerMode && !overdriveArmed && $gameStore.gameState !== 'guess_mode'}>
+<main
+	class:danger-active={(dangerMode || matchClockDanger) &&
+		!overdriveArmed &&
+		$gameStore.gameState !== 'guess_mode'}
+>
 	<!-- 👤 First-run: pick a username (required to play socially) -->
 	{#if loggedIn && hasInitialized && needsUsername}
 		<div
@@ -4011,6 +4088,62 @@
 										>{/each}
 								</div>
 							</div>
+
+							<div class="ch-field">
+								<span>Timing</span>
+								<div class="ch-seg">
+									<button
+										type="button"
+										class="ch-seg-btn"
+										class:on={mbClockMode === 'none'}
+										on:click={() => setClockMode('none')}>No timer</button
+									>
+									<button
+										type="button"
+										class="ch-seg-btn"
+										class:on={mbClockMode === 'puzzle'}
+										on:click={() => setClockMode('puzzle')}>Per-puzzle</button
+									>
+									<button
+										type="button"
+										class="ch-seg-btn"
+										class:on={mbClockMode === 'match'}
+										on:click={() => setClockMode('match')}>Whole-match</button
+									>
+								</div>
+								{#if mbClockMode !== 'none'}
+									<div class="ch-seg ch-seg-durations">
+										{#each mbClockMode === 'puzzle' ? CLOCK_PUZZLE_DURATIONS : CLOCK_MATCH_DURATIONS as d}
+											<button
+												type="button"
+												class="ch-seg-btn"
+												class:on={mbClockSeconds === d.v}
+												on:click={() => {
+													mbClockSeconds = d.v;
+													fx('tap');
+												}}>{d.l}</button
+											>
+										{/each}
+									</div>
+									<button
+										type="button"
+										class="ch-toggle"
+										class:on={mbTimeScores}
+										on:click={() => {
+											mbTimeScores = !mbTimeScores;
+											fx('tap');
+										}}
+									>
+										<span class="ch-tog-box"
+											>{#if mbTimeScores}<Icon name="check" size={13} />{/if}</span
+										>
+										<Icon name="bolt" size={14} /> Speed bonus
+									</button>
+									<p class="ch-hint">Solve faster to earn bonus points.</p>
+								{:else}
+									<p class="ch-hint">No clock — play at your own pace, like today.</p>
+								{/if}
+							</div>
 						{:else}
 							<!-- Step 3 · Stakes -->
 							<div class="ch-step-title">The stakes</div>
@@ -4461,8 +4594,9 @@
 	{:else}
 		<!-- ✅ GAME UI (Visible only when logged in) -->
 
-		<!-- 🚨 Last-stand red vignette — frames the whole screen when you're out of money. -->
-		{#if dangerMode}
+		<!-- 🚨 Last-stand red vignette — frames the whole screen when you're out of money, or
+		     (timed challenges) when the live clock is about to run out. -->
+		{#if dangerMode || matchClockDanger}
 			<div class="danger-vignette" class:daily={isDaily} aria-hidden="true"></div>
 		{/if}
 
@@ -4511,16 +4645,20 @@
 			</div>
 		{/if}
 
-		<!-- Match solve timer — same server-anchored count-up treatment as Daily. Anchored to
-		     matchInfo.started_at (challenge_participants.started_at, stamped once when the
-		     player starts the match — NOT reset per puzzle), so it tracks total time in the
-		     match, pausing its visual only at each puzzle's win screen like Daily does. -->
+		<!-- Match solve timer. Untimed challenges (clock_mode='none', today's default): same
+		     server-anchored count-up as Daily, anchored to matchInfo.started_at (stamped once
+		     at match_start — NOT reset per puzzle). Timed challenges: a countdown instead,
+		     anchored to puzzle_started_at ('puzzle' clock) or started_at ('match' clock);
+		     hitting 0 pokes the server so the authoritative fold resolves it. -->
 		{#if isMatch && matchInfo && !matchInfo.done && $gameStore.currentPhrase}
 			<div class="daily-timer-wrap">
 				<SolveTimer
-					openedAt={matchOpenedAt}
+					openedAt={matchClockOn ? matchClockAnchorMs : matchOpenedAt}
+					countdownSeconds={matchClockOn ? matchClockSeconds : null}
 					active={matchTimerActive}
 					solved={$gameStore.gameState === 'won'}
+					bind:danger={matchClockDangerRaw}
+					on:expire={handleMatchClockExpire}
 				/>
 			</div>
 		{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -202,6 +202,10 @@
 				go: () => respondToMatch(m)
 			}))
 	];
+	// Mirrors the server buy_powerup gate: an active Cash Game run, in-progress Daily,
+	// or an active challenge (server-truth signals, NOT gameStore's 'default' state).
+	$: hasActiveGame =
+		dailyInProgress || climbInProgress || resumables.some((r) => r.modeKey === 'match');
 	let showResumeMenu = false;
 	function resumeSolo(/** @type {string} */ mode) {
 		if (mode === 'daily') handleMenuDaily();
@@ -2778,7 +2782,7 @@
 			</h3>
 			{#if showMainMenu}
 				<div class="bag-inv"><InventoryList /></div>
-				{#if gameActive}
+				{#if hasActiveGame}
 					<button class="bag-store bag-store-locked" disabled
 						><Icon name="lock" size={15} /> Store closed during a game</button
 					>

--- a/src/routes/profile/+page.svelte
+++ b/src/routes/profile/+page.svelte
@@ -32,6 +32,9 @@
 	// Back then returns to the menu instead of the Overview the user never saw.
 	let deepLinked = $state(false);
 
+	// "My Items" (power-ups) block on Overview — purely presentational collapse, defaults open.
+	let itemsCollapsed = $state(false);
+
 	onMount(async () => {
 		track('profile_view');
 		const t = $page.url.searchParams.get('tab');
@@ -267,13 +270,30 @@
 				>
 			{/if}
 
-			<button class="ov-sec-link" onclick={() => goto('/shop?from=profile')}>
-				<span>My Items</span>
-				<span class="arrow">›</span>
-			</button>
-			<div class="ov-items">
-				<InventoryList addHref="/shop?from=profile" />
+			<div class="ov-sec-row">
+				<button
+					class="ov-sec-toggle"
+					onclick={() => (itemsCollapsed = !itemsCollapsed)}
+					aria-expanded={!itemsCollapsed}
+				>
+					<span class="ov-chevron" class:collapsed={itemsCollapsed}>
+						<Icon name="chevron-right" size={14} />
+					</span>
+					<span>My Items</span>
+				</button>
+				<button
+					class="ov-sec-goto"
+					onclick={() => goto('/shop?from=profile')}
+					aria-label="Go to shop"
+				>
+					<span class="arrow">›</span>
+				</button>
 			</div>
+			{#if !itemsCollapsed}
+				<div class="ov-items">
+					<InventoryList addHref="/shop?from=profile" />
+				</div>
+			{/if}
 
 			<div class="ov-nav">
 				<button class="ov-link" onclick={() => (tab = 'stats')}
@@ -804,6 +824,49 @@
 	.ov-sec-link .arrow {
 		margin-left: auto;
 		color: var(--text-faint);
+	}
+	/* My Items: header split into a collapse-toggle + a distinct shop-nav affordance. */
+	.ov-sec-row {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		margin: 18px 2px 8px;
+	}
+	.ov-sec-toggle {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		font-family: var(--font-display);
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.1em;
+		text-transform: uppercase;
+		color: var(--gold);
+	}
+	.ov-chevron {
+		display: inline-flex;
+		color: var(--text-faint);
+		transform: rotate(90deg);
+		transition: transform 0.18s ease;
+	}
+	.ov-chevron.collapsed {
+		transform: rotate(0deg);
+	}
+	.ov-sec-goto {
+		margin-left: auto;
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 4px;
+		line-height: 1;
+	}
+	.ov-sec-goto .arrow {
+		color: var(--text-faint);
+		font-size: 0.95rem;
 	}
 	.ov-badge-grid {
 		display: grid;

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -52,7 +52,7 @@
 		sabotage_tax: { icon: 'percent', desc: "An opponent's letters cost +50%" },
 		sabotage_fog: { icon: 'fog', desc: "Hide an opponent's clue" },
 		sabotage_toll: { icon: 'toll', desc: "An opponent's next letter costs 3×" },
-		sabotage_vowel_block: { icon: 'block', desc: "An opponent's vowels cost 3×" },
+		sabotage_vowel_block: { icon: 'block', desc: "An opponent's vowels cost 3× for their next 3 buys" },
 		sabotage_lock: { icon: 'trash', desc: "Wipe the opponent's most-recently-revealed letter" },
 		bounty_boost: { icon: 'boost', desc: 'Adds +50% Interest to your Daily deposit' },
 		jackpot_boost: { icon: 'gem', desc: 'Adds +100% Interest to your Daily deposit' }

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -97,7 +97,9 @@
 					? 'Not enough Cash.'
 					: res?.reason === 'owned'
 						? 'You already own one — use it first.'
-						: 'Could not buy that.';
+						: res?.reason === 'in_game'
+							? "Can't buy items during a game — finish first."
+							: 'Could not buy that.';
 		}
 	}
 	onMount(async () => {

--- a/supabase-group-add-notify.sql
+++ b/supabase-group-add-notify.sql
@@ -1,0 +1,42 @@
+-- "Added to a group" notification (migration: group_add_notify).
+-- add_group_member now _notify()s the newly-added member ("Added to a group")
+-- when user A adds friend B to a group. Fires ONLY on a genuinely-new insert
+-- (guarded by IF FOUND after ON CONFLICT DO NOTHING): never on a self-add (the
+-- 'self' guard above already returns), never on a re-add of an existing member
+-- (the 'already_member' guard + the FOUND check). Carries data.group_id (+ the
+-- group_join convention: group_name/from_id/from_name) so the client can render
+-- and deep-link to the group. Delivered live via the notifications realtime sub.
+-- Everything else in the RPC is byte-identical to the live body.
+BEGIN;
+CREATE OR REPLACE FUNCTION public.add_group_member(p_group_id uuid, p_username text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); v_target uuid; v_gname text;
+begin
+  if v_uid is null then return jsonb_build_object('ok',false,'reason','auth'); end if;
+  if not exists (select 1 from public.group_members where group_id = p_group_id and user_id = v_uid) then
+    return jsonb_build_object('ok',false,'reason','not_member');
+  end if;
+  select id into v_target from public.profiles where lower(username) = lower(trim(coalesce(p_username,'')));
+  if v_target is null then return jsonb_build_object('ok',false,'reason','not_found'); end if;
+  if v_target = v_uid then return jsonb_build_object('ok',false,'reason','self'); end if;
+  if not exists (select 1 from public.friendships where user_id = v_uid and friend_id = v_target) then
+    return jsonb_build_object('ok',false,'reason','not_friend');
+  end if;
+  if exists (select 1 from public.group_members where group_id = p_group_id and user_id = v_target) then
+    return jsonb_build_object('ok',false,'reason','already_member');
+  end if;
+  insert into public.group_members(group_id, user_id) values (p_group_id, v_target) on conflict do nothing;
+  -- Notify the newly-added member — only a genuinely-new insert (never self, never a re-add).
+  if found then
+    select name into v_gname from public.groups where id = p_group_id;
+    perform public._notify(v_target, 'group_added', 'Added to a group',
+      public._display_name(v_uid) || ' added you to ' || coalesce(v_gname, 'a group'),
+      jsonb_build_object('group_id', p_group_id, 'group_name', v_gname,
+        'from_id', v_uid, 'from_name', public._display_name(v_uid), 'route', 'group'));
+  end if;
+  return jsonb_build_object('ok',true,'group',public.get_group(p_group_id));
+end; $function$;
+COMMIT;

--- a/supabase-payout-choice.sql
+++ b/supabase-payout-choice.sql
@@ -1,0 +1,229 @@
+-- Challenge Batch 2 · Task 2 — Payout creator toggle (Winner-take-all vs Top-finishers-split)
+--
+-- Goal: let a GROUP creator choose the payout and make settle RESPECT the stored
+-- `challenge_matches.payout` instead of deriving winner-vs-split purely by field size.
+--   * create_match: store the incoming p_payout ('winner' | 'podium'); when null/absent,
+--     default by field size for back-compat (1v1 -> winner, group -> podium).
+--   * _match_settle: when m.payout = 'winner' pay the single top scorer the whole pot
+--     (even for 3+); otherwise ('podium' or legacy null) fall back to the existing
+--     count-based split (2 -> winner, 3 -> 70/30, 4+ -> 60/30/10). 1v1 is winner-take-all
+--     regardless. ALL other money math (pot, shares loop, _bank_credit, _log_game_result,
+--     notifies, refunds, tie handling) is byte-identical to the live body.
+--
+-- Dumped live 2026-07-16 via pg_get_functiondef and transformed surgically.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- create_match — resolve v_payout AFTER the field is known so a null defaults by count
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.create_match(p_opponent text, p_group_id uuid, p_categories text[], p_pack_size integer, p_wager bigint, p_mode text, p_payout text, p_window_seconds integer, p_items_allowed boolean)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); v_id uuid; v_opp uuid; v_size int; v_wager bigint; v_mode text; v_payout text;
+  v_n int; v_budget bigint; v_cash bigint; v_uids uuid[]; r record;
+begin
+  if v_uid is null then return jsonb_build_object('ok',false,'reason','auth'); end if;
+  v_size := least(greatest(coalesce(p_pack_size,1),1),10);
+  v_wager := greatest(coalesce(p_wager,0),0);
+  if v_wager > 0 and v_wager < 500 then return jsonb_build_object('ok',false,'reason','min_wager'); end if;
+  v_mode := 'standard';  -- Blitz retired; all matches are standard
+  if p_group_id is not null then
+    if not exists (select 1 from public.group_members where group_id = p_group_id and user_id = v_uid) then
+      return jsonb_build_object('ok',false,'reason','not_member'); end if;
+    select array_agg(user_id) into v_uids from public.group_members where group_id = p_group_id;
+  else
+    select id into v_opp from public.profiles where lower(username) = lower(trim(coalesce(p_opponent,'')));
+    if v_opp is null then return jsonb_build_object('ok',false,'reason','no_opponent'); end if;
+    if v_opp = v_uid then return jsonb_build_object('ok',false,'reason','self'); end if;
+    v_uids := array[v_uid, v_opp];
+  end if;
+  -- Payout: honor an explicit creator choice; else default by field size for back-compat
+  -- (1v1 -> winner-take-all, group -> top-finishers split). Settle respects this value.
+  v_payout := case when p_payout in ('winner','podium') then p_payout
+                   when coalesce(array_length(v_uids,1),0) <= 2 then 'winner'
+                   else 'podium' end;
+  if v_wager > 0 then
+    perform public._ensure_bank(v_uid);
+    select bank into v_cash from public.profiles where id = v_uid;
+    if v_cash < v_wager then return jsonb_build_object('ok',false,'reason','insufficient'); end if;
+    perform public._bank_credit(v_uid, -v_wager, 'wager_stake');
+  end if;
+  insert into public.challenge_matches(host_id, group_id, mode, categories, pack_size, wager, payout, settles_at, items_allowed, econ_v)
+  values (v_uid, p_group_id, v_mode, coalesce(p_categories,'{}'), v_size, v_wager, v_payout, now() + (least(greatest(coalesce(p_window_seconds,172800),3600),604800) || ' seconds')::interval, coalesce(p_items_allowed,false), 2)
+  returning id into v_id;
+  insert into public.challenge_pack(match_id, position, puzzle_id)
+  select v_id, row_number() over (), pid
+  from public._pick_casual_pack(v_uids, coalesce(p_categories,'{}'), v_size, 8) pid;
+  select count(*) into v_n from public.challenge_pack where match_id = v_id;
+  if v_n = 0 then return jsonb_build_object('ok',false,'reason','no_puzzles'); end if;
+  -- NEW: budget = puzzle-1 bounty (standardized), not GREATEST(wager,500).
+  v_budget := public._match_pos_bounty(v_id, 1);
+  insert into public.challenge_participants(match_id, user_id, paid, state, joined_at, bankroll, start_budget, stake)
+  values (v_id, v_uid, v_wager > 0, 'active', now(), v_budget, v_budget, v_wager);
+  perform public._mark_seen_many(v_uid, (select array_agg(puzzle_id) from public.challenge_pack where match_id = v_id));
+  if p_group_id is not null then
+    for r in select user_id from public.group_members where group_id = p_group_id and user_id <> v_uid loop
+      insert into public.challenge_participants(match_id, user_id) values (v_id, r.user_id) on conflict do nothing;
+      perform public._notify(r.user_id, 'challenge_incoming', 'Group challenge',
+        public._display_name(v_uid) || ' challenged your group' || case when v_wager>0 then ' — $' || v_wager else '' end,
+        jsonb_build_object('match_id', v_id));
+    end loop;
+  else
+    insert into public.challenge_participants(match_id, user_id) values (v_id, v_opp);
+    perform public._notify(v_opp, 'challenge_incoming', 'New challenge',
+      public._display_name(v_uid) || ' challenged you — ' || v_n || ' puzzle' || case when v_n=1 then '' else 's' end ||
+      case when v_wager>0 then ' · $' || v_wager else '' end, jsonb_build_object('match_id', v_id, 'route','challenge'));
+  end if;
+  return jsonb_build_object('ok',true, 'match', public.get_match(v_id));
+end; $function$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- _match_settle — the ONLY change is the v_shares decision: honor m.payout='winner'
+-- (whole pot to the single top scorer even for 3+); 'podium'/legacy-null falls back to
+-- the existing count-based split. Everything else is byte-identical to the live body.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public._match_settle(p_id uuid)
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare m public.challenge_matches; v_paid int; v_done int; v_solved_max int;
+  v_budget bigint; v_pot bigint := 0; v_refunded boolean := false; v_opponent uuid; v_winnings jsonb := '{}'::jsonb;
+  v_shares numeric[]; v_spent int; v_earned int; v_wins int; v_pay bigint; v_stake bigint; r record;
+begin
+  select * into m from public.challenge_matches where id = p_id for update;
+  if m.status <> 'open' then return; end if;
+  v_budget := greatest(m.wager, 500);
+  select count(*) into v_paid from public.challenge_participants where match_id = p_id and paid;
+  select count(*) into v_done from public.challenge_participants where match_id = p_id and paid and state = 'done';
+  select coalesce(max(solved),0) into v_solved_max from public.challenge_participants where match_id = p_id and state = 'done';
+
+  if m.wager > 0 then
+    if v_paid < 2 or v_done = 0 or v_solved_max = 0 then
+      v_refunded := true;
+      for r in select user_id, coalesce(stake, v_budget) as refund
+               from public.challenge_participants where match_id = p_id and paid loop
+        perform public._bank_credit(r.user_id, r.refund, 'wager_refund'); end loop;
+    else
+      -- pot = sum of the ACTUAL stakes (v2: per-player stake; old: start_budget = wager).
+      if m.econ_v = 2 then
+        select coalesce(sum(coalesce(stake,0)), 0) into v_pot
+          from public.challenge_participants where match_id = p_id and paid;
+      else
+        select coalesce(sum(coalesce(start_budget, v_budget)), 0) into v_pot
+          from public.challenge_participants where match_id = p_id and paid;
+      end if;
+      -- Payout shape: creator's choice wins. 'winner' -> whole pot to the single top scorer
+      -- (even for 3+ players). Otherwise ('podium' or legacy null) fall back to the field-size
+      -- rule: 1v1 winner-take-all, 3 -> 70/30, 4+ -> 60/30/10. A 1v1 is winner-take-all either way.
+      v_shares := case when m.payout = 'winner' then array[1.0]::numeric[]
+                       when v_paid <= 2 then array[1.0]::numeric[]
+                       when v_paid = 3  then array[0.7, 0.3]::numeric[]
+                       else                  array[0.6, 0.3, 0.1]::numeric[] end;
+      for r in
+        with done as (
+          select user_id, total_score,
+                 rank()  over (order by total_score desc, public._match_elapsed(started_at, finished_at, joined_at) asc) as rk,
+                 count(*) over (partition by total_score, public._match_elapsed(started_at, finished_at, joined_at))  as grp
+          from public.challenge_participants where match_id = p_id and paid and state = 'done'
+        )
+        select d.user_id,
+          ( (select coalesce(sum(case when p <= array_length(v_shares,1) then v_shares[p] else 0 end), 0)
+               from generate_series(d.rk, d.rk + d.grp - 1) p) / d.grp ) as frac
+        from done d
+      loop
+        v_pay := round(v_pot * r.frac)::bigint;
+        if v_pay > 0 then
+          perform public._bank_credit(r.user_id, v_pay, 'wager_win');
+          v_winnings := v_winnings || jsonb_build_object(r.user_id::text, v_pay);
+        end if;
+      end loop;
+    end if;
+  end if;
+
+  update public.challenge_matches set status = 'settled' where id = p_id;
+
+  for r in select cp.user_id, cp.solved, cp.bankroll, cp.total_score, cp.stake, coalesce(cp.start_budget, v_budget) as budget,
+                  rank() over (order by cp.total_score desc, public._match_elapsed(cp.started_at, cp.finished_at, cp.joined_at) asc) as rk,
+                  count(*) filter (where true) over (partition by cp.total_score, public._match_elapsed(cp.started_at, cp.finished_at, cp.joined_at)) as tied
+           from public.challenge_participants cp where cp.match_id = p_id and cp.state = 'done' loop
+    if v_refunded then
+      perform public._notify(r.user_id, 'challenge_result', 'Challenge tied',
+        'No one solved it — ' || (case when m.wager>0 then 'ante refunded.' else 'no winner.' end),
+        jsonb_build_object('match_id', p_id, 'tie', true, 'route','challenge'));
+    elsif coalesce((v_winnings->>r.user_id::text)::bigint,0) > 0 or (r.rk = 1 and r.tied = 1) then
+      perform public._notify(r.user_id, 'challenge_result',
+        case when r.rk = 1 then 'You won the challenge!' else 'You placed — took a share' end,
+        'Solved ' || r.solved || '/' || m.pack_size || (case when m.wager>0 then ' — +$' || coalesce((v_winnings->>r.user_id::text),'0') else '' end),
+        jsonb_build_object('match_id', p_id, 'rank', r.rk, 'route','challenge'));
+      if r.rk = 1 then
+        if m.wager > 0 then perform public._award_badge(r.user_id, 'first_blood'); end if;
+        if m.wager >= 10000 then perform public._award_badge(r.user_id, 'gold_duelist'); end if;
+      end if;
+    else
+      perform public._notify(r.user_id, 'challenge_result', 'Challenge settled',
+        'Solved ' || r.solved || '/' || m.pack_size || ' · rank #' || r.rk,
+        jsonb_build_object('match_id', p_id, 'rank', r.rk, 'route','challenge'));
+    end if;
+
+    v_opponent := case when m.group_id is null
+      then (select cp2.user_id from public.challenge_participants cp2 where cp2.match_id = p_id and cp2.user_id <> r.user_id limit 1) else null end;
+    if m.wager > 0 and not v_refunded then
+      -- game_results.spent = the actual STAKE so net (earned−spent) is true money P&L.
+      -- (The "letters spent" skill number lives in the match-detail view, not here.)
+      v_spent := case when m.econ_v = 2 then coalesce(r.stake, m.wager)::int else r.budget::int end;
+      v_earned := coalesce((v_winnings->>r.user_id::text)::int, 0);
+    else
+      v_spent := null; v_earned := null;
+    end if;
+    if m.wager > 0 then
+      perform public._log_game_result(
+        r.user_id, 'challenge',
+        case when v_refunded then 'tie'
+             when r.rk = 1 and r.tied > 1 then 'tie'
+             when r.rk = 1 then 'won'
+             else 'lost' end,
+        null, null, r.solved::int, m.pack_size::int, v_spent, v_earned, null, null,null,null,null,
+        p_id, v_opponent, m.group_id, r.rk::int, v_done::int,
+        (case when m.wager > 0 and not v_refunded then v_pot else null end), m.wager);
+    end if;
+
+    if r.rk = 1 and not v_refunded and r.tied = 1 then
+      select count(*) into v_wins from public.challenge_matches mm
+        join public.challenge_participants cpp on cpp.match_id = mm.id and cpp.user_id = r.user_id
+        where mm.status = 'settled' and cpp.total_score = (select max(total_score) from public.challenge_participants x where x.match_id = mm.id);
+      if m.wager > 0 and v_wins >= 10 then perform public._award_badge(r.user_id, 'hustler'); end if;
+    end if;
+  end loop;
+  -- Paid players who never finished (state<>'done' at settle) — the done-loop above skipped
+  -- them, so their money loss (stake swept into the pot) or refund was invisible: no result
+  -- row, no notification. Record it here.
+  for r in select cp.user_id, cp.solved, cp.stake, coalesce(cp.start_budget, v_budget) as budget
+           from public.challenge_participants cp
+           where cp.match_id = p_id and cp.paid and cp.state <> 'done' loop
+    v_opponent := case when m.group_id is null
+      then (select cp2.user_id from public.challenge_participants cp2 where cp2.match_id = p_id and cp2.user_id <> r.user_id limit 1) else null end;
+    if v_refunded then
+      perform public._notify(r.user_id, 'challenge_result', 'Challenge refunded',
+        'No one solved it — your buy-in was refunded.',
+        jsonb_build_object('match_id', p_id, 'tie', true, 'route','challenge'));
+      if m.wager > 0 then
+        perform public._log_game_result(r.user_id, 'challenge', 'tie',
+          null, null, coalesce(r.solved,0)::int, m.pack_size::int, null, null, null, null,null,null,null,
+          p_id, v_opponent, m.group_id, null, v_done::int, null, m.wager);
+      end if;
+    else
+      v_spent := case when m.econ_v = 2 then coalesce(r.stake, m.wager)::int else r.budget::int end;
+      perform public._notify(r.user_id, 'challenge_result', 'Challenge settled',
+        'You did not finish in time' || (case when m.wager>0 then ' — lost your $' || v_spent::text || ' buy-in' else '' end) || '.',
+        jsonb_build_object('match_id', p_id, 'route','challenge'));
+      if m.wager > 0 then
+        perform public._log_game_result(r.user_id, 'challenge', 'lost',
+          null, null, coalesce(r.solved,0)::int, m.pack_size::int, v_spent, 0, null, null,null,null,null,
+          p_id, v_opponent, m.group_id, null, v_done::int,
+          (case when m.wager > 0 then v_pot else null end), m.wager);
+      end if;
+    end if;
+  end loop;
+end; $function$;

--- a/supabase-realtime-enable.sql
+++ b/supabase-realtime-enable.sql
@@ -1,0 +1,59 @@
+-- Realtime social layer: friend-request live flips + self-clearing notifications.
+-- Adds friend_requests (and confirms notifications) to the supabase_realtime
+-- publication, and ensures each has an RLS SELECT policy so a user can read
+-- their own rows — Realtime only delivers rows a user is allowed to SELECT.
+-- Idempotent: safe to re-run.
+
+-- 1) friend_requests: user must be able to SELECT rows where they are the
+--    requester (to see their outgoing "Pending" flip/disappear on accept) or
+--    the addressee (to see incoming requests appear live). RLS is enabled on
+--    the table but had no policies, so add a self-scoped SELECT policy.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'friend_requests'
+      and policyname = 'friend_requests_self'
+  ) then
+    create policy "friend_requests_self" on public.friend_requests
+      for select using (requester = auth.uid() or addressee = auth.uid());
+  end if;
+end $$;
+
+-- Full replica identity so DELETE events carry the old row (requester/addressee)
+-- for the RLS check + client re-derive when a request is accepted/declined.
+alter table public.friend_requests replica identity full;
+
+-- 2) Add friend_requests to the realtime publication (guard so re-running is safe).
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public'
+      and tablename = 'friend_requests'
+  ) then
+    alter publication supabase_realtime add table public.friend_requests;
+  end if;
+end $$;
+
+-- 3) notifications: already in the publication with a self SELECT policy
+--    ("notifications_self" USING user_id = auth.uid()). Guard-add both in case
+--    this runs against an environment where they're missing.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'notifications'
+      and policyname = 'notifications_self'
+  ) then
+    create policy "notifications_self" on public.notifications
+      for select using (user_id = auth.uid());
+  end if;
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public'
+      and tablename = 'notifications'
+  ) then
+    alter publication supabase_realtime add table public.notifications;
+  end if;
+end $$;

--- a/supabase-store-active-game-gate.sql
+++ b/supabase-store-active-game-gate.sql
@@ -1,0 +1,35 @@
+-- Store active-game gate: block buying GAMEPLAY items during an active real game.
+-- Gameplay items (kind IN 'climb','daily','sabotage') can no longer be bought while
+-- the buyer has an active Cash Game run, an active challenge, or an in-progress Daily
+-- for today. Cosmetics are NOT sold via buy_powerup and are never affected.
+-- Everything else in buy_powerup is byte-identical to the live definition.
+
+CREATE OR REPLACE FUNCTION public.buy_powerup(p_id text)
+  RETURNS jsonb
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+ AS $function$
+ DECLARE v_uid UUID := auth.uid(); v_price BIGINT; v_cash BIGINT; v_owned INT; v_kind TEXT; v_cap INT;
+ BEGIN
+   IF v_uid IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','auth'); END IF;
+   IF COALESCE((SELECT loan FROM public.profiles WHERE id = v_uid),0) > 0 THEN RETURN jsonb_build_object('ok',false,'reason','in_debt'); END IF;
+   SELECT price, kind INTO v_price, v_kind FROM public.powerups WHERE id = p_id AND active;
+   IF v_price IS NULL THEN RETURN jsonb_build_object('ok',false,'reason','no_item'); END IF;
+   -- Active-game gate: gameplay items only; never blocks cosmetics.
+   IF v_kind IN ('climb','daily','sabotage') AND (
+        EXISTS (SELECT 1 FROM public.climb_state WHERE user_id = v_uid AND state = 'active')
+     OR EXISTS (SELECT 1 FROM public.challenge_participants WHERE user_id = v_uid AND state = 'active')
+     OR EXISTS (SELECT 1 FROM public.daily_sessions WHERE user_id = v_uid AND puzzle_date = CURRENT_DATE AND state = 'active')
+   ) THEN
+     RETURN jsonb_build_object('ok',false,'reason','in_game');
+   END IF;
+   v_cap := CASE WHEN v_kind = 'daily' THEN 5 ELSE 1 END;
+   SELECT COALESCE(qty,0) INTO v_owned FROM public.user_powerups_v2 WHERE user_id=v_uid AND powerup_id=p_id AND pool='cash';
+   IF COALESCE(v_owned,0) >= v_cap THEN RETURN jsonb_build_object('ok',false,'reason','owned'); END IF;
+   PERFORM public._ensure_bank(v_uid);
+   SELECT bank INTO v_cash FROM public.profiles WHERE id = v_uid;
+   IF v_cash < v_price THEN RETURN jsonb_build_object('ok',false,'reason','insufficient'); END IF;
+   PERFORM public._bank_credit(v_uid, -v_price, 'powerup_buy');
+   PERFORM public._award_powerup(v_uid, p_id, 'cash');
+   RETURN jsonb_build_object('ok',true);
+ END; $function$;

--- a/supabase-timed-engine.sql
+++ b/supabase-timed-engine.sql
@@ -1,0 +1,291 @@
+-- Timed challenges — clock enforcement + speed bonus (server engine)
+-- Task 8 of challenge batch 2. See docs/superpowers/specs/2026-07-17-timed-challenges.md
+--
+-- Touches four live functions; everything else is byte-identical to the dumped bodies:
+--   _match_tick                — authoritative clock enforcement (was a near no-op)
+--   _match_do_fold             — re-stamp puzzle_started_at on every advance
+--   _match_resolve_and_advance — re-stamp on advance + speed bonus in the WIN path
+--   _match_board               — expose clock config + anchors for the client countdown
+--
+-- Speed-bonus RATE = 3 points per leftover second (single tunable constant; see below).
+
+-- ---------------------------------------------------------------------------
+-- 1) _match_tick: enforce the clock.
+--    Re-entrancy note: _match_do_fold() calls _match_tick() at its top, so when
+--    WE invoke _match_do_fold() from here that nested tick must be a no-op (else
+--    it would re-detect the same expiry and recurse forever). A transaction-local
+--    GUC ('wordbank.match_tick_busy') guards that: while we drive the fold(s) the
+--    nested tick returns false, letting the real fold body run (which advances the
+--    position and re-stamps puzzle_started_at, breaking the recursion).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._match_tick(p_id uuid, p_uid uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_state text; v_i int;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN true; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  -- Re-entrant call (we are already inside our own fold loop): stand down so the
+  -- in-flight _match_do_fold() runs its real body instead of recursing.
+  IF current_setting('wordbank.match_tick_busy', true) = '1' THEN RETURN false; END IF;
+  -- Per-puzzle clock: the current puzzle's time is up -> force-fold it (advances or ends).
+  IF m.clock_mode = 'puzzle' AND cp.puzzle_started_at IS NOT NULL
+     AND EXTRACT(EPOCH FROM now() - cp.puzzle_started_at) > m.clock_seconds THEN
+    PERFORM set_config('wordbank.match_tick_busy', '1', true);
+    PERFORM public._match_do_fold(p_id, p_uid);
+    PERFORM set_config('wordbank.match_tick_busy', '0', true);
+    RETURN true;
+  -- Whole-match clock: the pack's total time is up -> fold every remaining puzzle
+  -- until this player is done (capped at pack_size iterations for safety).
+  ELSIF m.clock_mode = 'match' AND cp.started_at IS NOT NULL
+     AND EXTRACT(EPOCH FROM now() - cp.started_at) > m.clock_seconds THEN
+    PERFORM set_config('wordbank.match_tick_busy', '1', true);
+    FOR v_i IN 1 .. GREATEST(COALESCE(m.pack_size, 1), 1) LOOP
+      PERFORM public._match_do_fold(p_id, p_uid);
+      SELECT state INTO v_state FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+      EXIT WHEN v_state = 'done';
+    END LOOP;
+    PERFORM set_config('wordbank.match_tick_busy', '0', true);
+    RETURN true;
+  END IF;
+  RETURN false;
+END; $function$;
+
+-- ---------------------------------------------------------------------------
+-- 2) _match_do_fold: re-stamp puzzle_started_at = now() on every advance
+--    (both econ branches' non-final paths). 'done' branches don't re-stamp.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._match_do_fold(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare cp public.challenge_participants; m public.challenge_matches;
+  v_phrase text; v_charge bigint; v_left bigint; v_next_bounty int;
+begin
+  if p_uid is null then raise exception 'match_fold: not authenticated'; end if;
+  if public._match_tick(p_id, p_uid) then return public._match_board(p_id, p_uid); end if;
+  select * into cp from public.challenge_participants where match_id = p_id and user_id = p_uid for update;
+  if not found or cp.state <> 'active' then return public._match_board(p_id, p_uid); end if;
+  select * into m from public.challenge_matches where id = p_id;
+  -- full price of every still-unrevealed distinct letter (base cost), capped at remaining ante
+  select upper(phrase) into v_phrase from public.daily_puzzles where id = public._match_pid(p_id, cp.position);
+  select coalesce(sum(public.letter_cost(t.ch)), 0) into v_charge from (
+    select distinct substr(v_phrase, g.i+1, 1) as ch from generate_series(0, length(v_phrase)-1) g(i)
+    where substr(v_phrase, g.i+1, 1) ~ '[A-Z]' and not (g.i = any(cp.revealed_positions))
+  ) t;
+  v_charge := least(v_charge, cp.bankroll);
+  v_left := greatest(0, cp.bankroll - v_charge);
+
+  if m.econ_v = 2 then
+    -- Accumulate this puzzle's leftover; advance with a fresh bounty (mirrors the solve path).
+    if cp.position >= m.pack_size then
+      update public.challenge_participants
+        set state = 'done', bankroll = v_left, last_score = 0, total_score = total_score + v_left,
+            reveal_order = '{}',
+            finished_at = now(), joined_at = coalesce(joined_at, now())
+        where match_id = p_id and user_id = p_uid;
+      perform public._match_maybe_settle(p_id);
+      perform public._match_notify_opponent_played(p_id, p_uid);
+    else
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      update public.challenge_participants
+        set position = position + 1, bankroll = v_next_bounty,
+            start_budget = coalesce(start_budget, 0) + v_next_bounty,
+            last_score = 0, total_score = total_score + v_left,
+            revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+            reveal_order = '{}', sabotaged_targets = '{}',
+            fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+            p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0, puzzle_started_at = now()
+        where match_id = p_id and user_id = p_uid;
+    end if;
+    return public._match_board(p_id, p_uid);
+  end if;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = leftover.
+  if cp.position >= m.pack_size then
+    update public.challenge_participants
+      set state = 'done', bankroll = v_left, last_score = 0, total_score = v_left,
+          reveal_order = '{}',
+          finished_at = now(), joined_at = coalesce(joined_at, now())
+      where match_id = p_id and user_id = p_uid;
+    perform public._match_maybe_settle(p_id);
+  else
+    update public.challenge_participants
+      set position = position + 1, bankroll = v_left, last_score = 0, total_score = v_left,
+          revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+          reveal_order = '{}', sabotaged_targets = '{}',
+          fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+          p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0, puzzle_started_at = now()
+      where match_id = p_id and user_id = p_uid;
+  end if;
+  return public._match_board(p_id, p_uid);
+end; $function$;
+
+-- ---------------------------------------------------------------------------
+-- 3) _match_resolve_and_advance: re-stamp puzzle_started_at on advance +
+--    speed bonus (RATE=3 pts/leftover-sec) added onto the banked total_score
+--    in the WIN path when m.time_scores is on.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._match_resolve_and_advance(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_phrase TEXT; v_cat TEXT; v_won BOOLEAN;
+  v_score INT; v_combo INT; v_solved INT; v_budget BIGINT; v_next_bounty INT; v_bonus INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN public._match_board(p_id, p_uid); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_budget := GREATEST(COALESCE(m.wager,0), 500);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cp.revealed_positions)));
+  IF NOT v_won THEN RETURN public._match_board(p_id, p_uid); END IF;
+  IF COALESCE(m.wager,0) > 0 THEN PERFORM public._record_category_solve(p_uid, v_cat); END IF;  -- friendly (wager 0) earns no category credit
+  v_solved := cp.solved + 1;
+  -- Speed bonus: RATE = 3 points per leftover second (single tunable constant;
+  -- expect to re-tune after playtest). Only when time_scores is on; anchor is the
+  -- per-puzzle clock for 'puzzle', the whole-match clock for 'match' (earlier
+  -- solves bank more). Added on TOP of the kept bounty in every WIN UPDATE below.
+  v_bonus := 0;
+  IF COALESCE(m.time_scores, false) AND m.clock_seconds IS NOT NULL THEN
+    IF m.clock_mode = 'puzzle' AND cp.puzzle_started_at IS NOT NULL THEN
+      v_bonus := GREATEST(0, m.clock_seconds - EXTRACT(EPOCH FROM now() - cp.puzzle_started_at))::int * 3;
+    ELSIF m.clock_mode = 'match' AND cp.started_at IS NOT NULL THEN
+      v_bonus := GREATEST(0, m.clock_seconds - EXTRACT(EPOCH FROM now() - cp.started_at))::int * 3;
+    END IF;
+  END IF;
+  IF m.econ_v = 2 THEN
+    IF cp.position >= m.pack_size THEN
+      UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll + v_bonus, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+      WHERE match_id = p_id AND user_id = p_uid;
+      PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+    ELSE
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll + v_bonus, position = position + 1,
+        bankroll = v_next_bounty, start_budget = COALESCE(start_budget,0) + v_next_bounty,
+        revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+        reveal_order = '{}', sabotaged_targets = '{}',
+        fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+        p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0, puzzle_started_at = now()
+      WHERE match_id = p_id AND user_id = p_uid;
+    END IF;
+    RETURN public._match_board(p_id, p_uid);
+  END IF;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = bankroll.
+  IF cp.position >= m.pack_size THEN
+    UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+      total_score = cp.bankroll + v_bonus, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+    WHERE match_id = p_id AND user_id = p_uid;
+    PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+  ELSE
+    UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+      total_score = cp.bankroll + v_bonus, position = position + 1,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+      reveal_order = '{}', sabotaged_targets = '{}',
+      fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+      p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0, puzzle_started_at = now()
+    WHERE match_id = p_id AND user_id = p_uid;
+  END IF;
+  RETURN public._match_board(p_id, p_uid);
+END; $function$;
+
+-- ---------------------------------------------------------------------------
+-- 4) _match_board: expose clock config + anchors in v_minfo for the client
+--    countdown (purely additive: clock_mode, clock_seconds, time_scores,
+--    puzzle_started_at; started_at was already exposed).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT; v_cheapest INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  v_cheapest := public._match_cheapest(p_id, p_uid);  -- cheapest still-buyable effective cost (NULL if none)
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(CASE WHEN cp.vowel_block_left > 0 THEN array_append(COALESCE(cp.debuffs,'{}'), 'vowel_block') ELSE COALESCE(cp.debuffs,'{}') END), 'fog_buys_left', cp.fog_buys_left, 'vowel_block_left', cp.vowel_block_left,
+    'must_guess', (cp.state = 'active' AND (v_cheapest IS NULL OR v_cheapest > cp.bankroll)),
+    'started_at', cp.started_at,
+    'clock_mode', m.clock_mode, 'clock_seconds', m.clock_seconds, 'time_scores', m.time_scores, 'puzzle_started_at', cp.puzzle_started_at,
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id),
+        'position', o.position, 'pack_size', m.pack_size, 'can_fog', o.position < m.pack_size) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN cp.fog_buys_left > 0 THEN NULL ELSE v_clue END);
+END; $function$;

--- a/supabase-timed-schema.sql
+++ b/supabase-timed-schema.sql
@@ -1,0 +1,111 @@
+-- Timed challenges (Batch 2, Task 7): clock config columns + create_match/match_start wiring.
+-- Per docs/superpowers/specs/2026-07-17-timed-challenges.md
+-- Dump-transform-apply. create_match gains 3 trailing params -> DROP+CREATE (new signature).
+-- match_start keeps its signature -> CREATE OR REPLACE. Task-2 payout logic preserved byte-for-byte.
+
+BEGIN;
+
+-- 1) Match-level clock config.
+ALTER TABLE public.challenge_matches
+  ADD COLUMN IF NOT EXISTS clock_mode text NOT NULL DEFAULT 'none',
+  ADD COLUMN IF NOT EXISTS clock_seconds int,
+  ADD COLUMN IF NOT EXISTS time_scores boolean NOT NULL DEFAULT false;
+
+-- 2) Per-participant current-puzzle open time (per-puzzle clock anchor).
+ALTER TABLE public.challenge_participants
+  ADD COLUMN IF NOT EXISTS puzzle_started_at timestamptz;
+
+-- 3) create_match: add p_clock_mode/p_clock_seconds/p_time_scores (trailing, defaulted),
+--    normalize, and store on the inserted match. Everything else byte-identical to live.
+DROP FUNCTION IF EXISTS public.create_match(text, uuid, text[], integer, bigint, text, text, integer, boolean);
+
+CREATE OR REPLACE FUNCTION public.create_match(p_opponent text, p_group_id uuid, p_categories text[], p_pack_size integer, p_wager bigint, p_mode text, p_payout text, p_window_seconds integer, p_items_allowed boolean, p_clock_mode text DEFAULT 'none', p_clock_seconds integer DEFAULT NULL, p_time_scores boolean DEFAULT false)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare v_uid uuid := auth.uid(); v_id uuid; v_opp uuid; v_size int; v_wager bigint; v_mode text; v_payout text;
+  v_n int; v_budget bigint; v_cash bigint; v_uids uuid[]; r record;
+  v_clock_mode text; v_clock_seconds int; v_time_scores boolean;
+begin
+  if v_uid is null then return jsonb_build_object('ok',false,'reason','auth'); end if;
+  v_size := least(greatest(coalesce(p_pack_size,1),1),10);
+  v_wager := greatest(coalesce(p_wager,0),0);
+  if v_wager > 0 and v_wager < 500 then return jsonb_build_object('ok',false,'reason','min_wager'); end if;
+  v_mode := 'standard';  -- Blitz retired; all matches are standard
+  -- Clock config: only 'puzzle'|'match' are live clocks; anything else is 'none' (no limit).
+  v_clock_mode := case when p_clock_mode in ('puzzle','match') then p_clock_mode else 'none' end;
+  v_clock_seconds := case when v_clock_mode = 'none' then null
+                          else nullif(greatest(coalesce(p_clock_seconds,0),0),0) end;
+  if v_clock_seconds is null then v_clock_mode := 'none'; end if;
+  v_time_scores := (v_clock_mode <> 'none') and coalesce(p_time_scores,false);
+  if p_group_id is not null then
+    if not exists (select 1 from public.group_members where group_id = p_group_id and user_id = v_uid) then
+      return jsonb_build_object('ok',false,'reason','not_member'); end if;
+    select array_agg(user_id) into v_uids from public.group_members where group_id = p_group_id;
+  else
+    select id into v_opp from public.profiles where lower(username) = lower(trim(coalesce(p_opponent,'')));
+    if v_opp is null then return jsonb_build_object('ok',false,'reason','no_opponent'); end if;
+    if v_opp = v_uid then return jsonb_build_object('ok',false,'reason','self'); end if;
+    v_uids := array[v_uid, v_opp];
+  end if;
+  -- Payout: honor an explicit creator choice; else default by field size for back-compat
+  -- (1v1 -> winner-take-all, group -> top-finishers split). Settle respects this value.
+  v_payout := case when p_payout in ('winner','podium') then p_payout
+                   when coalesce(array_length(v_uids,1),0) <= 2 then 'winner'
+                   else 'podium' end;
+  if v_wager > 0 then
+    perform public._ensure_bank(v_uid);
+    select bank into v_cash from public.profiles where id = v_uid;
+    if v_cash < v_wager then return jsonb_build_object('ok',false,'reason','insufficient'); end if;
+    perform public._bank_credit(v_uid, -v_wager, 'wager_stake');
+  end if;
+  insert into public.challenge_matches(host_id, group_id, mode, categories, pack_size, wager, payout, settles_at, items_allowed, econ_v, clock_mode, clock_seconds, time_scores)
+  values (v_uid, p_group_id, v_mode, coalesce(p_categories,'{}'), v_size, v_wager, v_payout, now() + (least(greatest(coalesce(p_window_seconds,172800),3600),604800) || ' seconds')::interval, coalesce(p_items_allowed,false), 2, v_clock_mode, v_clock_seconds, v_time_scores)
+  returning id into v_id;
+  insert into public.challenge_pack(match_id, position, puzzle_id)
+  select v_id, row_number() over (), pid
+  from public._pick_casual_pack(v_uids, coalesce(p_categories,'{}'), v_size, 8) pid;
+  select count(*) into v_n from public.challenge_pack where match_id = v_id;
+  if v_n = 0 then return jsonb_build_object('ok',false,'reason','no_puzzles'); end if;
+  -- NEW: budget = puzzle-1 bounty (standardized), not GREATEST(wager,500).
+  v_budget := public._match_pos_bounty(v_id, 1);
+  insert into public.challenge_participants(match_id, user_id, paid, state, joined_at, bankroll, start_budget, stake)
+  values (v_id, v_uid, v_wager > 0, 'active', now(), v_budget, v_budget, v_wager);
+  perform public._mark_seen_many(v_uid, (select array_agg(puzzle_id) from public.challenge_pack where match_id = v_id));
+  if p_group_id is not null then
+    for r in select user_id from public.group_members where group_id = p_group_id and user_id <> v_uid loop
+      insert into public.challenge_participants(match_id, user_id) values (v_id, r.user_id) on conflict do nothing;
+      perform public._notify(r.user_id, 'challenge_incoming', 'Group challenge',
+        public._display_name(v_uid) || ' challenged your group' || case when v_wager>0 then ' — $' || v_wager else '' end,
+        jsonb_build_object('match_id', v_id));
+    end loop;
+  else
+    insert into public.challenge_participants(match_id, user_id) values (v_id, v_opp);
+    perform public._notify(v_opp, 'challenge_incoming', 'New challenge',
+      public._display_name(v_uid) || ' challenged you — ' || v_n || ' puzzle' || case when v_n=1 then '' else 's' end ||
+      case when v_wager>0 then ' · $' || v_wager else '' end, jsonb_build_object('match_id', v_id, 'route','challenge'));
+  end if;
+  return jsonb_build_object('ok',true, 'match', public.get_match(v_id));
+end; $function$;
+
+-- 4) match_start: stamp puzzle_started_at (per-puzzle clock anchor) alongside started_at.
+CREATE OR REPLACE FUNCTION public.match_start(p_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; m public.challenge_matches;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_start: not authenticated'; END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid;
+  IF NOT FOUND THEN RAISE EXCEPTION 'match_start: not a participant'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  UPDATE public.challenge_participants SET started_at = COALESCE(started_at, now()), puzzle_started_at = COALESCE(puzzle_started_at, now()) WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;
+
+-- Refresh PostgREST schema cache (create_match signature changed).
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase-vowel-block-buys.sql
+++ b/supabase-vowel-block-buys.sql
@@ -1,0 +1,376 @@
+-- Challenge Batch 2 — Task 1: Vowel Block lasts 3 buys (down from whole-puzzle)
+--
+-- Mirrors the proven Fog mechanism (fog_buys_left): a per-target buy-counter on
+-- challenge_participants that ticks down on every purchase and resets on advance,
+-- instead of a persistent entry in debuffs[] consumed forever.
+--
+-- Live bodies were dumped via pg_get_functiondef and kept byte-identical except
+-- the enumerated edits below. Consumers of the old `'vowel_block' = ANY(debuffs)`
+-- path are: match_buy_letter (cost stack), match_sabotage (applies it), and
+-- _match_cheapest (must_guess vowel x3 estimate) — all three updated to read the
+-- new counter. _match_board synthesizes 'vowel_block' into my_debuffs so the
+-- client Keyboard.svelte vowel x3 display is unchanged. Reset added to the
+-- per-puzzle advance branches of _match_resolve_and_advance and _match_do_fold
+-- (plain = 0, no carry-across; unlike fog there is no pending seed).
+
+BEGIN;
+
+-- 1. Per-participant buy counter (mirrors fog_buys_left).
+ALTER TABLE public.challenge_participants
+  ADD COLUMN IF NOT EXISTS vowel_block_left int NOT NULL DEFAULT 0;
+
+-- 2. match_sabotage: split vowel_block out of the debuffs[] ELSE branch into its
+--    own ELSIF (like fog) — set vowel_block_left = 3 on the target, NOT debuffs[].
+CREATE OR REPLACE FUNCTION public.match_sabotage(p_id uuid, p_target uuid, p_powerup text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); m public.challenge_matches; v_debuff TEXT; v_name TEXT; v_qty INT; v_tstate TEXT;
+  tcp public.challenge_participants; v_phrase TEXT; v_lockletter TEXT;
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_sabotage: not authenticated'; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  IF NOT FOUND OR NOT COALESCE(m.items_allowed,false) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF p_target = v_uid THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT effect_key, name INTO v_debuff, v_name FROM public.powerups WHERE id = p_powerup AND kind = 'sabotage' AND active;
+  IF v_debuff IS NULL THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid AND state = 'active') THEN
+    RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT * INTO tcp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_target;
+  IF tcp.user_id IS NULL OR tcp.state NOT IN ('active','invited') THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT qty INTO v_qty FROM public.user_powerups_v2 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+  IF COALESCE(v_qty,0) <= 0 THEN RETURN public._match_board(p_id, v_uid); END IF;
+  -- One sabotage per opponent per puzzle: reject a repeat against the same
+  -- target this puzzle (before decrement / effect, so it never charges).
+  IF p_target = ANY(COALESCE((SELECT sabotaged_targets FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid), '{}'::uuid[])) THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','already_sabotaged');
+  END IF;
+  -- Fog lands on the target's NEXT puzzle; reject (WITHOUT consuming the item) if
+  -- they have no un-started next puzzle. Validate before decrementing inventory.
+  IF v_debuff = 'fog' AND tcp.position >= m.pack_size THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','no_next_puzzle');
+  END IF;
+  -- Erase with nothing revealed: reject (WITHOUT consuming the item) so we never charge for
+  -- a no-op or fire a false "they wiped your letter" notify. Validate before the decrement.
+  IF v_debuff = 'lock' AND COALESCE(array_length(tcp.reveal_order,1),0) = 0 THEN
+    RETURN public._match_board(p_id, v_uid) || jsonb_build_object('sabotage_reason','nothing_to_erase');
+  END IF;
+  UPDATE public.user_powerups_v2 SET qty = qty - 1 WHERE user_id = v_uid AND powerup_id = p_powerup AND pool = 'cash';
+
+  IF v_debuff = 'lock' THEN
+    SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, tcp.position);
+    v_lockletter := tcp.reveal_order[array_length(tcp.reveal_order,1)];  -- most recently revealed
+    IF v_lockletter IS NOT NULL THEN
+      UPDATE public.challenge_participants SET
+        revealed_positions = ARRAY(SELECT DISTINCT p FROM unnest(revealed_positions) p WHERE substr(v_phrase, p+1, 1) <> v_lockletter ORDER BY 1),
+        reveal_order = reveal_order[1:array_length(reveal_order,1)-1]
+      WHERE match_id = p_id AND user_id = p_target;
+    END IF;
+  ELSIF v_debuff = 'fog' THEN
+    UPDATE public.challenge_participants SET pending_fog = true WHERE match_id = p_id AND user_id = p_target;
+  ELSIF v_debuff = 'vowel_block' THEN
+    UPDATE public.challenge_participants SET vowel_block_left = 3 WHERE match_id = p_id AND user_id = p_target;
+  ELSE
+    UPDATE public.challenge_participants SET
+      debuffs = (SELECT ARRAY(SELECT DISTINCT unnest(COALESCE(debuffs,'{}') || ARRAY[v_debuff]))),
+      debuff_by = COALESCE(debuff_by, '{}'::jsonb) || jsonb_build_object(v_debuff, v_uid::text)
+    WHERE match_id = p_id AND user_id = p_target;
+  END IF;
+
+  PERFORM public._notify(p_target, 'sabotaged', '💥 You got hit!',
+    public._display_name(v_uid) || ' hit you with ' || COALESCE(v_name,'a sabotage') ||
+    CASE v_debuff WHEN 'tax' THEN ' — your letters cost +50%' WHEN 'fog' THEN ' — your next puzzle starts foggy'
+      WHEN 'toll' THEN ' — your next letter costs 3×' WHEN 'vowel_block' THEN ' — your vowels cost 3×'
+      WHEN 'lock' THEN COALESCE(' — they wiped your ' || v_lockletter || 's', ' — a revealed letter is gone') ELSE '' END,
+    jsonb_build_object('match_id', p_id));
+  -- Record the sabotage against this opponent (success paths only). Resets on
+  -- the attacker's own advance (Task 1). Placed after all early-returns so a
+  -- rejected fog/erase never burns the per-opponent slot.
+  UPDATE public.challenge_participants SET sabotaged_targets = array_append(sabotaged_targets, p_target)
+    WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_board(p_id, v_uid);
+END; $function$;
+
+-- 3. match_buy_letter: trigger vowel x3 off vowel_block_left; decrement on every buy.
+CREATE OR REPLACE FUNCTION public.match_buy_letter(p_id uuid, p_letter text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE v_uid UUID := auth.uid(); cp public.challenge_participants; v_phrase TEXT; v_letter TEXT; v_cost INT; v_positions INT[]; v_debuffs text[];
+BEGIN
+  IF v_uid IS NULL THEN RAISE EXCEPTION 'match_buy_letter: not authenticated'; END IF;
+  IF public._match_tick(p_id, v_uid) THEN RETURN public._match_board(p_id, v_uid); END IF;
+  v_letter := upper(p_letter); v_cost := public.letter_cost(v_letter);
+  IF v_cost IS NULL THEN RAISE EXCEPTION 'match_buy_letter: invalid letter'; END IF;
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = v_uid FOR UPDATE;
+  IF NOT FOUND OR cp.state <> 'active' THEN RETURN public._match_board(p_id, v_uid); END IF;
+  v_debuffs := COALESCE(cp.debuffs, '{}');
+  IF 'half_off' = ANY(cp.active_powerups) THEN v_cost := CEIL(v_cost * 0.5)::int; END IF;
+  IF 'tax' = ANY(v_debuffs) THEN v_cost := CEIL(v_cost * 1.5)::int; END IF;
+  IF v_letter IN ('A','E','I','O','U') AND cp.vowel_block_left > 0 THEN v_cost := v_cost * 3; END IF;
+  IF 'toll' = ANY(v_debuffs) THEN v_cost := v_cost * 3; v_debuffs := array_remove(v_debuffs, 'toll'); END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  IF v_letter = ANY(cp.incorrect_letters) OR cp.bankroll < v_cost THEN RETURN public._match_board(p_id, v_uid); END IF;
+  SELECT array_agg(g.i) INTO v_positions FROM generate_series(0, length(v_phrase)-1) g(i) WHERE substr(v_phrase, g.i+1,1) = v_letter;
+  IF v_positions IS NOT NULL AND v_positions <@ cp.revealed_positions THEN RETURN public._match_board(p_id, v_uid); END IF;
+  IF v_letter IN ('A','E','I','O','U') THEN cp.p_vowels := cp.p_vowels + 1; END IF;
+  IF v_positions IS NULL THEN cp.incorrect_letters := array_append(cp.incorrect_letters, v_letter);
+  ELSE cp.revealed_positions := ARRAY(SELECT DISTINCT unnest(cp.revealed_positions || v_positions) ORDER BY 1);
+    cp.reveal_order := CASE WHEN v_letter = ANY(cp.reveal_order) THEN cp.reveal_order ELSE array_append(cp.reveal_order, v_letter) END; END IF;
+  UPDATE public.challenge_participants SET bankroll = cp.bankroll - v_cost, incorrect_letters = cp.incorrect_letters,
+    revealed_positions = cp.revealed_positions, reveal_order = cp.reveal_order, p_vowels = cp.p_vowels, debuffs = v_debuffs,
+    fog_buys_left = GREATEST(0, cp.fog_buys_left - 1), vowel_block_left = GREATEST(0, cp.vowel_block_left - 1) WHERE match_id = p_id AND user_id = v_uid;
+  RETURN public._match_resolve_and_advance(p_id, v_uid);
+END; $function$;
+
+-- 4. _match_cheapest: must_guess vowel x3 estimate now reads the counter.
+CREATE OR REPLACE FUNCTION public._match_cheapest(p_id uuid, p_uid uuid)
+ RETURNS integer
+ LANGUAGE plpgsql
+ STABLE
+AS $function$
+DECLARE cp public.challenge_participants; v_phrase text; v_half boolean; v_tax boolean; v_vblock boolean;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT upper(phrase) INTO v_phrase FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  IF v_phrase IS NULL THEN RETURN NULL; END IF;
+  v_half   := 'half_off'    = ANY(COALESCE(cp.active_powerups,'{}'));
+  v_tax    := 'tax'         = ANY(COALESCE(cp.debuffs,'{}'));
+  v_vblock := cp.vowel_block_left > 0;
+  RETURN (
+    SELECT MIN(CASE WHEN x.is_vowel AND v_vblock THEN x.c2 * 3 ELSE x.c2 END)
+    FROM (
+      SELECT (t.ch IN ('A','E','I','O','U')) AS is_vowel,
+             CASE WHEN v_tax THEN CEIL(c1.base_half * 1.5)::int ELSE c1.base_half END AS c2
+      FROM (
+        SELECT DISTINCT substr(v_phrase, g.i+1, 1) AS ch
+        FROM generate_series(0, length(v_phrase)-1) g(i)
+        WHERE substr(v_phrase, g.i+1, 1) ~ '[A-Z]'
+          AND NOT (g.i = ANY(cp.revealed_positions))
+      ) t
+      CROSS JOIN LATERAL (
+        SELECT CASE WHEN v_half THEN CEIL(public.letter_cost(t.ch) * 0.5)::int ELSE public.letter_cost(t.ch) END AS base_half
+      ) c1
+      WHERE NOT (t.ch = ANY(COALESCE(cp.incorrect_letters,'{}')))
+    ) x
+  );
+END; $function$;
+
+-- 5. _match_board: synthesize 'vowel_block' into my_debuffs while active so the
+--    client Keyboard vowel x3 display is unchanged; also expose vowel_block_left.
+CREATE OR REPLACE FUNCTION public._match_board(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_pid UUID; v_phrase TEXT; v_cat TEXT; v_sub TEXT; v_clue TEXT; v_board JSONB; v_minfo JSONB; v_budget BIGINT; v_default_budget BIGINT;
+  v_standing JSONB := NULL; v_field INT; v_finished INT; v_my_spent BIGINT; v_best_spent BIGINT; v_best_total BIGINT; v_ahead INT; v_state TEXT; v_rank INT;
+  v_pay_places INT; v_fin_count INT; v_target BIGINT; v_target_kind TEXT; v_cheapest INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF NOT FOUND THEN RETURN NULL; END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_default_budget := GREATEST(COALESCE(m.wager,0), 500);
+  v_budget := CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, cp.position)
+                   ELSE COALESCE(cp.start_budget, v_default_budget) END;  -- MY per-puzzle budget
+  v_cheapest := public._match_cheapest(p_id, p_uid);  -- cheapest still-buyable effective cost (NULL if none)
+  -- Podium-aware target: the Score to beat to reach a PAYING place (or to win).
+  v_field := (SELECT count(*) FROM public.challenge_participants WHERE match_id = p_id);
+  v_pay_places := CASE WHEN m.payout = 'podium' AND v_field >= 4 THEN 3
+                       WHEN m.payout = 'podium' AND v_field = 3 THEN 2 ELSE 1 END;
+  v_fin_count := (SELECT count(*) FROM public.challenge_participants
+                  WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+  IF v_fin_count = 0 THEN
+    v_target := NULL; v_target_kind := NULL;
+  ELSIF v_fin_count >= v_pay_places THEN
+    v_target := (SELECT min(q.ts) FROM (SELECT total_score ts FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done'
+                 ORDER BY total_score DESC LIMIT v_pay_places) q);
+    v_target_kind := CASE WHEN v_pay_places = 1 THEN 'win' ELSE 'place' END;
+  ELSE
+    v_target := (SELECT max(total_score) FROM public.challenge_participants
+                 WHERE match_id = p_id AND user_id <> p_uid AND state = 'done');
+    v_target_kind := 'win';
+  END IF;
+  v_minfo := jsonb_build_object('pack_size', m.pack_size, 'mode', m.mode, 'total_score', cp.total_score,
+    'last_score', cp.last_score, 'position', cp.position, 'done', cp.state = 'done', 'status', m.status,
+    'solved', cp.solved, 'spent', GREATEST(0, v_budget - cp.bankroll), 'budget', v_budget, 'wager', m.wager,
+    'pot', (SELECT m.wager * count(*) FROM public.challenge_participants WHERE match_id = p_id AND state <> 'declined'),
+    'target', v_target, 'target_kind', v_target_kind,
+    'items_allowed', COALESCE(m.items_allowed,false), 'used_powerups', to_jsonb(cp.active_powerups),
+    'my_debuffs', to_jsonb(CASE WHEN cp.vowel_block_left > 0 THEN array_append(COALESCE(cp.debuffs,'{}'), 'vowel_block') ELSE COALESCE(cp.debuffs,'{}') END), 'fog_buys_left', cp.fog_buys_left, 'vowel_block_left', cp.vowel_block_left,
+    'must_guess', (cp.state = 'active' AND (v_cheapest IS NULL OR v_cheapest > cp.bankroll)),
+    'started_at', cp.started_at,
+    'opponents', (SELECT COALESCE(jsonb_agg(jsonb_build_object('id', o.user_id, 'name', public._display_name(o.user_id),
+        'position', o.position, 'pack_size', m.pack_size, 'can_fog', o.position < m.pack_size) ORDER BY o.joined_at NULLS LAST), '[]'::jsonb)
+      FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state IN ('active','invited')));
+  IF cp.state = 'done' THEN RETURN jsonb_build_object('match', v_minfo); END IF;
+
+  IF m.status = 'open' THEN
+    SELECT count(*) INTO v_field FROM public.challenge_participants WHERE match_id = p_id;
+    SELECT count(*) INTO v_finished FROM public.challenge_participants WHERE match_id = p_id AND user_id <> p_uid AND state = 'done';
+    IF m.pack_size = 1 THEN
+      v_my_spent := GREATEST(0, v_budget - cp.bankroll);
+      SELECT min(GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll)) INTO v_best_spent
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1;
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.solved >= 1
+          AND GREATEST(0, (CASE WHEN m.econ_v = 2 THEN public._match_pos_bounty(p_id, o.position) ELSE COALESCE(o.start_budget, v_default_budget) END) - o.bankroll) < v_my_spent;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF v_best_spent IS NULL THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent < v_best_spent THEN v_state := 'lead'; v_rank := 1;
+      ELSIF v_my_spent = v_best_spent THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state);
+    ELSE
+      SELECT max(o.total_score) INTO v_best_total
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done';
+      SELECT count(*) INTO v_ahead
+        FROM public.challenge_participants o WHERE o.match_id = p_id AND o.user_id <> p_uid AND o.state = 'done' AND o.total_score > cp.total_score;
+      IF v_finished = 0 THEN v_state := 'first_to_play'; v_rank := 1;
+      ELSIF cp.total_score > v_best_total THEN v_state := 'lead'; v_rank := 1;
+      ELSIF cp.total_score = v_best_total THEN v_state := 'tied'; v_rank := v_ahead + 1;
+      ELSE v_state := 'behind'; v_rank := v_ahead + 1;
+      END IF;
+      v_standing := jsonb_build_object('field_size', v_field, 'finished', v_finished, 'rank', v_rank, 'state', v_state, 'provisional', true);
+    END IF;
+  END IF;
+
+  v_pid := public._match_pid(p_id, cp.position);
+  SELECT upper(phrase), category, COALESCE(subcategory,''), clue INTO v_phrase, v_cat, v_sub, v_clue FROM public.daily_puzzles WHERE id = v_pid;
+  v_board := public._daily_board(v_phrase, 'active', cp.bankroll, cp.guesses_remaining, cp.revealed_positions, cp.incorrect_letters, v_cat, v_sub);
+  RETURN v_board || jsonb_build_object('match', v_minfo, 'standing', v_standing,
+    'clue', CASE WHEN cp.fog_buys_left > 0 THEN NULL ELSE v_clue END);
+END; $function$;
+
+-- 6. _match_resolve_and_advance: reset vowel_block_left = 0 on both per-puzzle
+--    advance branches (no carry-across; plain reset alongside fog_buys_left).
+CREATE OR REPLACE FUNCTION public._match_resolve_and_advance(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+DECLARE cp public.challenge_participants; m public.challenge_matches; v_phrase TEXT; v_cat TEXT; v_won BOOLEAN;
+  v_score INT; v_combo INT; v_solved INT; v_budget BIGINT; v_next_bounty INT;
+BEGIN
+  SELECT * INTO cp FROM public.challenge_participants WHERE match_id = p_id AND user_id = p_uid;
+  IF cp.state <> 'active' THEN RETURN public._match_board(p_id, p_uid); END IF;
+  SELECT * INTO m FROM public.challenge_matches WHERE id = p_id;
+  v_budget := GREATEST(COALESCE(m.wager,0), 500);
+  SELECT upper(phrase), category INTO v_phrase, v_cat FROM public.daily_puzzles WHERE id = public._match_pid(p_id, cp.position);
+  v_won := NOT EXISTS (SELECT 1 FROM generate_series(0, length(v_phrase)-1) g(i)
+    WHERE substr(v_phrase, g.i+1, 1) <> ' ' AND NOT (g.i = ANY(cp.revealed_positions)));
+  IF NOT v_won THEN RETURN public._match_board(p_id, p_uid); END IF;
+  IF COALESCE(m.wager,0) > 0 THEN PERFORM public._record_category_solve(p_uid, v_cat); END IF;  -- friendly (wager 0) earns no category credit
+  v_solved := cp.solved + 1;
+  IF m.econ_v = 2 THEN
+    IF cp.position >= m.pack_size THEN
+      UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+      WHERE match_id = p_id AND user_id = p_uid;
+      PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+    ELSE
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+        total_score = total_score + cp.bankroll, position = position + 1,
+        bankroll = v_next_bounty, start_budget = COALESCE(start_budget,0) + v_next_bounty,
+        revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+        reveal_order = '{}', sabotaged_targets = '{}',
+        fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+        p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      WHERE match_id = p_id AND user_id = p_uid;
+    END IF;
+    RETURN public._match_board(p_id, p_uid);
+  END IF;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = bankroll.
+  IF cp.position >= m.pack_size THEN
+    UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+      total_score = cp.bankroll, state = 'done', finished_at = now(), joined_at = COALESCE(joined_at, now())
+    WHERE match_id = p_id AND user_id = p_uid;
+    PERFORM public._match_maybe_settle(p_id); PERFORM public._match_notify_opponent_played(p_id, p_uid);
+  ELSE
+    UPDATE public.challenge_participants SET solved = v_solved, solved_positions = array_append(solved_positions, cp.position), last_score = cp.bankroll,
+      total_score = cp.bankroll, position = position + 1,
+      revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+      reveal_order = '{}', sabotaged_targets = '{}',
+      fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+      p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+    WHERE match_id = p_id AND user_id = p_uid;
+  END IF;
+  RETURN public._match_board(p_id, p_uid);
+END; $function$;
+
+-- 7. _match_do_fold: reset vowel_block_left = 0 on both per-puzzle advance branches.
+CREATE OR REPLACE FUNCTION public._match_do_fold(p_id uuid, p_uid uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+AS $function$
+declare cp public.challenge_participants; m public.challenge_matches;
+  v_phrase text; v_charge bigint; v_left bigint; v_next_bounty int;
+begin
+  if p_uid is null then raise exception 'match_fold: not authenticated'; end if;
+  if public._match_tick(p_id, p_uid) then return public._match_board(p_id, p_uid); end if;
+  select * into cp from public.challenge_participants where match_id = p_id and user_id = p_uid for update;
+  if not found or cp.state <> 'active' then return public._match_board(p_id, p_uid); end if;
+  select * into m from public.challenge_matches where id = p_id;
+  -- full price of every still-unrevealed distinct letter (base cost), capped at remaining ante
+  select upper(phrase) into v_phrase from public.daily_puzzles where id = public._match_pid(p_id, cp.position);
+  select coalesce(sum(public.letter_cost(t.ch)), 0) into v_charge from (
+    select distinct substr(v_phrase, g.i+1, 1) as ch from generate_series(0, length(v_phrase)-1) g(i)
+    where substr(v_phrase, g.i+1, 1) ~ '[A-Z]' and not (g.i = any(cp.revealed_positions))
+  ) t;
+  v_charge := least(v_charge, cp.bankroll);
+  v_left := greatest(0, cp.bankroll - v_charge);
+
+  if m.econ_v = 2 then
+    -- Accumulate this puzzle's leftover; advance with a fresh bounty (mirrors the solve path).
+    if cp.position >= m.pack_size then
+      update public.challenge_participants
+        set state = 'done', bankroll = v_left, last_score = 0, total_score = total_score + v_left,
+            reveal_order = '{}',
+            finished_at = now(), joined_at = coalesce(joined_at, now())
+        where match_id = p_id and user_id = p_uid;
+      perform public._match_maybe_settle(p_id);
+      perform public._match_notify_opponent_played(p_id, p_uid);
+    else
+      v_next_bounty := public._match_pos_bounty(p_id, cp.position + 1);
+      update public.challenge_participants
+        set position = position + 1, bankroll = v_next_bounty,
+            start_budget = coalesce(start_budget, 0) + v_next_bounty,
+            last_score = 0, total_score = total_score + v_left,
+            revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+            reveal_order = '{}', sabotaged_targets = '{}',
+            fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+            p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+        where match_id = p_id and user_id = p_uid;
+    end if;
+    return public._match_board(p_id, p_uid);
+  end if;
+
+  -- OLD (econ_v NULL): rank by Cash left; single carried budget, total_score = leftover.
+  if cp.position >= m.pack_size then
+    update public.challenge_participants
+      set state = 'done', bankroll = v_left, last_score = 0, total_score = v_left,
+          reveal_order = '{}',
+          finished_at = now(), joined_at = coalesce(joined_at, now())
+      where match_id = p_id and user_id = p_uid;
+    perform public._match_maybe_settle(p_id);
+  else
+    update public.challenge_participants
+      set position = position + 1, bankroll = v_left, last_score = 0, total_score = v_left,
+          revealed_positions = '{}', incorrect_letters = '{}', active_powerups = '{}', debuffs = '{}',
+          reveal_order = '{}', sabotaged_targets = '{}',
+          fog_buys_left = CASE WHEN pending_fog THEN 3 ELSE 0 END, pending_fog = false, vowel_block_left = 0,
+          p_vowels = 0, p_reveals = 0, p_wrong_guesses = 0
+      where match_id = p_id and user_id = p_uid;
+  end if;
+  return public._match_board(p_id, p_uid);
+end; $function$;
+
+COMMIT;


### PR DESCRIPTION
Seven features from the design discussion. All server SQL applied to prod via rollback-tested migrations; this PR brings the client. Specs/plans in docs/superpowers/2026-07-16 & 2026-07-17.

## Features
1. **Timed challenges** (configurable): creator picks a clock — **none / per-puzzle / whole-match** — and whether **time affects score** (speed bonus, RATE 3 pts/leftover-sec). `_match_tick` auto-folds on expiry (recursion-guarded, iteration-capped); in-match countdown drives the danger cue and pokes the server at 0. Same for 1v1 and group.
2. **Payout choice:** group creator picks **Winner-take-all** vs **Top-finishers-split**; `_match_settle` honors it (money math byte-identical outside the one CASE arm).
3. **Vowel Block → lasts 3 buys** (down from whole-puzzle ×3) — mirrors the Fog counter.
4. **Store gate:** `buy_powerup` blocks gameplay items (power-ups/sabotages) while a Cash Game / Daily / challenge is active — patches a live "shop your way out of a bust" hole. Cosmetics unaffected.
5. **Realtime social:** friend-request "Pending" flips to accepted live; a friend-request notification self-clears when you act on it (Supabase Realtime + a missing self-SELECT RLS policy added).
6. **"Added to a group" notification.**
7. **Collapsible "My Items"** in the profile.

## Verification
- Every server task rollback-tested (BEGIN…ROLLBACK on seeded data) before prod apply; final whole-branch review verified the **composed live state** of all multiply-edited functions (create_match, _match_resolve_and_advance, _match_do_fold, _match_tick, _match_settle) — no task reverted another's field.
- **Live E2E**: both players' real 30s per-puzzle clocks expired and auto-folded mid-run; speed bonus banked (+75 = 25s×3); payout paid the full pot; store-gate + vowel-block confirmed.
- `svelte-check` clean (no new errors); build passes. Match-scoped — Daily / Cash Game / Free Play unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)