### PR TITLE
Fix iOS push delivery: hung dynamic import + missing APNs forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ scripts/check-nav.mjs
 *.mobileprovision
 # Local scratch folder (music, images, old backend) — not part of the app
 Wordbank Stuff/
+.env*
+!.env.example
+# Session scratch
+scratchpad/

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wordbank.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
@@ -328,6 +329,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wordbank.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App/App.entitlements
+++ b/ios/App/App/App.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -33,6 +33,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
+    // APNs -> Capacitor bridge. REQUIRED for push: PushNotifications.register() asks iOS for a
+    // token, iOS answers here, and nothing reaches the plugin unless we forward it. Without
+    // these two methods the JS 'registration' event never fires and no token is ever saved.
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+    }
+
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -12,7 +12,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.1"),
-        .package(name: "CapacitorHaptics", path: "../../../node_modules/@capacitor/haptics")
+        .package(name: "CapacitorHaptics", path: "../../../node_modules/@capacitor/haptics"),
+        .package(name: "CapacitorPushNotifications", path: "../../../node_modules/@capacitor/push-notifications")
     ],
     targets: [
         .target(
@@ -20,7 +21,8 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "CapacitorHaptics", package: "CapacitorHaptics")
+                .product(name: "CapacitorHaptics", package: "CapacitorHaptics"),
+                .product(name: "CapacitorPushNotifications", package: "CapacitorPushNotifications")
             ]
         )
     ]

--- a/src/lib/push.js
+++ b/src/lib/push.js
@@ -106,14 +106,21 @@ export async function requestPushPermission() {
 }
 
 /** Current permission state, for rendering the Settings toggle.
- * @returns {Promise<'granted'|'denied'|'prompt'|'prompt-with-rationale'|'unsupported'>} */
+ * TEMP DIAGNOSTIC: returns a descriptive reason instead of swallowing failures, so we can
+ * see WHY the toggle hides. Reverted once the root cause is known.
+ * @returns {Promise<string>} */
 export async function pushStatus() {
-	if (!isNative()) return 'unsupported';
+	if (!browser) return 'nobrowser';
 	try {
+		const nat = Capacitor?.isNativePlatform?.();
+		const plat = Capacitor?.getPlatform?.();
+		if (nat !== true) return 'notnative(' + String(nat) + '/' + String(plat) + ')';
 		const PushNotifications = await plugin();
-		return (await PushNotifications.checkPermissions()).receive;
-	} catch {
-		return 'unsupported';
+		if (!PushNotifications) return 'noplugin';
+		const r = await PushNotifications.checkPermissions();
+		return String(r?.receive ?? 'noreceive');
+	} catch (/** @type {any} */ e) {
+		return 'err:' + String((e && e.message) || e).slice(0, 45);
 	}
 }
 

--- a/src/lib/push.js
+++ b/src/lib/push.js
@@ -8,17 +8,19 @@
 // `requestPushPermission()` is the one that prompts, and it's called from a deliberate,
 // high-intent moment (the primer after a first challenge, or the Settings toggle).
 import { Capacitor } from '@capacitor/core';
+import { PushNotifications } from '@capacitor/push-notifications';
 import { browser } from '$app/environment';
 import { supabase } from '$lib/supabaseClient.js';
 import { goto } from '$app/navigation';
 
 const isNative = () => browser && Capacitor?.isNativePlatform?.() === true;
 
-/** Lazily import so the web bundle never touches the native plugin. */
-async function plugin() {
-	const { PushNotifications } = await import('@capacitor/push-notifications');
-	return PushNotifications;
-}
+// NOTE: import this plugin STATICALLY, exactly like @capacitor/haptics.
+// A dynamic import() here hangs forever inside the iOS WKWebView: Vite wraps it in
+// __vitePreload, which injects <link rel="modulepreload"> elements and awaits their
+// load/error events — and WKWebView fires neither, so the promise never settles and
+// push silently does nothing. The module is ~100 bytes and is inert on the web (it
+// only calls registerPlugin), so there is nothing to lazy-load anyway.
 
 let wired = false;
 
@@ -52,7 +54,6 @@ function routeFor(data) {
 async function wireListeners() {
 	if (wired) return;
 	wired = true;
-	const PushNotifications = await plugin();
 
 	await PushNotifications.addListener('registration', (t) => {
 		if (t?.value) saveToken(t.value);
@@ -74,7 +75,6 @@ async function wireListeners() {
 export async function initPush() {
 	if (!isNative()) return 'unsupported';
 	try {
-		const PushNotifications = await plugin();
 		const perm = await PushNotifications.checkPermissions();
 		if (perm.receive !== 'granted') return perm.receive; // 'prompt' | 'denied'
 		await wireListeners();
@@ -93,7 +93,6 @@ export async function initPush() {
 export async function requestPushPermission() {
 	if (!isNative()) return false;
 	try {
-		const PushNotifications = await plugin();
 		const res = await PushNotifications.requestPermissions();
 		if (res.receive !== 'granted') return false;
 		await wireListeners();
@@ -105,44 +104,18 @@ export async function requestPushPermission() {
 	}
 }
 
-/** Reject/settle a promise that may never settle, so a hang reports itself instead of
- * leaving the caller waiting forever.
- * @template T @param {Promise<T>} p @param {number} ms @param {string} tag
- * @returns {Promise<T|string>} */
-function withTimeout(p, ms, tag) {
-	return Promise.race([
-		p,
-		new Promise((resolve) => setTimeout(() => resolve('HUNG@' + tag), ms))
-	]);
-}
-
 /** Current permission state, for rendering the Settings toggle.
- * TEMP DIAGNOSTIC: reports each step it reaches via `step`, and time-boxes both awaits.
- * A Capacitor bridge call to a plugin the native binary doesn't handle never settles —
- * that silence is indistinguishable from "never ran", so we make it name itself.
- * Reverted once the root cause is known.
- * @param {(s: string) => void} [step]
- * @returns {Promise<string>} */
-export async function pushStatus(step = () => {}) {
-	if (!browser) return 'nobrowser';
+ * Never throws and never hangs: a native call that fails resolves to 'prompt' so the
+ * toggle stays visible and tappable rather than silently vanishing.
+ * @returns {Promise<'granted'|'denied'|'prompt'|'prompt-with-rationale'|'unsupported'>} */
+export async function pushStatus() {
+	if (!isNative()) return 'unsupported';
 	try {
-		const nat = Capacitor?.isNativePlatform?.();
-		const plat = Capacitor?.getPlatform?.();
-		step('s1:' + String(nat) + '/' + String(plat));
-		if (nat !== true) return 'notnative(' + String(nat) + '/' + String(plat) + ')';
-
-		step('s2:importing');
-		const mod = await withTimeout(plugin(), 6000, 'import');
-		if (typeof mod === 'string') return mod; // HUNG@import
-		const PushNotifications = /** @type {any} */ (mod);
-		if (!PushNotifications) return 'noplugin';
-
-		step('s3:checking');
-		const r = await withTimeout(PushNotifications.checkPermissions(), 6000, 'checkPerms');
-		if (typeof r === 'string') return r; // HUNG@checkPerms
-		return String(/** @type {any} */ (r)?.receive ?? 'noreceive');
-	} catch (/** @type {any} */ e) {
-		return 'err:' + String((e && e.message) || e).slice(0, 45);
+		const r = await PushNotifications.checkPermissions();
+		return r?.receive ?? 'prompt';
+	} catch (e) {
+		console.warn('[push] checkPermissions failed', e);
+		return 'prompt';
 	}
 }
 
@@ -150,7 +123,6 @@ export async function pushStatus(step = () => {}) {
 export async function clearBadge() {
 	if (!isNative()) return;
 	try {
-		const PushNotifications = await plugin();
 		await PushNotifications.removeAllDeliveredNotifications();
 	} catch {
 		/* no-op */
@@ -161,7 +133,6 @@ export async function clearBadge() {
 export async function unregisterPush() {
 	if (!isNative()) return;
 	try {
-		const PushNotifications = await plugin();
 		const perm = await PushNotifications.checkPermissions();
 		if (perm.receive !== 'granted') return;
 		// Best-effort: we can't read the token back, so rely on the server pruning 410s.

--- a/src/lib/push.js
+++ b/src/lib/push.js
@@ -105,20 +105,42 @@ export async function requestPushPermission() {
 	}
 }
 
+/** Reject/settle a promise that may never settle, so a hang reports itself instead of
+ * leaving the caller waiting forever.
+ * @template T @param {Promise<T>} p @param {number} ms @param {string} tag
+ * @returns {Promise<T|string>} */
+function withTimeout(p, ms, tag) {
+	return Promise.race([
+		p,
+		new Promise((resolve) => setTimeout(() => resolve('HUNG@' + tag), ms))
+	]);
+}
+
 /** Current permission state, for rendering the Settings toggle.
- * TEMP DIAGNOSTIC: returns a descriptive reason instead of swallowing failures, so we can
- * see WHY the toggle hides. Reverted once the root cause is known.
+ * TEMP DIAGNOSTIC: reports each step it reaches via `step`, and time-boxes both awaits.
+ * A Capacitor bridge call to a plugin the native binary doesn't handle never settles —
+ * that silence is indistinguishable from "never ran", so we make it name itself.
+ * Reverted once the root cause is known.
+ * @param {(s: string) => void} [step]
  * @returns {Promise<string>} */
-export async function pushStatus() {
+export async function pushStatus(step = () => {}) {
 	if (!browser) return 'nobrowser';
 	try {
 		const nat = Capacitor?.isNativePlatform?.();
 		const plat = Capacitor?.getPlatform?.();
+		step('s1:' + String(nat) + '/' + String(plat));
 		if (nat !== true) return 'notnative(' + String(nat) + '/' + String(plat) + ')';
-		const PushNotifications = await plugin();
+
+		step('s2:importing');
+		const mod = await withTimeout(plugin(), 6000, 'import');
+		if (typeof mod === 'string') return mod; // HUNG@import
+		const PushNotifications = /** @type {any} */ (mod);
 		if (!PushNotifications) return 'noplugin';
-		const r = await PushNotifications.checkPermissions();
-		return String(r?.receive ?? 'noreceive');
+
+		step('s3:checking');
+		const r = await withTimeout(PushNotifications.checkPermissions(), 6000, 'checkPerms');
+		if (typeof r === 'string') return r; // HUNG@checkPerms
+		return String(/** @type {any} */ (r)?.receive ?? 'noreceive');
 	} catch (/** @type {any} */ e) {
 		return 'err:' + String((e && e.message) || e).slice(0, 45);
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -277,10 +277,7 @@
 		// Native push is a DEVICE capability, not a session one — check it on every mount so
 		// the Settings toggle appears no matter how the user signed in (fresh login, restored
 		// session, etc). Never prompts here; the one iOS prompt lives behind the toggle.
-		pushState = 's0:called';
-		pushStatus((s) => {
-			pushState = s;
-		}).then((st) => {
+		pushStatus().then((st) => {
 			pushState = st;
 			if (st === 'granted') initPush();
 		});
@@ -3429,15 +3426,6 @@
 					<span><Icon name={$hapticsEnabled ? 'vibrate' : 'vibrate-off'} size={16} /> Haptics</span
 					><span class="ap-state" class:on={$hapticsEnabled}>{$hapticsEnabled ? 'On' : 'Off'}</span>
 				</button>
-				{#if pushState !== 'unsupported'}
-					<button class="ap-toggle" on:click={togglePush}>
-						<span><Icon name="bell" size={16} /> Notifications</span><span
-							class="ap-state"
-							class:on={pushState === 'granted'}
-							>{pushState === 'granted' ? 'On' : pushState === 'denied' ? 'Blocked' : 'Enable'}</span
-						>
-					</button>
-				{/if}
 				<button class="ap-toggle" on:click={toggleMusic}>
 					<span>Music</span><span class="ap-state" class:on={$musicEnabled}
 						>{$musicEnabled ? 'On' : 'Off'}</span
@@ -4444,12 +4432,19 @@
 								>{$hapticsEnabled ? 'On' : 'Off'}</span
 							>
 						</button>
-						<button class="set-row" on:click={togglePush}>
-							<span><Icon name="bell" size={16} /> Notifications</span><span
-								class="set-state"
-								class:on={pushState === 'granted'}>{pushState}</span
-							>
-						</button>
+						{#if pushState !== 'unsupported'}
+							<button class="set-row" on:click={togglePush}>
+								<span><Icon name="bell" size={16} /> Notifications</span><span
+									class="set-state"
+									class:on={pushState === 'granted'}
+									>{pushState === 'granted'
+										? 'On'
+										: pushState === 'denied'
+											? 'Blocked'
+											: 'Enable'}</span
+								>
+							</button>
+						{/if}
 						<button class="set-row" on:click={toggleMusic}>
 							<span>Music</span><span class="set-state" class:on={$musicEnabled}
 								>{$musicEnabled ? 'On' : 'Off'}</span

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -277,7 +277,10 @@
 		// Native push is a DEVICE capability, not a session one — check it on every mount so
 		// the Settings toggle appears no matter how the user signed in (fresh login, restored
 		// session, etc). Never prompts here; the one iOS prompt lives behind the toggle.
-		pushStatus().then((st) => {
+		pushState = 's0:called';
+		pushStatus((s) => {
+			pushState = s;
+		}).then((st) => {
 			pushState = st;
 			if (st === 'granted') initPush();
 		});

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4441,19 +4441,12 @@
 								>{$hapticsEnabled ? 'On' : 'Off'}</span
 							>
 						</button>
-						{#if pushState !== 'unsupported'}
-							<button class="set-row" on:click={togglePush}>
-								<span><Icon name="bell" size={16} /> Notifications</span><span
-									class="set-state"
-									class:on={pushState === 'granted'}
-									>{pushState === 'granted'
-										? 'On'
-										: pushState === 'denied'
-											? 'Blocked'
-											: 'Enable'}</span
-								>
-							</button>
-						{/if}
+						<button class="set-row" on:click={togglePush}>
+							<span><Icon name="bell" size={16} /> Notifications</span><span
+								class="set-state"
+								class:on={pushState === 'granted'}>{pushState}</span
+							>
+						</button>
 						<button class="set-row" on:click={toggleMusic}>
 							<span>Music</span><span class="set-state" class:on={$musicEnabled}
 								>{$musicEnabled ? 'On' : 'Off'}</span


### PR DESCRIPTION
Push notifications were fully dead on device. Two independent bugs — fixing either alone would still have looked broken.

## 1. Web: dynamic `import()` hangs in WKWebView
`push.js` lazily imported `@capacitor/push-notifications`. Vite compiles `import()` into `__vitePreload`, which injects `<link rel="modulepreload">` and awaits their `load`/`error` events — **WKWebView fires neither**, so the promise never settled.

No error, no rejection, just silence: `pushStatus()` hung forever, the Settings toggle sat at its initial value, and `requestPushPermission()` would have hung on tap too.

Fixed by importing statically, exactly like `@capacitor/haptics`. The module is ~100 bytes and only calls `registerPlugin`, so there was nothing worth lazy-loading.

**Evidence:** step instrumentation reported `HUNG@import`. Control test — `haptics` and `capacitor/core` are static and both work on device; push was the only dynamic Capacitor import and the only one that failed.

## 2. Native: AppDelegate never forwarded the APNs token
`register()` asks iOS for a device token and iOS answers via the `AppDelegate` — but the stock Capacitor template doesn't implement those callbacks. Permission was granted, the JS `registration` event never fired, `device_tokens` stayed empty.

## Also
- Link `CapacitorPushNotifications` into the SPM target; `aps-environment` entitlement (verified in the signed binary).
- `.gitignore`: never commit `.env` or signing keys. Confirmed no key material ever entered git history.
- Notifications row removed from the Sound & Music popover — it belongs only in the Settings sheet.

## Verification (on device, iPhone 16 Pro Max)
- Toggle renders `Enable` → tap → iOS prompt → Allow
- `device_tokens` = 1 (ios / sandbox / 64-char token)
- End-to-end through the real trigger (`notifications` INSERT → policy → pg_net → Edge Function → APNs): **`{"sent":1,"failures":[]}`**, delivered to the lock screen
- `npm run check` + `npm run build` clean; SSR renders 200 with the static native import

## Follow-ups (not in this PR)
- Token `env` is hardcoded `sandbox`; Edge Function self-heals on `BadDeviceToken` but that path is untested before TestFlight.
- Permission primer at a high-intent moment — iOS gives exactly one prompt ever, and today only the Settings toggle triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)