### PR TITLE
Fix push primer timing: only showed after a page remount

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1844,12 +1844,18 @@
 	let fpPoints = { total: 0, best: 0 };
 	// Native push: 'granted' | 'denied' | 'prompt' | 'unsupported' (web = unsupported, toggle hidden).
 	let pushState = 'unsupported';
-	// The primer waits for a natural pause: a challenge arms it, the menu shows it. Checked
-	// once per mount — pushStatus() is a native round-trip, not something to run per render.
-	let primerChecked = false;
-	$: if (showMainMenu && hasInitialized && !primerChecked) {
-		primerChecked = true;
-		maybeShowPushPrimer();
+	// The primer waits for a natural pause: a challenge arms it, the menu shows it. Fire on each
+	// menu ENTRY (edge false->true), not once per mount — a challenge is created mid-session and
+	// the player returns to the menu afterward, so a one-shot guard would miss it. maybeShow…()
+	// synchronously no-ops unless armed, so re-running it on every menu entry is cheap.
+	let menuWasShown = false;
+	$: if (showMainMenu && hasInitialized) {
+		if (!menuWasShown) {
+			menuWasShown = true;
+			maybeShowPushPrimer();
+		}
+	} else {
+		menuWasShown = false;
 	}
 	/** @param {boolean} yes */
 	async function primerAnswer(yes) {


### PR DESCRIPTION
Found in device testing of #637. The primer worked (token registered on Allow) but only appeared after navigating Profile → Settings and back, not when returning to the menu after a challenge.

**Cause:** the trigger used a one-shot `primerChecked` boolean that fires on the *first* menu render — before any challenge arms it — then blocks forever. Returning to the menu post-challenge never re-checked. It surfaced only because visiting another route remounts `+page.svelte` and resets the guard.

**Fix:** fire on each menu entry (edge false→true). `maybeShowPushPrimer()` already no-ops synchronously when not armed, so re-checking per menu entry is cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)