### PR TITLE
Fix Store-buy PIN, sounds dying with music, touch misalignment

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,11 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+		<!-- No viewport-fit=cover: the native shell uses contentInset "always" (WKWebView insets
+		     content below the status bar). With cover, the web drew edge-to-edge while the WebView
+		     inset the touch layer — so taps landed offset from the buttons. Dropping cover makes the
+		     web's coordinate space match where the WebView actually places content. -->
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="icon" href="/logo-mark.png" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<link rel="manifest" href="/manifest.webmanifest" />

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -35,6 +35,28 @@ export function toggleHaptics() {
 
 /** @type {AudioContext | null} */
 let ctx = null;
+/** @type {AudioBufferSourceNode | null} */
+let keepAlive = null;
+// iOS shares ONE audio session across the page. The background music (an HTMLAudioElement)
+// used to hold it open; now that music is menu-only, pausing it would let iOS deactivate the
+// session and suspend THIS Web Audio context — killing game sounds during puzzles until music
+// resumes. A silent, looping keep-alive source holds this context's session open on its own,
+// so game sounds no longer depend on music playing.
+function startKeepAlive(/** @type {AudioContext} */ c) {
+	if (keepAlive) return;
+	try {
+		const src = c.createBufferSource();
+		src.buffer = c.createBuffer(1, 1, 22050); // 1 silent sample
+		src.loop = true;
+		const g = c.createGain();
+		g.gain.value = 0;
+		src.connect(g).connect(c.destination);
+		src.start(0);
+		keepAlive = src;
+	} catch {
+		/* best-effort */
+	}
+}
 function ac() {
 	if (!browser) return null;
 	if (!ctx) {
@@ -44,6 +66,7 @@ function ac() {
 	}
 	// Browsers start the context suspended until a user gesture; resume on demand.
 	if (ctx.state === 'suspended') ctx.resume().catch(() => {});
+	startKeepAlive(ctx); // hold the audio session so sounds survive music pausing
 	return ctx;
 }
 

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/stores/statsStore.js';
 	import { track } from '$lib/analytics.js';
 	import { fx } from '$lib/sound.js';
+	import { requirePin } from '$lib/pinConfirm.js';
 	import InventoryList from '$lib/components/InventoryList.svelte';
 	import Icon from '$lib/components/Icon.svelte';
 
@@ -79,6 +80,14 @@
 	/** @param {any} item */
 	async function buyPup(item) {
 		if (busy) return;
+		// Money-out → PIN confirm (lazy-creates the PIN on the first purchase).
+		try {
+			await requirePin(`Buy ${item.name}`, [
+				{ label: item.name, value: '$' + Number(item.price ?? 0).toLocaleString() }
+			]);
+		} catch {
+			return; // cancelled at the PIN
+		}
 		busy = item.id;
 		msg = '';
 		const res = await buyPowerup(item.id);


### PR DESCRIPTION
1. **Store PIN:** powerup buys skipped requirePin — added it (lazy-creates on first buy).
2. **Sounds die with music:** Web Audio sound context relied on the iOS session the music element held. Added a silent keep-alive node so the sound context holds its own session; sounds survive music pausing.
3. **Touch misalignment:** viewport-fit=cover fought the shell's contentInset 'always'. Dropped cover so the web coordinate space matches the WebView. (Hypothesis — needs device test.)