### PR TITLE
QA scripts: guard against polluting the production DB

### DIFF
--- a/scripts/_qa-guard.mjs
+++ b/scripts/_qa-guard.mjs
@@ -1,0 +1,32 @@
+// Shared guard for QA/screenshot scripts that create throwaway accounts.
+//
+// WHY: these scripts sign up fresh test users (qa…@example.com etc). WordBank has ONE
+// database and it IS production — there is no separate dev/staging DB. So a stray
+// `BASE=https://wordbanksvelte.vercel.app node scripts/qa-e2e.mjs` silently pollutes the
+// real DB with test accounts (this is exactly how ~130 junk users got in). This guard
+// makes hitting any non-local target a deliberate, explicit act.
+//
+// Usage in a script:
+//   import { qaBase } from './_qa-guard.mjs';
+//   const BASE = qaBase('http://localhost:5174');   // was: process.env.BASE || '...'
+
+const LOCAL = /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?/i;
+
+/**
+ * Resolve BASE and refuse to run against a remote (production) target unless the operator
+ * explicitly sets QA_ALLOW_PROD=1. Prevents accidental prod pollution.
+ * @param {string} fallback local default, e.g. 'http://localhost:5174'
+ * @returns {string}
+ */
+export function qaBase(fallback) {
+	const base = process.env.BASE || fallback;
+	if (!LOCAL.test(base) && process.env.QA_ALLOW_PROD !== '1') {
+		console.error(
+			`\n⛔ Refusing to run QA against a non-local target: ${base}\n` +
+				`   This creates throwaway accounts, and WordBank's only DB is production.\n` +
+				`   If you REALLY mean to, re-run with QA_ALLOW_PROD=1 — and clean up after.\n`
+		);
+		process.exit(1);
+	}
+	return base;
+}

--- a/scripts/makeup-test.mjs
+++ b/scripts/makeup-test.mjs
@@ -1,7 +1,8 @@
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
 mkdirSync('screenshots', { recursive: true });
-const BASE = process.env.BASE || 'http://localhost:5173';
+const BASE = qaBase('http://localhost:5173');
 const PHASE = process.env.PHASE || 'setup';
 const ACC = { email: 'mka@example.com', pass: 'TestPass123!', user: 'mkalice' };
 const ANSWER = 'THEICEAGE';

--- a/scripts/measure.mjs
+++ b/scripts/measure.mjs
@@ -1,9 +1,10 @@
 // Measure the fixed bottom UI (keyboard / action buttons / wager bar) and screenshot
 // the game on mobile + desktop, in both daily and arcade(+wager) states.
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
 
-const BASE = process.env.BASE || 'http://localhost:5173';
+const BASE = qaBase('http://localhost:5173');
 const EMAIL = process.env.PW_EMAIL || 'pwtest+wb@example.com';
 const PASS = process.env.PW_PASS || 'TestPass123!';
 mkdirSync('screenshots', { recursive: true });

--- a/scripts/qa-e2e.mjs
+++ b/scripts/qa-e2e.mjs
@@ -1,9 +1,10 @@
 // End-to-end QA sweep: signup → gates → page sweep (console-error/hang detection) →
 // play a Daily to a real solve. Run: BASE=http://localhost:5174 node scripts/qa-e2e.mjs
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
 
-const BASE = process.env.BASE || 'http://localhost:5174';
+const BASE = qaBase('http://localhost:5174');
 const PASS = 'TestPass123!';
 const EMAIL = process.env.QA_EMAIL || `qa${Date.now()}@example.com`;
 const UNAME = 'qa' + String(Date.now()).slice(-7);

--- a/scripts/qa-group.mjs
+++ b/scripts/qa-group.mjs
@@ -4,10 +4,11 @@
 // challenge → accept → play → settle path is driven fully through the UI.
 // Run: set -a; . ./.env; set +a; BASE=http://localhost:5174 WAGER=500 node scripts/qa-group.mjs
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { execSync } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
 
-const BASE = process.env.BASE || 'http://localhost:5174';
+const BASE = qaBase('http://localhost:5174');
 const DB = process.env.SUPABASE_DB_URL;
 const PASS = 'TestPass123!';
 const PACK = Number(process.env.PACK || 1);

--- a/scripts/qa-h2h.mjs
+++ b/scripts/qa-h2h.mjs
@@ -2,10 +2,11 @@
 // real friendly match end-to-end. Reports console errors + UX observations.
 // Run: set -a; . ./.env; set +a; BASE=http://localhost:5174 node scripts/qa-h2h.mjs
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { execSync } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
 
-const BASE = process.env.BASE || 'http://localhost:5174';
+const BASE = qaBase('http://localhost:5174');
 const DB = process.env.SUPABASE_DB_URL;
 const PASS = 'TestPass123!';
 const PACK = Number(process.env.PACK || 2);

--- a/scripts/shoot-public.mjs
+++ b/scripts/shoot-public.mjs
@@ -1,7 +1,8 @@
 // Screenshot public-ish routes (no auth needed) for the redesign loop.
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
-const BASE = process.env.BASE || 'http://localhost:5174';
+const BASE = qaBase('http://localhost:5174');
 const TAG = process.env.TAG || 'pub';
 mkdirSync('screenshots', { recursive: true });
 const browser = await chromium.launch();

--- a/scripts/shoot-stats.mjs
+++ b/scripts/shoot-stats.mjs
@@ -1,8 +1,9 @@
 // Screenshots for the stats/history/profile/group/activity UI (seeded pwtest account).
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
 
-const BASE = process.env.BASE || 'http://localhost:5174';
+const BASE = qaBase('http://localhost:5174');
 const EMAIL = process.env.PW_EMAIL || 'pwtest+wb@example.com';
 const PASS = process.env.PW_PASS || 'TestPass123!';
 mkdirSync('screenshots', { recursive: true });

--- a/scripts/shoot.mjs
+++ b/scripts/shoot.mjs
@@ -1,8 +1,9 @@
 // Screenshot harness for the WordBank UI baseline/redesign loop.
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
 
-const BASE = process.env.BASE || 'http://localhost:5174';
+const BASE = qaBase('http://localhost:5174');
 const EMAIL = process.env.PW_EMAIL || 'pwtest+wb@example.com';
 const PASS = process.env.PW_PASS || 'TestPass123!';
 const TAG = process.env.TAG || 'base';

--- a/scripts/vs-walkthrough.mjs
+++ b/scripts/vs-walkthrough.mjs
@@ -1,10 +1,11 @@
 // 1v1 challenge walkthrough. Phases via env PHASE: setup | create | play | results.
 // Fixed creds so phases coordinate; clean up vsa@/vsb@ after.
 import { chromium } from 'playwright';
+import { qaBase } from './_qa-guard.mjs';
 import { mkdirSync } from 'node:fs';
 mkdirSync('screenshots', { recursive: true });
 
-const BASE = process.env.BASE || 'http://localhost:5173';
+const BASE = qaBase('http://localhost:5173');
 const PHASE = process.env.PHASE || 'setup';
 const ANSWER = (process.env.ANSWER || '').toUpperCase().replace(/[^A-Z]/g, '');
 const A = { email: 'vsa@example.com', pass: 'TestPass123!', user: 'vsalice' };


### PR DESCRIPTION
**Root cause of the ~130 test accounts in prod.** The QA/screenshot scripts sign up throwaway users against `$BASE`, and WordBank has exactly one database — which is production (no dev/staging DB exists, and the dev project for another product is off-limits). A stray `BASE=https://wordbanksvelte.vercel.app node scripts/qa-e2e.mjs` silently created real accounts (99 fake signups on July 13 alone).

Shared `scripts/_qa-guard.mjs`: `qaBase()` refuses any non-localhost target unless `QA_ALLOW_PROD=1` is explicitly set. Wired into all 9 account-creating scripts.

Verified: prod target refused with a clear message, localhost allowed, explicit override still works.

Follow-up (separate, needs backups confirmed first): delete the existing ~130 test accounts + their orphaned gameplay data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)