### PR TITLE
Fix PIN gate: keypad top row unresponsive + menu behind it

### DIFF
--- a/src/lib/components/PinGate.svelte
+++ b/src/lib/components/PinGate.svelte
@@ -176,7 +176,9 @@
 	.pin-screen {
 		position: fixed;
 		inset: 0;
-		z-index: 2500;
+		/* Above every other fixed overlay (menu top bar 3000, others up to 9999) so nothing
+		   can sit over the keypad and steal taps on the top row. */
+		z-index: 10000;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
@@ -224,7 +226,7 @@
 	.vault {
 		position: fixed;
 		inset: 0;
-		z-index: 2600;
+		z-index: 10001;
 		display: grid;
 		place-items: center;
 		cursor: pointer;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3538,6 +3538,11 @@
 	{:else if !hasInitialized}
 		<!-- ⏳ Loading (prevents flash of game UI / diagnostic before we know menu vs game) -->
 		<div class="init-loading">Loading…</div>
+	{:else if showPinUnlock || showPinSetup}
+		<!-- 🔒 PIN gate is up (the PinGate overlay above owns the screen). Render NOTHING
+		     behind it: the menu's fixed top bar sits at z-index 3000+ (above the PIN's 2500),
+		     so if the menu rendered here it would overlap the keypad and swallow taps on the
+		     top row — and it would flash the menu before the PIN appears. -->
 	{:else if showMainMenu}
 		<!-- 🏠 Main Menu (after sign-in) -->
 		<div class="main-menu fade-up">


### PR DESCRIPTION
The main-menu branch wasn't gated on the PIN flags, so the menu rendered behind the PIN overlay. Its fixed top bar (z-index 3000+, above the PIN's 2500) overlapped the keypad and ate taps on the top row (1/2/3). Fix: render nothing behind the PIN gate + raise the PIN z-index to 10000. Likely surfaced by the SPA render-timing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)