### PR TITLE
Menu tweaks: startup sequencing, menu-only music, receipt wrong-solves, wording

### DIFF
--- a/src/lib/components/ObjectiveCard.svelte
+++ b/src/lib/components/ObjectiveCard.svelte
@@ -34,15 +34,15 @@
 					icon: 'calendar',
 					title: "Today's Daily",
 					goal: 'Solve the hidden phrase.',
-					win: 'Spend as little as you can — your leftover Deposits to your account.',
-					bar: 'Earn Interest on every Deposit — from your streak, credit & boosts.'
+					win: 'Spend as little as you can — whatever’s left is deposited to your account.',
+					bar: 'Every deposit earns Interest — from your streak, credit & boosts.'
 				};
 			case 'climb':
 				return {
 					icon: 'coin',
 					title: 'Cash Game',
-					goal: 'Invest your buy-in → grow it by solving puzzles cheaply.',
-					win: 'Bank between puzzles — once you start one, it’s solve or bust. Your Interest climbs with each solve.',
+					goal: 'Invest your buy-in and grow it by solving puzzles cheaply.',
+					win: 'Bank your cash between puzzles — once you start one, it’s solve or bust. Your Interest climbs with every solve.',
 					bar: 'A wrong guess drains your budget — run out and you bust.'
 				};
 			case 'makeup':

--- a/src/lib/components/Tutorial.svelte
+++ b/src/lib/components/Tutorial.svelte
@@ -10,30 +10,30 @@
 		{
 			icon: 'cash',
 			title: 'Spend less, think more',
-			body: 'Crack the hidden phrase buying as few letters as you can.'
+			body: 'Crack the hidden phrase by buying as few letters as you can.'
 		},
 		{
 			icon: 'letter-a',
 			title: 'Buy letters',
-			body: 'Tap a letter to buy every copy. Wrong letters still cost you. Guessing the phrase is free — unlimited tries.'
+			body: 'Tap a letter to buy every copy of it. A letter that’s not in the phrase still costs you. Guessing the phrase is always free — try as often as you like.'
 		},
 		{
 			icon: 'coin',
 			title: 'Cash is your score',
 			isNew: true,
-			body: 'Start with $2,000 — your balance and your leaderboard rank. Spend it smart.'
+			body: 'You start with $2,000. It’s both your balance and your rank — the less you spend, the more you keep.'
 		},
 		{
 			icon: 'calendar',
 			title: 'Daily paycheck',
 			isNew: true,
-			body: 'One puzzle a day for everyone. Just showing up pays — more for a streak.'
+			body: 'One puzzle a day for everyone. Just showing up pays — and a streak pays more.'
 		},
 		{
 			icon: 'growth',
 			title: 'Cash Game & Challenges',
 			isNew: true,
-			body: 'Endless puzzles for Cash, or wager friends — solve efficiently and the highest Score takes the pot.'
+			body: 'Play endless puzzles in Cash Game, or challenge friends head-to-head — solve for the least and the top Score takes the pot.'
 		}
 	];
 

--- a/src/lib/music.js
+++ b/src/lib/music.js
@@ -14,10 +14,12 @@ export const TRACKS = [
 	{ id: 'stu-ball-recipes', title: 'Stu Ball Recipes', src: '/music/stu-ball-recipes.mp3' }
 ];
 
-const VOL_KEY = 'wb_music_vol';
+// VOL_KEY bumped to _v2 so the lower default takes effect for everyone (old saved
+// volumes are ignored). Menu-only music + this quieter default = a soft background bed.
+const VOL_KEY = 'wb_music_vol_v2';
 const ON_KEY = 'wb_music_on';
 const TRACK_KEY = 'wb_music_track';
-const DEFAULT_VOL = 0.2; // quiet by default (~20%)
+const DEFAULT_VOL = 0.08; // soft background (~8%) — menu-only, shouldn't dominate
 
 /** @param {any} v @param {number} d */
 function clamp01(v, d) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -450,6 +450,17 @@
 	// PIN gate: unlock screen for returning users; set-PIN after username for new ones.
 	$: showPinUnlock = loggedIn && hasInitialized && $pinLocked;
 	$: showPinSetup = loggedIn && hasInitialized && !$pinLocked && pinNotSet && !needsUsername;
+	// Single source of truth for "the user is actually on the live main menu" — fully past
+	// the auth, username, and PIN gates, and not inside a puzzle. Declared AFTER the gate
+	// flags above so it (and everything gated on it) recomputes with fresh gate values in the
+	// same reactive pass — no flash where music/tutorial fire before the PIN prompt.
+	$: onLiveMenu =
+		loggedIn &&
+		hasInitialized &&
+		showMainMenu &&
+		!needsUsername &&
+		!showPinUnlock &&
+		!showPinSetup;
 	// ===== Home "act-now" banner: the single most-urgent thing needing me =====
 	/** @type {any[]} incoming friend requests [{id,name,username}] */
 	let friendRequests = [];
@@ -484,10 +495,11 @@
 		pinNotSet = false;
 		handleLogout();
 	}
-	// Background music: play continuously through the whole session — menu AND in-game
-	// (it loops seamlessly across screens) — pausing only while locked / setting a PIN.
+	// Background music: MENU ONLY. Plays only on the live main menu (onLiveMenu covers the
+	// auth/username/PIN gates and excludes puzzles), and never over the tutorial / launch
+	// welcome. Stops the moment a puzzle starts.
 	$: if (browser) {
-		if (loggedIn && hasInitialized && !showPinUnlock && !showPinSetup) startMusic();
+		if (onLiveMenu && !showTutorial && !showLaunchWelcome) startMusic();
 		else stopMusic();
 	}
 
@@ -1479,17 +1491,9 @@
 	// Bump this key whenever the tutorial gains new content — it re-shows for
 	// everyone on next login (v3 = persistent Cash, spend-the-least, attendance, no loans).
 	const TUTORIAL_KEY = 'wb_tutorial_v3';
-	// First-run guided tutorial: show once a signed-in user is past the username/PIN
-	// gates and on the menu (not while those full-screen gates are up).
-	$: if (
-		browser &&
-		loggedIn &&
-		hasInitialized &&
-		!needsUsername &&
-		!showPinUnlock &&
-		!showPinSetup &&
-		localStorage.getItem(TUTORIAL_KEY) !== 'true'
-	) {
+	// First-run guided tutorial: only once the user is on the live main menu, fully past
+	// the username/PIN gates (onLiveMenu) — never before the PIN prompt.
+	$: if (browser && onLiveMenu && localStorage.getItem(TUTORIAL_KEY) !== 'true') {
 		showTutorial = true;
 	}
 
@@ -1498,12 +1502,7 @@
 	const LAUNCH_KEY = 'wb_launch_welcome_v1';
 	$: if (
 		browser &&
-		loggedIn &&
-		hasInitialized &&
-		showMainMenu &&
-		!needsUsername &&
-		!showPinUnlock &&
-		!showPinSetup &&
+		onLiveMenu &&
 		!showTutorial &&
 		localStorage.getItem(TUTORIAL_KEY) === 'true' &&
 		localStorage.getItem(LAUNCH_KEY) !== '1'
@@ -5120,6 +5119,13 @@
 						{@const mult = Number(dr.mult ?? $gameStore.bountyMult ?? 1)}
 						{@const prize = Number(dr.base ?? 0)}
 						{@const kept = Number(dr.kept ?? Math.max(0, prize - (dr.spent ?? 0)))}
+						{@const wrongSolves = Number($gameStore.wrongGuesses ?? 0)}
+						<!-- Wrong solves are the only thing that cuts the Daily multiplier below its base,
+						     so the lost winnings = (base mult − applied mult) × subtotal. -->
+						{@const wrongCost = Math.max(
+							0,
+							Math.round((Number($gameStore.bountyMult ?? mult) - mult) * kept)
+						)}
 						{@const banked = Number(
 							dr.winnings ?? dr.banked ?? dr.reward ?? Math.round(kept * mult)
 						)}
@@ -5170,6 +5176,13 @@
 									>−${(dr.spent ?? 0).toLocaleString()}</span
 								>
 							</div>
+							{#if wrongSolves > 0}
+								<div class="rcpt-line">
+									<span>Wrong solves <small>×{wrongSolves}</small></span><span
+										class="neg">{wrongCost > 0 ? `−$${wrongCost.toLocaleString()}` : '—'}</span
+									>
+								</div>
+							{/if}
 							<div class="rcpt-rule"></div>
 							<div class="rcpt-line">
 								<span>Subtotal</span><span>${kept.toLocaleString()}</span>


### PR DESCRIPTION
Batch of small game tweaks.

**1. Tutorial/music firing before the PIN prompt** — root cause: music wasn't gated on the username step, so on a *new* account it played during username entry (before PIN setup). Added a single `onLiveMenu` flag (past auth + username + PIN, on the menu, not in a puzzle) and gate music + tutorial + launch-welcome on it. (It's a first-sign-in issue; returning users' PIN-unlock already gated correctly.)

**2. Music: menu-only + quieter** — stops the moment a puzzle starts; default volume 20% → 8% (VOL_KEY bumped so it takes effect for everyone).

**3. Wrong solves on the receipt** — Daily receipt now shows "Wrong solves ×N" and the dollar cost (winnings lost to the multiplier hit = (base mult − applied mult) × subtotal). **Cash Game & Challenge:** the run-total wrong-solve count isn't tracked/surfaced server-side (persisted stat is 0 everywhere) — needs a server addition, flagged as follow-up.

**4. Wording** — fixed grammar bugs ("phrase buying"→"phrase by buying"; broken "leftover Deposits to your account") and tightened the tutorial + objective-card copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)