### PR TITLE
Fix game sounds broke entirely; hold audio session via music element

### DIFF
--- a/src/lib/music.js
+++ b/src/lib/music.js
@@ -66,9 +66,12 @@ function ensureAudio() {
 function apply() {
 	const a = audio;
 	if (!a) return;
-	a.volume = enabled ? volume : 0;
-	if (wantPlaying && enabled) a.play().catch(() => armAutoplay());
-	else if (!enabled) a.pause();
+	// Audible ONLY on the menu with music enabled; silent otherwise. But keep the element
+	// PLAYING even when silent (volume 0) rather than pausing — on iOS all page audio shares
+	// one session, and pausing this element drops it, suspending the Web-Audio game sounds.
+	// Volume 0 still counts as "playing", so the session (and game sounds) stay alive.
+	a.volume = enabled && wantPlaying ? volume : 0;
+	a.play().catch(() => armAutoplay());
 }
 
 // Browsers block audio until a user gesture. If play() is rejected, wait for the
@@ -103,7 +106,7 @@ musicEnabled.subscribe((v) => {
 musicVolume.subscribe((v) => {
 	volume = clamp01(v, DEFAULT_VOL);
 	if (browser) localStorage.setItem(VOL_KEY, String(volume));
-	if (audio) audio.volume = enabled ? volume : 0;
+	apply();
 });
 currentTrackId.subscribe((v) => {
 	if (!v) return;
@@ -120,15 +123,15 @@ currentTrackId.subscribe((v) => {
 /** Start lobby music (call when entering the menu lobby). */
 export function startMusic() {
 	wantPlaying = true;
-	const a = ensureAudio();
-	if (!a) return;
-	if (enabled) a.play().catch(() => armAutoplay());
+	ensureAudio();
+	apply();
 }
 
-/** Pause lobby music (call when leaving the lobby / starting a game). */
+/** Silence lobby music (call when leaving the lobby / starting a game). Goes to volume 0
+ *  but keeps PLAYING — pausing would drop the iOS audio session and kill game sounds. */
 export function stopMusic() {
 	wantPlaying = false;
-	if (audio) audio.pause();
+	apply();
 }
 
 /** @param {number} v 0..1 */

--- a/src/lib/sound.js
+++ b/src/lib/sound.js
@@ -35,28 +35,6 @@ export function toggleHaptics() {
 
 /** @type {AudioContext | null} */
 let ctx = null;
-/** @type {AudioBufferSourceNode | null} */
-let keepAlive = null;
-// iOS shares ONE audio session across the page. The background music (an HTMLAudioElement)
-// used to hold it open; now that music is menu-only, pausing it would let iOS deactivate the
-// session and suspend THIS Web Audio context — killing game sounds during puzzles until music
-// resumes. A silent, looping keep-alive source holds this context's session open on its own,
-// so game sounds no longer depend on music playing.
-function startKeepAlive(/** @type {AudioContext} */ c) {
-	if (keepAlive) return;
-	try {
-		const src = c.createBufferSource();
-		src.buffer = c.createBuffer(1, 1, 22050); // 1 silent sample
-		src.loop = true;
-		const g = c.createGain();
-		g.gain.value = 0;
-		src.connect(g).connect(c.destination);
-		src.start(0);
-		keepAlive = src;
-	} catch {
-		/* best-effort */
-	}
-}
 function ac() {
 	if (!browser) return null;
 	if (!ctx) {
@@ -66,7 +44,6 @@ function ac() {
 	}
 	// Browsers start the context suspended until a user gesture; resume on demand.
 	if (ctx.state === 'suspended') ctx.resume().catch(() => {});
-	startKeepAlive(ctx); // hold the audio session so sounds survive music pausing
 	return ctx;
 }
 


### PR DESCRIPTION
The Web-Audio keep-alive from #646 killed game sounds on iOS. Reverted it. For the sounds-die-when-music-stops coupling, keep the music element playing at volume 0 (not paused) so it holds the shared iOS audio session that the Web-Audio game sounds share. Menu-only music unchanged (silent off-menu, not paused).